### PR TITLE
test(awsdiscover): static tripwire + live probe for the CloudControl required-field bug class

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -377,6 +377,14 @@ func NewAWSDiscovererWithConcurrency(cfg aws.Config, maxConcurrency int) *AWSDis
 	if cc, ok := byTypeEnricher["aws_lambda_function"]; ok {
 		byTypeEnricher["aws_lambda_function"] = newLambdaFunctionEnricher(cc)
 	}
+	// aws_cloudfront_function: composite enricher (#665). Same shape as
+	// the lambda composite — delegates the bulk mapping to the CC
+	// enricher, then overlays the required `code` + `runtime`
+	// attributes CloudControl GetResource does not return. Unlike
+	// lambda, the overlay is mandatory (both are required arguments).
+	if cc, ok := byTypeEnricher["aws_cloudfront_function"]; ok {
+		byTypeEnricher["aws_cloudfront_function"] = newCloudfrontFunctionEnricher(cc)
+	}
 	disc := &AWSDiscoverer{
 		defaultRegion:  cfg.Region,
 		cfg:            cfg,

--- a/cmd/insideout-import/awsdiscover/cc_required_field_live_test.go
+++ b/cmd/insideout-import/awsdiscover/cc_required_field_live_test.go
@@ -1,0 +1,292 @@
+//go:build integration
+
+// Live probe for the "CloudControl cannot read back a required field"
+// bug class (#665 — the class behind #661 / #662 / #664).
+//
+// The static tripwire (cc_required_field_tripwire_test.go) freezes the
+// at-risk surface but cannot PROVE whether cloudcontrol:GetResource
+// actually returns a given required field — the CFN registry schema
+// does not declare the gap (AWS::IAM::ManagedPolicy does not mark
+// PolicyDocument write-only, yet the handler omits it). Only a real
+// GetResource against a real resource can.
+//
+// This probe provisions throwaway instances of the suspected types,
+// then runs the genuine discover→enrich pipeline against them:
+// DiscoverTypes produces the production-faithful Identity (so the probe
+// can't accidentally test a strawman identifier), and EnrichAttributes
+// routes each to its generic CloudControl enricher. It then asserts
+// every REQUIRED schema field came back populated — an empty required
+// field is the bug, confirmed for that type.
+//
+// expectedGaps records the types a prior run found broken: the probe
+// downgrades a known gap to a logged warning (so the probe stays green
+// while #665 tracks the fix) but FAILS if (a) a not-listed type turns
+// up broken — a new instance of the class — or (b) a listed type turns
+// up fixed and should be removed from the map.
+//
+// Run (from a shell with AWS creds, e.g. aws_jump <acct> <role>):
+//
+//	go test -tags=integration ./cmd/insideout-import/awsdiscover/... \
+//	    -v -run TestLive665_CloudControlRequiredFieldProbe -timeout 15m
+//
+// Self-skips when AWS credentials cannot be resolved.
+
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// expectedGaps lists types a prior probe run confirmed the CloudControl
+// path cannot fully populate, each pointing at the tracking issue. A
+// type in this map is a logged warning, not a failure; a type NOT in
+// it that turns up broken fails the probe (new bug-class instance), and
+// a listed type that turns up fixed also fails (stale entry — remove).
+var expectedGaps = map[string]string{
+	// Both confirmed by the first live run (2026-05) against a real
+	// account — see #665 for the fixes.
+
+	// aws_cloudfront_function: cloudcontrol:GetResource for
+	// AWS::CloudFront::Function does not return the function `code`
+	// (nor `runtime`) — the CFN handler treats FunctionCode as
+	// create-time input. Needs a hand-rolled enricher
+	// (cloudfront:GetFunction → Code + DescribeFunction → Runtime).
+	"aws_cloudfront_function": "GetResource omits code/runtime — see #665",
+
+	// aws_key_pair: cloudcontrol:GetResource for AWS::EC2::KeyPair
+	// returns the fingerprint but never the `public_key` material —
+	// EC2 does not expose public-key material on read. The required
+	// `public_key` argument is genuinely unrecoverable from the API;
+	// the fix is an adoption-style enricher that pins it under
+	// lifecycle.ignore_changes (the lambda-code precedent).
+	"aws_key_pair": "GetResource never returns public_key material — see #665",
+}
+
+// e2eThrowawayPublicKey is a throwaway ed25519 public key for the
+// aws_key_pair probe. The matching private key was generated and
+// discarded at authoring time — a public key is not a secret, and
+// ImportKeyPair only validates that the material is a well-formed key.
+const e2eThrowawayPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBYRn+c+IPlLaBIAbZvs13Vq3XdJvTtWNvMdoeR9s/Ea io-e2e665-throwaway"
+
+// TestLive665_CloudControlRequiredFieldProbe is the live detector.
+func TestLive665_CloudControlRequiredFieldProbe(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Minute)
+	defer cancel()
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		t.Skipf("AWS config not resolvable, skipping: %v", err)
+	}
+	if cfg.Region == "" {
+		cfg.Region = "us-east-1"
+	}
+	region := cfg.Region
+	if _, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}); err != nil {
+		t.Skipf("STS GetCallerIdentity failed (no usable AWS creds), skipping: %v", err)
+	}
+
+	clients := EnrichClients{CloudControl: cloudcontrol.NewFromConfig(cfg)}
+	disc := NewAWSDiscoverer(cfg)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	// Each probe provisions a resource and returns the resource name —
+	// the value the discoverer stamps on Identity.NameHint — so the
+	// probe can pick its resource out of the discovered set.
+	probes := []struct {
+		tfType    string
+		provision func(t *testing.T) (name string, ok bool)
+	}{
+		{
+			tfType: "aws_cloudwatch_log_resource_policy",
+			provision: func(t *testing.T) (string, bool) {
+				c := cloudwatchlogs.NewFromConfig(cfg)
+				name := "io-e2e665-logpol-" + suffix
+				doc := `{"Version":"2012-10-17","Statement":[{"Sid":"e2e","Effect":"Allow","Principal":{"Service":"route53.amazonaws.com"},"Action":["logs:PutLogEvents","logs:CreateLogStream"],"Resource":"*"}]}`
+				if _, err := c.PutResourcePolicy(ctx, &cloudwatchlogs.PutResourcePolicyInput{
+					PolicyName:     aws.String(name),
+					PolicyDocument: aws.String(doc),
+				}); err != nil {
+					t.Logf("provision skipped: PutResourcePolicy: %v", err)
+					return "", false
+				}
+				t.Cleanup(func() {
+					if _, err := c.DeleteResourcePolicy(context.Background(), &cloudwatchlogs.DeleteResourcePolicyInput{
+						PolicyName: aws.String(name),
+					}); err != nil {
+						t.Logf("cleanup DeleteResourcePolicy(%s): %v", name, err)
+					}
+				})
+				return name, true
+			},
+		},
+		{
+			tfType: "aws_key_pair",
+			provision: func(t *testing.T) (string, bool) {
+				c := ec2.NewFromConfig(cfg)
+				name := "io-e2e665-key-" + suffix
+				if _, err := c.ImportKeyPair(ctx, &ec2.ImportKeyPairInput{
+					KeyName:           aws.String(name),
+					PublicKeyMaterial: []byte(e2eThrowawayPublicKey),
+				}); err != nil {
+					t.Logf("provision skipped: ImportKeyPair: %v", err)
+					return "", false
+				}
+				t.Cleanup(func() {
+					if _, err := c.DeleteKeyPair(context.Background(), &ec2.DeleteKeyPairInput{
+						KeyName: aws.String(name),
+					}); err != nil {
+						t.Logf("cleanup DeleteKeyPair(%s): %v", name, err)
+					}
+				})
+				return name, true
+			},
+		},
+		{
+			tfType: "aws_cloudfront_function",
+			provision: func(t *testing.T) (string, bool) {
+				c := cloudfront.NewFromConfig(cfg)
+				name := "io-e2e665-fn-" + suffix
+				code := []byte("function handler(event) { return event.request; }")
+				if _, err := c.CreateFunction(ctx, &cloudfront.CreateFunctionInput{
+					Name:         aws.String(name),
+					FunctionCode: code,
+					FunctionConfig: &cftypes.FunctionConfig{
+						Comment: aws.String("io-e2e665 throwaway - safe to delete"),
+						Runtime: cftypes.FunctionRuntimeCloudfrontJs20,
+					},
+				}); err != nil {
+					t.Logf("provision skipped: CreateFunction: %v", err)
+					return "", false
+				}
+				t.Cleanup(func() {
+					desc, derr := c.DescribeFunction(context.Background(), &cloudfront.DescribeFunctionInput{Name: aws.String(name)})
+					if derr != nil {
+						t.Logf("cleanup DescribeFunction(%s): %v", name, derr)
+						return
+					}
+					if _, err := c.DeleteFunction(context.Background(), &cloudfront.DeleteFunctionInput{
+						Name:    aws.String(name),
+						IfMatch: desc.ETag,
+					}); err != nil {
+						t.Logf("cleanup DeleteFunction(%s): %v", name, err)
+					}
+				})
+				return name, true
+			},
+		},
+	}
+
+	for _, p := range probes {
+		t.Run(p.tfType, func(t *testing.T) {
+			name, ok := p.provision(t)
+			if !ok {
+				t.Skip("provisioning did not complete (see log)")
+			}
+
+			// Run the production discover path so the Identity (import
+			// id, region, native ids) is exactly what a real import
+			// would carry — no hand-constructed strawman identifier.
+			discovered, err := disc.DiscoverTypes(ctx, []string{p.tfType}, DiscoverArgs{Regions: []string{region}})
+			if err != nil {
+				t.Fatalf("DiscoverTypes(%s): %v", p.tfType, err)
+			}
+			idx := -1
+			for i := range discovered {
+				id := discovered[i].Identity
+				if id.NameHint == name || id.ImportID == name || strings.Contains(id.ImportID, name) {
+					idx = i
+					break
+				}
+			}
+			if idx < 0 {
+				t.Skipf("provisioned %s %q not found by DiscoverTypes (propagation lag?)", p.tfType, name)
+			}
+
+			irs := discovered[idx : idx+1]
+			if err := disc.EnrichAttributes(ctx, irs, clients, nil); err != nil {
+				t.Fatalf("EnrichAttributes(%s): %v", p.tfType, err)
+			}
+			missing := missingRequiredFields(t, p.tfType, irs[0].Attrs)
+			reason, known := expectedGaps[p.tfType]
+			switch {
+			case len(missing) > 0 && known:
+				t.Logf("KNOWN GAP (%s): CloudControl did not populate %v — tracked: %s",
+					p.tfType, missing, reason)
+			case len(missing) > 0 && !known:
+				t.Fatalf("NEW BUG-CLASS INSTANCE: %s — the CloudControl enrich path did not "+
+					"populate required field(s) %v. This needs a hand-rolled enricher "+
+					"(the #661 fix shape). Add it, or record the gap in expectedGaps "+
+					"with a tracking issue.", p.tfType, missing)
+			case len(missing) == 0 && known:
+				t.Fatalf("%s is in expectedGaps but the probe found all required fields "+
+					"populated — the gap is fixed; remove %q from expectedGaps.", p.tfType, p.tfType)
+			default:
+				t.Logf("OK (%s): all required fields populated by the CloudControl path", p.tfType)
+			}
+		})
+	}
+}
+
+// missingRequiredFields returns the REQUIRED schema fields of tfType
+// that are absent or empty in the enriched Attrs JSON. Generic — keyed
+// off the generated schema — so it covers every required field of the
+// type. An entirely empty Attrs payload (the enricher soft-failed) is
+// reported as every required field missing, which is what it is.
+func missingRequiredFields(t *testing.T, tfType string, attrs json.RawMessage) []string {
+	t.Helper()
+	_, schema, ok := generated.Lookup(tfType)
+	require.Truef(t, ok, "%s not registered in generated", tfType)
+
+	required := func() []string {
+		var r []string
+		for name, fs := range schema {
+			if fs.Required {
+				r = append(r, name)
+			}
+		}
+		sort.Strings(r)
+		return r
+	}
+
+	if len(attrs) == 0 {
+		return required()
+	}
+	var m map[string]json.RawMessage
+	require.NoErrorf(t, json.Unmarshal(attrs, &m), "%s: Attrs is not a JSON object", tfType)
+	var missing []string
+	for _, name := range required() {
+		v, present := m[name]
+		if !present || isEmptyJSONValue(v) {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+// isEmptyJSONValue reports whether a raw JSON value is absent-equivalent
+// — null, an empty string, or an empty object/array.
+func isEmptyJSONValue(v json.RawMessage) bool {
+	switch strings.TrimSpace(string(v)) {
+	case "", "null", `""`, "{}", "[]":
+		return true
+	}
+	return false
+}

--- a/cmd/insideout-import/awsdiscover/cc_required_field_live_test.go
+++ b/cmd/insideout-import/awsdiscover/cc_required_field_live_test.go
@@ -36,7 +36,11 @@ package awsdiscover
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
@@ -52,6 +56,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/stretchr/testify/require"
 
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
 
@@ -61,23 +67,22 @@ import (
 // it that turns up broken fails the probe (new bug-class instance), and
 // a listed type that turns up fixed also fails (stale entry — remove).
 var expectedGaps = map[string]string{
-	// Both confirmed by the first live run (2026-05) against a real
-	// account — see #665 for the fixes.
-
-	// aws_cloudfront_function: cloudcontrol:GetResource for
-	// AWS::CloudFront::Function does not return the function `code`
-	// (nor `runtime`) — the CFN handler treats FunctionCode as
-	// create-time input. Needs a hand-rolled enricher
-	// (cloudfront:GetFunction → Code + DescribeFunction → Runtime).
-	"aws_cloudfront_function": "GetResource omits code/runtime — see #665",
-
 	// aws_key_pair: cloudcontrol:GetResource for AWS::EC2::KeyPair
 	// returns the fingerprint but never the `public_key` material —
-	// EC2 does not expose public-key material on read. The required
-	// `public_key` argument is genuinely unrecoverable from the API;
-	// the fix is an adoption-style enricher that pins it under
-	// lifecycle.ignore_changes (the lambda-code precedent).
-	"aws_key_pair": "GetResource never returns public_key material — see #665",
+	// EC2 does not expose it on read, so NO enricher can recover it.
+	// This is a permanent enricher-layer gap by design; the #665 fix
+	// is composer-layer (composer.ensureKeyPairPlaceholder injects a
+	// placeholder public_key pinned under lifecycle.ignore_changes).
+	// The probe's compose+plan phase below verifies that fix end to
+	// end. This entry stays because the probe's per-type phase
+	// inspects the *enricher* output, which legitimately still lacks
+	// public_key.
+	"aws_key_pair": "public_key unrecoverable from any API — fixed at the composer layer, see #665",
+
+	// aws_cloudfront_function was a confirmed gap (GetResource omits
+	// code/runtime) — FIXED by the cloudfrontFunctionEnricher composite
+	// (#665), which overlays both from the CloudFront API. It is no
+	// longer listed here; the probe now asserts it enriches cleanly.
 }
 
 // e2eThrowawayPublicKey is a throwaway ed25519 public key for the
@@ -103,9 +108,17 @@ func TestLive665_CloudControlRequiredFieldProbe(t *testing.T) {
 		t.Skipf("STS GetCallerIdentity failed (no usable AWS creds), skipping: %v", err)
 	}
 
-	clients := EnrichClients{CloudControl: cloudcontrol.NewFromConfig(cfg)}
+	clients := EnrichClients{
+		CloudControl: cloudcontrol.NewFromConfig(cfg),
+		CloudFront:   cloudfront.NewFromConfig(cfg),
+	}
 	disc := NewAWSDiscoverer(cfg)
 	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+
+	// enriched collects the enriched IRs across the per-type subtests
+	// so the compose+terraform-plan subtest can verify the composed
+	// HCL end to end. Subtests run sequentially, so the append is safe.
+	var enriched []imported.ImportedResource
 
 	// Each probe provisions a resource and returns the resource name —
 	// the value the discoverer stamps on Identity.NameHint — so the
@@ -194,9 +207,15 @@ func TestLive665_CloudControlRequiredFieldProbe(t *testing.T) {
 		},
 	}
 
+	// rootT owns the resource teardown: each provision registers its
+	// t.Cleanup on rootT (not the per-type subtest) so the resources
+	// outlive the per-type subtests and are still present for the
+	// terraform-plan subtest, which imports them. A t.Cleanup on a
+	// subtest fires when that subtest ends — far too early here.
+	rootT := t
 	for _, p := range probes {
 		t.Run(p.tfType, func(t *testing.T) {
-			name, ok := p.provision(t)
+			name, ok := p.provision(rootT)
 			if !ok {
 				t.Skip("provisioning did not complete (see log)")
 			}
@@ -224,6 +243,7 @@ func TestLive665_CloudControlRequiredFieldProbe(t *testing.T) {
 			if err := disc.EnrichAttributes(ctx, irs, clients, nil); err != nil {
 				t.Fatalf("EnrichAttributes(%s): %v", p.tfType, err)
 			}
+			enriched = append(enriched, irs[0])
 			missing := missingRequiredFields(t, p.tfType, irs[0].Attrs)
 			reason, known := expectedGaps[p.tfType]
 			switch {
@@ -243,6 +263,65 @@ func TestLive665_CloudControlRequiredFieldProbe(t *testing.T) {
 			}
 		})
 	}
+
+	// End-to-end verification: compose the enriched IRs to HCL and run
+	// `terraform plan` against the live account. This proves the fixes
+	// hold where it matters — a plan ERROR is the regression. For
+	// aws_key_pair specifically, this is the only phase that exercises
+	// the composer-layer fix (placeholder public_key + ignore_changes),
+	// since the per-type phase above inspects only the enricher output.
+	t.Run("terraform plan accepts the composed imported.tf", func(t *testing.T) {
+		if len(enriched) == 0 {
+			t.Skip("no resources enriched (all provisioning skipped)")
+		}
+		tfBin, lookErr := exec.LookPath("terraform")
+		if lookErr != nil {
+			t.Skip("terraform binary not on PATH")
+		}
+		out, _ := composer.EmitImportedTF("aws", enriched, composer.EmitImportedOpts{})
+		require.NotEmpty(t, out, "EmitImportedTF produced no HCL")
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "imported.tf"), out, 0o600))
+		providers := fmt.Sprintf(`terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+provider "aws" {
+  region = %q
+}
+provider "aws" {
+  alias  = "imported"
+  region = %q
+}
+`, region, region)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(providers), 0o600))
+
+		runTF := func(args ...string) (string, error) {
+			cmd := exec.CommandContext(ctx, tfBin, args...)
+			cmd.Dir = dir
+			cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
+			b, err := cmd.CombinedOutput()
+			return string(b), err
+		}
+		if o, err := runTF("init", "-input=false", "-no-color"); err != nil {
+			t.Fatalf("terraform init failed: %v\n%s", err, o)
+		}
+		o, err := runTF("plan", "-input=false", "-no-color", "-detailed-exitcode")
+		if err != nil {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) && exitErr.ExitCode() == 2 {
+				t.Logf("terraform plan clean (exit 2 = non-empty diff, expected for import)")
+				return
+			}
+			t.Fatalf("terraform plan ERRORED — the composed imported.tf is not plan-clean:\n%s", o)
+		}
+		t.Logf("terraform plan clean (exit 0 = no diff)")
+	})
 }
 
 // missingRequiredFields returns the REQUIRED schema fields of tfType

--- a/cmd/insideout-import/awsdiscover/cc_required_field_tripwire_test.go
+++ b/cmd/insideout-import/awsdiscover/cc_required_field_tripwire_test.go
@@ -1,0 +1,108 @@
+package awsdiscover
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// TestCloudControlRequiredFieldTripwire is a static CI gate for the
+// "CloudControl cannot read back a required field" bug class — the
+// class behind #661 / #662 / #664 and tracked by #665.
+//
+// The bug: a Terraform type routed through the generic CloudControl
+// enricher has a REQUIRED argument that cloudcontrol:GetResource does
+// not return (the CFN handler treats it as create-time input). The
+// enricher fail-opens, the composed HCL ships an empty required arg,
+// and `terraform plan` blows up at the customer — not at compose time.
+//
+// This bug is NOT statically declarable: the CFN registry schema for
+// AWS::IAM::ManagedPolicy does not mark PolicyDocument write-only, yet
+// the handler never returns it. So no check can PROVE correctness from
+// static data — only a live GetResource probe can (see the
+// build-tagged live probe in cc_required_field_live_test.go).
+//
+// What this test DOES do is freeze the at-risk surface. It enumerates
+// every CloudControl-routed type that (a) has no hand-rolled enricher
+// override and (b) has at least one REQUIRED schema field, and diffs
+// that set against testdata/cc_required_fields.golden. When a new
+// CloudControl type is added — or an existing one gains a required
+// field — this test fails, forcing a human to answer: "does
+// GetResource actually return this required field?" If yes, re-seed
+// the golden. If no, the type needs a hand-rolled enricher (the #661
+// fix shape). Either way the gap can no longer ship silently, which is
+// exactly how #661 shipped.
+//
+// Re-seed after an intentional change:
+//
+//	UPDATE_GOLDEN=1 go test ./cmd/insideout-import/awsdiscover/ \
+//	    -run TestCloudControlRequiredFieldTripwire
+func TestCloudControlRequiredFieldTripwire(t *testing.T) {
+	t.Parallel()
+
+	// NewAWSDiscoverer issues no AWS calls; it just wires the registry.
+	d := NewAWSDiscoverer(aws.Config{Region: "us-east-1"})
+
+	var lines []string
+	for _, cfg := range cloudControlTypeConfigs {
+		tf := cfg.TFType
+		enr, ok := d.byTypeEnricher[tf]
+		if !ok {
+			continue
+		}
+		// A hand-rolled override (or the lambda composite) owns its own
+		// required-field correctness and is covered by its own tests —
+		// only the generic CloudControl path is at risk here.
+		if _, isGenericCC := enr.(*cloudControlEnricher); !isGenericCC {
+			continue
+		}
+		_, schema, found := generated.Lookup(tf)
+		if !found {
+			continue
+		}
+		var req []string
+		for name, fs := range schema {
+			if fs.Required {
+				req = append(req, name)
+			}
+		}
+		if len(req) == 0 {
+			continue
+		}
+		sort.Strings(req)
+		lines = append(lines, tf+": "+strings.Join(req, ", "))
+	}
+	sort.Strings(lines)
+	current := strings.Join(lines, "\n") + "\n"
+
+	goldenPath := filepath.Join("testdata", "cc_required_fields.golden")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		require.NoError(t, os.MkdirAll(filepath.Dir(goldenPath), 0o755))
+		require.NoError(t, os.WriteFile(goldenPath, []byte(current), 0o644))
+		t.Logf("wrote golden: %s (%d CloudControl-routed types with required fields)", goldenPath, len(lines))
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	require.NoError(t, err,
+		"golden missing — seed with `UPDATE_GOLDEN=1 go test ./cmd/insideout-import/awsdiscover/ -run TestCloudControlRequiredFieldTripwire`")
+	require.Equal(t, string(want), current,
+		"The set of CloudControl-routed types with REQUIRED fields and no hand-rolled "+
+			"enricher override changed.\n\n"+
+			"This is the #661/#665 bug-class tripwire. For every ADDED line below, verify "+
+			"that cloudcontrol:GetResource actually returns the listed required field(s) "+
+			"against a real resource — the CFN schema does NOT reliably declare this (see "+
+			"AWS::IAM::ManagedPolicy.PolicyDocument). If GetResource omits a required field, "+
+			"the type needs a hand-rolled enricher (the #661 fix shape: a per-type "+
+			"AttributeEnricher in byTypeEnricher). If GetResource does return it, re-seed "+
+			"the golden:\n\n"+
+			"  UPDATE_GOLDEN=1 go test ./cmd/insideout-import/awsdiscover/ -run TestCloudControlRequiredFieldTripwire\n\n"+
+			"golden: "+goldenPath)
+}

--- a/cmd/insideout-import/awsdiscover/cloudfront_function_enrich.go
+++ b/cmd/insideout-import/awsdiscover/cloudfront_function_enrich.go
@@ -1,0 +1,217 @@
+// Package awsdiscover — aws_cloudfront_function code enricher (#665).
+//
+// aws_cloudfront_function is routed through the generic CloudControl
+// enricher, but cloudcontrol:GetResource for AWS::CloudFront::Function
+// returns neither the function `code` nor its `runtime` — both are
+// REQUIRED Terraform arguments. The CFN handler treats FunctionCode as
+// create-time input and surfaces Runtime only under a nested
+// FunctionConfig the camelToSnake projection does not flatten onto the
+// top-level `runtime` attribute. Confirmed live by
+// TestLive665_CloudControlRequiredFieldProbe.
+//
+// Unlike a zip Lambda's code (genuinely unrecoverable), a CloudFront
+// function's code IS readable: cloudfront:GetFunction returns the
+// function source, and cloudfront:DescribeFunction returns the runtime.
+// So this is a real fix, not an adoption placeholder.
+//
+// Composite, like the lambda enricher: it delegates the bulk mapping
+// (name, arn, status, etag, comment, …) to the CloudControl enricher,
+// then overlays `code` + `runtime`. The overlay is MANDATORY here —
+// both fields are required, so a missing CloudFront client or a failed
+// fetch is a hard error (not the best-effort skip the lambda image_uri
+// overlay uses), surfaced as EnrichmentStatusFailed rather than a
+// silently plan-breaking payload.
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// cloudfrontFunctionTFType is the registered Terraform type for the
+// CloudFront function enricher.
+const cloudfrontFunctionTFType = "aws_cloudfront_function"
+
+// cloudfrontFunctionCode carries the two required attributes the
+// CloudControl path cannot recover.
+type cloudfrontFunctionCode struct {
+	Code    string
+	Runtime string
+}
+
+// cloudfrontFunctionAPI is the narrow subset of the CloudFront API the
+// enricher's fetch path issues.
+type cloudfrontFunctionAPI interface {
+	DescribeFunction(ctx context.Context, in *cloudfront.DescribeFunctionInput, opts ...func(*cloudfront.Options)) (*cloudfront.DescribeFunctionOutput, error)
+	GetFunction(ctx context.Context, in *cloudfront.GetFunctionInput, opts ...func(*cloudfront.Options)) (*cloudfront.GetFunctionOutput, error)
+}
+
+// cloudfrontFunctionEnricher composes the CloudControl enricher with a
+// GetFunction/DescribeFunction-sourced code+runtime overlay.
+type cloudfrontFunctionEnricher struct {
+	// inner is the CloudControl enricher that does the bulk mapping.
+	inner AttributeEnricher
+	// fetch is overridable for tests. Defaults to the real two-call
+	// DescribeFunction + GetFunction path.
+	fetch func(ctx context.Context, c *cloudfront.Client, name string) (*cloudfrontFunctionCode, error)
+}
+
+// newCloudfrontFunctionEnricher wraps inner (the CloudControl enricher
+// registered for aws_cloudfront_function) with the code overlay.
+func newCloudfrontFunctionEnricher(inner AttributeEnricher) *cloudfrontFunctionEnricher {
+	return &cloudfrontFunctionEnricher{inner: inner, fetch: defaultCloudfrontFunctionFetch}
+}
+
+func (cloudfrontFunctionEnricher) ResourceType() string { return cloudfrontFunctionTFType }
+
+// Enrich runs the inner CloudControl enricher, then overlays the
+// required `code` + `runtime` attributes from the CloudFront API.
+// Returns ErrEnrichClientUnavailable when EnrichClients.CloudFront is
+// nil and ErrNotFound when the function no longer exists; any other
+// fetch error is propagated. The overlay is mandatory — both fields
+// are required Terraform arguments.
+func (e cloudfrontFunctionEnricher) Enrich(ctx context.Context, ir *imported.ImportedResource, c EnrichClients) error {
+	if err := e.inner.Enrich(ctx, ir, c); err != nil {
+		return err
+	}
+	patched, err := e.overlay(ctx, &ir.Identity, ir.Attrs, c)
+	if err != nil {
+		return err
+	}
+	ir.Attrs = patched
+	return nil
+}
+
+// EnrichByID delegates to the inner enricher's ByIDEnricher
+// implementation, then overlays code + runtime.
+func (e cloudfrontFunctionEnricher) EnrichByID(ctx context.Context, identity *imported.ResourceIdentity, c EnrichClients) (json.RawMessage, error) {
+	if identity == nil {
+		return nil, errors.New(cloudfrontFunctionTFType + ": identity is nil")
+	}
+	byID, ok := e.inner.(ByIDEnricher)
+	if !ok {
+		return nil, fmt.Errorf("%s: inner enricher %T does not support EnrichByID", cloudfrontFunctionTFType, e.inner)
+	}
+	raw, err := byID.EnrichByID(ctx, identity, c)
+	if err != nil {
+		return nil, err
+	}
+	return e.overlay(ctx, identity, raw, c)
+}
+
+// overlay fetches code + runtime and patches them into attrs. A nil
+// CloudFront client or a fetch failure is a hard error — unlike the
+// lambda image_uri overlay, these attributes are required.
+func (e cloudfrontFunctionEnricher) overlay(ctx context.Context, id *imported.ResourceIdentity, attrs json.RawMessage, c EnrichClients) (json.RawMessage, error) {
+	if c.CloudFront == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	if len(attrs) == 0 {
+		return nil, fmt.Errorf("%s: inner enricher produced no payload to overlay", cloudfrontFunctionTFType)
+	}
+	name := cloudfrontFunctionNameForEnrich(id)
+	if name == "" {
+		return nil, fmt.Errorf("%s: cannot derive function name from Identity (Address=%q ImportID=%q)",
+			cloudfrontFunctionTFType, id.Address, id.ImportID)
+	}
+	info, err := e.fetch(ctx, c.CloudFront, name)
+	if err != nil {
+		if isAPIErrorCode(err, "NoSuchFunctionExists") {
+			return nil, fmt.Errorf("%s %q: %w", cloudfrontFunctionTFType, name, ErrNotFound)
+		}
+		return nil, fmt.Errorf("%s: fetch %q: %w", cloudfrontFunctionTFType, name, err)
+	}
+	return patchCloudfrontFunctionCode(attrs, info)
+}
+
+// cloudfrontFunctionNameForEnrich derives the function name. The
+// CloudControl discoverer's ImportIDFromIdentifier strips the function
+// ARN down to the bare name, which is also the Terraform import id and
+// what cloudfront:GetFunction / DescribeFunction accept.
+func cloudfrontFunctionNameForEnrich(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if s := strings.TrimSpace(id.ImportID); s != "" {
+		return s
+	}
+	return strings.TrimSpace(id.NameHint)
+}
+
+// defaultCloudfrontFunctionFetch is the production fetch path: it wires
+// the real *cloudfront.Client into fetchCloudfrontFunctionWithClient.
+func defaultCloudfrontFunctionFetch(ctx context.Context, c *cloudfront.Client, name string) (*cloudfrontFunctionCode, error) {
+	if c == nil {
+		return nil, ErrEnrichClientUnavailable
+	}
+	return fetchCloudfrontFunctionWithClient(ctx, c, name)
+}
+
+// fetchCloudfrontFunctionWithClient issues DescribeFunction (for the
+// runtime) and GetFunction (for the code) behind the narrow
+// cloudfrontFunctionAPI interface so the overlay is unit-testable.
+//
+// Both calls target the DEVELOPMENT stage (the default): it always
+// holds the latest code, whereas LIVE exists only after a publish.
+func fetchCloudfrontFunctionWithClient(ctx context.Context, c cloudfrontFunctionAPI, name string) (*cloudfrontFunctionCode, error) {
+	desc, err := c.DescribeFunction(ctx, &cloudfront.DescribeFunctionInput{
+		Name:  aws.String(name),
+		Stage: cftypes.FunctionStageDevelopment,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront:DescribeFunction: %w", err)
+	}
+	if desc == nil || desc.FunctionSummary == nil || desc.FunctionSummary.FunctionConfig == nil {
+		return nil, errors.New("cloudfront:DescribeFunction: nil function summary in response")
+	}
+	got, err := c.GetFunction(ctx, &cloudfront.GetFunctionInput{
+		Name:  aws.String(name),
+		Stage: cftypes.FunctionStageDevelopment,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("cloudfront:GetFunction: %w", err)
+	}
+	if got == nil || len(got.FunctionCode) == 0 {
+		return nil, errors.New("cloudfront:GetFunction: empty function code in response")
+	}
+	return &cloudfrontFunctionCode{
+		Code:    string(got.FunctionCode),
+		Runtime: string(desc.FunctionSummary.FunctionConfig.Runtime),
+	}, nil
+}
+
+// patchCloudfrontFunctionCode unmarshals the CloudControl payload back
+// into the typed struct, overlays code + runtime, and re-marshals.
+func patchCloudfrontFunctionCode(attrs json.RawMessage, info *cloudfrontFunctionCode) (json.RawMessage, error) {
+	var typed generated.AWSCloudfrontFunction
+	if err := json.Unmarshal(attrs, &typed); err != nil {
+		return nil, fmt.Errorf("%s: unmarshal CC payload for code overlay: %w", cloudfrontFunctionTFType, err)
+	}
+	if info.Code != "" {
+		typed.Code = generated.LiteralOf(info.Code)
+	}
+	if info.Runtime != "" {
+		typed.Runtime = generated.LiteralOf(info.Runtime)
+	}
+	raw, err := json.Marshal(&typed)
+	if err != nil {
+		return nil, fmt.Errorf("%s: re-marshal code overlay: %w", cloudfrontFunctionTFType, err)
+	}
+	return raw, nil
+}
+
+// Compile-time assertions.
+var (
+	_ AttributeEnricher = (*cloudfrontFunctionEnricher)(nil)
+	_ ByIDEnricher      = (*cloudfrontFunctionEnricher)(nil)
+)

--- a/cmd/insideout-import/awsdiscover/cloudfront_function_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudfront_function_enrich_test.go
@@ -1,0 +1,252 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+const sampleFunctionCode = "function handler(event) { return event.request; }"
+
+// fakeCloudfrontAPI is a cloudfrontFunctionAPI fake.
+type fakeCloudfrontAPI struct {
+	descOut *cloudfront.DescribeFunctionOutput
+	descErr error
+	getOut  *cloudfront.GetFunctionOutput
+	getErr  error
+	getRan  bool
+}
+
+func (f *fakeCloudfrontAPI) DescribeFunction(_ context.Context, _ *cloudfront.DescribeFunctionInput, _ ...func(*cloudfront.Options)) (*cloudfront.DescribeFunctionOutput, error) {
+	return f.descOut, f.descErr
+}
+
+func (f *fakeCloudfrontAPI) GetFunction(_ context.Context, _ *cloudfront.GetFunctionInput, _ ...func(*cloudfront.Options)) (*cloudfront.GetFunctionOutput, error) {
+	f.getRan = true
+	return f.getOut, f.getErr
+}
+
+var _ cloudfrontFunctionAPI = (*fakeCloudfrontAPI)(nil)
+
+// ccFunctionPayload is a minimal CloudControl-shaped aws_cloudfront_function
+// payload — what the inner enricher produces (no code, no runtime).
+func ccFunctionPayload(t *testing.T) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(&generated.AWSCloudfrontFunction{
+		Name:    generated.LiteralOf("my-fn"),
+		Comment: generated.LiteralOf("cc-mapped"),
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+func TestCloudfrontFunctionEnricher_ResourceType(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "aws_cloudfront_function",
+		newCloudfrontFunctionEnricher(&fakeInnerEnricher{}).ResourceType())
+}
+
+func TestCloudfrontFunctionEnricher_OverlaysCodeAndRuntime(t *testing.T) {
+	t.Parallel()
+	enr := cloudfrontFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: ccFunctionPayload(t)},
+		fetch: func(_ context.Context, _ *cloudfront.Client, name string) (*cloudfrontFunctionCode, error) {
+			assert.Equal(t, "my-fn", name)
+			return &cloudfrontFunctionCode{Code: sampleFunctionCode, Runtime: "cloudfront-js-2.0"}, nil
+		},
+	}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{CloudFront: &cloudfront.Client{}}))
+
+	var got generated.AWSCloudfrontFunction
+	require.NoError(t, json.Unmarshal(ir.Attrs, &got))
+	require.NotNil(t, got.Code)
+	assert.Equal(t, sampleFunctionCode, *got.Code.Literal)
+	require.NotNil(t, got.Runtime)
+	assert.Equal(t, "cloudfront-js-2.0", *got.Runtime.Literal)
+	// CC-mapped fields survive the overlay round-trip.
+	require.NotNil(t, got.Name)
+	assert.Equal(t, "my-fn", *got.Name.Literal)
+	require.NotNil(t, got.Comment)
+	assert.Equal(t, "cc-mapped", *got.Comment.Literal)
+}
+
+func TestCloudfrontFunctionEnricher_InnerErrorPropagates(t *testing.T) {
+	t.Parallel()
+	want := errors.New("cc boom")
+	fetched := false
+	enr := cloudfrontFunctionEnricher{
+		inner: &fakeInnerEnricher{err: want},
+		fetch: func(context.Context, *cloudfront.Client, string) (*cloudfrontFunctionCode, error) {
+			fetched = true
+			return nil, nil
+		},
+	}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}},
+		EnrichClients{CloudFront: &cloudfront.Client{}})
+	require.ErrorIs(t, err, want)
+	assert.False(t, fetched, "fetch must not run after the inner enricher fails")
+}
+
+func TestCloudfrontFunctionEnricher_NilClientIsError(t *testing.T) {
+	t.Parallel()
+	// Unlike the lambda overlay, the CloudFront overlay is mandatory:
+	// code/runtime are required, so a nil client must fail the resource
+	// rather than ship a plan-breaking payload.
+	enr := cloudfrontFunctionEnricher{inner: &fakeInnerEnricher{attrs: ccFunctionPayload(t)}}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}},
+		EnrichClients{})
+	require.ErrorIs(t, err, ErrEnrichClientUnavailable)
+}
+
+func TestCloudfrontFunctionEnricher_NoSuchFunctionMapsToNotFound(t *testing.T) {
+	t.Parallel()
+	enr := cloudfrontFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: ccFunctionPayload(t)},
+		fetch: func(context.Context, *cloudfront.Client, string) (*cloudfrontFunctionCode, error) {
+			return nil, &fakeIAMSmithyErr{code: "NoSuchFunctionExists"}
+		},
+	}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "gone"}},
+		EnrichClients{CloudFront: &cloudfront.Client{}})
+	require.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestCloudfrontFunctionEnricher_FetchErrorPropagates(t *testing.T) {
+	t.Parallel()
+	want := errors.New("throttled")
+	enr := cloudfrontFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: ccFunctionPayload(t)},
+		fetch: func(context.Context, *cloudfront.Client, string) (*cloudfrontFunctionCode, error) {
+			return nil, want
+		},
+	}
+	err := enr.Enrich(context.Background(),
+		&imported.ImportedResource{Identity: imported.ResourceIdentity{ImportID: "my-fn"}},
+		EnrichClients{CloudFront: &cloudfront.Client{}})
+	require.ErrorIs(t, err, want)
+}
+
+func TestCloudfrontFunctionEnricher_EnrichByID(t *testing.T) {
+	t.Parallel()
+	enr := cloudfrontFunctionEnricher{
+		inner: &fakeInnerEnricher{attrs: ccFunctionPayload(t), supportByID: true},
+		fetch: func(context.Context, *cloudfront.Client, string) (*cloudfrontFunctionCode, error) {
+			return &cloudfrontFunctionCode{Code: sampleFunctionCode, Runtime: "cloudfront-js-2.0"}, nil
+		},
+	}
+	raw, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "my-fn"}, EnrichClients{CloudFront: &cloudfront.Client{}})
+	require.NoError(t, err)
+	var got generated.AWSCloudfrontFunction
+	require.NoError(t, json.Unmarshal(raw, &got))
+	require.NotNil(t, got.Code)
+	assert.Equal(t, sampleFunctionCode, *got.Code.Literal)
+}
+
+func TestCloudfrontFunctionEnricher_EnrichByID_InnerLacksByID(t *testing.T) {
+	t.Parallel()
+	enr := cloudfrontFunctionEnricher{inner: innerNoByID{attrs: ccFunctionPayload(t)}}
+	_, err := enr.EnrichByID(context.Background(),
+		&imported.ResourceIdentity{ImportID: "my-fn"}, EnrichClients{CloudFront: &cloudfront.Client{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support EnrichByID")
+}
+
+func TestFetchCloudfrontFunctionWithClient(t *testing.T) {
+	t.Parallel()
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeCloudfrontAPI{
+			descOut: &cloudfront.DescribeFunctionOutput{FunctionSummary: &cftypes.FunctionSummary{
+				FunctionConfig: &cftypes.FunctionConfig{Runtime: cftypes.FunctionRuntimeCloudfrontJs20},
+			}},
+			getOut: &cloudfront.GetFunctionOutput{FunctionCode: []byte(sampleFunctionCode)},
+		}
+		info, err := fetchCloudfrontFunctionWithClient(context.Background(), f, "fn")
+		require.NoError(t, err)
+		assert.Equal(t, sampleFunctionCode, info.Code)
+		assert.Equal(t, "cloudfront-js-2.0", info.Runtime)
+	})
+	t.Run("DescribeFunction error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeCloudfrontAPI{descErr: errors.New("boom")}
+		_, err := fetchCloudfrontFunctionWithClient(context.Background(), f, "fn")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cloudfront:DescribeFunction")
+		assert.False(t, f.getRan, "GetFunction must not run after DescribeFunction fails")
+	})
+	t.Run("nil function summary is an error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeCloudfrontAPI{descOut: &cloudfront.DescribeFunctionOutput{FunctionSummary: nil}}
+		_, err := fetchCloudfrontFunctionWithClient(context.Background(), f, "fn")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "nil function summary")
+	})
+	t.Run("GetFunction error is wrapped", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeCloudfrontAPI{
+			descOut: &cloudfront.DescribeFunctionOutput{FunctionSummary: &cftypes.FunctionSummary{
+				FunctionConfig: &cftypes.FunctionConfig{Runtime: cftypes.FunctionRuntimeCloudfrontJs20},
+			}},
+			getErr: errors.New("boom"),
+		}
+		_, err := fetchCloudfrontFunctionWithClient(context.Background(), f, "fn")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cloudfront:GetFunction")
+	})
+	t.Run("empty function code is an error", func(t *testing.T) {
+		t.Parallel()
+		f := &fakeCloudfrontAPI{
+			descOut: &cloudfront.DescribeFunctionOutput{FunctionSummary: &cftypes.FunctionSummary{
+				FunctionConfig: &cftypes.FunctionConfig{Runtime: cftypes.FunctionRuntimeCloudfrontJs20},
+			}},
+			getOut: &cloudfront.GetFunctionOutput{FunctionCode: nil},
+		}
+		_, err := fetchCloudfrontFunctionWithClient(context.Background(), f, "fn")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty function code")
+	})
+}
+
+func TestPatchCloudfrontFunctionCode(t *testing.T) {
+	t.Parallel()
+	t.Run("invalid attrs JSON is an error", func(t *testing.T) {
+		t.Parallel()
+		_, err := patchCloudfrontFunctionCode([]byte("not json"), &cloudfrontFunctionCode{Code: "x", Runtime: "y"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unmarshal CC payload")
+	})
+}
+
+func TestCloudfrontFunctionNameForEnrich(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "imp", cloudfrontFunctionNameForEnrich(&imported.ResourceIdentity{ImportID: "imp", NameHint: "hint"}))
+	assert.Equal(t, "hint", cloudfrontFunctionNameForEnrich(&imported.ResourceIdentity{NameHint: "hint"}))
+	assert.Equal(t, "", cloudfrontFunctionNameForEnrich(nil))
+}
+
+func TestCloudfrontFunctionEnricher_RegisteredAsComposite(t *testing.T) {
+	t.Parallel()
+	d := NewAWSDiscoverer(aws.Config{Region: "us-east-1"})
+	enr, ok := d.byTypeEnricher["aws_cloudfront_function"]
+	require.True(t, ok)
+	composite, isComposite := enr.(*cloudfrontFunctionEnricher)
+	require.True(t, isComposite, "got %T", enr)
+	require.NotNil(t, composite.inner)
+	_, innerIsCC := composite.inner.(*cloudControlEnricher)
+	assert.True(t, innerIsCC, "inner must be the Cloud Control enricher, got %T", composite.inner)
+}

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
@@ -247,6 +248,13 @@ type EnrichClients struct {
 	// the lambda enricher still delegates to the Cloud Control path
 	// and simply skips the GetFunction-sourced code attributes.
 	Lambda *lambda.Client
+	// CloudFront is the shared client for the aws_cloudfront_function
+	// code enricher (#665). CloudFront is a global service, so no
+	// per-region override is needed. Unlike the lambda overlay, the
+	// CloudFront overlay is mandatory (code + runtime are required
+	// Terraform arguments) — a nil client surfaces as
+	// ErrEnrichClientUnavailable for the resource.
+	CloudFront *cloudfront.Client
 	// AutoScaling is the shared client for the
 	// aws_autoscaling_group_tag enricher (#482 final-2 push). Auto
 	// Scaling is regional, so the enricher's fetch closure pins the

--- a/cmd/insideout-import/awsdiscover/testdata/cc_required_fields.golden
+++ b/cmd/insideout-import/awsdiscover/testdata/cc_required_fields.golden
@@ -12,7 +12,6 @@ aws_backup_plan: name, rule
 aws_backup_selection: iam_role_arn, name, plan_id
 aws_backup_vault: name
 aws_cloudfront_distribution: default_cache_behavior, enabled, origin, restrictions, viewer_certificate
-aws_cloudfront_function: code, name, runtime
 aws_cloudfront_monitoring_subscription: distribution_id, monitoring_subscription
 aws_cloudwatch_dashboard: dashboard_body, dashboard_name
 aws_cloudwatch_log_resource_policy: policy_document

--- a/cmd/insideout-import/awsdiscover/testdata/cc_required_fields.golden
+++ b/cmd/insideout-import/awsdiscover/testdata/cc_required_fields.golden
@@ -1,0 +1,68 @@
+aws_api_gateway_deployment: rest_api_id
+aws_api_gateway_resource: parent_id, path_part, rest_api_id
+aws_api_gateway_stage: deployment_id, rest_api_id, stage_name
+aws_apigatewayv2_api: name, protocol_type
+aws_apigatewayv2_api_mapping: api_id, domain_name, stage
+aws_apigatewayv2_authorizer: api_id, authorizer_type, name
+aws_apigatewayv2_domain_name: domain_name, domain_name_configuration
+aws_apigatewayv2_integration: api_id, integration_type
+aws_apigatewayv2_route: api_id, route_key
+aws_autoscaling_group: max_size, min_size
+aws_backup_plan: name, rule
+aws_backup_selection: iam_role_arn, name, plan_id
+aws_backup_vault: name
+aws_cloudfront_distribution: default_cache_behavior, enabled, origin, restrictions, viewer_certificate
+aws_cloudfront_function: code, name, runtime
+aws_cloudfront_monitoring_subscription: distribution_id, monitoring_subscription
+aws_cloudwatch_dashboard: dashboard_body, dashboard_name
+aws_cloudwatch_log_resource_policy: policy_document
+aws_cloudwatch_log_stream: log_group_name, name
+aws_cloudwatch_metric_alarm: alarm_name
+aws_cognito_identity_provider: provider_details, provider_name, provider_type, user_pool_id
+aws_cognito_resource_server: identifier, name, user_pool_id
+aws_cognito_user_pool: name
+aws_cognito_user_pool_client: name, user_pool_id
+aws_cognito_user_pool_domain: domain, user_pool_id
+aws_db_instance: instance_class
+aws_db_parameter_group: family
+aws_db_subnet_group: subnet_ids
+aws_ebs_volume: availability_zone
+aws_ecs_cluster: name
+aws_ecs_cluster_capacity_providers: cluster_name
+aws_eks_access_entry: cluster_name, principal_arn
+aws_eks_addon: addon_name, cluster_name
+aws_eks_cluster: name, role_arn, vpc_config
+aws_eks_fargate_profile: cluster_name, fargate_profile_name, pod_execution_role_arn, selector
+aws_eks_node_group: cluster_name, node_role_arn, scaling_config, subnet_ids
+aws_eks_pod_identity_association: cluster_name, namespace, role_arn, service_account
+aws_elasticache_parameter_group: family, name
+aws_elasticache_replication_group: description, replication_group_id
+aws_elasticache_subnet_group: name, subnet_ids
+aws_iam_group: name
+aws_iam_service_linked_role: aws_service_name
+aws_iam_user: name
+aws_key_pair: public_key
+aws_kms_alias: target_key_id
+aws_lambda_alias: function_name, function_version, name
+aws_lambda_event_source_mapping: function_name
+aws_lambda_function_url: authorization_type, function_name
+aws_lambda_permission: action, function_name, principal
+aws_lb_listener: default_action, load_balancer_arn
+aws_msk_cluster: broker_node_group_info, cluster_name, kafka_version, number_of_broker_nodes
+aws_msk_configuration: name, server_properties
+aws_network_acl: vpc_id
+aws_network_interface: subnet_id
+aws_opensearch_domain: domain_name
+aws_opensearchserverless_access_policy: name, policy, type
+aws_opensearchserverless_collection: name
+aws_opensearchserverless_security_policy: name, policy, type
+aws_route53_zone: name
+aws_route_table: vpc_id
+aws_secretsmanager_secret_rotation: rotation_rules, secret_id
+aws_sns_topic_subscription: endpoint, protocol, topic_arn
+aws_ssm_parameter: name, type
+aws_subnet: vpc_id
+aws_vpc_endpoint: vpc_id
+aws_vpc_security_group_egress_rule: ip_protocol, security_group_id
+aws_vpc_security_group_ingress_rule: ip_protocol, security_group_id
+aws_wafv2_web_acl: default_action, scope, visibility_config

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -54,6 +54,7 @@ func applyResourceTypeFixups(raw []byte) ([]byte, error) {
 // by cleanGenerated.
 var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lambda_function":       fixupLambdaSource,
+	"aws_key_pair":              fixupKeyPairPublicKey,
 	"aws_kms_key":               fixupKMSRotationPeriodZero,
 	"aws_dynamodb_table":        fixupDynamoDBPITRRecoveryPeriodZero,
 	"aws_vpc":                   fixupVPCIPv6NetmaskOrphan,
@@ -106,6 +107,30 @@ func fixupLambdaSource(blk *hclwrite.Block) {
 	}
 	lc := body.AppendNewBlock("lifecycle", nil)
 	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(lambdaIgnoreChanges))
+}
+
+// fixupKeyPairPublicKey is the aws_key_pair counterpart to
+// fixupLambdaSource (#665). ec2:DescribeKeyPairs never returns the
+// public-key material, so an imported aws_key_pair lands with no
+// `public_key` — a REQUIRED, ForceNew argument. The fixup injects the
+// shared placeholder and pins `public_key` under
+// `lifecycle.ignore_changes` so terraform does not force-replace the
+// live key pair to match the placeholder. The composer's imported.tf
+// emitter (ensureKeyPairPlaceholder) does the identical injection on
+// the SDK-enrich path.
+func fixupKeyPairPublicKey(blk *hclwrite.Block) {
+	body := blk.Body()
+	if !hasUsableValue(body, "public_key") {
+		body.SetAttributeValue("public_key", cty.StringVal(imported.KeyPairPlaceholderPublicKey))
+	}
+	for _, sub := range body.Blocks() {
+		if sub.Type() == "lifecycle" {
+			mergeIgnoreChanges(sub, imported.KeyPairPublicKeyAttr)
+			return
+		}
+	}
+	lc := body.AppendNewBlock("lifecycle", nil)
+	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(imported.KeyPairPublicKeyAttr))
 }
 
 // fixupKMSRotationPeriodZero drops aws_kms_key.rotation_period_in_days

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -2339,3 +2339,56 @@ resource "aws_other_resource" "extra" {
 		t.Errorf("aws_other_resource's empty domain_dns_ips must be preserved (fixup keyed by aws_db_instance)\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupKeyPair_NoPublicKeyInjectsPlaceholderAndIgnore pins the #665
+// fix: an imported aws_key_pair lands with no `public_key` (EC2 never
+// returns key material). The fixup injects the shared placeholder and
+// pins `public_key` under lifecycle.ignore_changes.
+func TestFixupKeyPair_NoPublicKeyInjectsPlaceholderAndIgnore(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_key_pair" "kp" {
+  key_name = "alpha"
+  key_type = "ed25519"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, imported.KeyPairPlaceholderPublicKey) {
+		t.Errorf("placeholder public_key not injected\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "lifecycle") || !strings.Contains(got, "ignore_changes") {
+		t.Errorf("lifecycle.ignore_changes block not added\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?s)ignore_changes\s*=\s*\[[^]]*public_key`).MatchString(got) {
+		t.Errorf("ignore_changes must pin public_key\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupKeyPair_ExistingPublicKeyNotOverwritten pins the friendly-
+// fire guard: an operator-supplied public_key must survive — only the
+// ignore_changes pin is added.
+func TestFixupKeyPair_ExistingPublicKeyNotOverwritten(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_key_pair" "kp" {
+  key_name   = "alpha"
+  public_key = "ssh-ed25519 REALKEYMATERIAL operator-supplied"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "REALKEYMATERIAL") {
+		t.Errorf("operator-supplied public_key was clobbered\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, imported.KeyPairPlaceholderPublicKey) {
+		t.Errorf("placeholder injected over existing public_key\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "ignore_changes") {
+		t.Errorf("ignore_changes pin missing\n--- got ---\n%s", got)
+	}
+}

--- a/pkg/composer/imported/keypair.go
+++ b/pkg/composer/imported/keypair.go
@@ -1,0 +1,29 @@
+package imported
+
+// KeyPairPublicKeyAttr is the single aws_key_pair argument that an
+// imported key pair cannot reproduce: ec2:DescribeKeyPairs (and the
+// AWS::EC2::KeyPair CloudControl handler) return the key fingerprint
+// but NEVER the public-key material — EC2 does not expose it on read.
+//
+// `public_key` is REQUIRED and ForceNew on the Terraform schema, so an
+// imported aws_key_pair both fails the composer's required-argument
+// check and — if a value were guessed — would force-replace (destroy)
+// the live key pair on the first apply. The fix mirrors the Lambda
+// code adoption pattern (#652 / #665): inject a syntactically valid
+// placeholder and pin `public_key` under `lifecycle { ignore_changes }`
+// so terraform never acts on the placeholder.
+var KeyPairPublicKeyAttr = []string{"public_key"}
+
+// KeyPairPlaceholderPublicKey is the value pinned on
+// `aws_key_pair.public_key` for an imported key pair. It is a real,
+// syntactically valid ed25519 SSH public key (the AWS provider
+// validates the key format), generated once at authoring time with its
+// private key immediately discarded — so it is inert and corresponds
+// to no usable private key. The comment field marks it unmistakably.
+//
+// It is always paired with `lifecycle { ignore_changes = ["public_key"] }`
+// so terraform never replaces the live key pair to match this
+// placeholder. Both the genconfig fixup (terraform-driven path) and the
+// composer's imported.tf emitter (SDK-enrich path) inject this same
+// value.
+const KeyPairPlaceholderPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBYRn+c+IPlLaBIAbZvs13Vq3XdJvTtWNvMdoeR9s/Ea insideout-imported-placeholder-key"

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -246,6 +246,7 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 			return nil, fmt.Errorf("decode typed Attrs for %q: %w", ir.Identity.Type, err)
 		}
 		ensureLambdaPlaceholderSource(typed)
+		ensureKeyPairPlaceholder(typed)
 		body, err := generated.MarshalHCL(typed)
 		if err != nil {
 			return nil, fmt.Errorf("marshal typed body for %q: %w", ir.Identity.Type, err)
@@ -362,6 +363,11 @@ func writeOpaqueAttr(body *hclwrite.Body, name string, v any) error {
 // the IR does not carry meta-blocks — so the emitter must re-add it.
 var importedLifecycleIgnoreChanges = map[string][]string{
 	"aws_lambda_function": imported.LambdaCodeAttrs,
+	// aws_key_pair: public_key is unrecoverable from the API (EC2 never
+	// returns key material) and is ForceNew — pinning it under
+	// ignore_changes keeps the placeholder from force-replacing the
+	// live key pair. See ensureKeyPairPlaceholder and #665.
+	"aws_key_pair": imported.KeyPairPublicKeyAttr,
 }
 
 // appendImportedLifecycle appends a `lifecycle { ignore_changes = [...] }`
@@ -423,6 +429,31 @@ func ensureLambdaPlaceholderSource(typed any) {
 		return
 	}
 	lf.Filename = generated.LiteralOf(imported.LambdaPlaceholderFilename)
+}
+
+// ensureKeyPairPlaceholder injects a placeholder `public_key` onto an
+// imported aws_key_pair whose typed payload carries none.
+//
+// `public_key` is REQUIRED and ForceNew, and ec2:DescribeKeyPairs never
+// returns the key material — so the enricher cannot recover it (#665).
+// Without a value the composed block fails the composer's required-
+// argument check; with a guessed value that did not match, the first
+// apply would force-replace (destroy) the live key pair. The fix is the
+// Lambda-code adoption pattern: a syntactically valid placeholder,
+// always paired with the `lifecycle { ignore_changes = ["public_key"] }`
+// block appendImportedLifecycle adds for aws_key_pair, so terraform
+// never acts on the placeholder.
+//
+// A non-pointer / wrong type is a no-op.
+func ensureKeyPairPlaceholder(typed any) {
+	kp, ok := typed.(*generated.AWSKeyPair)
+	if !ok {
+		return
+	}
+	if kp.PublicKey != nil {
+		return
+	}
+	kp.PublicKey = generated.LiteralOf(imported.KeyPairPlaceholderPublicKey)
 }
 
 func wrapResourceBlock(tfType, label, providerAlias string, body []byte) []byte {

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -194,6 +194,89 @@ func TestEmitImportedTF_LambdaTypedAttrsInjectsPlaceholderFilename(t *testing.T)
 	assert.Contains(t, s, "ignore_changes", "placeholder filename must still be pinned under ignore_changes")
 }
 
+// TestEmitImportedTF_KeyPairInjectsPlaceholderPublicKey pins the #665
+// fix: an imported aws_key_pair carries no public_key (EC2 never
+// returns key material), a REQUIRED + ForceNew argument. The emitter
+// must inject the shared placeholder and pin public_key under
+// lifecycle.ignore_changes so terraform never force-replaces the live
+// key pair.
+func TestEmitImportedTF_KeyPairInjectsPlaceholderPublicKey(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSKeyPair{
+		KeyName: generated.LiteralOf("alpha"),
+		KeyType: generated.LiteralOf("ed25519"),
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_key_pair",
+			Address:  "aws_key_pair.kp",
+			ImportID: "alpha",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.Truef(t, strings.Contains(s, "insideout-imported-placeholder-key"),
+		"key pair must get a placeholder public_key:\n%s", s)
+	file, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
+	// public_key must be pinned under lifecycle.ignore_changes.
+	var lifecycle *hclsyntax.Body
+	for _, blk := range file.Body.(*hclsyntax.Body).Blocks {
+		if blk.Type != "resource" {
+			continue
+		}
+		for _, sub := range blk.Body.Blocks {
+			if sub.Type == "lifecycle" {
+				lifecycle = sub.Body
+			}
+		}
+	}
+	require.NotNilf(t, lifecycle, "aws_key_pair must emit a lifecycle block:\n%s", s)
+	ic := lifecycle.Attributes["ignore_changes"]
+	require.NotNil(t, ic, "lifecycle must set ignore_changes")
+	tuple, ok := ic.Expr.(*hclsyntax.TupleConsExpr)
+	require.True(t, ok, "ignore_changes must be a list")
+	var got []string
+	for _, e := range tuple.Exprs {
+		trav, isTrav := e.(*hclsyntax.ScopeTraversalExpr)
+		require.Truef(t, isTrav, "ignore_changes entry must be an attribute reference, got %T", e)
+		got = append(got, trav.Traversal.RootName())
+	}
+	assert.Equal(t, []string{"public_key"}, got, "ignore_changes must pin exactly public_key")
+}
+
+// TestEmitImportedTF_KeyPairExistingPublicKeyKept is the negative: an
+// aws_key_pair that already carries a public_key keeps it — the
+// placeholder is injected only when the field is absent.
+func TestEmitImportedTF_KeyPairExistingPublicKeyKept(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSKeyPair{
+		KeyName:   generated.LiteralOf("alpha"),
+		PublicKey: generated.LiteralOf("ssh-ed25519 REALKEY operator"),
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_key_pair",
+			Address:  "aws_key_pair.kp",
+			ImportID: "alpha",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.Contains(t, s, "REALKEY", "operator public_key must survive")
+	assert.NotContains(t, s, "insideout-imported-placeholder-key", "placeholder must not overwrite a real public_key")
+}
+
 // TestEmitImportedTF_LambdaImagePackageNoPlaceholderFilename is the
 // negative: a container-image function carries image_uri (recovered by
 // the enricher) and must NOT get a placeholder filename — filename and


### PR DESCRIPTION
## Summary
Detection **and fixes** for the bug class behind [#661](https://github.com/luthersystems/insideout-terraform-presets/issues/661) / [#662](https://github.com/luthersystems/insideout-terraform-presets/pull/662) / [#664](https://github.com/luthersystems/insideout-terraform-presets/pull/664): a type routed through the **generic CloudControl enricher** has a **required argument** `cloudcontrol:GetResource` doesn't return, so the composed HCL ships an empty required arg and `terraform plan` blows up at the customer.

### Detection
- **Static tripwire** (`TestCloudControlRequiredFieldTripwire`) — every PR, no AWS. Freezes the set of CloudControl-routed types with required schema fields and no hand-rolled override against a golden; a new at-risk type fails CI.
- **Live probe** (`TestLive665_CloudControlRequiredFieldProbe`, build-tagged) — provisions throwaway resources, runs the real discover→enrich pipeline, **composes to HCL and runs `terraform plan`** against the live account.

### Fixes (the probe found two real bugs — fixed here)
| Type | Bug | Fix |
|---|---|---|
| `aws_cloudfront_function` | `GetResource` omits `code` + `runtime` (both required) | **Composite enricher** — overlays `code` via `cloudfront:GetFunction`, `runtime` via `DescribeFunction`. Recoverable, so a real fix. |
| `aws_key_pair` | `GetResource` never returns `public_key` material (required + ForceNew) | **Adoption placeholder** — `public_key` is unrecoverable from any API; the composer injects a placeholder pinned under `lifecycle { ignore_changes }` (the lambda-code pattern), on both the SDK-enrich and genconfig paths. |
| `aws_cloudwatch_log_resource_policy` | — | Probed: ✅ OK, no fix needed |
| `aws_opensearchserverless_*_policy` | — | Spot-checked via CloudControl: ✅ returns `policy`, not a bug |

## Test plan
- [x] `go test ./...` — 3578 pass (incl. tripwire + cloudfront/key_pair unit + composer emit + genconfig fixup tests)
- [x] `go vet` (incl. `-tags=integration`) — clean
- [x] **Live probe ran green** against a real account: `aws_cloudfront_function` now enriches fully, `aws_key_pair` fixed at the composer layer, and the composed `imported.tf` for all three resources **`terraform plan`s with no errors** (exit 2 = expected import diff). Teardown confirmed zero residue.

Closes #665