### PR TITLE
feat(imported): export cross-ref field map as runtime API (FieldRefs)

### DIFF
--- a/cmd/imported-codegen/emit_dependencies.go
+++ b/cmd/imported-codegen/emit_dependencies.go
@@ -3,17 +3,17 @@
 //
 // Scope (v1): emit an edge-list mapping each Layer-1 typed resource
 // to the other TF types it references via cross-resource fields. The
-// initial implementation uses a hand-curated map of TF-tag → target-
-// type to detect references — see crossRefMap below for the list. This
-// avoids the brittleness of guessing target types from field names
-// like `id` or `arn` alone (e.g. `aws_lambda_function.role` is an IAM
-// role ARN; `aws_lambda_function.kms_key_arn` is a KMS key) while
-// staying simple enough to extend by appending to one map.
+// references are detected via the curated TF-tag → target-type map in
+// the pkg/imported/dependencies package (dependencies.Lookup). That
+// map avoids the brittleness of guessing target types from field
+// names like `id` or `arn` alone (e.g. `aws_lambda_function.role` is
+// an IAM role ARN; `aws_lambda_function.kms_key_arn` is a KMS key)
+// while staying simple enough to extend by appending one entry.
 //
 // Phase 3 doesn't ship a full dependency-graph consumer — this is
 // informational scaffolding. Expansion follows real consumer demand:
-// when a UI consumer needs an edge that isn't in crossRefMap, add
-// the field-name entry and bump the golden test.
+// when a UI consumer needs an edge that isn't recognized, add the
+// field-name entry in pkg/imported/dependencies and bump the golden.
 package main
 
 import (
@@ -23,41 +23,8 @@ import (
 	"strings"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/dependencies"
 )
-
-// crossRefMap is the hand-curated set of (Terraform-tag-name →
-// target-TF-type) pairs the v1 dependency-emitter recognizes. Each
-// entry says: "any *Value[string] (or []*Value[string]) field with this
-// tf tag, on any Layer-1 typed struct, references a resource of type
-// <target>".
-//
-// The map is intentionally small and conservative — only well-known,
-// unambiguous cross-resource references. False-positive edges are
-// worse than missing edges because they propagate into the eventual
-// UI graph; missing edges can be filled in later by appending entries.
-//
-// To extend: add the field-name (the lowercase tf-tag, exactly as
-// declared on the generated struct's `tf:"<name>"`) and the target
-// TF type. The emitter handles `*Value[string]` and `[]*Value[string]`
-// shapes automatically; nested-block tags are not currently scanned
-// (callers usually want the top-level wiring, not nested doc fields).
-var crossRefMap = map[string]string{
-	// GCP — compute graph
-	"network":    "google_compute_network",
-	"subnetwork": "google_compute_subnetwork",
-	// GCP — KMS
-	"kms_key_name": "google_kms_crypto_key",
-	// AWS — IAM
-	"role":     "aws_iam_role",
-	"role_arn": "aws_iam_role",
-	// AWS — KMS
-	"kms_key_arn":       "aws_kms_key",
-	"kms_key_id":        "aws_kms_key",
-	"kms_master_key_id": "aws_kms_key",
-	// AWS — VPC primitives
-	"vpc_id":    "aws_vpc",
-	"subnet_id": "aws_subnet",
-}
 
 // runDependencies is the `dependencies` subcommand: walk every Layer-1
 // typed struct registered in pkg/composer/imported/generated and emit
@@ -98,8 +65,8 @@ func buildDependenciesMap() map[string][]string {
 
 // inferEdges walks the top-level fields of a Layer-1 typed struct and
 // returns the sorted, deduped set of target TF types its tf-tagged
-// fields reference per crossRefMap. Nested-block fields are skipped —
-// the v1 contract is top-level wiring only.
+// fields reference per the dependencies registry. Nested-block fields
+// are skipped — the v1 contract is top-level wiring only.
 //
 // Recognized field shapes:
 //   - *Value[string]  (scalar reference, e.g. Network)
@@ -132,7 +99,7 @@ func inferEdges(goType reflect.Type) []string {
 		if i := strings.Index(name, ","); i >= 0 {
 			name = name[:i]
 		}
-		target, ok := crossRefMap[name]
+		target, ok := dependencies.Lookup(name)
 		if !ok {
 			continue
 		}

--- a/pkg/imported/dependencies/dependencies.go
+++ b/pkg/imported/dependencies/dependencies.go
@@ -1,0 +1,80 @@
+// Package dependencies is the canonical, runtime-importable registry of
+// field-name → target-Terraform-type cross-references for imported
+// resources. It is the single source of truth for the map that used to
+// live as an unexported `crossRefMap` in `cmd/imported-codegen`'s
+// `dependencies` subcommand (presets#482).
+//
+// Two kinds of consumer use this map:
+//
+//   - The imported-codegen `dependencies` subcommand, which aggregates
+//     it to the per-type edge list emitted as `imported-dependencies.json`
+//     (type → []type). That JSON deliberately drops the field-name level.
+//
+//   - Per-instance dependency matchers (e.g. reliable's import wizard),
+//     which walk a concrete resource's attributes and, for each cross-ref
+//     field, resolve the sibling target. The aggregated JSON cannot
+//     answer that — it needs the field-name level. Before this package
+//     existed, reliable hand-mirrored `crossRefMap` in
+//     `internal/agentapi/import_dependencies.go` with a drift test
+//     (issue #667). Such consumers now call FieldRefs / Lookup instead.
+//
+// Authoring rule: the map is intentionally small and conservative —
+// only well-known, unambiguous cross-resource references. A false-
+// positive edge propagates into the eventual UI dependency graph, which
+// is worse than a missing edge; missing edges can be filled in later by
+// appending an entry. Keys are the lowercase Terraform tag name exactly
+// as declared on the generated struct's `tf:"<name>"`.
+package dependencies
+
+import "maps"
+
+// fieldRefs is the curated set of (Terraform-tag-name → target-TF-type)
+// pairs. Each entry says: "any *Value[string] (or []*Value[string])
+// field with this tf tag, on any Layer-1 typed struct, references a
+// resource of type <target>".
+//
+// The map is keyed by bare field name — not (tfType, field) — by
+// design: the same well-known field name (e.g. `vpc_id`) carries the
+// same target meaning on every resource that declares it. This keeps
+// the registry tiny and is the contract per-instance consumers depend
+// on.
+//
+// To extend: add the field-name and target TF type here. The
+// imported-codegen emitter and the contract test in dependencies_test.go
+// pick it up automatically; the JSON golden bumps on the next codegen
+// run.
+var fieldRefs = map[string]string{
+	// GCP — compute graph
+	"network":    "google_compute_network",
+	"subnetwork": "google_compute_subnetwork",
+	// GCP — KMS
+	"kms_key_name": "google_kms_crypto_key",
+	// AWS — IAM
+	"role":     "aws_iam_role",
+	"role_arn": "aws_iam_role",
+	// AWS — KMS
+	"kms_key_arn":       "aws_kms_key",
+	"kms_key_id":        "aws_kms_key",
+	"kms_master_key_id": "aws_kms_key",
+	// AWS — VPC primitives
+	"vpc_id":    "aws_vpc",
+	"subnet_id": "aws_subnet",
+}
+
+// FieldRefs returns the canonical field-name → target Terraform type
+// map used to resolve per-instance cross-references in imported
+// resources. The returned map is a fresh copy on every call — callers
+// may read, range, or mutate it without affecting the registry or
+// other callers.
+func FieldRefs() map[string]string {
+	return maps.Clone(fieldRefs)
+}
+
+// Lookup returns the target Terraform type for a cross-ref field name
+// and true; or ("", false) if the field is not a recognized cross-
+// reference. It saves per-instance consumers a FieldRefs() copy plus
+// their own nil check when resolving one field at a time.
+func Lookup(field string) (string, bool) {
+	target, ok := fieldRefs[field]
+	return target, ok
+}

--- a/pkg/imported/dependencies/dependencies_test.go
+++ b/pkg/imported/dependencies/dependencies_test.go
@@ -1,0 +1,92 @@
+package dependencies
+
+import (
+	"testing"
+)
+
+// TestFieldRefs_KnownEntries pins the curated cross-ref map. This is
+// the contract reliable (and any other per-instance consumer) resolves
+// against — issue #667. A change here is a deliberate registry edit
+// and must show up loudly in the diff; downstream golden / drift tests
+// bump in lockstep.
+func TestFieldRefs_KnownEntries(t *testing.T) {
+	t.Parallel()
+	want := map[string]string{
+		"network":           "google_compute_network",
+		"subnetwork":        "google_compute_subnetwork",
+		"kms_key_name":      "google_kms_crypto_key",
+		"role":              "aws_iam_role",
+		"role_arn":          "aws_iam_role",
+		"kms_key_arn":       "aws_kms_key",
+		"kms_key_id":        "aws_kms_key",
+		"kms_master_key_id": "aws_kms_key",
+		"vpc_id":            "aws_vpc",
+		"subnet_id":         "aws_subnet",
+	}
+	got := FieldRefs()
+	if len(got) != len(want) {
+		t.Fatalf("FieldRefs() has %d entries, want %d: %v", len(got), len(want), got)
+	}
+	for field, target := range want {
+		if got[field] != target {
+			t.Errorf("FieldRefs()[%q] = %q, want %q", field, got[field], target)
+		}
+	}
+}
+
+// TestFieldRefs_ReturnsCopy pins the defensive-copy contract: mutating
+// the returned map must not affect the registry or other callers.
+func TestFieldRefs_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+	first := FieldRefs()
+	first["vpc_id"] = "tampered"
+	delete(first, "role")
+
+	second := FieldRefs()
+	if second["vpc_id"] != "aws_vpc" {
+		t.Errorf("registry leaked a mutation: FieldRefs()[\"vpc_id\"] = %q, want %q", second["vpc_id"], "aws_vpc")
+	}
+	if _, ok := second["role"]; !ok {
+		t.Error("registry leaked a deletion: FieldRefs()[\"role\"] missing after caller deleted its copy")
+	}
+}
+
+// TestLookup_HitAndMiss pins the single-field resolution helper for
+// both the hit and miss paths.
+func TestLookup_HitAndMiss(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		field      string
+		wantTarget string
+		wantOK     bool
+	}{
+		{"hit_vpc_id", "vpc_id", "aws_vpc", true},
+		{"hit_role", "role", "aws_iam_role", true},
+		{"hit_subnetwork", "subnetwork", "google_compute_subnetwork", true},
+		{"miss_id", "id", "", false},
+		{"miss_arn", "arn", "", false},
+		{"miss_empty", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotTarget, gotOK := Lookup(tc.field)
+			if gotTarget != tc.wantTarget || gotOK != tc.wantOK {
+				t.Errorf("Lookup(%q) = (%q, %t), want (%q, %t)", tc.field, gotTarget, gotOK, tc.wantTarget, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestLookup_AgreesWithFieldRefs pins that the two accessors never
+// diverge — every FieldRefs() entry resolves identically via Lookup.
+func TestLookup_AgreesWithFieldRefs(t *testing.T) {
+	t.Parallel()
+	for field, target := range FieldRefs() {
+		got, ok := Lookup(field)
+		if !ok || got != target {
+			t.Errorf("Lookup(%q) = (%q, %t), want (%q, true)", field, got, ok, target)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- The field-name → target-TF-type map driving imported-resource dependency edges lived as an unexported `crossRefMap` in `cmd/imported-codegen`'s `dependencies` subcommand — unimportable, so per-instance dependency consumers (reliable's import wizard) had to hand-mirror it with a drift test.
- Promotes it to `pkg/imported/dependencies`, a runtime-importable registry with `FieldRefs() map[string]string` (defensive copy) and `Lookup(field) (target, ok)` — mirroring the `pkg/imported/forcenew` sibling's API style.
- The codegen emitter now resolves edges via `dependencies.Lookup`; `imported-dependencies.json` output is byte-identical (same map contents). No behavior change.

## Test plan
- [x] `go test ./pkg/imported/dependencies/... ./cmd/imported-codegen/... -count=1` — 354 passed
- [x] `go build ./...`, `go vet`, `gofmt` clean
- New `dependencies_test.go` pins the curated map, the defensive-copy contract, and `Lookup` hit/miss + accessor agreement.

## Review notes
- /review findings: no P0/P1/P2/P3.
- qa-professor: PASS — applied two MINOR nits (test naming consistency + `t.Run` subtests).

## Follow-up (other repo, not this PR)
- `reliable` can now delete its hand-mirrored `crossRefFieldMap` in `internal/agentapi/import_dependencies.go` and resolve against `dependencies.FieldRefs` / `Lookup` directly (luthersystems/reliable#1479).

Closes #667