### PR TITLE
fix(imported): skip computed-only attrs in typed HCL codegen (#669)

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -296,6 +296,11 @@ jobs:
         with:
           terraform_version: "1.7.5"
       - run: go test -race ./...
+      # Build-tagged terraform-validate harness (imported_tfvalidate_test.go,
+      # #669): emits imported.tf and runs `terraform validate` against the
+      # real provider schema. Excluded from the untagged run above; run it
+      # explicitly so a computed-attr leak is caught end-to-end in CI.
+      - run: go test -tags tfvalidate -run TestImportedTF_TerraformValidate ./pkg/composer/
 
   # NOTE (#406): the previous localstack-discover-gate job was removed
   # alongside Bundle 13c. The unified discoverer routes every AWS

--- a/pkg/composer/imported/generated/hcl.go
+++ b/pkg/composer/imported/generated/hcl.go
@@ -25,6 +25,26 @@ import (
 // wrapper themselves; this keeps the marshaler indifferent to whether the
 // struct represents a top-level resource, a module call, or a nested block.
 func MarshalHCL(into any) ([]byte, error) {
+	return marshalHCL(into, nil)
+}
+
+// MarshalHCLConfigurable behaves like MarshalHCL but, when schema is
+// non-nil, skips any top-level field whose registered FieldSchema is not
+// Configurable() — i.e. computed-only attributes such as a resource's
+// synthesized `arn`. Terraform rejects a computed attribute supplied
+// inside a `resource {}` block ("Value for unconfigurable attribute"), so
+// the imported-resource emitter must drop them. This mirrors the filter
+// the opaque-Attributes path already applies in composer.emitOpaqueAttrsBody.
+//
+// schema is the flat top-level <Type>Schema map (see registry.Lookup); it
+// intentionally does not reach into nested blocks, matching the opaque
+// path's top-level-only behavior. A nil schema disables filtering and is
+// byte-identical to MarshalHCL.
+func MarshalHCLConfigurable(into any, schema map[string]FieldSchema) ([]byte, error) {
+	return marshalHCL(into, schema)
+}
+
+func marshalHCL(into any, schema map[string]FieldSchema) ([]byte, error) {
 	v := reflect.ValueOf(into)
 	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
@@ -34,7 +54,7 @@ func MarshalHCL(into any) ([]byte, error) {
 	}
 
 	f := hclwrite.NewEmptyFile()
-	if err := writeBody(f.Body(), v); err != nil {
+	if err := writeBody(f.Body(), v, schema); err != nil {
 		return nil, err
 	}
 	return bytes.TrimRight(f.Bytes(), "\n"), nil
@@ -57,7 +77,12 @@ func UnmarshalHCL(src []byte, body *hclsyntax.Body, into any) error {
 // Marshal
 // ----------------------------------------------------------------------
 
-func writeBody(body *hclwrite.Body, v reflect.Value) error {
+// writeBody serializes the tf:-tagged fields of struct v into body. When
+// schema is non-nil, top-level fields whose FieldSchema is not
+// Configurable() are skipped (see MarshalHCLConfigurable). Nested blocks
+// recurse with a nil schema — the flat <Type>Schema map only covers
+// top-level attributes.
+func writeBody(body *hclwrite.Body, v reflect.Value, schema map[string]FieldSchema) error {
 	t := v.Type()
 	for i := 0; i < t.NumField(); i++ {
 		fld := t.Field(i)
@@ -67,6 +92,11 @@ func writeBody(body *hclwrite.Body, v reflect.Value) error {
 		tag, kind := parseTag(fld.Tag.Get("tf"))
 		if tag == "" {
 			continue
+		}
+		if schema != nil {
+			if fs, ok := schema[tag]; ok && !fs.Configurable() {
+				continue
+			}
 		}
 		fv := v.Field(i)
 		if err := writeField(body, tag, kind, fv); err != nil {
@@ -91,7 +121,7 @@ func writeField(body *hclwrite.Body, name string, kind tagKind, fv reflect.Value
 			return fmt.Errorf("block field must be struct or *struct, got %v", fv.Kind())
 		}
 		blk := body.AppendNewBlock(name, nil)
-		return writeBody(blk.Body(), fv)
+		return writeBody(blk.Body(), fv, nil)
 	case tagBlocks:
 		if fv.Kind() != reflect.Slice {
 			return fmt.Errorf("blocks field must be slice, got %v", fv.Kind())
@@ -108,7 +138,7 @@ func writeField(body *hclwrite.Body, name string, kind tagKind, fv reflect.Value
 				return fmt.Errorf("blocks element must be struct, got %v", elem.Kind())
 			}
 			blk := body.AppendNewBlock(name, nil)
-			if err := writeBody(blk.Body(), elem); err != nil {
+			if err := writeBody(blk.Body(), elem, nil); err != nil {
 				return err
 			}
 		}

--- a/pkg/composer/imported/generated/hcl_test.go
+++ b/pkg/composer/imported/generated/hcl_test.go
@@ -198,6 +198,47 @@ future_block {
 	assert.Equal(t, "orders-DLQ", *q.Name.Literal)
 }
 
+// TestMarshalHCLConfigurable_SkipsComputedOnly pins #669: when a schema is
+// supplied, MarshalHCLConfigurable must drop top-level fields whose
+// FieldSchema is not Configurable() (computed-only attributes), while a
+// nil schema stays byte-identical to MarshalHCL.
+func TestMarshalHCLConfigurable_SkipsComputedOnly(t *testing.T) {
+	t.Parallel()
+	q := hclTestQueue{
+		Name:      LiteralOf("orders-DLQ"),
+		FifoQueue: LiteralOf(false),
+	}
+
+	// nil schema → no filtering, identical to MarshalHCL.
+	nilOut, err := MarshalHCLConfigurable(&q, nil)
+	require.NoError(t, err)
+	plainOut, err := MarshalHCL(&q)
+	require.NoError(t, err)
+	assert.Equal(t, string(plainOut), string(nilOut),
+		"nil schema must be byte-identical to MarshalHCL")
+	assert.Contains(t, string(nilOut), "fifo_queue")
+
+	// Schema marking fifo_queue computed-only must drop it; the
+	// configurable `name` survives.
+	schema := map[string]FieldSchema{
+		"name":       {Optional: true},
+		"fifo_queue": {Computed: true},
+	}
+	out, err := MarshalHCLConfigurable(&q, schema)
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, `name`, "configurable attr must survive:\n%s", s)
+	assert.NotContains(t, s, "fifo_queue",
+		"computed-only attr must be dropped:\n%s", s)
+
+	// Optional+Computed is still Configurable() — must NOT be dropped.
+	schema["fifo_queue"] = FieldSchema{Optional: true, Computed: true}
+	out2, err := MarshalHCLConfigurable(&q, schema)
+	require.NoError(t, err)
+	assert.Contains(t, string(out2), "fifo_queue",
+		"Optional+Computed attr is configurable and must survive")
+}
+
 // parseAndUnmarshal is a small helper that wraps hclsyntax parsing so test
 // bodies stay focused on the assertions.
 func parseAndUnmarshal(t *testing.T, src []byte, into any) error {

--- a/pkg/composer/imported/generated/hcl_test.go
+++ b/pkg/composer/imported/generated/hcl_test.go
@@ -209,14 +209,14 @@ func TestMarshalHCLConfigurable_SkipsComputedOnly(t *testing.T) {
 		FifoQueue: LiteralOf(false),
 	}
 
-	// nil schema → no filtering, identical to MarshalHCL.
+	// nil schema → no filtering. The byte-for-byte equality is the
+	// load-bearing assertion: a nil schema must change nothing.
 	nilOut, err := MarshalHCLConfigurable(&q, nil)
 	require.NoError(t, err)
 	plainOut, err := MarshalHCL(&q)
 	require.NoError(t, err)
 	assert.Equal(t, string(plainOut), string(nilOut),
 		"nil schema must be byte-identical to MarshalHCL")
-	assert.Contains(t, string(nilOut), "fifo_queue")
 
 	// Schema marking fifo_queue computed-only must drop it; the
 	// configurable `name` survives.
@@ -227,7 +227,10 @@ func TestMarshalHCLConfigurable_SkipsComputedOnly(t *testing.T) {
 	out, err := MarshalHCLConfigurable(&q, schema)
 	require.NoError(t, err)
 	s := string(out)
-	assert.Contains(t, s, `name`, "configurable attr must survive:\n%s", s)
+	// Anchored: `name` must be emitted as an actual attribute assignment,
+	// not merely appear as a substring of a comment / block label.
+	assert.Regexp(t, `(?m)^\s*name\s*=\s*"orders-DLQ"`, s,
+		"configurable attr must survive as a real attribute:\n%s", s)
 	assert.NotContains(t, s, "fifo_queue",
 		"computed-only attr must be dropped:\n%s", s)
 

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -235,6 +235,15 @@ const computedResourceIDAttr = "id"
 // Attrs / opaque Attributes bag, but `id` is never a legal resource
 // argument — it must only ever appear in the `import {}` block. Emitting
 // it produces the malformed-HCL "Invalid or unknown key" plan failure.
+//
+// Computed-only attributes (e.g. a resource's synthesized `arn`) are
+// likewise dropped from both paths: the opaque path filters them in
+// emitOpaqueAttrsBody, and the typed path passes the registered
+// <Type>Schema to generated.MarshalHCLConfigurable so the marshaler skips
+// any field whose FieldSchema is not Configurable(). An enricher may stamp
+// a computed value (e.g. the S3 enricher synthesizes ARN for identity
+// use); emitting it inside a `resource {}` block fails terraform plan with
+// "Value for unconfigurable attribute" (#669).
 func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 	if len(ir.Attrs) > 0 {
 		attrs, err := stripResourceIDAttr(ir.Attrs)
@@ -247,7 +256,11 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 		}
 		ensureLambdaPlaceholderSource(typed)
 		ensureKeyPairPlaceholder(typed)
-		body, err := generated.MarshalHCL(typed)
+		// Pass the registered schema so computed-only attributes are
+		// dropped. Lookup returns a nil schema for unregistered types,
+		// which makes MarshalHCLConfigurable byte-identical to MarshalHCL.
+		_, schema, _ := generated.Lookup(ir.Identity.Type)
+		body, err := generated.MarshalHCLConfigurable(typed, schema)
 		if err != nil {
 			return nil, fmt.Errorf("marshal typed body for %q: %w", ir.Identity.Type, err)
 		}

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -1038,3 +1038,37 @@ func TestEmitImportedTF_IAMPolicyCarriesPolicy(t *testing.T) {
 	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
 }
+
+// TestEmitImportedTF_TypedDropsComputedAttrs pins #669: the typed-Attrs
+// emit path must drop computed-only attributes. The S3 enricher
+// synthesizes a bucket `arn` for identity use and stamps it onto the typed
+// Attrs; `arn` on aws_s3_bucket is schema-Computed-only (not Optional, not
+// Required). Emitting it inside the `resource {}` block makes terraform
+// plan fail hard: "Value for unconfigurable attribute ... Can't configure
+// a value for arn". The configurable `bucket` attribute must still emit.
+func TestEmitImportedTF_TypedDropsComputedAttrs(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.io_uploads",
+			ImportID: "io-uploads",
+		},
+		Tier: imported.TierImportedFlat,
+		Attrs: []byte(`{` +
+			`"bucket":{"literal":"io-uploads"},` +
+			`"arn":{"literal":"arn:aws:s3:::io-uploads"}}`),
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	// Output must parse.
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
+	// The configurable attribute survives.
+	assert.True(t, hasAttr(t, s, "bucket", `"io-uploads"`), "bucket attr missing in:\n%s", s)
+	// The computed-only `arn` must NOT appear as a resource argument.
+	assert.Falsef(t, hasAttr(t, s, "arn", `"arn:aws:s3:::io-uploads"`),
+		"computed-only `arn` leaked into the resource body — terraform plan would fail:\n%s", s)
+}

--- a/pkg/composer/imported_tfvalidate_test.go
+++ b/pkg/composer/imported_tfvalidate_test.go
@@ -1,0 +1,131 @@
+//go:build tfvalidate
+
+// Build-tagged Terraform-validate harness for the imported.tf codegen.
+//
+// Normal `go test` skips this file (it shells out to the `terraform`
+// binary and does a one-time provider download). Run it explicitly:
+//
+//	go test -tags tfvalidate -run TestImportedTF_TerraformValidate -v ./pkg/composer/
+//
+// It emits imported.tf via EmitImportedTF for a set of representative
+// imported resources, drops it next to a minimal providers.tf in a temp
+// dir, and runs `terraform init -backend=false` + `terraform validate`.
+//
+// `terraform validate` is a pure provider-schema check — NO AWS
+// credentials and no network beyond the one-time provider download
+// (TF_PLUGIN_CACHE_DIR keeps that warm across runs). It catches
+// schema-level errors the hclsyntax-parse check in imported_emit_test.go
+// cannot — notably the #669 "Value for unconfigurable attribute" leak of
+// computed-only attributes (e.g. aws_s3_bucket.arn) into a resource body.
+
+package composer
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// tfValidateProvidersHCL declares the aws.imported alias the emitted
+// resource blocks reference. The skip_*/static creds keep `terraform
+// validate` from ever touching AWS — validate is schema-only anyway, but
+// the explicit creds avoid an interactive prompt under -input=false.
+const tfValidateProvidersHCL = `terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  alias                       = "imported"
+  region                      = "us-east-1"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+}
+`
+
+func TestImportedTF_TerraformValidate(t *testing.T) {
+	tfBin, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skip("terraform binary not on PATH")
+	}
+
+	// Representative imported resources. The aws_s3_bucket carries a
+	// synthesized `arn` in its typed Attrs — exactly the #669 leak: `arn`
+	// is schema-Computed-only and must NOT reach the resource body.
+	irs := []imported.ImportedResource{
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.io_uploads",
+				ImportID: "io-uploads",
+			},
+			Tier: imported.TierImportedFlat,
+			Attrs: []byte(`{` +
+				`"bucket":{"literal":"io-uploads"},` +
+				`"arn":{"literal":"arn:aws:s3:::io-uploads"}}`),
+		},
+		{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+			},
+			Tier:  imported.TierImportedFlat,
+			Attrs: []byte(`{"name":{"literal":"orders"}}`),
+		},
+	}
+
+	out, _ := EmitImportedTF("aws", irs, EmitImportedOpts{})
+	if len(out) == 0 {
+		t.Fatal("EmitImportedTF returned no output")
+	}
+
+	dir := t.TempDir()
+	if werr := os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(tfValidateProvidersHCL), 0o644); werr != nil {
+		t.Fatal(werr)
+	}
+	if werr := os.WriteFile(filepath.Join(dir, "imported.tf"), out, 0o644); werr != nil {
+		t.Fatal(werr)
+	}
+
+	// Persistent plugin cache so the aws provider download is paid once.
+	cache := filepath.Join(os.TempDir(), "tf-plugin-cache")
+	_ = os.MkdirAll(cache, 0o755)
+	env := append(os.Environ(), "TF_PLUGIN_CACHE_DIR="+cache, "TF_IN_AUTOMATION=1")
+
+	run := func(args ...string) (string, error) {
+		cmd := exec.Command(tfBin, args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		b, cerr := cmd.CombinedOutput()
+		return string(b), cerr
+	}
+
+	if initOut, ierr := run("init", "-backend=false", "-input=false", "-no-color"); ierr != nil {
+		t.Fatalf("terraform init failed: %v\n%s", ierr, initOut)
+	}
+
+	validateOut, verr := run("validate", "-no-color")
+	t.Logf("terraform validate output:\n%s", validateOut)
+	if verr != nil {
+		t.Errorf("terraform validate failed (exit error: %v)", verr)
+	}
+	// The #669 regression assertion: a computed-only attribute leaking
+	// into a resource block fails validate with this exact phrase.
+	if strings.Contains(validateOut, "unconfigurable attribute") {
+		t.Errorf("#669 regression — computed-only attribute leaked into a resource block:\n%s\n--- generated imported.tf ---\n%s", validateOut, out)
+	}
+}


### PR DESCRIPTION
## Summary

The typed-Attrs `imported.tf` codegen path emitted **every** populated `tf:`-tagged struct field and never consulted the registered `<Type>Schema`. Computed-only attributes — e.g. `aws_s3_bucket.arn`, which the S3 enricher synthesizes for identity use — leaked into the `resource {}` block, making `terraform plan` fail hard:

```
Error: Value for unconfigurable attribute
  Can't configure a value for "arn": its value will be decided automatically
```

This blocked **all** S3 imports in the Reverse-Terraform flow.

The opaque-`Attributes` fallback path already filters these via `FieldSchema.Configurable()` (`emitOpaqueAttrsBody`); the typed path (which S3 buckets take) did not.

## Fix

- `generated.MarshalHCLConfigurable(into, schema)` — new schema-aware marshaler; `writeBody` skips top-level fields whose `FieldSchema` is not `Configurable()`. Nested blocks recurse with a nil schema (the flat `<Type>Schema` map only covers top-level attrs), matching the opaque path's top-level-only behavior.
- `MarshalHCL` is unchanged (delegates with a nil schema → no filtering).
- `emitImportedResourceBody` passes the looked-up `<Type>Schema`; unregistered types get a nil schema → byte-identical to old behavior.

## Test plan

- [x] \`go test ./pkg/composer/...\` — new \`TestEmitImportedTF_TypedDropsComputedAttrs\` (S3 \`arn\` dropped, \`bucket\` kept, output parses) + \`TestMarshalHCLConfigurable_SkipsComputedOnly\` (nil schema = identity; computed-only dropped; Optional+Computed kept)
- [x] Full suite: 5099 passed, \`go vet\` clean

Closes #669