### PR TITLE
Add reverse import SDK and CLI

### DIFF
--- a/cmd/insideout-import/awsdiscover/arn_rules.go
+++ b/cmd/insideout-import/awsdiscover/arn_rules.go
@@ -232,7 +232,7 @@ var arnRules = []arnRule{
 			return rest
 		}},
 	{matchService: "iam", matchResourceType: "role",
-		cfnType: "AWS::IAM::Role", identifierFn: identityResourceID},
+		cfnType: "AWS::IAM::Role", identifierFn: iamRoleNameIdentifier},
 	{matchService: "iam", matchResourceType: "policy",
 		cfnType: "AWS::IAM::ManagedPolicy", identifierFn: identityFullARN},
 	// IAM Instance Profile — untaggable (no Tags property on the CFN
@@ -403,6 +403,16 @@ func identityResourceID(p parsedARN) string { return p.resourceID }
 // identityFullARN is the common identifierFn for types whose Cloud Control
 // primary identifier is the entire ARN string.
 func identityFullARN(p parsedARN) string { return p.full }
+
+// iamRoleNameIdentifier extracts the IAM RoleName from either
+// role/<RoleName> or role/<path>/<RoleName>. Terraform and iam:GetRole both
+// key roles by RoleName, not by the path-qualified ARN resource ID.
+func iamRoleNameIdentifier(p parsedARN) string {
+	if idx := strings.LastIndex(p.resourceID, "/"); idx >= 0 {
+		return p.resourceID[idx+1:]
+	}
+	return p.resourceID
+}
 
 // wafv2WebACLIdentifier builds the Cloud Control primary identifier
 // for AWS::WAFv2::WebACL from a parsed ARN. The CC identifier is

--- a/cmd/insideout-import/awsdiscover/arn_rules_test.go
+++ b/cmd/insideout-import/awsdiscover/arn_rules_test.go
@@ -387,6 +387,8 @@ func TestLookupRule(t *testing.T) {
 		// IAM
 		{name: "iam_role_name", arn: "arn:aws:iam::111111111111:role/my-role",
 			wantCFN: "AWS::IAM::Role", wantIdent: "my-role"},
+		{name: "iam_role_path_stripped_to_role_name", arn: "arn:aws:iam::111111111111:role/service-role/my-role",
+			wantCFN: "AWS::IAM::Role", wantIdent: "my-role"},
 		{name: "iam_policy_full_arn", arn: "arn:aws:iam::111111111111:policy/my-policy",
 			wantCFN: "AWS::IAM::ManagedPolicy", wantIdent: "arn:aws:iam::111111111111:policy/my-policy"},
 		{name: "iam_instance_profile", arn: "arn:aws:iam::111111111111:instance-profile/my-profile",

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -515,28 +515,32 @@ func (d *cloudControlDiscoverer) DiscoverByID(ctx context.Context, id, region, a
 	if id == "" {
 		return imported.ImportedResource{}, fmt.Errorf("%s: empty id: %w", d.cfg.TFType, ErrNotSupported)
 	}
+	identifier, err := d.discoverByIDIdentifier(id)
+	if err != nil {
+		return imported.ImportedResource{}, err
+	}
 	// Identifiers the per-type config excludes (e.g. AWS-managed IAM
 	// policies — #652) must not be imported even when dep-chase reaches
 	// them via a cross-reference. ErrNotSupported tells the dep-chase
 	// loop to drop the reference rather than retry with another
 	// discoverer.
-	if d.cfg.SkipIdentifier != nil && d.cfg.SkipIdentifier(id) {
+	if d.cfg.SkipIdentifier != nil && d.cfg.SkipIdentifier(identifier) {
 		return imported.ImportedResource{}, fmt.Errorf("%s %q: not customer-owned: %w", d.cfg.TFType, id, ErrNotSupported)
 	}
 	client := d.new(region)
 	resp, err := client.GetResource(ctx, &cloudcontrol.GetResourceInput{
 		TypeName:   aws.String(d.cfg.CloudFormationType),
-		Identifier: aws.String(id),
+		Identifier: aws.String(identifier),
 	})
 	if err != nil {
 		if isCloudControlNotFound(err) {
-			return imported.ImportedResource{}, fmt.Errorf("%s %q: %w", d.cfg.TFType, id, ErrNotFound)
+			return imported.ImportedResource{}, fmt.Errorf("%s %q: %w", d.cfg.TFType, identifier, ErrNotFound)
 		}
 		if isCloudControlMalformedIdentifier(err) {
 			// Cloud Control rejected the identifier shape — Stage 2c3's
 			// dep-chase loop treats this as "not parseable by this
 			// discoverer" so it can try a different one.
-			return imported.ImportedResource{}, fmt.Errorf("%s %q: %w", d.cfg.TFType, id, ErrNotSupported)
+			return imported.ImportedResource{}, fmt.Errorf("%s %q: %w", d.cfg.TFType, identifier, ErrNotSupported)
 		}
 		return imported.ImportedResource{}, fmt.Errorf("GetResource %s: %w", d.cfg.CloudFormationType, err)
 	}
@@ -544,17 +548,17 @@ func (d *cloudControlDiscoverer) DiscoverByID(ctx context.Context, id, region, a
 	if err != nil {
 		return imported.ImportedResource{}, fmt.Errorf("parse properties %s %q: %w", d.cfg.CloudFormationType, id, err)
 	}
-	importID := id
+	importID := identifier
 	if d.cfg.ImportIDFromIdentifier != nil {
-		importID = d.cfg.ImportIDFromIdentifier(id, props)
+		importID = d.cfg.ImportIDFromIdentifier(identifier, props)
 	}
-	name := id
+	name := identifier
 	if d.cfg.NameHintFromProperties != nil {
-		name = d.cfg.NameHintFromProperties(id, props)
+		name = d.cfg.NameHintFromProperties(identifier, props)
 	}
 	var native map[string]string
 	if d.cfg.NativeIDsFromProperties != nil {
-		native = d.cfg.NativeIDsFromProperties(id, props)
+		native = d.cfg.NativeIDsFromProperties(identifier, props)
 	}
 	var tags map[string]string
 	if d.cfg.TagsFromProperties != nil {
@@ -570,6 +574,27 @@ func (d *cloudControlDiscoverer) DiscoverByID(ctx context.Context, id, region, a
 		native,
 		tags,
 	), nil
+}
+
+func (d *cloudControlDiscoverer) discoverByIDIdentifier(id string) (string, error) {
+	if !strings.HasPrefix(id, "arn:") {
+		return id, nil
+	}
+	parsed, err := parseARN(id)
+	if err != nil {
+		return "", fmt.Errorf("%s %q: %w", d.cfg.TFType, id, ErrNotSupported)
+	}
+	rule, ok := lookupRule(parsed)
+	if !ok || rule.cfnType == "" {
+		return "", fmt.Errorf("%s %q: no Cloud Control ARN rule: %w", d.cfg.TFType, id, ErrNotSupported)
+	}
+	if rule.cfnType != d.cfg.CloudFormationType {
+		return "", fmt.Errorf("%s %q maps to %s, not %s: %w", d.cfg.TFType, id, rule.cfnType, d.cfg.CloudFormationType, ErrNotSupported)
+	}
+	if rule.identifierFn == nil {
+		return id, nil
+	}
+	return rule.identifierFn(parsed), nil
 }
 
 // parsePropertiesPayload extracts the JSON properties blob from a Cloud

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
@@ -638,6 +638,41 @@ func TestCloudControlDiscoverByID_HappyPath(t *testing.T) {
 	}
 }
 
+func TestCloudControlDiscoverByID_NormalizesARNIdentifier(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		propsByIdentifier: map[string]map[string]any{
+			"lambda-exec": {
+				"RoleName": "lambda-exec",
+				"Arn":      "arn:aws:iam::123:role/service-role/lambda-exec",
+				"Tags":     []any{map[string]any{"Key": "Project", "Value": "io-test"}},
+			},
+		},
+	}
+	d := &cloudControlDiscoverer{
+		cfg:            configByTFType(t, "aws_iam_role"),
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+
+	got, err := d.DiscoverByID(context.Background(), "arn:aws:iam::123:role/service-role/lambda-exec", "us-east-1", "123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.getResourceCalls) != 1 || fake.getResourceCalls[0] != "lambda-exec" {
+		t.Fatalf("GetResource identifiers = %v, want [lambda-exec]", fake.getResourceCalls)
+	}
+	if got.Identity.ImportID != "lambda-exec" {
+		t.Errorf("ImportID=%q, want lambda-exec", got.Identity.ImportID)
+	}
+	if got.Identity.NameHint != "lambda-exec" {
+		t.Errorf("NameHint=%q, want lambda-exec", got.Identity.NameHint)
+	}
+	if got.Identity.NativeIDs["arn"] != "arn:aws:iam::123:role/service-role/lambda-exec" {
+		t.Errorf("NativeIDs[arn]=%q, want role ARN", got.Identity.NativeIDs["arn"])
+	}
+}
+
 // TestCloudControlDiscoverByID_NotFound pins that ResourceNotFoundException
 // (typed or via smithy APIError ErrorCode) maps to ErrNotFound so the
 // Stage-2c3 dep-chase loop can convert it to an operator-facing warning.

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_skip_identifier_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_skip_identifier_test.go
@@ -41,7 +41,17 @@ func TestIsAWSManagedPolicyARN(t *testing.T) {
 // skipManagedConfig is testConfig with the production AWS-managed-policy
 // SkipIdentifier hook wired in, matching the aws_iam_policy config.
 func skipManagedConfig() cloudControlConfig {
-	cfg := testConfig()
+	cfg := cloudControlConfig{
+		TFType:                 "aws_iam_policy",
+		CloudFormationType:     "AWS::IAM::ManagedPolicy",
+		Slug:                   "iam_policy",
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: nameOrIdentifier("ManagedPolicyName"),
+		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+			return map[string]string{"arn": identifier}
+		},
+		TagsFromProperties: tagsFromKey("Tags"),
+	}
 	cfg.SkipIdentifier = isAWSManagedPolicyARN
 	return cfg
 }

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -50,12 +50,12 @@ type Discoverer interface {
 // generated.tf without standing up terraform.
 //
 // Contract: RunGenconfig must return a GenconfigResult whose
-// Resources slice is a *superset* of the input — i.e. it may
-// populate Attributes on the input resources or add metadata, but it
-// must not drop entries. Depchase relies on this to keep the
-// resolved-set monotonic across iterations; a regenerate that
-// silently filters resources would let the loop oscillate by
-// re-marking previously resolved ARNs as unresolved.
+// Resources slice reflects the resources that survived config
+// generation. It may populate Attributes on the input resources and it
+// may drop entries Terraform could not render (for example orphan
+// imports). Depchase treats newly discovered resources that disappear
+// from this result as unresolvable warnings so the loop does not
+// oscillate on references to provider-generated gaps.
 type PipelineFns struct {
 	// RunGenconfig regenerates generated.tf from the current resource
 	// set. Receives the current []ImportedResource (the original set
@@ -187,6 +187,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 
 	res := &Result{Resources: slices.Clone(resources)}
 	seenWarning := make(map[string]struct{})
+	ignoredARNs := make(map[string]struct{})
 	var prevUnresolved []string
 
 	// seenEdges deduplicates Edges across iterations: the same
@@ -203,6 +204,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		if err != nil {
 			return nil, err
 		}
+		unresolved = filterIgnoredARNs(unresolved, ignoredARNs)
 		if len(unresolved) == 0 {
 			res.GeneratedPath = generatedPath
 			sortEdges(res)
@@ -242,10 +244,12 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				if errors.Is(err, ErrUnsupportedType) {
 					addWarning(res, seenWarning,
 						fmt.Sprintf("unsupported ARN type %q (no Terraform discoverer)", arn))
+					ignoredARNs[arn] = struct{}{}
 					continue
 				}
 				addWarning(res, seenWarning,
 					fmt.Sprintf("could not parse ARN %q: %v", arn, err))
+				ignoredARNs[arn] = struct{}{}
 				continue
 			}
 			newSeeds = append(newSeeds, seed{arn: arn, ref: ref})
@@ -255,6 +259,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		sort.Slice(newSeeds, func(i, j int) bool { return newSeeds[i].arn < newSeeds[j].arn })
 
 		var added []imported.ImportedResource
+		var discoveries []discoveredResource
 		for _, s := range newSeeds {
 			ir, err := opts.Discoverer.DiscoverByID(ctx, s.ref.TFType, s.ref.ImportID, opts.Region, opts.AccountID)
 			if err != nil {
@@ -269,29 +274,19 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				case errors.Is(err, awsdiscover.ErrNotFound), errors.Is(err, gcpdiscover.ErrNotFound):
 					addWarning(res, seenWarning,
 						fmt.Sprintf("ARN %q (%s): %v", s.arn, s.ref.TFType, err))
+					ignoredARNs[s.arn] = struct{}{}
 				case errors.Is(err, awsdiscover.ErrNotSupported), errors.Is(err, gcpdiscover.ErrNotSupported):
 					addWarning(res, seenWarning,
 						fmt.Sprintf("ARN %q: %s discoverer rejected ID: %v", s.arn, s.ref.TFType, err))
+					ignoredARNs[s.arn] = struct{}{}
 				default:
 					sortEdges(res)
 					return res, fmt.Errorf("DiscoverByID(%s, %s): %w", s.ref.TFType, s.ref.ImportID, err)
 				}
 				continue
 			}
-			// Record one edge per (consumer, discovered) pair (#297).
-			// consumersByARN was filled from the same generated.tf
-			// pass that produced unresolved; every unresolved literal
-			// that successfully discovered MUST appear in that map.
-			// A defensively-empty consumer slice (e.g. the literal
-			// surfaced from a body the walker doesn't handle) just
-			// drops the edge — better than panicking on a missing key.
-			toAddr := ir.Identity.Address
-			if toAddr != "" {
-				for _, fromAddr := range consumersByARN[s.arn] {
-					recordEdge(res, seenEdges, fromAddr, toAddr)
-				}
-			}
 			added = append(added, ir)
+			discoveries = append(discoveries, discoveredResource{seed: s, resource: ir})
 		}
 
 		if len(added) == 0 {
@@ -303,7 +298,6 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		}
 
 		res.Resources = append(res.Resources, added...)
-		res.Added = append(res.Added, added...)
 
 		gcRes, err := opts.Pipeline.RunGenconfig(ctx, res.Resources)
 		if err != nil {
@@ -313,8 +307,32 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		// Pick up the populated Attributes the regenerate pass wrote
 		// back; the next iteration's FindUnresolved should see them
 		// reflected in the generated.tf re-read.
-		if gcRes != nil && len(gcRes.Resources) > 0 {
+		if gcRes != nil {
 			res.Resources = gcRes.Resources
+		}
+		kept, dropped := partitionDiscoveries(discoveries, res.Resources)
+		for _, d := range dropped {
+			ignoredARNs[d.seed.arn] = struct{}{}
+			removeEdgesTo(res, seenEdges, d.resource.Identity.Address)
+			addWarning(res, seenWarning,
+				fmt.Sprintf("ARN %q (%s) discovered as %s, but generated config omitted it; leaving the literal reference",
+					d.seed.arn, d.seed.ref.TFType, d.resource.Identity.Address))
+		}
+		for _, d := range kept {
+			// Record one edge per (consumer, discovered) pair (#297).
+			// consumersByARN was filled from the same generated.tf
+			// pass that produced unresolved; every unresolved literal
+			// that successfully discovered and survived regeneration
+			// MUST appear in that map. A defensively-empty consumer
+			// slice just drops the edge — better than panicking on a
+			// missing key.
+			toAddr := d.resource.Identity.Address
+			if toAddr != "" {
+				for _, fromAddr := range consumersByARN[d.seed.arn] {
+					recordEdge(res, seenEdges, fromAddr, toAddr)
+				}
+			}
+			res.Added = append(res.Added, d.resource)
 		}
 
 		if _, err := opts.Pipeline.RunDriftfix(ctx); err != nil {
@@ -353,6 +371,45 @@ type seed struct {
 	ref Ref
 }
 
+type discoveredResource struct {
+	seed     seed
+	resource imported.ImportedResource
+}
+
+func filterIgnoredARNs(unresolved []string, ignored map[string]struct{}) []string {
+	if len(unresolved) == 0 || len(ignored) == 0 {
+		return unresolved
+	}
+	out := unresolved[:0]
+	for _, arn := range unresolved {
+		if _, ok := ignored[arn]; ok {
+			continue
+		}
+		out = append(out, arn)
+	}
+	return out
+}
+
+func partitionDiscoveries(discoveries []discoveredResource, resources []imported.ImportedResource) (kept, dropped []discoveredResource) {
+	if len(discoveries) == 0 {
+		return nil, nil
+	}
+	live := make(map[string]struct{}, len(resources))
+	for _, r := range resources {
+		if r.Identity.Address != "" {
+			live[r.Identity.Address] = struct{}{}
+		}
+	}
+	for _, d := range discoveries {
+		if _, ok := live[d.resource.Identity.Address]; ok {
+			kept = append(kept, d)
+			continue
+		}
+		dropped = append(dropped, d)
+	}
+	return kept, dropped
+}
+
 // recordEdge appends a (from, to) GraphEdge to res.Edges if the same
 // pair hasn't been recorded before in this run. Dedup is per-pair so
 // a consumer that references the same target twice (or that
@@ -373,6 +430,22 @@ func recordEdge(res *Result, seen map[string]struct{}, from, to string) {
 	}
 	seen[key] = struct{}{}
 	res.Edges = append(res.Edges, GraphEdge{From: from, To: to})
+}
+
+func removeEdgesTo(res *Result, seen map[string]struct{}, to string) {
+	if to == "" || len(res.Edges) == 0 {
+		return
+	}
+	out := res.Edges[:0]
+	for _, edge := range res.Edges {
+		key := edge.From + "\x00" + edge.To
+		if edge.To == to {
+			delete(seen, key)
+			continue
+		}
+		out = append(out, edge)
+	}
+	res.Edges = out
 }
 
 // sortEdges sorts res.Edges in (From, To) order. Called once per

--- a/cmd/insideout-import/depchase/depchase_test.go
+++ b/cmd/insideout-import/depchase/depchase_test.go
@@ -78,6 +78,7 @@ type scriptedPipeline struct {
 	t           *testing.T
 	workdir     string
 	generatedTF []string // slice of generated.tf bodies, one per RunGenconfig call
+	resources   [][]imported.ImportedResource
 	gcCalls     int
 	dfCalls     int
 }
@@ -91,9 +92,16 @@ func (p *scriptedPipeline) runGenconfig(_ context.Context, resources []imported.
 	if err := os.WriteFile(filepath.Join(p.workdir, generatedFile), []byte(body), 0o644); err != nil {
 		return nil, err
 	}
+	out := resources
+	if len(p.resources) > 0 {
+		if p.gcCalls > len(p.resources) {
+			p.t.Fatalf("scriptedPipeline: resources override missing for call %d", p.gcCalls)
+		}
+		out = p.resources[p.gcCalls-1]
+	}
 	return &GenconfigResult{
 		GeneratedPath: filepath.Join(p.workdir, generatedFile),
-		Resources:     resources,
+		Resources:     out,
 	}, nil
 }
 
@@ -174,6 +182,51 @@ resource "aws_iam_role" "io_foo_handler_role" {
 	}
 	if len(got.Warnings) != 0 {
 		t.Errorf("Warnings=%v, want none", got.Warnings)
+	}
+}
+
+func TestRun_DiscoveredResourceDroppedByPipelineWarnsAndConverges(t *testing.T) {
+	t.Parallel()
+	roleARN := "arn:aws:iam::123:role/io-foo-handler-role"
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  function_name = "io-foo-handler"
+  role          = "` + roleARN + `"
+}`
+	dir := writeGen(t, gen0)
+	lambda := newRes("aws_lambda_function.h", "io-foo-handler", "arn:aws:lambda:us-east-1:123:function:io-foo-handler", "aws_lambda_function")
+	role := newRes("aws_iam_role.io_foo_handler_role", "io-foo-handler-role", roleARN, "aws_iam_role")
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_iam_role|" + roleARN: role,
+	}}
+	p := &scriptedPipeline{
+		t:           t,
+		workdir:     dir,
+		generatedTF: []string{gen0},
+		resources:   [][]imported.ImportedResource{{lambda}},
+	}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{lambda})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if got.Iterations != 1 {
+		t.Errorf("Iterations=%d, want 1", got.Iterations)
+	}
+	if len(got.Added) != 0 {
+		t.Errorf("Added=%+v, want none because role was dropped by genconfig", got.Added)
+	}
+	if len(got.Edges) != 0 {
+		t.Errorf("Edges=%+v, want none for dropped role", got.Edges)
+	}
+	if len(got.Warnings) != 1 || !strings.Contains(got.Warnings[0], "generated config omitted it") {
+		t.Errorf("Warnings=%v, want generated-config omission warning", got.Warnings)
+	}
+	if p.gcCalls != 1 || p.dfCalls != 1 {
+		t.Errorf("pipeline calls gc=%d df=%d, want 1/1", p.gcCalls, p.dfCalls)
 	}
 }
 

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -176,6 +176,15 @@ func (a awsAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, acc
 	return a.d.DiscoverByID(ctx, tfType, id, region, accountID)
 }
 
+func (a awsAggAdapter) DiscoverClosure(ctx context.Context, req reverseimport.ClosureRequest) ([]imported.ImportedResource, error) {
+	types := unionStrings(req.ParentTypes, req.ChildTypes)
+	return a.d.DiscoverTypes(ctx, types, awsdiscover.DiscoverArgs{
+		Project:   req.Project,
+		Regions:   req.Regions,
+		AccountID: req.AccountID,
+	})
+}
+
 // gcpAggAdapter wraps *gcpdiscover.GCPDiscoverer to satisfy
 // discoveryAggregator. Converts AggArgs into gcpdiscover.DiscoverArgs via
 // aggArgsToGCP; otherwise mirrors awsAggAdapter.
@@ -190,6 +199,33 @@ func (a gcpAggAdapter) DiscoverTypes(ctx context.Context, args AggArgs) ([]impor
 
 func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
 	return a.d.DiscoverByID(ctx, tfType, id, region, accountID)
+}
+
+func (a gcpAggAdapter) DiscoverClosure(ctx context.Context, req reverseimport.ClosureRequest) ([]imported.ImportedResource, error) {
+	types := unionStrings(req.ParentTypes, req.ChildTypes)
+	return a.d.DiscoverTypes(ctx, types, gcpdiscover.DiscoverArgs{
+		Project: req.Project,
+		Regions: req.Regions,
+	})
+}
+
+func unionStrings(groups ...[]string) []string {
+	seen := map[string]struct{}{}
+	for _, group := range groups {
+		for _, value := range group {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			seen[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // unsupportedAWSEnumerator is the function-shaped seam used by
@@ -980,6 +1016,9 @@ Exit codes:
 			Region:                primaryRegion,
 			GCPProjectID:          *gcpProjectID,
 			AWSEndpointURL:        *awsEndpointURL,
+			DiscoverProject:       *project,
+			DiscoverRegions:       resolvedRegions,
+			AccountID:             accountID,
 			MaxDepChaseIterations: *maxDepChaseIter,
 			Discoverer:            d,
 		})

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -22,6 +22,8 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
+	reversejob "github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
 )
 
 const (
@@ -241,6 +243,11 @@ type discoverDeps struct {
 	// fake the depchase package directly to exercise the orchestrator
 	// branch without scripting a multi-pass pipeline.
 	runDepChase func(ctx context.Context, opts depchase.Options, resources []imported.ImportedResource) (*depchase.Result, error)
+	// runReverse is the production SDK path for Stage 2b+. Tests that
+	// leave this nil continue to exercise the older injected
+	// genconfig/driftfix/depchase fakes directly; production wires it to
+	// reverseimport.Run so local discover and Mars share the same engine.
+	runReverse func(ctx context.Context, req reversejob.Request, opts reverseimport.Options) (reversejob.Result, error)
 	// enumerateUnsupportedAWS is the AWS-side seam for the
 	// --include-unsupported broad-enumeration path (#296). Production
 	// wires it to a closure that constructs a per-region Resource
@@ -357,6 +364,7 @@ func productionDiscoverDeps() discoverDeps {
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
 		runDepChase:  depchase.Run,
+		runReverse:   reverseimport.Run,
 		enumerateUnsupportedAWS: func(ctx context.Context, cfg aws.Config, args awsdiscover.UnsupportedArgs) ([]awsdiscover.UnsupportedResource, bool, error) {
 			if args.Searcher == nil {
 				args.Searcher = awsdiscover.NewRealResourceExplorerSearcher(cfg)
@@ -951,6 +959,42 @@ Exit codes:
 	}
 
 	if *noHCL || n == 0 {
+		return discoverExitOK
+	}
+
+	if deps.runReverse != nil && !*noDriftFix && !*noDepChase {
+		req := reversejob.Request{
+			Version:   reversejob.Version,
+			Resources: make([]reversejob.ResourceSpec, 0, len(resources)),
+		}
+		for _, r := range resources {
+			req.Resources = append(req.Resources, reversejob.ResourceSpec{
+				Identity: r.Identity,
+				Tier:     r.Tier,
+				Source:   r.Source,
+			})
+		}
+		rev, err := deps.runReverse(ctx, req, reverseimport.Options{
+			OutputDir:             *outputDir,
+			Cloud:                 cloud,
+			Region:                primaryRegion,
+			GCPProjectID:          *gcpProjectID,
+			AWSEndpointURL:        *awsEndpointURL,
+			MaxDepChaseIterations: *maxDepChaseIter,
+			Discoverer:            d,
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "discover: reverse import SDK: %v\n", err)
+			fmt.Fprintln(os.Stderr, "discover: imported.json was written before reverse import. Re-run with --no-hcl to skip the provider-backed reverse import explicitly.")
+			return discoverExitFatal
+		}
+		summaryResources = rev.Imported
+		fmt.Fprintf(summaryOut, "reverse import SDK wrote %s (%d imported, %d add, %d change, %d destroy)\n",
+			filepath.Join(*outputDir, "reverse-result.json"),
+			rev.PlanSummary.ImportCount,
+			rev.PlanSummary.AddCount,
+			rev.PlanSummary.ChangeCount,
+			rev.PlanSummary.DestroyCount)
 		return discoverExitOK
 	}
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
+	reversejob "github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
 )
 
 // runDiscover error-path tests. Happy-path requires AWS credentials and
@@ -728,6 +730,41 @@ func TestRunDiscoverWithDeps_NoHCLSkipsGenconfig(t *testing.T) {
 	}
 	if gc.called != 0 {
 		t.Errorf("runGenconfig called %d times with --no-hcl, want 0", gc.called)
+	}
+}
+
+func TestRunDiscoverWithDeps_DefaultHCLUsesReverseSDK(t *testing.T) {
+	dir := t.TempDir()
+	agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.orders")}}
+	deps := okDeps(agg)
+	called := 0
+	deps.runReverse = func(_ context.Context, req reversejob.Request, opts reverseimport.Options) (reversejob.Result, error) {
+		called++
+		if len(req.Resources) != 1 {
+			t.Fatalf("runReverse got %d resources, want 1", len(req.Resources))
+		}
+		if opts.OutputDir != dir {
+			t.Fatalf("OutputDir = %q, want %q", opts.OutputDir, dir)
+		}
+		return reversejob.Result{
+			Version:     reversejob.Version,
+			Status:      reversejob.StatusSucceeded,
+			Imported:    req.ImportedResources(),
+			PlanSummary: reversejob.PlanSummary{ImportCount: 1},
+		}, nil
+	}
+
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws",
+		"--project", "p",
+		"--region", "us-east-1",
+		"--output-dir", dir,
+	}, deps)
+	if rc != discoverExitOK {
+		t.Fatalf("exit = %d, want %d", rc, discoverExitOK)
+	}
+	if called != 1 {
+		t.Fatalf("runReverse called %d times, want 1", called)
 	}
 }
 

--- a/cmd/insideout-import/genconfig/attributes.go
+++ b/cmd/insideout-import/genconfig/attributes.go
@@ -3,6 +3,7 @@ package genconfig
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -13,6 +14,7 @@ import (
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
 
 // genconfigEvalContext is the evaluation context for decodeAttribute. It
@@ -72,6 +74,11 @@ func extractAttributes(cleaned []byte, resources []imported.ImportedResource) ([
 		byAddr[labels[0]+"."+labels[1]] = blk
 	}
 
+	syntaxByAddr, err := syntaxResourceBodies(cleaned)
+	if err != nil {
+		return nil, err
+	}
+
 	out := make([]imported.ImportedResource, len(resources))
 	copy(out, resources)
 	for i := range out {
@@ -86,8 +93,57 @@ func extractAttributes(cleaned []byte, resources []imported.ImportedResource) ([
 		if len(attrs) > 0 {
 			out[i].Attributes = attrs
 		}
+		body, ok := syntaxByAddr[out[i].Identity.Address]
+		if !ok {
+			continue
+		}
+		typedAttrs, err := decodeTypedAttrs(cleaned, out[i].Identity.Type, body)
+		if err != nil {
+			return nil, fmt.Errorf("resource %q: typed attrs: %w", out[i].Identity.Address, err)
+		}
+		if len(typedAttrs) > 0 {
+			out[i].Attrs = typedAttrs
+		}
 	}
 	return out, nil
+}
+
+func syntaxResourceBodies(src []byte) (map[string]*hclsyntax.Body, error) {
+	file, diags := hclsyntax.ParseConfig(src, generatedFile, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse cleaned generated.tf for typed attrs: %s", diags.Error())
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, fmt.Errorf("parse cleaned generated.tf for typed attrs: unexpected body type %T", file.Body)
+	}
+	out := map[string]*hclsyntax.Body{}
+	for _, blk := range body.Blocks {
+		if blk.Type != "resource" || len(blk.Labels) != 2 {
+			continue
+		}
+		out[blk.Labels[0]+"."+blk.Labels[1]] = blk.Body
+	}
+	return out, nil
+}
+
+func decodeTypedAttrs(src []byte, tfType string, body *hclsyntax.Body) (json.RawMessage, error) {
+	goType, _, ok := generated.Lookup(tfType)
+	if !ok {
+		return nil, nil
+	}
+	ptr := reflect.New(goType)
+	if err := generated.UnmarshalHCL(src, body, ptr.Interface()); err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(ptr.Interface())
+	if err != nil {
+		return nil, err
+	}
+	if string(raw) == "{}" {
+		return nil, nil
+	}
+	return raw, nil
 }
 
 // decodeBlockAttrs returns the populated Attributes map for one resource

--- a/cmd/insideout-import/genconfig/attributes_test.go
+++ b/cmd/insideout-import/genconfig/attributes_test.go
@@ -101,7 +101,7 @@ func TestExtractAttributes_ScalarTypes(t *testing.T) {
 }
 `)
 	out, err := extractAttributes(in, []imported.ImportedResource{
-		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.x"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.x"}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -129,6 +129,17 @@ func TestExtractAttributes_ScalarTypes(t *testing.T) {
 	if len(got) != 4 {
 		t.Errorf("Attributes len=%d, want 4 (all fixture attrs decoded)\n--- got ---\n%v", len(got), got)
 	}
+
+	var typed map[string]map[string]any
+	if err := json.Unmarshal(out[0].Attrs, &typed); err != nil {
+		t.Fatalf("Attrs should decode as typed JSON: %v\n%s", err, out[0].Attrs)
+	}
+	if typed["name"]["literal"] != "alpha" {
+		t.Errorf("typed Attrs name literal = %v, want alpha", typed["name"]["literal"])
+	}
+	if typed["fifo_queue"]["literal"] != true {
+		t.Errorf("typed Attrs fifo_queue literal = %v, want true", typed["fifo_queue"]["literal"])
+	}
 }
 
 // TestExtractAttributes_PreservesRefAsSource pins the contract for
@@ -143,7 +154,7 @@ func TestExtractAttributes_PreservesRefAsSource(t *testing.T) {
 }
 `)
 	out, err := extractAttributes(in, []imported.ImportedResource{
-		{Identity: imported.ResourceIdentity{Address: "aws_secretsmanager_secret.x"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_secretsmanager_secret", Address: "aws_secretsmanager_secret.x"}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -154,6 +165,14 @@ func TestExtractAttributes_PreservesRefAsSource(t *testing.T) {
 	}
 	if got != "aws_kms_key.foo.arn" {
 		t.Errorf("kms_key_id = %q, want \"aws_kms_key.foo.arn\"", got)
+	}
+
+	var typed map[string]map[string]any
+	if err := json.Unmarshal(out[0].Attrs, &typed); err != nil {
+		t.Fatalf("Attrs should decode as typed JSON: %v\n%s", err, out[0].Attrs)
+	}
+	if typed["kms_key_id"]["expr"] != "aws_kms_key.foo.arn" {
+		t.Errorf("typed Attrs kms_key_id expr = %v, want aws_kms_key.foo.arn", typed["kms_key_id"]["expr"])
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -54,6 +54,7 @@ func applyResourceTypeFixups(raw []byte) ([]byte, error) {
 // by cleanGenerated.
 var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lambda_function":       fixupLambdaSource,
+	"aws_cognito_user_pool":     fixupCognitoVerificationMessageConflict,
 	"aws_key_pair":              fixupKeyPairPublicKey,
 	"aws_kms_key":               fixupKMSRotationPeriodZero,
 	"aws_dynamodb_table":        fixupDynamoDBPITRRecoveryPeriodZero,
@@ -68,6 +69,28 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_db_instance":           fixupDBInstanceProviderQuirks,
 	"aws_secretsmanager_secret": fixupSecretsManagerSecretDefaults,
 	"google_compute_firewall":   fixupComputeFirewallEmptySourceTargetArrays,
+}
+
+// fixupCognitoVerificationMessageConflict drops Cognito's legacy top-level
+// email verification fields when generate-config-out also emits the newer
+// verification_message_template block carrying the same settings. The AWS
+// provider schema marks the two forms as mutually exclusive, but live
+// imports can include both.
+func fixupCognitoVerificationMessageConflict(blk *hclwrite.Block) {
+	body := blk.Body()
+	for _, sub := range body.Blocks() {
+		if sub.Type() != "verification_message_template" {
+			continue
+		}
+		subBody := sub.Body()
+		if subBody.GetAttribute("email_message") != nil {
+			body.RemoveAttribute("email_verification_message")
+		}
+		if subBody.GetAttribute("email_subject") != nil {
+			body.RemoveAttribute("email_verification_subject")
+		}
+		return
+	}
 }
 
 // lambdaPlaceholderFile is what we set `filename` to so the block

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -161,6 +161,36 @@ func TestFixupLambda_NonLambdaResourceUntouched(t *testing.T) {
 	}
 }
 
+func TestFixupCognito_DropsLegacyVerificationFieldsWhenTemplatePresent(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_cognito_user_pool" "pool" {
+  email_verification_message = "Your verification code is {####}"
+  email_verification_subject = "alpha verification code"
+  name                       = "alpha"
+
+  verification_message_template {
+    default_email_option = "CONFIRM_WITH_CODE"
+    email_message        = "Your verification code is {####}"
+    email_subject        = "alpha verification code"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "email_verification_message") {
+		t.Errorf("legacy email_verification_message must be dropped when template carries email_message\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "email_verification_subject") {
+		t.Errorf("legacy email_verification_subject must be dropped when template carries email_subject\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "verification_message_template") {
+		t.Errorf("verification_message_template must be preserved\n--- got ---\n%s", got)
+	}
+}
+
 // TestFixupKMS_RotationPeriodZeroDropped pins the LocalStack 4.x
 // fidelity workaround for #272: DescribeKey returns
 // rotation_period_in_days=0 for keys without rotation enabled, but the

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -187,15 +187,6 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		return nil, fmt.Errorf("resource-type fixups: %w", err)
 	}
 
-	cleaned, err = applyCrossRefs(cleaned, resources, provider)
-	if err != nil {
-		return nil, fmt.Errorf("cross-ref: %w", err)
-	}
-
-	if err := os.WriteFile(generatedPath, cleaned, 0o644); err != nil {
-		return nil, fmt.Errorf("rewrite generated.tf: %w", err)
-	}
-
 	// Orphan-import safety net (#362): drop any import { to = X.Y }
 	// whose target resource has no body in generated.tf. terraform
 	// plan -generate-config-out occasionally produces no body for a
@@ -205,6 +196,11 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	// it here keeps the rest of the import set running. Captured
 	// orphans are written to imports-skipped.json for traceability
 	// plus a stderr WARN per drop so the operator sees the soft-fail.
+	//
+	// This must run before cross-reference replacement. If an orphan
+	// resource remains in the cross-ref index, a surviving resource can
+	// be rewritten to reference a block that was just pruned from
+	// imports.tf and never existed in generated.tf.
 	skipped, err := pruneOrphanImports(opts.Workdir, cleaned)
 	if err != nil {
 		return nil, fmt.Errorf("orphan-import safety net: %w", err)
@@ -221,6 +217,15 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				s.Address, s.ImportID, s.Reason)
 		}
 		resources = filterSkippedResources(resources, skipped)
+	}
+
+	cleaned, err = applyCrossRefs(cleaned, resources, provider)
+	if err != nil {
+		return nil, fmt.Errorf("cross-ref: %w", err)
+	}
+
+	if err := os.WriteFile(generatedPath, cleaned, 0o644); err != nil {
+		return nil, fmt.Errorf("rewrite generated.tf: %w", err)
 	}
 
 	if err := runner.Validate(ctx); err != nil {

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -220,6 +220,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 			fmt.Fprintf(os.Stderr, "genconfig: WARN: dropped orphan import %s (id=%q, reason=%s) — terraform plan -generate-config-out produced no resource body\n",
 				s.Address, s.ImportID, s.Reason)
 		}
+		resources = filterSkippedResources(resources, skipped)
 	}
 
 	if err := runner.Validate(ctx); err != nil {
@@ -231,4 +232,22 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		return nil, fmt.Errorf("extract attributes: %w", err)
 	}
 	return &Result{GeneratedPath: generatedPath, Resources: out}, nil
+}
+
+func filterSkippedResources(resources []imported.ImportedResource, skipped []OrphanImport) []imported.ImportedResource {
+	if len(resources) == 0 || len(skipped) == 0 {
+		return resources
+	}
+	skippedAddr := make(map[string]struct{}, len(skipped))
+	for _, s := range skipped {
+		skippedAddr[s.Address] = struct{}{}
+	}
+	out := make([]imported.ImportedResource, 0, len(resources))
+	for _, r := range resources {
+		if _, ok := skippedAddr[r.Identity.Address]; ok {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -254,6 +254,56 @@ func TestFilterSkippedResourcesDropsOrphanAddresses(t *testing.T) {
 	}
 }
 
+func TestRun_PrunesOrphansBeforeCrossRefs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	roleARN := "arn:aws:iam::123:role/service-role/lambda-exec"
+	runner := &fakeRunner{
+		planBody: `resource "aws_lambda_function" "fn" {
+  function_name = "fn"
+  role          = "` + roleARN + `"
+}
+`,
+		schemas: &tfjson.ProviderSchemas{Schemas: map[string]*tfjson.ProviderSchema{
+			awsProviderKey: {ResourceSchemas: map[string]*tfjson.Schema{}},
+		}},
+	}
+	res, err := Run(context.Background(), Options{
+		Workdir: dir,
+		Region:  "us-east-1",
+		Runner:  runner,
+	}, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_lambda_function.fn", ImportID: "fn"}},
+		{Identity: imported.ResourceIdentity{
+			Address:  "aws_iam_role.lambda_exec",
+			ImportID: "lambda-exec",
+			NativeIDs: map[string]string{
+				"arn": roleARN,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Resources) != 1 || res.Resources[0].Identity.Address != "aws_lambda_function.fn" {
+		t.Fatalf("Resources = %+v, want only the non-orphan lambda", res.Resources)
+	}
+	validateBody := string(runner.bytesAtValidate)
+	if !strings.Contains(validateBody, `role          = "`+roleARN+`"`) {
+		t.Fatalf("validate body should keep orphan role ARN literal:\n%s", validateBody)
+	}
+	if strings.Contains(validateBody, "aws_iam_role.lambda_exec") {
+		t.Fatalf("validate body references pruned orphan role:\n%s", validateBody)
+	}
+	importsRaw, err := os.ReadFile(filepath.Join(dir, importsFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(importsRaw), "aws_iam_role.lambda_exec") {
+		t.Fatalf("imports.tf still contains pruned orphan role:\n%s", importsRaw)
+	}
+}
+
 // TestRun_PropagatesPlanErrorWhenFileMissing pins the negative side of
 // the recovery: a plan error with no on-disk file is fatal — there's
 // nothing for the fixup pass to act on, so the operator gets the

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -236,6 +236,24 @@ func TestRun_RecoversFromPlanErrorWhenFileWritten(t *testing.T) {
 	}
 }
 
+func TestFilterSkippedResourcesDropsOrphanAddresses(t *testing.T) {
+	t.Parallel()
+	in := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.keep"}},
+		{Identity: imported.ResourceIdentity{Address: "aws_network_acl.orphan"}},
+		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.keep2"}},
+	}
+	out := filterSkippedResources(in, []OrphanImport{{Address: "aws_network_acl.orphan"}})
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2", len(out))
+	}
+	for _, r := range out {
+		if r.Identity.Address == "aws_network_acl.orphan" {
+			t.Fatalf("orphan resource was not dropped: %+v", out)
+		}
+	}
+}
+
 // TestRun_PropagatesPlanErrorWhenFileMissing pins the negative side of
 // the recovery: a plan error with no on-disk file is fatal — there's
 // nothing for the fixup pass to act on, so the operator gets the

--- a/cmd/insideout-import/main.go
+++ b/cmd/insideout-import/main.go
@@ -16,6 +16,9 @@
 //	          only). Stage 2c2/2c3/2c4 add SDK QoS, dependency chasing,
 //	          and a localstack CI gate; Stage 2d adds GCP.
 //
+//	reverse   Run the provider-backed reverse-import SDK engine against a
+//	          selected resource request or imported.json manifest.
+//
 // Run `insideout-import <subcommand> --help` for subcommand flags.
 package main
 
@@ -34,6 +37,8 @@ func main() {
 		os.Exit(runAdopt(os.Args[2:]))
 	case "discover":
 		os.Exit(runDiscover(os.Args[2:]))
+	case "reverse":
+		os.Exit(runReverse(os.Args[2:]))
 	case "-h", "--help", "help":
 		usage()
 		os.Exit(0)
@@ -50,6 +55,7 @@ func usage() {
 Subcommands:
   adopt     emit import {} blocks against a known preset stack
   discover  discover cloud resources, write imported.json, generate validated HCL, and loop drift fix (AWS only — Stages 2a+2b+2c1 of #189)
+  reverse   run provider-backed reverse import against selected resources
 
 Run 'insideout-import <subcommand> --help' for subcommand flags.`)
 }

--- a/cmd/insideout-import/plan.go
+++ b/cmd/insideout-import/plan.go
@@ -9,8 +9,9 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"strconv"
 	"strings"
+
+	reversejob "github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
 )
 
 // planVerdict summarizes what `terraform plan` showed in the stack after
@@ -31,16 +32,6 @@ type planVerdict struct {
 // plan — the value `adopt` reports back to the operator. Equals the number
 // of unexpected imports plus all non-import banners.
 func (v planVerdict) unrelated() int { return v.unexpected + v.nonImport }
-
-// planSummaryRE matches the summary line Terraform prints at the bottom of a
-// plan when there are pending changes. The format has been stable since
-// Terraform 1.5 introduced the import action:
-//
-//	Plan: 5 to import, 0 to add, 0 to change, 0 to destroy.
-//
-// All four fields are required; the entire line is optional (Terraform omits
-// it when the plan is empty).
-var planSummaryRE = regexp.MustCompile(`Plan:\s+(\d+)\s+to import,\s+(\d+)\s+to add,\s+(\d+)\s+to change,\s+(\d+)\s+to destroy\.`)
 
 // changeLineRE matches the per-resource change banners in plain plan output:
 //
@@ -114,16 +105,12 @@ func parsePlanOutput(out string, expectedImports map[string]struct{}) planVerdic
 	// under-report. Importantly, this check only INCREASES drift counts —
 	// banners that exceed the summary (e.g. duplicate banner from a
 	// refresh-also-show output) leave the verdict alone.
-	if m := planSummaryRE.FindStringSubmatch(out); m != nil {
-		nImport, _ := strconv.Atoi(m[1])
-		nAdd, _ := strconv.Atoi(m[2])
-		nChange, _ := strconv.Atoi(m[3])
-		nDestroy, _ := strconv.Atoi(m[4])
-		summaryNonImport := nAdd + nChange + nDestroy
+	if summary, ok := reversejob.PlanSummaryFromText(out); ok {
+		summaryNonImport := summary.AddCount + summary.ChangeCount + summary.DestroyCount
 
 		bannerImports := v.imports + v.unexpected
-		if nImport > bannerImports {
-			v.unexpected += nImport - bannerImports
+		if summary.ImportCount > bannerImports {
+			v.unexpected += summary.ImportCount - bannerImports
 		}
 		if summaryNonImport > v.nonImport {
 			v.nonImport += summaryNonImport - v.nonImport

--- a/cmd/insideout-import/reverse.go
+++ b/cmd/insideout-import/reverse.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
+	reversejob "github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+const (
+	reverseExitOK    = 0
+	reverseExitFatal = 1
+)
+
+func runReverse(args []string) int {
+	fs := flag.NewFlagSet("reverse", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, `insideout-import reverse — run provider-backed reverse import for selected resources.
+
+Usage:
+  insideout-import reverse --input selected-imports.json --output-dir DIR [flags]
+
+The input may be the new reverse-import request envelope or a local
+imported.json array from insideout-import discover.
+
+Flags:`)
+		fs.PrintDefaults()
+	}
+
+	input := fs.String("input", "", "selected reverse-import request JSON, or imported.json from discover (required)")
+	outputDir := fs.String("output-dir", "", "directory to write imported.tf, imported.json, tfplan.json, plan-summary.json, and reverse-result.json (required)")
+	provider := fs.String("provider", "", "cloud provider override: aws or gcp (default: derive from input)")
+	region := fs.String("region", "", "AWS region or GCP provider region override (default: derive from input)")
+	gcpProjectID := fs.String("gcp-project-id", "", "GCP project ID override (default: derive from input)")
+	importProjectID := fs.String("import-project-id", "", "InsideOut import project ID for provenance tags/labels")
+	importSessionID := fs.String("import-session-id", "", "InsideOut import session ID for provenance tags/labels")
+	tfBinary := fs.String("terraform-binary", "", "path to terraform binary (default: lookup PATH)")
+	awsEndpointURL := fs.String("aws-endpoint-url", "", "override AWS endpoint URL for SDK and Terraform provider, e.g. LocalStack")
+	noDriftFix := fs.Bool("no-driftfix", false, "skip driftfix after generated-config cleanup")
+	noDepChase := fs.Bool("no-depchase", false, "skip dependency chase")
+	maxDepChaseIter := fs.Int("max-depchase-iterations", depchase.DefaultMaxIterations, "max dependency-chase iterations")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return reverseExitOK
+		}
+		return reverseExitFatal
+	}
+	if strings.TrimSpace(*input) == "" {
+		fmt.Fprintln(os.Stderr, "reverse: --input is required")
+		return reverseExitFatal
+	}
+	if strings.TrimSpace(*outputDir) == "" {
+		fmt.Fprintln(os.Stderr, "reverse: --output-dir is required")
+		return reverseExitFatal
+	}
+	if *maxDepChaseIter <= 0 {
+		fmt.Fprintf(os.Stderr, "reverse: --max-depchase-iterations must be positive (got %d)\n", *maxDepChaseIter)
+		return reverseExitFatal
+	}
+
+	f, err := os.Open(*input)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reverse: open --input: %v\n", err)
+		return reverseExitFatal
+	}
+	req, err := reversejob.DecodeRequest(f)
+	_ = f.Close()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reverse: decode --input: %v\n", err)
+		return reverseExitFatal
+	}
+
+	cloud := strings.TrimSpace(*provider)
+	if cloud == "" && len(req.Resources) > 0 {
+		cloud = req.Resources[0].Identity.Cloud
+	}
+	switch cloud {
+	case "aws", "gcp":
+	case "":
+		fmt.Fprintln(os.Stderr, "reverse: cloud is required; pass --provider or include identity.cloud in input")
+		return reverseExitFatal
+	default:
+		fmt.Fprintf(os.Stderr, "reverse: unknown --provider %q (one of: aws, gcp)\n", cloud)
+		return reverseExitFatal
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeoutOverall)
+	defer cancel()
+
+	discoverer, cleanup, err := newReverseDiscoverer(ctx, cloud, firstReqRegion(req, *region), firstReqProjectID(req, *gcpProjectID), *awsEndpointURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reverse: build discoverer: %v\n", err)
+		return reverseExitFatal
+	}
+	defer cleanup()
+
+	result, err := reverseimport.Run(ctx, req, reverseimport.Options{
+		OutputDir:             *outputDir,
+		Cloud:                 cloud,
+		Region:                *region,
+		GCPProjectID:          *gcpProjectID,
+		AWSEndpointURL:        *awsEndpointURL,
+		ImportProjectID:       *importProjectID,
+		ImportSessionID:       *importSessionID,
+		ImportedAt:            time.Now().UTC(),
+		TerraformBinary:       *tfBinary,
+		SkipDriftFix:          *noDriftFix,
+		SkipDepChase:          *noDepChase,
+		MaxDepChaseIterations: *maxDepChaseIter,
+		Discoverer:            discoverer,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "reverse: %v\n", err)
+		return reverseExitFatal
+	}
+	fmt.Printf("reverse import succeeded: %d imported, %d add, %d change, %d destroy\n",
+		result.PlanSummary.ImportCount,
+		result.PlanSummary.AddCount,
+		result.PlanSummary.ChangeCount,
+		result.PlanSummary.DestroyCount)
+	return reverseExitOK
+}
+
+func newReverseDiscoverer(ctx context.Context, cloud, region, gcpProjectID, awsEndpointURL string) (reverseimport.Discoverer, func(), error) {
+	switch cloud {
+	case "aws":
+		opts := []func(*config.LoadOptions) error{
+			config.WithRegion(region),
+			config.WithRetryMaxAttempts(discoverRetryMaxAttempts),
+			config.WithRetryMode(discoverRetryMode),
+		}
+		if awsEndpointURL != "" {
+			opts = append(opts, config.WithBaseEndpoint(awsEndpointURL))
+		}
+		cfg, err := config.LoadDefaultConfig(ctx, opts...)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return awsdiscover.NewAWSDiscovererWithConcurrency(cfg, awsdiscover.DefaultMaxConcurrency), func() {}, nil
+	case "gcp":
+		searcher, err := gcpdiscover.NewRealAssetSearcher(ctx)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return gcpdiscover.NewGCPDiscoverer(searcher, gcpProjectID, gcpdiscover.GCPDiscovererOpts{}), func() { _ = searcher.Close() }, nil
+	default:
+		return nil, func() {}, fmt.Errorf("unknown cloud %q", cloud)
+	}
+}
+
+func firstReqRegion(req reversejob.Request, fallback string) string {
+	if strings.TrimSpace(fallback) != "" {
+		return fallback
+	}
+	for _, r := range req.Resources {
+		if strings.TrimSpace(r.Identity.Region) != "" {
+			return r.Identity.Region
+		}
+	}
+	return ""
+}
+
+func firstReqProjectID(req reversejob.Request, fallback string) string {
+	if strings.TrimSpace(fallback) != "" {
+		return fallback
+	}
+	for _, r := range req.Resources {
+		if strings.TrimSpace(r.Identity.ProjectID) != "" {
+			return r.Identity.ProjectID
+		}
+	}
+	return ""
+}

--- a/cmd/insideout-import/reverse.go
+++ b/cmd/insideout-import/reverse.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -42,6 +43,7 @@ Flags:`)
 	input := fs.String("input", "", "selected reverse-import request JSON, or imported.json from discover (required)")
 	outputDir := fs.String("output-dir", "", "directory to write imported.tf, imported.json, tfplan.json, plan-summary.json, and reverse-result.json (required)")
 	provider := fs.String("provider", "", "cloud provider override: aws or gcp (default: derive from input)")
+	project := fs.String("project", "", "InsideOut project tag/label filter for parent-child closure discovery")
 	region := fs.String("region", "", "AWS region or GCP provider region override (default: derive from input)")
 	gcpProjectID := fs.String("gcp-project-id", "", "GCP project ID override (default: derive from input)")
 	importProjectID := fs.String("import-project-id", "", "InsideOut import project ID for provenance tags/labels")
@@ -116,6 +118,8 @@ Flags:`)
 		ImportProjectID:       *importProjectID,
 		ImportSessionID:       *importSessionID,
 		ImportedAt:            time.Now().UTC(),
+		DiscoverProject:       *project,
+		DiscoverRegions:       requestRegions(req, *region),
 		TerraformBinary:       *tfBinary,
 		SkipDriftFix:          *noDriftFix,
 		SkipDepChase:          *noDepChase,
@@ -149,13 +153,13 @@ func newReverseDiscoverer(ctx context.Context, cloud, region, gcpProjectID, awsE
 		if err != nil {
 			return nil, func() {}, err
 		}
-		return awsdiscover.NewAWSDiscovererWithConcurrency(cfg, awsdiscover.DefaultMaxConcurrency), func() {}, nil
+		return awsAggAdapter{d: awsdiscover.NewAWSDiscovererWithConcurrency(cfg, awsdiscover.DefaultMaxConcurrency)}, func() {}, nil
 	case "gcp":
 		searcher, err := gcpdiscover.NewRealAssetSearcher(ctx)
 		if err != nil {
 			return nil, func() {}, err
 		}
-		return gcpdiscover.NewGCPDiscoverer(searcher, gcpProjectID, gcpdiscover.GCPDiscovererOpts{}), func() { _ = searcher.Close() }, nil
+		return gcpAggAdapter{d: gcpdiscover.NewGCPDiscoverer(searcher, gcpProjectID, gcpdiscover.GCPDiscovererOpts{})}, func() { _ = searcher.Close() }, nil
 	default:
 		return nil, func() {}, fmt.Errorf("unknown cloud %q", cloud)
 	}
@@ -171,6 +175,26 @@ func firstReqRegion(req reversejob.Request, fallback string) string {
 		}
 	}
 	return ""
+}
+
+func requestRegions(req reversejob.Request, override string) []string {
+	if strings.TrimSpace(override) != "" {
+		return []string{strings.TrimSpace(override)}
+	}
+	seen := map[string]struct{}{}
+	for _, r := range req.Resources {
+		region := strings.TrimSpace(r.Identity.Region)
+		if region == "" {
+			continue
+		}
+		seen[region] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for region := range seen {
+		out = append(out, region)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func firstReqProjectID(req reversejob.Request, fallback string) string {

--- a/cmd/insideout-import/reverse_test.go
+++ b/cmd/insideout-import/reverse_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	reversejob "github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+func TestRequestRegions(t *testing.T) {
+	req := reversejob.Request{
+		Resources: []reversejob.ResourceSpec{
+			{Identity: imported.ResourceIdentity{Region: "us-west-2"}},
+			{Identity: imported.ResourceIdentity{Region: "us-east-1"}},
+			{Identity: imported.ResourceIdentity{Region: "us-west-2"}},
+			{Identity: imported.ResourceIdentity{}},
+		},
+	}
+	got := requestRegions(req, "")
+	want := []string{"us-east-1", "us-west-2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("requestRegions() = %v, want %v", got, want)
+	}
+}
+
+func TestRequestRegionsUsesOverride(t *testing.T) {
+	req := reversejob.Request{
+		Resources: []reversejob.ResourceSpec{
+			{Identity: imported.ResourceIdentity{Region: "us-east-1"}},
+		},
+	}
+	got := requestRegions(req, " eu-west-2 ")
+	want := []string{"eu-west-2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("requestRegions() = %v, want %v", got, want)
+	}
+}

--- a/docs/reverse-import-reconcile-architecture.html
+++ b/docs/reverse-import-reconcile-architecture.html
@@ -1,0 +1,911 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Reverse Import Reconcile Architecture</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17212b;
+      --muted: #5c6b78;
+      --line: #cfd8e3;
+      --panel: #f8fafc;
+      --panel-strong: #edf3f8;
+      --accent: #1f6f8b;
+      --accent-soft: #d9eef4;
+      --good: #1f7a4d;
+      --warn: #9a5b10;
+      --paper: #ffffff;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.48;
+    }
+
+    main {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 40px 28px 64px;
+    }
+
+    h1,
+    h2,
+    h3 {
+      margin: 0;
+      line-height: 1.15;
+      letter-spacing: 0;
+    }
+
+    h1 {
+      font-size: 36px;
+      max-width: 760px;
+    }
+
+    h2 {
+      font-size: 23px;
+      margin-top: 42px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    h3 {
+      font-size: 16px;
+      margin-top: 0;
+      margin-bottom: 10px;
+    }
+
+    p {
+      margin: 10px 0 0;
+      color: var(--muted);
+      max-width: 880px;
+    }
+
+    code,
+    pre {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 13px;
+    }
+
+    pre {
+      overflow: auto;
+      padding: 14px;
+      background: #101820;
+      color: #e6edf3;
+      border-radius: 6px;
+      line-height: 1.45;
+    }
+
+    .intro {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 320px;
+      gap: 28px;
+      align-items: start;
+      margin-bottom: 22px;
+    }
+
+    .summary {
+      border: 1px solid var(--line);
+      background: var(--panel);
+      border-radius: 8px;
+      padding: 18px;
+    }
+
+    .summary dl {
+      display: grid;
+      grid-template-columns: 96px 1fr;
+      gap: 8px 14px;
+      margin: 0;
+    }
+
+    .summary dt {
+      color: var(--muted);
+      font-size: 12px;
+      text-transform: uppercase;
+    }
+
+    .summary dd {
+      margin: 0;
+      font-weight: 600;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 16px;
+      margin-top: 18px;
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      background: var(--panel);
+      border-radius: 8px;
+      padding: 16px;
+    }
+
+    .card p {
+      margin-top: 6px;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 3px 8px;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 700;
+      margin-bottom: 10px;
+    }
+
+    .diagram {
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 18px;
+      margin-top: 18px;
+      overflow-x: auto;
+    }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(6, minmax(145px, 1fr));
+      gap: 12px;
+      align-items: stretch;
+      min-width: 1040px;
+    }
+
+    .node {
+      min-height: 96px;
+      border: 1px solid #b8c7d3;
+      border-radius: 8px;
+      background: #fff;
+      padding: 12px;
+      position: relative;
+    }
+
+    .node:not(:last-child)::after {
+      content: "->";
+      position: absolute;
+      right: -23px;
+      top: 40px;
+      color: var(--accent);
+      font-weight: 700;
+      z-index: 2;
+    }
+
+    .node strong {
+      display: block;
+      font-size: 14px;
+      margin-bottom: 6px;
+    }
+
+    .node span {
+      display: block;
+      color: var(--muted);
+      font-size: 13px;
+    }
+
+    .loop {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(190px, 1fr));
+      gap: 14px;
+      min-width: 760px;
+    }
+
+    .loop .node {
+      min-height: 108px;
+    }
+
+    .loop .node:nth-child(3)::after {
+      content: "";
+    }
+
+    .loop-return {
+      grid-column: 1 / 4;
+      border: 1px dashed var(--accent);
+      border-radius: 8px;
+      padding: 10px 12px;
+      background: #fff;
+      color: var(--accent);
+      font-weight: 700;
+      text-align: center;
+    }
+
+    .lanes {
+      display: grid;
+      grid-template-columns: 150px repeat(5, minmax(150px, 1fr));
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      min-width: 1080px;
+      background: #fff;
+    }
+
+    .lane-head,
+    .lane-cell {
+      padding: 12px;
+      border-right: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+    }
+
+    .lane-head {
+      background: var(--panel-strong);
+      font-weight: 700;
+    }
+
+    .lane-cell {
+      color: var(--muted);
+      min-height: 84px;
+    }
+
+    .lane-cell:last-child,
+    .lane-head:last-child {
+      border-right: 0;
+    }
+
+    .lanes > :nth-last-child(-n + 6) {
+      border-bottom: 0;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 18px;
+      font-size: 14px;
+    }
+
+    th,
+    td {
+      border: 1px solid var(--line);
+      padding: 10px 12px;
+      vertical-align: top;
+      text-align: left;
+    }
+
+    th {
+      background: var(--panel-strong);
+    }
+
+    ul {
+      margin: 10px 0 0;
+      padding-left: 20px;
+    }
+
+    li {
+      margin: 6px 0;
+    }
+
+    .status {
+      border-left: 4px solid var(--good);
+      padding-left: 12px;
+    }
+
+    .warning {
+      border-left: 4px solid var(--warn);
+      padding-left: 12px;
+    }
+
+    @media (max-width: 820px) {
+      main {
+        padding: 28px 16px 48px;
+      }
+
+      h1 {
+        font-size: 30px;
+      }
+
+      .intro,
+      .grid {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="intro">
+      <div>
+        <div class="badge">Working design</div>
+        <h1>Reverse Import Reconcile Architecture</h1>
+        <p>
+          The durable design is to expose reverse import as a presets Go SDK,
+          then let a Mars Go job binary call that SDK beside Terraform and the
+          providers. The SDK converts provider readback into typed imported
+          resource IR, and Reliable persists that IR as the source of truth.
+          Resource selection should be parent-first: the UI sends the
+          top-level resources the user chose, and presets expands the
+          provider-specific child/dependency closure before generating IR.
+          Reliable should orchestrate the job and consume the returned result,
+          not attempt provider enrichment in Vercel.
+        </p>
+      </div>
+      <aside class="summary">
+        <dl>
+          <dt>Runtime</dt>
+          <dd>Mars Go job binary</dd>
+          <dt>Caller</dt>
+          <dd>Reliable via UI Core job</dd>
+          <dt>Canonical</dt>
+          <dd><code>ImportedResource.Attrs</code></dd>
+          <dt>Artifact</dt>
+          <dd><code>imported.tf</code></dd>
+          <dt>Validation</dt>
+          <dd>zero add/change/destroy, N import</dd>
+          <dt>SDK</dt>
+          <dd>presets reverse import</dd>
+          <dt>Closure</dt>
+          <dd>presets expands parents</dd>
+          <dt>Ticket</dt>
+          <dd>presets #672</dd>
+        </dl>
+      </aside>
+    </section>
+
+    <section>
+      <h2>Decision</h2>
+      <div class="grid">
+        <article class="card status">
+          <h3>Use provider runtime readback</h3>
+          <p>
+            Static enrichment from provider schema interrogation is not robust
+            enough for Lambda, KMS, and other resources whose usable HCL depends
+            on provider readback, import IDs, state behavior, or provider-specific
+            normalization.
+          </p>
+        </article>
+        <article class="card status">
+          <h3>Persist IR, regenerate HCL</h3>
+          <p>
+            The reverse job returns a typed imported resource snapshot. Reliable
+            persists that snapshot and later asks presets to regenerate HCL from
+            the same IR, rather than storing raw generated HCL as the truth.
+          </p>
+        </article>
+        <article class="card status">
+          <h3>Presets exposes the engine</h3>
+          <p>
+            The reusable implementation lives in a presets Go SDK. The existing
+            CLI becomes a thin wrapper over that SDK, and the Mars job binary
+            imports the same package rather than shelling out to presets.
+          </p>
+        </article>
+        <article class="card status">
+          <h3>Mars adapts job protocol</h3>
+          <p>
+            Mars owns execution concerns: env, credentials, work directories,
+            logs, artifact paths, and UI Core job protocol. It does not
+            re-implement import enrichment, HCL projection, or validation.
+          </p>
+        </article>
+        <article class="card status">
+          <h3>Presets owns dependency closure</h3>
+          <p>
+            The UI should not need to flood users with every sidecar resource.
+            Users select top-level parents; presets expands provider-specific
+            children, sidecars, and hard dependencies before Terraform
+            generation.
+          </p>
+        </article>
+        <article class="card status">
+          <h3>Local CLI exercises SDK</h3>
+          <p>
+            The local discover CLI should call the same SDK entry point that
+            Mars calls for Reliable. Troubleshooting here should reproduce the
+            same import selection, provider readback, IR projection, and final
+            plan validation path.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>End-to-end Flow</h2>
+      <div class="diagram">
+        <div class="flow" aria-label="Reverse import end-to-end flow">
+          <div class="node">
+            <strong>Reliable discover</strong>
+            <span>Select top-level parent resources and build import candidates with identity, type, region, and native IDs.</span>
+          </div>
+          <div class="node">
+            <strong>UI Core job</strong>
+            <span>Launch a reverse Terraform job in Argo using the Mars image.</span>
+          </div>
+          <div class="node">
+            <strong>Mars Go binary</strong>
+            <span>Prepare job env, credentials, workdir, logs, and artifact locations.</span>
+          </div>
+          <div class="node">
+            <strong>Presets SDK</strong>
+            <span>Expand parent selections, run reverse import, project typed IR, render HCL, and validate the final plan.</span>
+          </div>
+          <div class="node">
+            <strong>Terraform provider</strong>
+            <span>Import, read provider state, generate config, and produce final plan JSON.</span>
+          </div>
+          <div class="node">
+            <strong>Reliable ingest</strong>
+            <span>Parse artifacts, persist imported IR, and expose plan data using existing job output conventions.</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Selection Closure</h2>
+      <p>
+        Dependency closure belongs in presets because it is provider and
+        Terraform-schema knowledge, not frontend presentation logic. The
+        frontend can group and display parents, but the SDK decides which
+        sidecars and dependencies are required for a clean import plan.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Input kind</th>
+            <th>Presets expansion</th>
+            <th>Why it lives here</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Selected parent</td>
+            <td>Resource explicitly chosen by the user, such as Lambda, S3 bucket, VPC, API, or load balancer.</td>
+            <td>The UI should stay focused on understandable infrastructure components.</td>
+          </tr>
+          <tr>
+            <td>Child/sidecar</td>
+            <td>Provider-specific resources owned by the parent, such as bucket configuration resources, log groups, stages, listeners, target groups, and security group rules.</td>
+            <td>These rules change with provider schemas and Terraform import behavior.</td>
+          </tr>
+          <tr>
+            <td>Hard dependency</td>
+            <td>Resources required by references in generated HCL, such as VPCs, subnets, security groups, route tables, KMS keys, queues, and roles.</td>
+            <td>The SDK can prove the closure by re-running generated config, dep chasing, and the final import-only plan.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Canonicality Loop</h2>
+      <div class="diagram">
+        <div class="loop" aria-label="Canonical imported resource loop">
+          <div class="node">
+            <strong>Provider readback</strong>
+            <span>Terraform imports the selected resources and produces provider-normalized state and generated config.</span>
+          </div>
+          <div class="node">
+            <strong>Typed IR projection</strong>
+            <span>Presets converts the usable HCL/state into <code>ImportedResource</code> with canonical <code>Attrs</code>.</span>
+          </div>
+          <div class="node">
+            <strong>HCL regeneration</strong>
+            <span><code>EmitImportedTF</code> renders <code>imported.tf</code> from the same IR that Reliable will store.</span>
+          </div>
+          <div class="loop-return">
+            Final validation plans the regenerated imported.tf and proves: zero add, zero change, zero destroy, N import.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Package Shape</h2>
+      <p>
+        The implementation should make the SDK the real product surface. CLI
+        and Mars are adapters with different IO, not separate implementations.
+      </p>
+      <pre><code>insideout-terraform-presets
+  pkg/reverseimport/job
+    Request, ResourceSpec, Result, ArtifactSet, PlanSummary
+    pure JSON contract shared by presets, Mars, UI Core, and Reliable
+
+  pkg/reverseimport
+    Run(ctx, job.Request, options) -&gt; job.Result
+    selection closure, Terraform runner, reverse-import engine, HCL projection, validation
+
+  cmd/insideout-import
+    discover/adopt CLI wrappers around pkg/reverseimport
+    local discover exercises the same logic Mars calls for Reliable
+
+mars
+  cmd/mars-job
+    reverse-import job adapter
+    imports pkg/reverseimport
+    owns env, credentials, logs, workdir, and artifact upload
+
+reliable
+  imports pkg/reverseimport/job models or lightweight parsers
+  submits UI Core job and persists imported.json</code></pre>
+    </section>
+
+    <section>
+      <h2>Responsibility Lanes</h2>
+      <div class="diagram">
+        <div class="lanes" aria-label="Component responsibilities">
+          <div class="lane-head">Stage</div>
+          <div class="lane-head">Reliable</div>
+          <div class="lane-head">UI Core</div>
+          <div class="lane-head">Mars Go</div>
+          <div class="lane-head">Presets SDK</div>
+          <div class="lane-head">Terraform</div>
+
+          <div class="lane-head">Input</div>
+          <div class="lane-cell">Build selected parent snapshot from discovery results.</div>
+          <div class="lane-cell">Accept job payload and upload working input files.</div>
+          <div class="lane-cell">Decode job payload, configure env, credentials, workspace, and artifact paths.</div>
+          <div class="lane-cell">Validate selected parent identities, expand dependency closure, and prepare Terraform import blocks.</div>
+          <div class="lane-cell">Use installed binary, provider cache, backend config, and generated working files.</div>
+
+          <div class="lane-head">Runtime</div>
+          <div class="lane-cell">Poll job status and stream logs.</div>
+          <div class="lane-cell">Run the Argo workflow and collect artifacts.</div>
+          <div class="lane-cell">Call <code>pkg/reverseimport.Run</code> and proxy progress to UI Core.</div>
+          <div class="lane-cell">Iterate through import, cleanup, dep chasing, typed projection, and final plan validation.</div>
+          <div class="lane-cell">Perform provider readback, generated config, state refresh, and final plan.</div>
+
+          <div class="lane-head">Output</div>
+          <div class="lane-cell">Persist <code>imported.json</code> into stack version state and expose plan summary.</div>
+          <div class="lane-cell">Return artifacts using the same pattern as plan/apply jobs.</div>
+          <div class="lane-cell">Upload logs, plan JSON, HCL, result JSON, and diagnostics.</div>
+          <div class="lane-cell">Guarantee the returned IR regenerates the returned <code>imported.tf</code>.</div>
+          <div class="lane-cell">Provide final plan JSON and provider-normalized values.</div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <h2>Job Input</h2>
+      <p>
+        The job input should be the selected parent import snapshot, not just
+        raw ARNs. ARN is one useful native ID, but Terraform import IDs differ
+        by resource type. The job needs type, address, import ID, cloud,
+        account, region, and any native IDs already discovered. Presets may add
+        child and dependency resources to the returned <code>imported.json</code>.
+      </p>
+      <pre><code>{
+  "version": 1,
+  "resources": [
+    {
+      "identity": {
+        "cloud": "aws",
+        "type": "aws_lambda_function",
+        "address": "aws_lambda_function.worker",
+        "import_id": "worker",
+        "region": "us-east-1",
+        "account_id": "123456789012",
+        "native_ids": {
+          "arn": "arn:aws:lambda:us-east-1:123456789012:function:worker"
+        }
+      },
+      "tier": "ImportedFlat",
+      "source": "importer"
+    }
+  ]
+}</code></pre>
+    </section>
+
+    <section>
+      <h2>Job Output</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Artifact</th>
+            <th>Purpose</th>
+            <th>Consumer</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>imported.json</code></td>
+            <td>Canonical imported resource snapshot with typed <code>Attrs</code>.</td>
+            <td>Reliable persistence and future HCL regeneration.</td>
+          </tr>
+          <tr>
+            <td><code>imported.tf</code></td>
+            <td>Human-reviewable HCL rendered from <code>imported.json</code>.</td>
+            <td>UI preview, debugging, and final validation.</td>
+          </tr>
+          <tr>
+            <td><code>tfplan.json</code></td>
+            <td>Terraform plan JSON from the final validation plan.</td>
+            <td>Reliable plan display and import summary.</td>
+          </tr>
+          <tr>
+            <td><code>plan-summary.json</code></td>
+            <td>Small import-aware summary: exported import/add/change/destroy counts and diagnostics.</td>
+            <td>Reliable job status and UI copy.</td>
+          </tr>
+          <tr>
+            <td><code>reverse-result.json</code></td>
+            <td>Envelope linking all artifacts, diagnostics, resource results, and validation status.</td>
+            <td>Reliable SDK parser.</td>
+          </tr>
+          <tr>
+            <td><code>generated.tf</code>, <code>imports.tf</code>, <code>graph.json</code></td>
+            <td>Debug artifacts from Terraform generation and dependency chasing.</td>
+            <td>Operator diagnostics and test fixtures.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Model Contract</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Model</th>
+            <th>Contract</th>
+            <th>Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>PlanSummary</code></td>
+            <td>Export <code>ImportCount</code> alongside add/change/destroy counts.</td>
+            <td>
+              The current CLI can count imports internally, but Reliable and UI
+              Core need the value in the result contract to show and validate
+              "N imported, 0 added, 0 changed, 0 destroyed".
+            </td>
+          </tr>
+          <tr>
+            <td><code>ReverseImportRequest</code></td>
+            <td>Carry selected resources with identity, type, address, import ID, region, account/project, and native IDs.</td>
+            <td>
+              Raw ARNs are not enough. Terraform import IDs vary by resource
+              type, and the SDK needs enough identity to render import blocks
+              and bind the returned IR to stable addresses.
+            </td>
+          </tr>
+          <tr>
+            <td><code>ReverseImportResult</code></td>
+            <td>Return imported resources, final plan summary, artifact metadata, diagnostics, and validation issues.</td>
+            <td>
+              Reliable should parse one stable envelope rather than infer
+              success from files, logs, or Terraform text output.
+            </td>
+          </tr>
+          <tr>
+            <td><code>ResourceResult</code></td>
+            <td>Report per-resource status, applied fixups, dependency additions, closure-added resources, and validation notes.</td>
+            <td>
+              The UI needs a way to explain why Lambda, KMS, or dependency
+              resources were adjusted without treating every case as bespoke
+              enrichment logic.
+            </td>
+          </tr>
+          <tr>
+            <td><code>ArtifactSet</code></td>
+            <td>Describe output paths, names, and optional checksums for <code>imported.json</code>, <code>imported.tf</code>, <code>tfplan.json</code>, and debug files.</td>
+            <td>
+              Mars can upload artifacts consistently while the SDK remains
+              testable with local file paths.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Model Position</h2>
+      <div class="grid">
+        <article class="card">
+          <h3>Existing model fits</h3>
+          <p>
+            <code>ImportedResource</code> and <code>ResourceIdentity</code> are the right
+            durable carriers. The missing piece is not a new persistence model;
+            it is an SDK request/result envelope, exported plan import counts,
+            and the projection from Terraform readback into typed <code>Attrs</code>.
+          </p>
+        </article>
+        <article class="card warning">
+          <h3>Deprecate opaque attributes</h3>
+          <p>
+            <code>Attributes</code> is a legacy Phase 1 compatibility field. New reverse
+            import output should write <code>Attrs</code>. When both are present,
+            <code>Attrs</code> is authoritative.
+          </p>
+        </article>
+        <article class="card">
+          <h3>SDK boundary</h3>
+          <p>
+            Runtime implementation belongs in presets. Mars imports it and
+            proxies job IO. Reliable imports only shared request/result models
+            or parsers, not Terraform execution code.
+          </p>
+        </article>
+        <article class="card">
+          <h3>CLI boundary</h3>
+          <p>
+            <code>cmd/insideout-import</code> should become a human/operator adapter
+            over the same SDK. It should not keep private result types that the
+            Mars job needs, such as the number of imported resources.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section>
+      <h2>Required Work</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Area</th>
+            <th>Work</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Presets SDK models</td>
+            <td>Add exported request/result types, including <code>PlanSummary.ImportCount</code>, artifact metadata, diagnostics, and per-resource results.</td>
+          </tr>
+          <tr>
+            <td>Presets SDK engine</td>
+            <td>Move reusable reverse-import execution out of <code>cmd/insideout-import</code> into an importable package that runs Terraform, projects typed IR, emits HCL, and validates the final plan.</td>
+          </tr>
+          <tr>
+            <td>Dependency closure</td>
+            <td>Expand user-selected parents into required child, sidecar, and hard dependency resources before final HCL generation.</td>
+          </tr>
+          <tr>
+            <td>Presets composer</td>
+            <td>Guarantee <code>imported.json -> EmitImportedTF -> imported.tf</code> is stable and validates with the final plan.</td>
+          </tr>
+          <tr>
+            <td>Presets CLI</td>
+            <td>Keep <code>insideout-import</code> as a thin wrapper over the SDK. Its discover path should exercise the same logic Mars calls for Reliable, so local debugging is representative.</td>
+          </tr>
+          <tr>
+            <td>Mars</td>
+            <td>Add a Go job binary that imports the presets SDK, replaces bash for this path, and handles job IO, env, credentials, logs, and artifact upload.</td>
+          </tr>
+          <tr>
+            <td>UI Core</td>
+            <td>Add the reverse Terraform job type and artifact collection contract.</td>
+          </tr>
+          <tr>
+            <td>Reliable</td>
+            <td>Start the job, pass selected import identities, ingest <code>reverse-result.json</code>, persist <code>imported.json</code>, and display final plan data.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section>
+      <h2>Invariants</h2>
+      <ul>
+        <li>The final validation plan runs against the regenerated <code>imported.tf</code>, not Terraform's scratch generated config.</li>
+        <li><code>Attrs</code> is the only new canonical desired-state payload; <code>Attributes</code> is compatibility only.</li>
+        <li><code>imported.tf</code> is a review artifact and reproducible output, not the persisted source of truth.</li>
+        <li>Provider-specific edge cases become reverse-import policies or fixups inside presets, not static enrichment in Reliable.</li>
+        <li>Parent-to-child and dependency closure lives in presets; the frontend may display groups but does not own correctness.</li>
+        <li>Mars imports the presets SDK and adapts job IO; it does not re-implement reverse import or depend on CLI-only private types.</li>
+        <li>The local discover CLI calls the same SDK path as Mars, so CLI reproduction is meaningful for Reliable failures.</li>
+        <li>The job may run multiple Terraform commands inside one Argo job, but Reliable sees one reverse job with one result envelope.</li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Implementation Plan</h2>
+      <p>
+        Presets ticket: <code>insideout-terraform-presets#672</code>. This plan is
+        repo-scoped. Mars gets a companion ticket for the Go job binary and
+        image wiring once the SDK contract and engine entry point are ready.
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Order</th>
+            <th>Task</th>
+            <th>Output</th>
+            <th>Validation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1</td>
+            <td>Define the shared job contract.</td>
+            <td>
+              <code>pkg/reverseimport/job</code> exposes <code>Request</code>,
+              <code>ResourceSpec</code>, <code>Result</code>,
+              <code>PlanSummary.ImportCount</code>, artifact metadata,
+              diagnostics, validation issues, and per-resource results.
+            </td>
+            <td>JSON round-trip tests prove import identity and import counts survive the contract.</td>
+          </tr>
+          <tr>
+            <td>2</td>
+            <td>Add parent selection closure in presets.</td>
+            <td>
+              The SDK accepts selected parent resources, expands provider-owned
+              children/sidecars and hard dependencies, and records dependency
+              additions in <code>ResourceResult.Dependencies</code>.
+            </td>
+            <td>Tests prove parent-only inputs add expected children without exposing those children as required UI selections.</td>
+          </tr>
+          <tr>
+            <td>3</td>
+            <td>Extract the runtime SDK engine from CLI-only code.</td>
+            <td>
+              <code>pkg/reverseimport.Run(ctx, job.Request, options)</code>
+              owns Terraform invocation, provider readback, generated-config
+              cleanup, dep chasing, typed IR projection, artifact writing, and
+              final result construction.
+            </td>
+            <td>Unit tests cover options, runner boundaries, result construction, and failure diagnostics without shelling out to real Terraform.</td>
+          </tr>
+          <tr>
+            <td>4</td>
+            <td>Move import-count planning into the SDK contract.</td>
+            <td>
+              The current CLI-private import count path becomes an exported
+              plan summary helper that can parse final plan JSON and populate
+              <code>PlanSummary.ImportCount</code>.
+            </td>
+            <td>Tests cover N import, zero add/change/destroy; unexpected create/update/destroy; and import count mismatch.</td>
+          </tr>
+          <tr>
+            <td>5</td>
+            <td>Make local CLI discover call the SDK.</td>
+            <td>
+              <code>insideout-import discover</code> and the new reverse path
+              exercise the same SDK logic that Mars calls for Reliable.
+            </td>
+            <td>Existing discover tests remain green, and local CLI fixtures use the SDK result contract.</td>
+          </tr>
+          <tr>
+            <td>6</td>
+            <td>Project provider readback into canonical imported IR.</td>
+            <td>
+              The SDK writes typed <code>ImportedResource.Attrs</code>, renders
+              <code>imported.tf</code> through <code>EmitImportedTF</code>, and
+              treats <code>Attributes</code> only as a compatibility fallback.
+            </td>
+            <td>Round-trip tests prove <code>imported.json -> EmitImportedTF -> imported.tf</code> stays stable for representative AWS and GCP resources.</td>
+          </tr>
+          <tr>
+            <td>7</td>
+            <td>Validate regenerated HCL with Terraform.</td>
+            <td>
+              The final plan runs against the regenerated <code>imported.tf</code>
+              and populates <code>reverse-result.json</code>,
+              <code>plan-summary.json</code>, and validation issues.
+            </td>
+            <td><code>ValidateFirstImportPlan</code> passes with N imports and zero unapproved non-import changes.</td>
+          </tr>
+          <tr>
+            <td>8</td>
+            <td>Add live AWS CLI smoke coverage.</td>
+            <td>
+              With operator-provided AWS auth in the Cust2 account, the local
+              CLI can run the same SDK path end to end and preserve artifacts
+              for debugging.
+            </td>
+            <td>Manual/live test produces <code>imported.json</code>, <code>imported.tf</code>, <code>tfplan.json</code>, and clean import summary.</td>
+          </tr>
+          <tr>
+            <td>9</td>
+            <td>Prepare Mars companion ticket.</td>
+            <td>
+              Document the Mars Go binary requirements, SDK import path, job
+              payload, artifact mapping, and Docker image changes.
+            </td>
+            <td>Companion ticket can be executed without re-deciding the presets SDK contract.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </main>
+</body>
+</html>

--- a/pkg/composer/imported/generated/hcl.go
+++ b/pkg/composer/imported/generated/hcl.go
@@ -215,14 +215,9 @@ func writeValueSlice(body *hclwrite.Body, name string, slice reflect.Value) erro
 			}
 			elem = elem.Elem()
 		}
-		state := valueState(elem)
-		if state != StateLiteral {
-			return fmt.Errorf("non-literal list elements not yet supported (field %q index %d)", name, i)
-		}
-		lit := elem.FieldByName("Literal").Elem().Interface()
-		ctyVal, err := goToCty(lit)
+		ctyVal, err := valueToCty(elem)
 		if err != nil {
-			return err
+			return fmt.Errorf("field %q index %d: %w", name, i, err)
 		}
 		vals[i] = ctyVal
 	}
@@ -246,19 +241,119 @@ func writeValueMap(body *hclwrite.Body, name string, m reflect.Value) error {
 			}
 			val = val.Elem()
 		}
-		state := valueState(val)
-		if state != StateLiteral {
-			return fmt.Errorf("non-literal map elements not yet supported (field %q key %q)", name, k)
-		}
-		lit := val.FieldByName("Literal").Elem().Interface()
-		ctyVal, err := goToCty(lit)
+		ctyVal, err := valueToCty(val)
 		if err != nil {
-			return err
+			return fmt.Errorf("field %q key %q: %w", name, k, err)
 		}
 		out[k] = ctyVal
 	}
 	body.SetAttributeValue(name, cty.ObjectVal(out))
 	return nil
+}
+
+func valueToCty(v reflect.Value) (cty.Value, error) {
+	if isValueStruct(v) {
+		state := valueState(v)
+		switch state {
+		case StateLiteral:
+			lit := v.FieldByName("Literal").Elem().Interface()
+			return goToCty(lit)
+		case StateNull:
+			return cty.NullVal(cty.DynamicPseudoType), nil
+		case StateExpr:
+			return cty.NilVal, fmt.Errorf("expression value not yet supported")
+		case StateAbsent:
+			return cty.NilVal, fmt.Errorf("absent value not supported")
+		}
+	}
+	if v.Kind() == reflect.Struct {
+		return structToCty(v)
+	}
+	return cty.NilVal, fmt.Errorf("unsupported value shape %v", v.Kind())
+}
+
+func structToCty(v reflect.Value) (cty.Value, error) {
+	out := map[string]cty.Value{}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		fld := t.Field(i)
+		if !fld.IsExported() {
+			continue
+		}
+		tag, kind := parseTag(fld.Tag.Get("tf"))
+		if tag == "" || kind != tagAttr {
+			continue
+		}
+		val, ok, err := fieldToCty(v.Field(i))
+		if err != nil {
+			return cty.NilVal, fmt.Errorf("field %s: %w", fld.Name, err)
+		}
+		if ok {
+			out[tag] = val
+		}
+	}
+	return cty.ObjectVal(out), nil
+}
+
+func fieldToCty(fv reflect.Value) (cty.Value, bool, error) {
+	switch fv.Kind() {
+	case reflect.Pointer:
+		if fv.IsNil() {
+			return cty.NilVal, false, nil
+		}
+		val, err := valueToCty(fv.Elem())
+		return val, true, err
+	case reflect.Slice:
+		if fv.IsNil() {
+			return cty.NilVal, false, nil
+		}
+		if fv.Len() == 0 {
+			return cty.EmptyTupleVal, true, nil
+		}
+		vals := make([]cty.Value, fv.Len())
+		for i := 0; i < fv.Len(); i++ {
+			elem := fv.Index(i)
+			if elem.Kind() == reflect.Pointer {
+				if elem.IsNil() {
+					vals[i] = cty.NullVal(cty.DynamicPseudoType)
+					continue
+				}
+				elem = elem.Elem()
+			}
+			val, err := valueToCty(elem)
+			if err != nil {
+				return cty.NilVal, false, fmt.Errorf("index %d: %w", i, err)
+			}
+			vals[i] = val
+		}
+		return cty.TupleVal(vals), true, nil
+	case reflect.Map:
+		if fv.IsNil() {
+			return cty.NilVal, false, nil
+		}
+		if fv.Len() == 0 {
+			return cty.EmptyObjectVal, true, nil
+		}
+		if fv.Type().Key().Kind() != reflect.String {
+			return cty.NilVal, false, fmt.Errorf("map key must be string")
+		}
+		out := map[string]cty.Value{}
+		iter := fv.MapRange()
+		for iter.Next() {
+			rawVal := iter.Value()
+			if rawVal.Kind() == reflect.Pointer && rawVal.IsNil() {
+				out[iter.Key().String()] = cty.NullVal(cty.DynamicPseudoType)
+				continue
+			}
+			val, err := valueToCty(derefValue(rawVal))
+			if err != nil {
+				return cty.NilVal, false, fmt.Errorf("key %q: %w", iter.Key().String(), err)
+			}
+			out[iter.Key().String()] = val
+		}
+		return cty.ObjectVal(out), true, nil
+	}
+	return cty.NilVal, false, fmt.Errorf("unsupported field kind %v", fv.Kind())
 }
 
 // valueState reads the Null/Expr/Literal fields of a Value[T] struct via
@@ -459,7 +554,13 @@ func readValueInto(src []byte, expr hcl.Expression, v reflect.Value) error {
 
 func readSliceInto(_ []byte, expr hcl.Expression, fv reflect.Value) error {
 	val, diags := expr.Value(nil)
-	if diags.HasErrors() || !val.CanIterateElements() {
+	if diags.HasErrors() {
+		return fmt.Errorf("expected list-typed value")
+	}
+	if val.IsNull() {
+		return nil
+	}
+	if !val.CanIterateElements() {
 		return fmt.Errorf("expected list-typed value")
 	}
 	elemType := fv.Type().Elem()
@@ -473,7 +574,7 @@ func readSliceInto(_ []byte, expr hcl.Expression, fv reflect.Value) error {
 			ptr2 := reflect.New(elemType.Elem())
 			target = ptr2.Elem()
 		}
-		if err := setLiteralFromCty(target, ev); err != nil {
+		if err := setFromCty(target, ev); err != nil {
 			return err
 		}
 		if elemType.Kind() == reflect.Pointer {
@@ -488,7 +589,13 @@ func readSliceInto(_ []byte, expr hcl.Expression, fv reflect.Value) error {
 
 func readMapInto(_ []byte, expr hcl.Expression, fv reflect.Value) error {
 	val, diags := expr.Value(nil)
-	if diags.HasErrors() || !val.CanIterateElements() {
+	if diags.HasErrors() {
+		return fmt.Errorf("expected map/object-typed value")
+	}
+	if val.IsNull() {
+		return nil
+	}
+	if !val.CanIterateElements() {
 		return fmt.Errorf("expected map/object-typed value")
 	}
 	out := reflect.MakeMapWithSize(fv.Type(), val.LengthInt())
@@ -502,7 +609,7 @@ func readMapInto(_ []byte, expr hcl.Expression, fv reflect.Value) error {
 			ptr2 := reflect.New(elemType.Elem())
 			target = ptr2.Elem()
 		}
-		if err := setLiteralFromCty(target, ev); err != nil {
+		if err := setFromCty(target, ev); err != nil {
 			return err
 		}
 		if elemType.Kind() == reflect.Pointer {
@@ -513,6 +620,16 @@ func readMapInto(_ []byte, expr hcl.Expression, fv reflect.Value) error {
 	}
 	fv.Set(out)
 	return nil
+}
+
+func setFromCty(v reflect.Value, ev cty.Value) error {
+	if isValueStruct(v) {
+		return setLiteralFromCty(v, ev)
+	}
+	if v.Kind() == reflect.Struct {
+		return setStructFromCty(v, ev)
+	}
+	return fmt.Errorf("unsupported cty target shape %v", v.Kind())
 }
 
 // setLiteralFromCty sets the Literal field of a Value[T] from a cty.Value.
@@ -531,6 +648,130 @@ func setLiteralFromCty(v reflect.Value, ev cty.Value) error {
 	ptr.Elem().Set(reflect.ValueOf(gv).Convert(litType))
 	litField.Set(ptr)
 	return nil
+}
+
+func setStructFromCty(v reflect.Value, ev cty.Value) error {
+	if ev.IsNull() {
+		return nil
+	}
+	if !ev.IsKnown() {
+		return fmt.Errorf("unknown object value")
+	}
+	if !ev.CanIterateElements() {
+		return fmt.Errorf("expected object-typed value")
+	}
+	fields := attrFieldIndexes(v.Type())
+	it := ev.ElementIterator()
+	for it.Next() {
+		key, val := it.Element()
+		idx, ok := fields[key.AsString()]
+		if !ok {
+			continue
+		}
+		if err := setFieldFromCty(v.Field(idx), val); err != nil {
+			return fmt.Errorf("field %q: %w", key.AsString(), err)
+		}
+	}
+	return nil
+}
+
+func setFieldFromCty(fv reflect.Value, val cty.Value) error {
+	switch fv.Kind() {
+	case reflect.Pointer:
+		if fv.IsNil() {
+			fv.Set(reflect.New(fv.Type().Elem()))
+		}
+		return setFromCty(fv.Elem(), val)
+	case reflect.Slice:
+		if val.IsNull() {
+			return nil
+		}
+		if !val.CanIterateElements() {
+			return fmt.Errorf("expected list-typed value")
+		}
+		elemType := fv.Type().Elem()
+		out := reflect.MakeSlice(fv.Type(), 0, val.LengthInt())
+		it := val.ElementIterator()
+		for it.Next() {
+			_, ev := it.Element()
+			target := reflect.New(elemType).Elem()
+			if elemType.Kind() == reflect.Pointer {
+				target = reflect.New(elemType.Elem()).Elem()
+			}
+			if err := setFromCty(target, ev); err != nil {
+				return err
+			}
+			if elemType.Kind() == reflect.Pointer {
+				out = reflect.Append(out, target.Addr())
+			} else {
+				out = reflect.Append(out, target)
+			}
+		}
+		fv.Set(out)
+		return nil
+	case reflect.Map:
+		if val.IsNull() {
+			return nil
+		}
+		if !val.CanIterateElements() {
+			return fmt.Errorf("expected map/object-typed value")
+		}
+		if fv.Type().Key().Kind() != reflect.String {
+			return fmt.Errorf("map key must be string")
+		}
+		out := reflect.MakeMapWithSize(fv.Type(), val.LengthInt())
+		elemType := fv.Type().Elem()
+		it := val.ElementIterator()
+		for it.Next() {
+			key, ev := it.Element()
+			target := reflect.New(elemType).Elem()
+			if elemType.Kind() == reflect.Pointer {
+				target = reflect.New(elemType.Elem()).Elem()
+			}
+			if err := setFromCty(target, ev); err != nil {
+				return err
+			}
+			if elemType.Kind() == reflect.Pointer {
+				out.SetMapIndex(reflect.ValueOf(key.AsString()), target.Addr())
+			} else {
+				out.SetMapIndex(reflect.ValueOf(key.AsString()), target)
+			}
+		}
+		fv.Set(out)
+		return nil
+	}
+	return fmt.Errorf("unsupported field kind %v", fv.Kind())
+}
+
+func attrFieldIndexes(t reflect.Type) map[string]int {
+	out := map[string]int{}
+	for i := 0; i < t.NumField(); i++ {
+		fld := t.Field(i)
+		if !fld.IsExported() {
+			continue
+		}
+		tag, kind := parseTag(fld.Tag.Get("tf"))
+		if tag != "" && kind == tagAttr {
+			out[tag] = i
+		}
+	}
+	return out
+}
+
+func isValueStruct(v reflect.Value) bool {
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+	return v.FieldByName("Literal").IsValid() &&
+		v.FieldByName("Expr").IsValid() &&
+		v.FieldByName("Null").IsValid()
+}
+
+func derefValue(v reflect.Value) reflect.Value {
+	if v.Kind() == reflect.Pointer && !v.IsNil() {
+		return v.Elem()
+	}
+	return v
 }
 
 // ctyToGo converts a cty.Value to the Go type T expected by the generated

--- a/pkg/composer/imported/generated/hcl_test.go
+++ b/pkg/composer/imported/generated/hcl_test.go
@@ -18,6 +18,8 @@ type hclTestQueue struct {
 	FifoQueue                *Value[bool]              `tf:"fifo_queue"`
 	VisibilityTimeoutSeconds *Value[int64]             `tf:"visibility_timeout_seconds"`
 	KMSMasterKeyID           *Value[string]            `tf:"kms_master_key_id"`
+	ReplacementIDs           []*Value[string]          `tf:"replacement_ids"`
+	ObjectAttrs              []hclTestObjectAttr       `tf:"object_attrs"`
 	Tags                     map[string]*Value[string] `tf:"tags"`
 	RedrivePolicy            *Value[string]            `tf:"redrive_policy"`
 }
@@ -35,6 +37,12 @@ type hclTestVersioning struct {
 type hclTestLifecycle struct {
 	ID      *Value[string] `tf:"id"`
 	Enabled *Value[bool]   `tf:"enabled"`
+}
+
+type hclTestObjectAttr struct {
+	Name    *Value[string]   `tf:"name"`
+	Enabled *Value[bool]     `tf:"enabled"`
+	IDs     []*Value[string] `tf:"ids"`
 }
 
 func TestUnmarshalHCL_Scalars(t *testing.T) {
@@ -118,6 +126,35 @@ redrive_policy             = null
 	assert.Equal(t, q, q2)
 }
 
+func TestRoundTrip_HCL_ListObjectAttribute(t *testing.T) {
+	t.Parallel()
+	src := []byte(`name = "orders-DLQ"
+object_attrs = [{
+  enabled = true
+  ids     = []
+  name    = null
+}]
+`)
+	var q hclTestQueue
+	require.NoError(t, parseAndUnmarshal(t, src, &q))
+	require.Len(t, q.ObjectAttrs, 1)
+	require.NotNil(t, q.ObjectAttrs[0].Name)
+	assert.True(t, q.ObjectAttrs[0].Name.Null)
+	require.NotNil(t, q.ObjectAttrs[0].Enabled)
+	require.NotNil(t, q.ObjectAttrs[0].Enabled.Literal)
+	assert.True(t, *q.ObjectAttrs[0].Enabled.Literal)
+	assert.NotNil(t, q.ObjectAttrs[0].IDs)
+	assert.Empty(t, q.ObjectAttrs[0].IDs)
+
+	out, err := MarshalHCL(&q)
+	require.NoError(t, err)
+	assert.Regexp(t, `(?m)^\s*ids\s*=\s*\[\]`, string(out))
+	assert.Regexp(t, `(?m)^\s*name\s*=\s*null`, string(out))
+	var q2 hclTestQueue
+	require.NoError(t, parseAndUnmarshal(t, out, &q2))
+	assert.Equal(t, q, q2)
+}
+
 func TestUnmarshalHCL_NestedBlocks(t *testing.T) {
 	t.Parallel()
 	src := []byte(`
@@ -196,6 +233,22 @@ future_block {
 	require.NotNil(t, q.Name)
 	require.NotNil(t, q.Name.Literal)
 	assert.Equal(t, "orders-DLQ", *q.Name.Literal)
+}
+
+func TestUnmarshalHCL_NullCollectionsLeaveZeroValue(t *testing.T) {
+	t.Parallel()
+	src := []byte(`
+name            = "orders-DLQ"
+replacement_ids = null
+tags            = null
+`)
+	var q hclTestQueue
+	require.NoError(t, parseAndUnmarshal(t, src, &q))
+	require.NotNil(t, q.Name)
+	require.NotNil(t, q.Name.Literal)
+	assert.Equal(t, "orders-DLQ", *q.Name.Literal)
+	assert.Nil(t, q.ReplacementIDs)
+	assert.Nil(t, q.Tags)
 }
 
 // TestMarshalHCLConfigurable_SkipsComputedOnly pins #669: when a schema is

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -7,10 +7,10 @@ import (
 
 // Note on Attrs vs Attributes: ImportedResource carries two attribute
 // representations to support a phased migration to the typed Layer 1 model.
-// Attributes is the Phase 1 opaque map; Attrs holds the typed shape decoded
-// from a generated struct (see pkg/composer/imported/generated). Storing
-// Attrs as json.RawMessage keeps this package free of any dependency on the
-// generated package and avoids future import cycles. Decoding goes through
+// Attrs is the canonical desired-state payload for new reverse-import code.
+// Attributes is the deprecated Phase 1 opaque map fallback. Storing Attrs as
+// json.RawMessage keeps this package free of any dependency on the generated
+// package and avoids future import cycles. Decoding goes through
 // generated.UnmarshalAttrs(id.Type, ir.Attrs).
 
 // ImportedResource is the IR carrier for one cloud resource that lives outside
@@ -18,11 +18,9 @@ import (
 // observed by the inspector. It rides alongside composer.Components in the
 // stack snapshot. See docs/managed-resource-tiers.md lines 477-500.
 //
-// Phase 2 stores desired provider attributes in the opaque Attributes bag for
-// wire-compatibility with the Phase 1 importer. A future ticket (#145) will
-// add a sibling typed Attrs field backed by per-resource-type generated
-// structs; the JSON key for that typed shape will differ from "attributes"
-// so both can coexist.
+// Reverse import should write desired provider state into Attrs. Attributes
+// remains only for wire-compatibility with the Phase 1 importer and consumers
+// that have not adopted the typed shape yet.
 type ImportedResource struct {
 	// Identity carries the immutable Terraform address and cloud-side
 	// correlation identifiers.
@@ -35,11 +33,12 @@ type ImportedResource struct {
 	// | inspector).
 	Source Source `json:"source,omitempty"`
 
-	// Attributes is the current desired provider attributes as an opaque
-	// bag (Phase 1 / wire-compatible shape). The composer emits HCL from
-	// this state. Interactive-agent chat edits update the values here
-	// through the model write path; FieldEdits records audit/conflict
-	// metadata only — the composer does not emit from FieldEdits.
+	// Attributes is the legacy desired provider attributes as an opaque
+	// bag (Phase 1 / wire-compatible shape).
+	//
+	// Deprecated: Use Attrs as the canonical desired-state payload.
+	// Attributes is retained only as a legacy fallback for consumers that
+	// have not adopted typed Attrs.
 	Attributes map[string]any `json:"attributes,omitempty"`
 
 	// FieldEdits is audit/conflict metadata for changes made via the model

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -257,6 +257,7 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 		}
 		ensureLambdaPlaceholderSource(typed)
 		ensureKeyPairPlaceholder(typed)
+		ensureSecurityGroupRuleLists(typed)
 		// Pass the registered schema so computed-only attributes are
 		// dropped. Lookup returns a nil schema for unregistered types,
 		// which makes MarshalHCLConfigurable byte-identical to MarshalHCL.
@@ -268,6 +269,43 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 		return body, nil
 	}
 	return emitOpaqueAttrsBody(ir)
+}
+
+func ensureSecurityGroupRuleLists(typed any) {
+	sg, ok := typed.(*generated.AWSSecurityGroup)
+	if !ok {
+		return
+	}
+	for i := range sg.Egress {
+		ensureSecurityGroupEgressRuleLists(&sg.Egress[i])
+	}
+	for i := range sg.Ingress {
+		ensureSecurityGroupIngressRuleLists(&sg.Ingress[i])
+	}
+}
+
+func ensureSecurityGroupEgressRuleLists(rule *generated.AWSSecurityGroupEgress) {
+	if rule.IPV6CIDRBlocks == nil {
+		rule.IPV6CIDRBlocks = []*generated.Value[string]{}
+	}
+	if rule.PrefixListIDS == nil {
+		rule.PrefixListIDS = []*generated.Value[string]{}
+	}
+	if rule.SecurityGroups == nil {
+		rule.SecurityGroups = []*generated.Value[string]{}
+	}
+}
+
+func ensureSecurityGroupIngressRuleLists(rule *generated.AWSSecurityGroupIngress) {
+	if rule.IPV6CIDRBlocks == nil {
+		rule.IPV6CIDRBlocks = []*generated.Value[string]{}
+	}
+	if rule.PrefixListIDS == nil {
+		rule.PrefixListIDS = []*generated.Value[string]{}
+	}
+	if rule.SecurityGroups == nil {
+		rule.SecurityGroups = []*generated.Value[string]{}
+	}
 }
 
 // stripResourceIDAttr removes the top-level `id` key from a typed-Attrs
@@ -382,6 +420,12 @@ var importedLifecycleIgnoreChanges = map[string][]string{
 	// ignore_changes keeps the placeholder from force-replacing the
 	// live key pair. See ensureKeyPairPlaceholder and #665.
 	"aws_key_pair": imported.KeyPairPublicKeyAttr,
+	// aws_secretsmanager_secret: the provider plans schema defaults for
+	// these write-only/default-rich arguments even when AWS reads them
+	// back as null, producing a spurious post-import update. Terraform's
+	// generate-config path pins them; the IR emitter must preserve that
+	// adoption behavior because lifecycle blocks are not stored in Attrs.
+	"aws_secretsmanager_secret": {"force_overwrite_replica_secret", "recovery_window_in_days"},
 }
 
 // appendImportedLifecycle appends a `lifecycle { ignore_changes = [...] }`

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -24,6 +24,35 @@ func hasAttr(t *testing.T, body, name, value string) bool {
 	return pattern.MatchString(body)
 }
 
+func lifecycleIgnoreChanges(t *testing.T, out []byte, tfType string) []string {
+	t.Helper()
+	file, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), out)
+	for _, blk := range file.Body.(*hclsyntax.Body).Blocks {
+		if blk.Type != "resource" || len(blk.Labels) != 2 || blk.Labels[0] != tfType {
+			continue
+		}
+		for _, sub := range blk.Body.Blocks {
+			if sub.Type != "lifecycle" {
+				continue
+			}
+			ic := sub.Body.Attributes["ignore_changes"]
+			require.NotNil(t, ic, "lifecycle must set ignore_changes")
+			tuple, ok := ic.Expr.(*hclsyntax.TupleConsExpr)
+			require.True(t, ok, "ignore_changes must be a list")
+			got := make([]string, 0, len(tuple.Exprs))
+			for _, e := range tuple.Exprs {
+				trav, isTrav := e.(*hclsyntax.ScopeTraversalExpr)
+				require.Truef(t, isTrav, "ignore_changes entry must be an attribute reference, got %T", e)
+				got = append(got, trav.Traversal.RootName())
+			}
+			return got
+		}
+	}
+	require.Failf(t, "missing lifecycle block", "%s must emit lifecycle.ignore_changes:\n%s", tfType, out)
+	return nil
+}
+
 func TestEmitImportedTF_Empty(t *testing.T) {
 	t.Parallel()
 	out, used := EmitImportedTF("aws", nil, EmitImportedOpts{})
@@ -222,6 +251,66 @@ func TestEmitImportedTF_LambdaTypedAttrsInjectsPlaceholderFilename(t *testing.T)
 	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
 	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
 	assert.Contains(t, s, "ignore_changes", "placeholder filename must still be pinned under ignore_changes")
+}
+
+func TestEmitImportedTF_SecurityGroupTypedAttrsRestoresEmptyRuleLists(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSSecurityGroup{
+		Name:  generated.LiteralOf("web"),
+		VPCID: generated.LiteralOf("vpc-123"),
+		Ingress: []generated.AWSSecurityGroupIngress{{
+			CIDRBlocks:  []*generated.Value[string]{generated.LiteralOf("0.0.0.0/0")},
+			Description: generated.LiteralOf("http"),
+			FromPort:    generated.LiteralOf[float64](80),
+			Protocol:    generated.LiteralOf("tcp"),
+			Self:        generated.LiteralOf(false),
+			ToPort:      generated.LiteralOf[float64](80),
+		}},
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_security_group",
+			Address:  "aws_security_group.web",
+			ImportID: "sg-123",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	for _, want := range []string{"ipv6_cidr_blocks", "prefix_list_ids", "security_groups"} {
+		assert.Regexpf(t, regexp.MustCompile(`(?m)^\s*`+want+`\s*=\s*\[\]`), s,
+			"security group rule must restore required empty list %s:\n%s", want, s)
+	}
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
+}
+
+func TestEmitImportedTF_SecretsManagerPinsProviderDefaultDrift(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSSecretsmanagerSecret{
+		Name:   generated.LiteralOf("app-secret"),
+		Region: generated.LiteralOf("eu-west-2"),
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_secretsmanager_secret",
+			Address:  "aws_secretsmanager_secret.app",
+			ImportID: "arn:aws:secretsmanager:eu-west-2:123456789012:secret:app-secret-AbCdEf",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	got := lifecycleIgnoreChanges(t, out, "aws_secretsmanager_secret")
+	assert.Equal(t, []string{"force_overwrite_replica_secret", "recovery_window_in_days"}, got,
+		"Secrets Manager imported resources must pin provider default drift")
 }
 
 // TestEmitImportedTF_KeyPairInjectsPlaceholderPublicKey pins the #665

--- a/pkg/reverseimport/artifacts.go
+++ b/pkg/reverseimport/artifacts.go
@@ -1,0 +1,92 @@
+package reverseimport
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+const (
+	importedJSONFile    = "imported.json"
+	importedTFFile      = "imported.tf"
+	importedProvidersTF = "providers-imported.tf"
+	validateJSONFile    = "validate.json"
+	tfplanJSONFile      = "tfplan.json"
+	tfplanFile          = "tfplan.bin"
+	planSummaryJSONFile = "plan-summary.json"
+	reverseResultFile   = "reverse-result.json"
+	graphJSONFile       = "graph.json"
+)
+
+func writeJSON(path string, v any) error {
+	body, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", filepath.Base(path), err)
+	}
+	body = append(body, '\n')
+	return writeFileAtomic(path, body, 0o644)
+}
+
+func writeFileAtomic(path string, body []byte, perm os.FileMode) (rerr error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return fmt.Errorf("open temp %s: %w", tmp, err)
+	}
+	defer func() {
+		if rerr != nil {
+			_ = os.Remove(tmp)
+		}
+	}()
+	if _, err := f.Write(body); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write temp %s: %w", tmp, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("fsync temp %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close temp %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("rename %s -> %s: %w", tmp, path, err)
+	}
+	return nil
+}
+
+func artifact(path, mediaType string) (*job.Artifact, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(body)
+	return &job.Artifact{
+		Name:      filepath.Base(path),
+		Path:      path,
+		MediaType: mediaType,
+		SHA256:    hex.EncodeToString(sum[:]),
+		SizeBytes: info.Size(),
+	}, nil
+}
+
+func addArtifact(ptr **job.Artifact, path, mediaType string) error {
+	a, err := artifact(path, mediaType)
+	if err != nil {
+		return err
+	}
+	*ptr = a
+	return nil
+}

--- a/pkg/reverseimport/closure.go
+++ b/pkg/reverseimport/closure.go
@@ -1,0 +1,271 @@
+package reverseimport
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/labels"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+type selectionClosureResult struct {
+	resources    []imported.ImportedResource
+	dependencies map[string][]imported.ResourceIdentity
+	diagnostics  []job.Diagnostic
+}
+
+type selectionClosureInput struct {
+	resources    []imported.ImportedResource
+	opts         Options
+	cloud        string
+	region       string
+	gcpProjectID string
+}
+
+type mergeClosureInput struct {
+	current         []imported.ImportedResource
+	selectedParents []imported.ImportedResource
+	parentTypes     []string
+	childTypes      []string
+	discovered      []imported.ImportedResource
+}
+
+func expandSelectionClosure(ctx context.Context, in selectionClosureInput) (selectionClosureResult, error) {
+	out := selectionClosureResult{
+		resources:    in.resources,
+		dependencies: map[string][]imported.ResourceIdentity{},
+	}
+	parents, parentTypes := selectedParentResources(in.resources)
+	if len(parents) == 0 {
+		return out, nil
+	}
+	childTypes := childTypesForParents(parentTypes)
+	if len(childTypes) == 0 {
+		return out, nil
+	}
+
+	discoverer := in.opts.ClosureDiscoverer
+	if discoverer == nil {
+		if d, ok := in.opts.Discoverer.(ClosureDiscoverer); ok {
+			discoverer = d
+		}
+	}
+	if discoverer == nil {
+		out.diagnostics = append(out.diagnostics, job.Diagnostic{
+			Severity: "warning",
+			Code:     "selection_closure_unavailable",
+			Message:  "selected parent resources have registered child resources, but no closure discoverer was configured",
+		})
+		return out, nil
+	}
+
+	regions := append([]string(nil), in.opts.DiscoverRegions...)
+	if len(regions) == 0 && strings.TrimSpace(in.region) != "" {
+		regions = []string{in.region}
+	}
+	found, err := discoverer.DiscoverClosure(ctx, ClosureRequest{
+		Cloud:           in.cloud,
+		Project:         in.opts.DiscoverProject,
+		Regions:         regions,
+		AccountID:       firstNonEmpty(in.opts.AccountID, firstResourceField(in.resources, func(id imported.ResourceIdentity) string { return id.AccountID })),
+		GCPProjectID:    firstNonEmpty(in.gcpProjectID, firstResourceField(in.resources, func(id imported.ResourceIdentity) string { return id.ProjectID })),
+		ParentResources: parents,
+		ParentTypes:     parentTypes,
+		ChildTypes:      childTypes,
+	})
+	if err != nil {
+		return out, fmt.Errorf("selection closure: %w", err)
+	}
+	merged, deps, diags := mergeClosureResources(mergeClosureInput{
+		current:         in.resources,
+		selectedParents: parents,
+		parentTypes:     parentTypes,
+		childTypes:      childTypes,
+		discovered:      found,
+	})
+	out.resources = merged
+	out.dependencies = deps
+	out.diagnostics = append(out.diagnostics, diags...)
+	return out, nil
+}
+
+func selectedParentResources(resources []imported.ImportedResource) ([]imported.ImportedResource, []string) {
+	childrenByParent := parentToChildTypes()
+	parentSet := map[string]struct{}{}
+	parents := make([]imported.ImportedResource, 0)
+	for _, r := range resources {
+		if _, ok := childrenByParent[r.Identity.Type]; !ok {
+			continue
+		}
+		parents = append(parents, r)
+		parentSet[r.Identity.Type] = struct{}{}
+	}
+	parentTypes := sortedKeys(parentSet)
+	return parents, parentTypes
+}
+
+func childTypesForParents(parentTypes []string) []string {
+	childrenByParent := parentToChildTypes()
+	childSet := map[string]struct{}{}
+	for _, parentType := range parentTypes {
+		for _, childType := range childrenByParent[parentType] {
+			childSet[childType] = struct{}{}
+		}
+	}
+	return sortedKeys(childSet)
+}
+
+func parentToChildTypes() map[string][]string {
+	out := map[string][]string{}
+	for _, childType := range labels.ChildTfTypes() {
+		parentType, ok := labels.ParentTfType(childType)
+		if !ok {
+			continue
+		}
+		out[parentType] = append(out[parentType], childType)
+	}
+	for parentType := range out {
+		sort.Strings(out[parentType])
+	}
+	return out
+}
+
+func mergeClosureResources(in mergeClosureInput) ([]imported.ImportedResource, map[string][]imported.ResourceIdentity, []job.Diagnostic) {
+	parentTypeSet := setOf(in.parentTypes)
+	childTypeSet := setOf(in.childTypes)
+	selectedByAddr := map[string]imported.ImportedResource{}
+	for _, parent := range in.selectedParents {
+		if strings.TrimSpace(parent.Identity.Address) == "" {
+			continue
+		}
+		selectedByAddr[parent.Identity.Address] = parent
+	}
+
+	discoveredParentToSelected := map[string]string{}
+	for _, parent := range in.selectedParents {
+		if strings.TrimSpace(parent.Identity.Address) != "" {
+			discoveredParentToSelected[parent.Identity.Address] = parent.Identity.Address
+		}
+	}
+	for _, r := range in.discovered {
+		if _, ok := parentTypeSet[r.Identity.Type]; !ok {
+			continue
+		}
+		selected, ok := matchSelectedParent(r, in.selectedParents)
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(r.Identity.Address) != "" && strings.TrimSpace(selected.Identity.Address) != "" {
+			discoveredParentToSelected[r.Identity.Address] = selected.Identity.Address
+		}
+	}
+
+	existing := map[string]struct{}{}
+	for _, r := range in.current {
+		existing[resourceKey(r.Identity)] = struct{}{}
+	}
+	merged := append([]imported.ImportedResource(nil), in.current...)
+	deps := map[string][]imported.ResourceIdentity{}
+	var diagnostics []job.Diagnostic
+
+	for _, r := range in.discovered {
+		if _, ok := childTypeSet[r.Identity.Type]; !ok {
+			continue
+		}
+		parentAddr := strings.TrimSpace(r.Identity.ParentAddress)
+		selectedParentAddr, ok := discoveredParentToSelected[parentAddr]
+		if !ok {
+			if _, selected := selectedByAddr[parentAddr]; selected {
+				selectedParentAddr = parentAddr
+				ok = true
+			}
+		}
+		if !ok || selectedParentAddr == "" {
+			continue
+		}
+		if _, ok := existing[resourceKey(r.Identity)]; ok {
+			continue
+		}
+		r.Identity.ParentAddress = selectedParentAddr
+		existing[resourceKey(r.Identity)] = struct{}{}
+		merged = append(merged, r)
+		deps[selectedParentAddr] = append(deps[selectedParentAddr], r.Identity)
+		diagnostics = append(diagnostics, job.Diagnostic{
+			Severity: "info",
+			Code:     "selection_closure_added",
+			Field:    r.Identity.Address,
+			Message:  fmt.Sprintf("selected parent %s pulled in %s", selectedParentAddr, r.Identity.Address),
+		})
+	}
+	return merged, deps, diagnostics
+}
+
+func matchSelectedParent(candidate imported.ImportedResource, selected []imported.ImportedResource) (imported.ImportedResource, bool) {
+	for _, parent := range selected {
+		if !sameOptional(candidate.Identity.Cloud, parent.Identity.Cloud) || candidate.Identity.Type != parent.Identity.Type {
+			continue
+		}
+		if sameNonEmpty(candidate.Identity.Address, parent.Identity.Address) ||
+			sameNonEmpty(candidate.Identity.ImportID, parent.Identity.ImportID) ||
+			nativeIDsOverlap(candidate.Identity.NativeIDs, parent.Identity.NativeIDs) {
+			return parent, true
+		}
+	}
+	return imported.ImportedResource{}, false
+}
+
+func resourceKey(id imported.ResourceIdentity) string {
+	parts := []string{
+		strings.TrimSpace(id.Cloud),
+		strings.TrimSpace(id.Type),
+		strings.TrimSpace(id.ImportID),
+		strings.TrimSpace(id.Region),
+		strings.TrimSpace(id.AccountID),
+		strings.TrimSpace(id.ProjectID),
+	}
+	if parts[2] == "" {
+		parts[2] = strings.TrimSpace(id.Address)
+	}
+	return strings.Join(parts, "\x00")
+}
+
+func sameOptional(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	return a == "" || b == "" || a == b
+}
+
+func sameNonEmpty(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	return a != "" && a == b
+}
+
+func nativeIDsOverlap(a, b map[string]string) bool {
+	for k, av := range a {
+		if sameNonEmpty(av, b[k]) {
+			return true
+		}
+	}
+	return false
+}
+
+func sortedKeys(in map[string]struct{}) []string {
+	out := make([]string, 0, len(in))
+	for k := range in {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func setOf(in []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(in))
+	for _, v := range in {
+		out[v] = struct{}{}
+	}
+	return out
+}

--- a/pkg/reverseimport/job/io.go
+++ b/pkg/reverseimport/job/io.go
@@ -1,0 +1,72 @@
+package job
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// DecodeRequest reads a reverse-import request from r.
+//
+// The preferred shape is Request. For local CLI troubleshooting, this also
+// accepts the historical imported.json shape ([]ImportedResource) and converts
+// it into a Request using each resource's identity/tier/source.
+func DecodeRequest(r io.Reader) (Request, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return Request{}, err
+	}
+	if bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return Request{}, fmt.Errorf("reverse import request cannot be null")
+	}
+
+	var req Request
+	if err := json.Unmarshal(raw, &req); err == nil && (req.Version != 0 || len(req.Resources) > 0) {
+		if req.Version == 0 {
+			req.Version = Version
+		}
+		return req, nil
+	}
+
+	var resources []imported.ImportedResource
+	if err := json.Unmarshal(raw, &resources); err != nil {
+		return Request{}, fmt.Errorf("decode reverse import request: %w", err)
+	}
+	req = Request{
+		Version:   Version,
+		Resources: make([]ResourceSpec, 0, len(resources)),
+	}
+	for _, r := range resources {
+		req.Resources = append(req.Resources, ResourceSpec{
+			Identity: r.Identity,
+			Tier:     r.Tier,
+			Source:   r.Source,
+		})
+	}
+	return req, nil
+}
+
+// ImportedResources returns the request resources as ImportedResource carriers,
+// filling in the default reverse-import tier/source when omitted.
+func (r Request) ImportedResources() []imported.ImportedResource {
+	out := make([]imported.ImportedResource, 0, len(r.Resources))
+	for _, spec := range r.Resources {
+		tier := spec.Tier
+		if tier == "" {
+			tier = imported.TierImportedFlat
+		}
+		source := spec.Source
+		if source == "" {
+			source = imported.SourceImporter
+		}
+		out = append(out, imported.ImportedResource{
+			Identity: spec.Identity,
+			Tier:     tier,
+			Source:   source,
+		})
+	}
+	return out
+}

--- a/pkg/reverseimport/job/plan.go
+++ b/pkg/reverseimport/job/plan.go
@@ -1,0 +1,72 @@
+package job
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+var planSummaryRE = regexp.MustCompile(`Plan:\s+(\d+)\s+to import,\s+(\d+)\s+to add,\s+(\d+)\s+to change,\s+(\d+)\s+to destroy\.`)
+
+// DecodeTerraformPlan decodes Terraform's `terraform show -json` plan output.
+func DecodeTerraformPlan(r io.Reader) (*tfjson.Plan, error) {
+	var plan tfjson.Plan
+	if err := json.NewDecoder(r).Decode(&plan); err != nil {
+		return nil, fmt.Errorf("decode terraform plan JSON: %w", err)
+	}
+	return &plan, nil
+}
+
+// PlanSummaryFromTerraformPlan builds the small exported count surface from a
+// Terraform plan.
+func PlanSummaryFromTerraformPlan(plan *tfjson.Plan) PlanSummary {
+	var summary PlanSummary
+	if plan == nil {
+		return summary
+	}
+	for _, rc := range append(plan.ResourceChanges, plan.ResourceDrift...) {
+		if rc == nil || rc.Change == nil {
+			continue
+		}
+		if rc.Change.Importing != nil {
+			summary.ImportCount++
+		}
+		actions := rc.Change.Actions
+		switch {
+		case actions.Replace():
+			summary.ReplaceCount++
+		case actions.Create():
+			summary.AddCount++
+		case actions.Update():
+			summary.ChangeCount++
+		case actions.Delete():
+			summary.DestroyCount++
+		case actions.Read():
+			summary.ReadCount++
+		}
+	}
+	return summary
+}
+
+// PlanSummaryFromText parses Terraform's human-readable summary line as a
+// fallback when plan JSON is unavailable.
+func PlanSummaryFromText(out string) (PlanSummary, bool) {
+	m := planSummaryRE.FindStringSubmatch(out)
+	if m == nil {
+		return PlanSummary{}, false
+	}
+	nImport, _ := strconv.Atoi(m[1])
+	nAdd, _ := strconv.Atoi(m[2])
+	nChange, _ := strconv.Atoi(m[3])
+	nDestroy, _ := strconv.Atoi(m[4])
+	return PlanSummary{
+		ImportCount:  nImport,
+		AddCount:     nAdd,
+		ChangeCount:  nChange,
+		DestroyCount: nDestroy,
+	}, true
+}

--- a/pkg/reverseimport/job/types.go
+++ b/pkg/reverseimport/job/types.go
@@ -1,0 +1,142 @@
+// Package job defines the pure reverse-import job contract shared by
+// presets, Mars, UI Core, and Reliable.
+//
+// Keep this package free of Terraform execution behavior. The runtime engine
+// belongs in pkg/reverseimport; this package is the stable JSON surface that
+// adapters can pass around without depending on CLI-private structs.
+package job
+
+import "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+
+// Version is the current reverse-import job contract version.
+const Version = 1
+
+// Request is the JSON payload Reliable sends to a reverse-import job.
+//
+// It contains selected resource identities, not just ARNs. Terraform import
+// IDs vary by resource type, and the reverse-import engine needs stable
+// Terraform addresses plus cloud scope to render import blocks and bind the
+// returned IR.
+type Request struct {
+	Version   int            `json:"version"`
+	Resources []ResourceSpec `json:"resources"`
+}
+
+// ResourceSpec is one selected cloud resource that should be reverse-imported.
+type ResourceSpec struct {
+	Identity imported.ResourceIdentity `json:"identity"`
+	Tier     imported.Tier             `json:"tier,omitempty"`
+	Source   imported.Source           `json:"source,omitempty"`
+}
+
+// Status is the lifecycle status of a reverse-import job result.
+type Status string
+
+const (
+	StatusSucceeded Status = "succeeded"
+	StatusFailed    Status = "failed"
+	StatusPartial   Status = "partial"
+)
+
+// Result is the structured output returned by the reverse-import job.
+type Result struct {
+	Version          int                         `json:"version"`
+	Status           Status                      `json:"status"`
+	Imported         []imported.ImportedResource `json:"imported,omitempty"`
+	PlanSummary      PlanSummary                 `json:"plan_summary"`
+	Artifacts        ArtifactSet                 `json:"artifacts,omitempty"`
+	Resources        []ResourceResult            `json:"resources,omitempty"`
+	Diagnostics      []Diagnostic                `json:"diagnostics,omitempty"`
+	ValidationIssues []Issue                     `json:"validation_issues,omitempty"`
+}
+
+// PlanSummary is the small plan-count surface Reliable and UI Core need for
+// import UX and validation.
+//
+// ImportCount is intentionally exported. The current CLI can compute this
+// internally, but Mars and Reliable need it in the SDK result contract to
+// report "N imported, 0 added, 0 changed, 0 destroyed" without scraping logs.
+type PlanSummary struct {
+	ImportCount  int `json:"import_count"`
+	AddCount     int `json:"add_count"`
+	ChangeCount  int `json:"change_count"`
+	DestroyCount int `json:"destroy_count"`
+	ReplaceCount int `json:"replace_count"`
+	ReadCount    int `json:"read_count"`
+}
+
+// HasNoNonImportChanges reports whether the plan summary is clean aside from
+// imports. Callers still need the full plan validator for the authoritative
+// contract; this helper is for status display and cheap result checks.
+func (s PlanSummary) HasNoNonImportChanges() bool {
+	return s.AddCount == 0 &&
+		s.ChangeCount == 0 &&
+		s.DestroyCount == 0 &&
+		s.ReplaceCount == 0
+}
+
+// ArtifactSet names the important files produced by a reverse-import job.
+type ArtifactSet struct {
+	ImportedJSON    *Artifact  `json:"imported_json,omitempty"`
+	ImportedTF      *Artifact  `json:"imported_tf,omitempty"`
+	ValidateJSON    *Artifact  `json:"validate_json,omitempty"`
+	TFPlanJSON      *Artifact  `json:"tfplan_json,omitempty"`
+	PlanSummaryJSON *Artifact  `json:"plan_summary_json,omitempty"`
+	ResultJSON      *Artifact  `json:"result_json,omitempty"`
+	Debug           []Artifact `json:"debug,omitempty"`
+}
+
+// Artifact describes one file produced by the job.
+type Artifact struct {
+	Name      string `json:"name,omitempty"`
+	Path      string `json:"path,omitempty"`
+	MediaType string `json:"media_type,omitempty"`
+	SHA256    string `json:"sha256,omitempty"`
+	SizeBytes int64  `json:"size_bytes,omitempty"`
+}
+
+// ResourceStatus is the per-resource status in a reverse-import result.
+type ResourceStatus string
+
+const (
+	ResourceStatusImported ResourceStatus = "imported"
+	ResourceStatusSkipped  ResourceStatus = "skipped"
+	ResourceStatusFailed   ResourceStatus = "failed"
+)
+
+// ResourceResult records per-resource reverse-import details.
+type ResourceResult struct {
+	Identity     imported.ResourceIdentity   `json:"identity"`
+	Status       ResourceStatus              `json:"status"`
+	Imported     *imported.ImportedResource  `json:"imported,omitempty"`
+	Dependencies []imported.ResourceIdentity `json:"dependencies,omitempty"`
+	Fixups       []Fixup                     `json:"fixups,omitempty"`
+	Diagnostics  []Diagnostic                `json:"diagnostics,omitempty"`
+}
+
+// Fixup describes a provider-specific normalization or repair applied by the
+// presets reverse-import engine.
+type Fixup struct {
+	Code    string   `json:"code"`
+	Message string   `json:"message,omitempty"`
+	Fields  []string `json:"fields,omitempty"`
+}
+
+// Diagnostic is a non-fatal note emitted by the reverse-import job.
+type Diagnostic struct {
+	Severity string `json:"severity,omitempty"`
+	Code     string `json:"code,omitempty"`
+	Field    string `json:"field,omitempty"`
+	Message  string `json:"message"`
+}
+
+// Issue mirrors the composer validation issue JSON shape without importing
+// the full composer package into the pure job contract package.
+type Issue struct {
+	Field      string   `json:"field"`
+	Value      string   `json:"value,omitempty"`
+	Allowed    []string `json:"allowed,omitempty"`
+	Suggestion string   `json:"suggestion,omitempty"`
+	Code       string   `json:"code"`
+	Reason     string   `json:"reason"`
+}

--- a/pkg/reverseimport/job/types_test.go
+++ b/pkg/reverseimport/job/types_test.go
@@ -1,0 +1,205 @@
+package job_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	reversejob "github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+func TestPlanSummaryExportsImportCount(t *testing.T) {
+	summary := reversejob.PlanSummary{
+		ImportCount: 3,
+		AddCount:    0,
+		ChangeCount: 0,
+	}
+
+	b, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("marshal plan summary: %v", err)
+	}
+	if !strings.Contains(string(b), `"import_count":3`) {
+		t.Fatalf("plan summary did not export import_count: %s", b)
+	}
+
+	var got reversejob.PlanSummary
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal plan summary: %v", err)
+	}
+	if got.ImportCount != 3 {
+		t.Fatalf("ImportCount = %d, want 3", got.ImportCount)
+	}
+	if !got.HasNoNonImportChanges() {
+		t.Fatal("expected summary with only imports to be clean")
+	}
+}
+
+func TestRequestRoundTripCarriesImportIdentity(t *testing.T) {
+	req := reversejob.Request{
+		Version: reversejob.Version,
+		Resources: []reversejob.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:     "aws",
+				Type:      "aws_lambda_function",
+				Address:   "aws_lambda_function.worker",
+				ImportID:  "worker",
+				Region:    "us-east-1",
+				AccountID: "123456789012",
+				NativeIDs: map[string]string{
+					"arn": "arn:aws:lambda:us-east-1:123456789012:function:worker",
+				},
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	var got reversejob.Request
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal request: %v", err)
+	}
+	if got.Version != reversejob.Version {
+		t.Fatalf("Version = %d, want %d", got.Version, reversejob.Version)
+	}
+	if len(got.Resources) != 1 {
+		t.Fatalf("Resources length = %d, want 1", len(got.Resources))
+	}
+	id := got.Resources[0].Identity
+	if id.Address != "aws_lambda_function.worker" || id.ImportID != "worker" {
+		t.Fatalf("identity = %+v, want address and import ID preserved", id)
+	}
+	if id.NativeIDs["arn"] == "" {
+		t.Fatalf("NativeIDs did not preserve arn: %+v", id.NativeIDs)
+	}
+}
+
+func TestDecodeRequestAcceptsImportedResourceManifest(t *testing.T) {
+	manifest := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.orders",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}}
+	b, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	req, err := reversejob.DecodeRequest(strings.NewReader(string(b)))
+	if err != nil {
+		t.Fatalf("DecodeRequest: %v", err)
+	}
+	if req.Version != reversejob.Version {
+		t.Fatalf("Version = %d, want %d", req.Version, reversejob.Version)
+	}
+	resources := req.ImportedResources()
+	if len(resources) != 1 || resources[0].Identity.Address != "aws_sqs_queue.orders" {
+		t.Fatalf("ImportedResources = %+v, want aws_sqs_queue.orders", resources)
+	}
+}
+
+func TestPlanSummaryFromTerraformPlanCountsImportsAndChanges(t *testing.T) {
+	plan := &tfjson.Plan{
+		ResourceChanges: []*tfjson.ResourceChange{
+			{
+				Address: "aws_sqs_queue.orders",
+				Change: &tfjson.Change{
+					Actions:   tfjson.Actions{tfjson.ActionNoop},
+					Importing: &tfjson.Importing{},
+				},
+			},
+			{
+				Address: "aws_sqs_queue.extra",
+				Change: &tfjson.Change{
+					Actions: tfjson.Actions{tfjson.ActionCreate},
+				},
+			},
+			{
+				Address: "aws_sqs_queue.replace",
+				Change: &tfjson.Change{
+					Actions: tfjson.Actions{tfjson.ActionDelete, tfjson.ActionCreate},
+				},
+			},
+		},
+	}
+
+	got := reversejob.PlanSummaryFromTerraformPlan(plan)
+	if got.ImportCount != 1 {
+		t.Fatalf("ImportCount = %d, want 1", got.ImportCount)
+	}
+	if got.AddCount != 1 {
+		t.Fatalf("AddCount = %d, want 1", got.AddCount)
+	}
+	if got.ReplaceCount != 1 {
+		t.Fatalf("ReplaceCount = %d, want 1", got.ReplaceCount)
+	}
+	if got.HasNoNonImportChanges() {
+		t.Fatal("summary with add/replace should not be clean")
+	}
+}
+
+func TestPlanSummaryFromText(t *testing.T) {
+	got, ok := reversejob.PlanSummaryFromText("Plan: 3 to import, 0 to add, 1 to change, 2 to destroy.")
+	if !ok {
+		t.Fatal("PlanSummaryFromText did not find summary line")
+	}
+	if got.ImportCount != 3 || got.AddCount != 0 || got.ChangeCount != 1 || got.DestroyCount != 2 {
+		t.Fatalf("summary = %+v, want import=3 add=0 change=1 destroy=2", got)
+	}
+}
+
+func TestResultRoundTripCarriesArtifactsAndImportedResources(t *testing.T) {
+	result := reversejob.Result{
+		Version: reversejob.Version,
+		Status:  reversejob.StatusSucceeded,
+		Imported: []imported.ImportedResource{{
+			Identity: imported.ResourceIdentity{
+				Cloud:   "aws",
+				Type:    "aws_kms_key",
+				Address: "aws_kms_key.primary",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+		PlanSummary: reversejob.PlanSummary{ImportCount: 1},
+		Artifacts: reversejob.ArtifactSet{
+			ImportedJSON: &reversejob.Artifact{Name: "imported.json", Path: "/work/imported.json"},
+			ImportedTF:   &reversejob.Artifact{Name: "imported.tf", Path: "/work/imported.tf"},
+			TFPlanJSON:   &reversejob.Artifact{Name: "tfplan.json", Path: "/work/tfplan.json"},
+		},
+	}
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+
+	var got reversejob.Result
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if got.Status != reversejob.StatusSucceeded {
+		t.Fatalf("Status = %q, want %q", got.Status, reversejob.StatusSucceeded)
+	}
+	if got.PlanSummary.ImportCount != 1 {
+		t.Fatalf("ImportCount = %d, want 1", got.PlanSummary.ImportCount)
+	}
+	if len(got.Imported) != 1 || got.Imported[0].Identity.Address != "aws_kms_key.primary" {
+		t.Fatalf("Imported = %+v, want aws_kms_key.primary", got.Imported)
+	}
+	if got.Artifacts.ImportedJSON == nil || got.Artifacts.ImportedJSON.Name != "imported.json" {
+		t.Fatalf("ImportedJSON artifact = %+v, want imported.json", got.Artifacts.ImportedJSON)
+	}
+}

--- a/pkg/reverseimport/options.go
+++ b/pkg/reverseimport/options.go
@@ -19,6 +19,27 @@ type Discoverer interface {
 	DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error)
 }
 
+// ClosureRequest describes the selected parent resources whose scoped
+// children should be discovered before provider readback.
+type ClosureRequest struct {
+	Cloud           string
+	Project         string
+	Regions         []string
+	AccountID       string
+	GCPProjectID    string
+	ParentResources []imported.ImportedResource
+	ParentTypes     []string
+	ChildTypes      []string
+}
+
+// ClosureDiscoverer is the optional parent-selection expansion surface.
+// The local CLI implements this by calling the same cloud discoverer used for
+// top-level discovery; Mars can wrap the same SDK-backed discoverer without
+// shelling out to CLI-private code.
+type ClosureDiscoverer interface {
+	DiscoverClosure(ctx context.Context, req ClosureRequest) ([]imported.ImportedResource, error)
+}
+
 // Options configures a reverse-import run.
 type Options struct {
 	OutputDir string
@@ -32,12 +53,16 @@ type Options struct {
 	ImportProjectID string
 	ImportSessionID string
 	ImportedAt      time.Time
+	DiscoverProject string
+	DiscoverRegions []string
+	AccountID       string
 
 	TerraformBinary       string
 	SkipDriftFix          bool
 	SkipDepChase          bool
 	MaxDepChaseIterations int
 	Discoverer            Discoverer
+	ClosureDiscoverer     ClosureDiscoverer
 
 	deps deps
 }

--- a/pkg/reverseimport/options.go
+++ b/pkg/reverseimport/options.go
@@ -1,0 +1,72 @@
+// Package reverseimport contains the reusable reverse-import engine used by
+// the local CLI and, later, the Mars Go job binary.
+package reverseimport
+
+import (
+	"context"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Discoverer is the dependency-resolution surface needed by the dep-chase
+// phase. Mars and the local CLI can provide a cloud-backed implementation;
+// tests can provide a fake.
+type Discoverer interface {
+	DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error)
+}
+
+// Options configures a reverse-import run.
+type Options struct {
+	OutputDir string
+	Workdir   string
+
+	Cloud          string
+	Region         string
+	GCPProjectID   string
+	AWSEndpointURL string
+
+	ImportProjectID string
+	ImportSessionID string
+	ImportedAt      time.Time
+
+	TerraformBinary       string
+	SkipDriftFix          bool
+	SkipDepChase          bool
+	MaxDepChaseIterations int
+	Discoverer            Discoverer
+
+	deps deps
+}
+
+type deps struct {
+	runGenconfig func(context.Context, genconfig.Options, []imported.ImportedResource) (*genconfig.Result, error)
+	runDriftfix  func(context.Context, driftfix.Options) (*driftfix.Result, error)
+	runDepChase  func(context.Context, depchase.Options, []imported.ImportedResource) (*depchase.Result, error)
+	tf           terraformRunner
+}
+
+func defaultDeps(terraformBinary string) deps {
+	return deps{
+		runGenconfig: genconfig.Run,
+		runDriftfix:  driftfix.Run,
+		runDepChase:  depchase.Run,
+		tf:           execTerraformRunner{binary: terraformBinary},
+	}
+}
+
+func (o Options) withDefaults() Options {
+	if o.MaxDepChaseIterations <= 0 {
+		o.MaxDepChaseIterations = depchase.DefaultMaxIterations
+	}
+	if o.deps.runGenconfig == nil ||
+		o.deps.runDriftfix == nil ||
+		o.deps.runDepChase == nil ||
+		o.deps.tf == nil {
+		o.deps = defaultDeps(o.TerraformBinary)
+	}
+	return o
+}

--- a/pkg/reverseimport/providers.go
+++ b/pkg/reverseimport/providers.go
@@ -1,0 +1,82 @@
+package reverseimport
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+)
+
+var localstackEndpointServices = []string{
+	"cloudwatchlogs",
+	"dynamodb",
+	"iam",
+	"kms",
+	"lambda",
+	"s3",
+	"secretsmanager",
+	"sqs",
+	"sts",
+}
+
+func renderImportedProvidersTF(cloud, region, gcpProjectID, awsEndpointURL string, providersUsed map[string]bool) ([]byte, error) {
+	f := hclwrite.NewEmptyFile()
+	body := f.Body()
+	tfBlk := body.AppendNewBlock("terraform", nil)
+	rp := tfBlk.Body().AppendNewBlock("required_providers", nil)
+	body.AppendNewline()
+
+	switch strings.ToLower(strings.TrimSpace(cloud)) {
+	case "gcp":
+		rp.Body().SetAttributeValue("google", cty.ObjectVal(map[string]cty.Value{
+			"source":  cty.StringVal("hashicorp/google"),
+			"version": cty.StringVal("~> 5.0"),
+		}))
+		if providersUsed[composer.ProvidersUsedKeyGCPBeta] {
+			rp.Body().SetAttributeValue("google-beta", cty.ObjectVal(map[string]cty.Value{
+				"source":  cty.StringVal("hashicorp/google-beta"),
+				"version": cty.StringVal("~> 5.0"),
+			}))
+		}
+		prov := body.AppendNewBlock("provider", []string{"google"})
+		prov.Body().SetAttributeValue("alias", cty.StringVal("imported"))
+		prov.Body().SetAttributeValue("project", cty.StringVal(gcpProjectID))
+		if region != "" {
+			prov.Body().SetAttributeValue("region", cty.StringVal(region))
+		}
+		if providersUsed[composer.ProvidersUsedKeyGCPBeta] {
+			beta := body.AppendNewBlock("provider", []string{"google-beta"})
+			beta.Body().SetAttributeValue("alias", cty.StringVal("imported"))
+			beta.Body().SetAttributeValue("project", cty.StringVal(gcpProjectID))
+			if region != "" {
+				beta.Body().SetAttributeValue("region", cty.StringVal(region))
+			}
+		}
+	case "aws", "":
+		rp.Body().SetAttributeValue("aws", cty.ObjectVal(map[string]cty.Value{
+			"source":  cty.StringVal("hashicorp/aws"),
+			"version": cty.StringVal("~> 6.0"),
+		}))
+		prov := body.AppendNewBlock("provider", []string{"aws"})
+		prov.Body().SetAttributeValue("alias", cty.StringVal("imported"))
+		prov.Body().SetAttributeValue("region", cty.StringVal(region))
+		if awsEndpointURL != "" {
+			prov.Body().SetAttributeValue("access_key", cty.StringVal("test"))
+			prov.Body().SetAttributeValue("secret_key", cty.StringVal("test"))
+			prov.Body().SetAttributeValue("skip_credentials_validation", cty.True)
+			prov.Body().SetAttributeValue("skip_metadata_api_check", cty.True)
+			prov.Body().SetAttributeValue("skip_requesting_account_id", cty.True)
+			prov.Body().SetAttributeValue("s3_use_path_style", cty.True)
+			ep := prov.Body().AppendNewBlock("endpoints", nil)
+			for _, svc := range localstackEndpointServices {
+				ep.Body().SetAttributeValue(svc, cty.StringVal(awsEndpointURL))
+			}
+		}
+	default:
+		return nil, fmt.Errorf("unknown cloud %q", cloud)
+	}
+	return f.Bytes(), nil
+}

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -49,6 +49,19 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			resources[i].Identity.Cloud = cloud
 		}
 	}
+	closure, err := expandSelectionClosure(ctx, selectionClosureInput{
+		resources:    resources,
+		opts:         opts,
+		cloud:        cloud,
+		region:       region,
+		gcpProjectID: gcpProjectID,
+	})
+	if err != nil {
+		return result, err
+	}
+	resources = closure.resources
+	result.Diagnostics = append(result.Diagnostics, closure.diagnostics...)
+	dependenciesByAddress := closure.dependencies
 
 	workdir := opts.Workdir
 	if workdir == "" {
@@ -105,6 +118,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 		}
 		if dcRes != nil {
 			resources = dcRes.Resources
+			appendDepChaseDependencies(dependenciesByAddress, resources, dcRes.Edges)
 		}
 	}
 
@@ -112,7 +126,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 		return result, err
 	}
 	result.Imported = resources
-	result.Resources = resourceResults(resources)
+	result.Resources = resourceResults(resources, dependenciesByAddress)
 
 	importedTF, providersUsed := composer.EmitImportedTF(cloud, resources, composer.EmitImportedOpts{
 		ImportProjectID: opts.ImportProjectID,
@@ -176,6 +190,15 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	if dcRes != nil && len(dcRes.Edges) > 0 {
 		if err := writeJSON(filepath.Join(opts.OutputDir, graphJSONFile), dcRes.Edges); err != nil {
 			return result, err
+		}
+	}
+	if dcRes != nil {
+		for _, warning := range dcRes.Warnings {
+			result.Diagnostics = append(result.Diagnostics, job.Diagnostic{
+				Severity: "warning",
+				Code:     "depchase_warning",
+				Message:  warning,
+			})
 		}
 	}
 	planSummaryPath := filepath.Join(opts.OutputDir, planSummaryJSONFile)
@@ -257,17 +280,37 @@ func populateArtifacts(result *job.Result, outputDir, generatedPath string, dcRe
 	return nil
 }
 
-func resourceResults(resources []imported.ImportedResource) []job.ResourceResult {
+func resourceResults(resources []imported.ImportedResource, dependenciesByAddress map[string][]imported.ResourceIdentity) []job.ResourceResult {
 	out := make([]job.ResourceResult, 0, len(resources))
 	for _, r := range resources {
 		rr := r
 		out = append(out, job.ResourceResult{
-			Identity: r.Identity,
-			Status:   job.ResourceStatusImported,
-			Imported: &rr,
+			Identity:     r.Identity,
+			Status:       job.ResourceStatusImported,
+			Imported:     &rr,
+			Dependencies: dependenciesByAddress[r.Identity.Address],
 		})
 	}
 	return out
+}
+
+func appendDepChaseDependencies(dependenciesByAddress map[string][]imported.ResourceIdentity, resources []imported.ImportedResource, edges []depchase.GraphEdge) {
+	if len(edges) == 0 {
+		return
+	}
+	byAddress := make(map[string]imported.ResourceIdentity, len(resources))
+	for _, r := range resources {
+		if strings.TrimSpace(r.Identity.Address) != "" {
+			byAddress[r.Identity.Address] = r.Identity
+		}
+	}
+	for _, edge := range edges {
+		to, ok := byAddress[edge.To]
+		if !ok {
+			continue
+		}
+		dependenciesByAddress[edge.From] = append(dependenciesByAddress[edge.From], to)
+	}
 }
 
 func issuesFromComposer(in []composer.ValidationIssue) []job.Issue {

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -1,0 +1,332 @@
+package reverseimport
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+// Run executes the reverse-import engine for a selected resource set.
+func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error) {
+	opts = opts.withDefaults()
+	result := job.Result{Version: job.Version, Status: job.StatusFailed}
+	if opts.OutputDir == "" {
+		return result, fmt.Errorf("reverseimport: OutputDir required")
+	}
+	if err := os.MkdirAll(opts.OutputDir, 0o755); err != nil {
+		return result, fmt.Errorf("mkdir output dir: %w", err)
+	}
+
+	resources := req.ImportedResources()
+	if len(resources) == 0 {
+		return result, fmt.Errorf("reverseimport: no resources selected")
+	}
+	cloud := firstNonEmpty(opts.Cloud, resources[0].Identity.Cloud)
+	if cloud == "" {
+		return result, fmt.Errorf("reverseimport: cloud required")
+	}
+	region := firstNonEmpty(opts.Region, firstResourceField(resources, func(id imported.ResourceIdentity) string { return id.Region }))
+	gcpProjectID := firstNonEmpty(opts.GCPProjectID, firstResourceField(resources, func(id imported.ResourceIdentity) string { return id.ProjectID }))
+	if cloud == "aws" && region == "" {
+		return result, fmt.Errorf("reverseimport: Region required for aws")
+	}
+	if cloud == "gcp" && gcpProjectID == "" {
+		return result, fmt.Errorf("reverseimport: GCPProjectID required for gcp")
+	}
+	for i := range resources {
+		if resources[i].Identity.Cloud == "" {
+			resources[i].Identity.Cloud = cloud
+		}
+	}
+
+	workdir := opts.Workdir
+	if workdir == "" {
+		workdir = filepath.Join(opts.OutputDir, "genconfig")
+	}
+	gcOpts := genconfig.Options{
+		Workdir:        workdir,
+		Provider:       cloud,
+		Region:         region,
+		GCPProjectID:   gcpProjectID,
+		AWSEndpointURL: opts.AWSEndpointURL,
+	}
+
+	gcRes, err := opts.deps.runGenconfig(ctx, gcOpts, resources)
+	if err != nil {
+		return result, fmt.Errorf("genconfig: %w", err)
+	}
+	resources = gcRes.Resources
+
+	if !opts.SkipDriftFix {
+		if _, err := opts.deps.runDriftfix(ctx, driftfix.Options{Workdir: workdir}); err != nil {
+			return result, fmt.Errorf("driftfix: %w", err)
+		}
+	}
+
+	var dcRes *depchase.Result
+	if !opts.SkipDriftFix && !opts.SkipDepChase && opts.Discoverer != nil {
+		pipeline := depchase.PipelineFns{
+			RunGenconfig: func(ictx context.Context, expanded []imported.ImportedResource) (*depchase.GenconfigResult, error) {
+				r, err := opts.deps.runGenconfig(ictx, gcOpts, expanded)
+				if err != nil {
+					return nil, err
+				}
+				return &depchase.GenconfigResult{GeneratedPath: r.GeneratedPath, Resources: r.Resources}, nil
+			},
+			RunDriftfix: func(ictx context.Context) (*depchase.DriftfixResult, error) {
+				r, err := opts.deps.runDriftfix(ictx, driftfix.Options{Workdir: workdir})
+				if err != nil {
+					return nil, err
+				}
+				return &depchase.DriftfixResult{GeneratedPath: r.GeneratedPath, Iterations: r.Iterations}, nil
+			},
+		}
+		dcRes, err = opts.deps.runDepChase(ctx, depchase.Options{
+			Workdir:       workdir,
+			Region:        region,
+			AccountID:     firstResourceField(resources, func(id imported.ResourceIdentity) string { return id.AccountID }),
+			MaxIterations: opts.MaxDepChaseIterations,
+			Discoverer:    opts.Discoverer,
+			Pipeline:      pipeline,
+		}, resources)
+		if err != nil {
+			return result, fmt.Errorf("depchase: %w", err)
+		}
+		if dcRes != nil {
+			resources = dcRes.Resources
+		}
+	}
+
+	if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
+		return result, err
+	}
+	result.Imported = resources
+	result.Resources = resourceResults(resources)
+
+	importedTF, providersUsed := composer.EmitImportedTF(cloud, resources, composer.EmitImportedOpts{
+		ImportProjectID: opts.ImportProjectID,
+		ImportSessionID: opts.ImportSessionID,
+		ImportedAt:      importedAtOrNow(opts.ImportedAt),
+	})
+	if len(importedTF) == 0 {
+		return result, fmt.Errorf("reverseimport: EmitImportedTF produced no HCL")
+	}
+	importedTFPath := filepath.Join(opts.OutputDir, importedTFFile)
+	if err := writeFileAtomic(importedTFPath, importedTF, 0o644); err != nil {
+		return result, fmt.Errorf("write imported.tf: %w", err)
+	}
+	providersTF, err := renderImportedProvidersTF(cloud, region, gcpProjectID, opts.AWSEndpointURL, providersUsed)
+	if err != nil {
+		return result, err
+	}
+	providersTFPath := filepath.Join(opts.OutputDir, importedProvidersTF)
+	if err := writeFileAtomic(providersTFPath, providersTF, 0o644); err != nil {
+		return result, fmt.Errorf("write providers-imported.tf: %w", err)
+	}
+	if err := ensurePlaceholderFiles(opts.OutputDir, resources); err != nil {
+		return result, err
+	}
+
+	planPath := filepath.Join(opts.OutputDir, tfplanFile)
+	validateJSONPath := filepath.Join(opts.OutputDir, validateJSONFile)
+	tfplanJSONPath := filepath.Join(opts.OutputDir, tfplanJSONFile)
+	if err := opts.deps.tf.Init(ctx, opts.OutputDir); err != nil {
+		return result, fmt.Errorf("terraform init final: %w", err)
+	}
+	validateJSON, err := opts.deps.tf.Validate(ctx, opts.OutputDir)
+	if len(validateJSON) > 0 {
+		if writeErr := writeFileAtomic(validateJSONPath, validateJSON, 0o644); writeErr != nil {
+			return result, fmt.Errorf("write validate.json: %w", writeErr)
+		}
+	}
+	if err != nil {
+		return result, fmt.Errorf("terraform validate final: %w", err)
+	}
+	if err := opts.deps.tf.Plan(ctx, opts.OutputDir, planPath); err != nil {
+		return result, fmt.Errorf("terraform plan final: %w", err)
+	}
+	planJSON, err := opts.deps.tf.ShowPlanJSON(ctx, opts.OutputDir, planPath)
+	if err != nil {
+		return result, fmt.Errorf("terraform show final plan: %w", err)
+	}
+	if err := writeFileAtomic(tfplanJSONPath, planJSON, 0o644); err != nil {
+		return result, fmt.Errorf("write tfplan.json: %w", err)
+	}
+	plan, err := job.DecodeTerraformPlan(bytes.NewReader(planJSON))
+	if err != nil {
+		return result, err
+	}
+	result.PlanSummary = job.PlanSummaryFromTerraformPlan(plan)
+	result.ValidationIssues = issuesFromComposer(composer.ValidateFirstImportPlan(plan, composer.ValidateFirstImportPlanOpts{
+		ExpectedImports:     len(resources),
+		ProvenanceLabelKeys: composer.FirstImportProvenanceKeys(cloud),
+	}))
+
+	if dcRes != nil && len(dcRes.Edges) > 0 {
+		if err := writeJSON(filepath.Join(opts.OutputDir, graphJSONFile), dcRes.Edges); err != nil {
+			return result, err
+		}
+	}
+	planSummaryPath := filepath.Join(opts.OutputDir, planSummaryJSONFile)
+	if err := writeJSON(planSummaryPath, result.PlanSummary); err != nil {
+		return result, err
+	}
+	if err := populateArtifacts(&result, opts.OutputDir, gcRes.GeneratedPath, dcRes); err != nil {
+		return result, err
+	}
+	if len(result.ValidationIssues) > 0 {
+		if err := writeResult(opts.OutputDir, &result); err != nil {
+			return result, err
+		}
+		return result, fmt.Errorf("final plan validation failed with %d issue(s)", len(result.ValidationIssues))
+	}
+	result.Status = job.StatusSucceeded
+	if err := writeResult(opts.OutputDir, &result); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func writeResult(outputDir string, result *job.Result) error {
+	path := filepath.Join(outputDir, reverseResultFile)
+	result.Artifacts.ResultJSON = &job.Artifact{
+		Name:      reverseResultFile,
+		Path:      path,
+		MediaType: "application/json",
+	}
+	if err := writeJSON(path, result); err != nil {
+		return err
+	}
+	return nil
+}
+
+func populateArtifacts(result *job.Result, outputDir, generatedPath string, dcRes *depchase.Result) error {
+	if err := addArtifact(&result.Artifacts.ImportedJSON, filepath.Join(outputDir, importedJSONFile), "application/json"); err != nil {
+		return err
+	}
+	if err := addArtifact(&result.Artifacts.ImportedTF, filepath.Join(outputDir, importedTFFile), "text/hcl"); err != nil {
+		return err
+	}
+	if err := addArtifact(&result.Artifacts.ValidateJSON, filepath.Join(outputDir, validateJSONFile), "application/json"); err != nil {
+		return err
+	}
+	if err := addArtifact(&result.Artifacts.TFPlanJSON, filepath.Join(outputDir, tfplanJSONFile), "application/json"); err != nil {
+		return err
+	}
+	if err := addArtifact(&result.Artifacts.PlanSummaryJSON, filepath.Join(outputDir, planSummaryJSONFile), "application/json"); err != nil {
+		return err
+	}
+	for _, path := range []string{
+		generatedPath,
+		filepath.Join(filepath.Dir(generatedPath), "imports.tf"),
+		filepath.Join(filepath.Dir(generatedPath), "providers.tf"),
+		filepath.Join(outputDir, importedProvidersTF),
+	} {
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		if _, err := os.Stat(path); err == nil {
+			a, err := artifact(path, "text/hcl")
+			if err != nil {
+				return err
+			}
+			result.Artifacts.Debug = append(result.Artifacts.Debug, *a)
+		}
+	}
+	if dcRes != nil {
+		graphPath := filepath.Join(outputDir, graphJSONFile)
+		if _, err := os.Stat(graphPath); err == nil {
+			a, err := artifact(graphPath, "application/json")
+			if err != nil {
+				return err
+			}
+			result.Artifacts.Debug = append(result.Artifacts.Debug, *a)
+		}
+	}
+	return nil
+}
+
+func resourceResults(resources []imported.ImportedResource) []job.ResourceResult {
+	out := make([]job.ResourceResult, 0, len(resources))
+	for _, r := range resources {
+		rr := r
+		out = append(out, job.ResourceResult{
+			Identity: r.Identity,
+			Status:   job.ResourceStatusImported,
+			Imported: &rr,
+		})
+	}
+	return out
+}
+
+func issuesFromComposer(in []composer.ValidationIssue) []job.Issue {
+	out := make([]job.Issue, 0, len(in))
+	for _, issue := range in {
+		out = append(out, job.Issue{
+			Field:      issue.Field,
+			Value:      issue.Value,
+			Allowed:    issue.Allowed,
+			Suggestion: issue.Suggestion,
+			Code:       issue.Code,
+			Reason:     issue.Reason,
+		})
+	}
+	return out
+}
+
+func ensurePlaceholderFiles(dir string, resources []imported.ImportedResource) error {
+	for _, r := range resources {
+		if r.Identity.Type != "aws_lambda_function" {
+			continue
+		}
+		return writeFileAtomic(filepath.Join(dir, imported.LambdaPlaceholderFilename), emptyZipBytes(), 0o644)
+	}
+	return nil
+}
+
+func emptyZipBytes() []byte {
+	return []byte{
+		0x50, 0x4b, 0x05, 0x06,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00,
+	}
+}
+
+func importedAtOrNow(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Now().UTC()
+	}
+	return t
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}
+
+func firstResourceField(resources []imported.ImportedResource, fn func(imported.ResourceIdentity) string) string {
+	for _, r := range resources {
+		if v := strings.TrimSpace(fn(r.Identity)); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -2,6 +2,7 @@ package reverseimport
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,6 +70,101 @@ func TestRunEmitsArtifactsAndImportSummary(t *testing.T) {
 	}
 }
 
+func TestRunExpandsSelectedParentClosure(t *testing.T) {
+	dir := t.TempDir()
+	discoverer := &fakeClosureDiscoverer{
+		resources: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_s3_bucket",
+					Address:  "aws_s3_bucket.discovered_uploads",
+					ImportID: "io-uploads",
+					Region:   "us-east-1",
+				},
+				Tier:   imported.TierImportedFlat,
+				Source: imported.SourceImporter,
+			},
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:         "aws",
+					Type:          "aws_s3_bucket_versioning",
+					Address:       "aws_s3_bucket_versioning.uploads",
+					ImportID:      "io-uploads",
+					Region:        "us-east-1",
+					ParentAddress: "aws_s3_bucket.discovered_uploads",
+				},
+				Tier:   imported.TierImportedFlat,
+				Source: imported.SourceImporter,
+			},
+		},
+	}
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.uploads",
+				ImportID: "io-uploads",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	result, err := Run(context.Background(), req, Options{
+		OutputDir:         dir,
+		SkipDepChase:      true,
+		DiscoverProject:   "io-test",
+		DiscoverRegions:   []string{"us-east-1"},
+		ClosureDiscoverer: discoverer,
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           fakeTerraformRunner{importCount: 2},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.PlanSummary.ImportCount != 2 {
+		t.Fatalf("ImportCount = %d, want 2", result.PlanSummary.ImportCount)
+	}
+	if len(result.Imported) != 2 {
+		t.Fatalf("Imported len = %d, want 2", len(result.Imported))
+	}
+	if !containsString(discoverer.req.ParentTypes, "aws_s3_bucket") {
+		t.Fatalf("ParentTypes = %v, want aws_s3_bucket", discoverer.req.ParentTypes)
+	}
+	if !containsString(discoverer.req.ChildTypes, "aws_s3_bucket_versioning") {
+		t.Fatalf("ChildTypes = %v, want aws_s3_bucket_versioning", discoverer.req.ChildTypes)
+	}
+	parentResult, ok := resourceResultByAddress(result.Resources, "aws_s3_bucket.uploads")
+	if !ok {
+		t.Fatalf("missing parent resource result: %#v", result.Resources)
+	}
+	if len(parentResult.Dependencies) != 1 {
+		t.Fatalf("parent dependencies = %#v, want one closure child", parentResult.Dependencies)
+	}
+	child := parentResult.Dependencies[0]
+	if child.Type != "aws_s3_bucket_versioning" {
+		t.Fatalf("dependency type = %q, want aws_s3_bucket_versioning", child.Type)
+	}
+	if child.ParentAddress != "aws_s3_bucket.uploads" {
+		t.Fatalf("dependency ParentAddress = %q, want selected parent address", child.ParentAddress)
+	}
+	importedTF, err := os.ReadFile(filepath.Join(dir, "imported.tf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(importedTF), `resource "aws_s3_bucket_versioning" "uploads"`) {
+		t.Fatalf("imported.tf missing versioning child:\n%s", importedTF)
+	}
+}
+
 func fakeGenconfig(_ context.Context, opts genconfig.Options, resources []imported.ImportedResource) (*genconfig.Result, error) {
 	if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
 		return nil, err
@@ -85,7 +181,16 @@ func fakeGenconfig(_ context.Context, opts genconfig.Options, resources []import
 
 	out := make([]imported.ImportedResource, len(resources))
 	copy(out, resources)
-	out[0].Attrs = []byte(`{"name":{"literal":"orders"}}`)
+	for i := range out {
+		switch out[i].Identity.Type {
+		case "aws_sqs_queue":
+			out[i].Attrs = []byte(`{"name":{"literal":"orders"}}`)
+		case "aws_s3_bucket":
+			out[i].Attrs = []byte(`{"bucket":{"literal":"io-uploads"},"region":{"literal":"us-east-1"}}`)
+		case "aws_s3_bucket_versioning":
+			out[i].Attrs = []byte(`{"bucket":{"literal":"io-uploads"},"region":{"literal":"us-east-1"},"versioning_configuration":[{"status":{"literal":"Enabled"}}]}`)
+		}
+	}
 	return &genconfig.Result{GeneratedPath: generatedPath, Resources: out}, nil
 }
 
@@ -97,7 +202,9 @@ func fakeDepChase(_ context.Context, _ depchase.Options, resources []imported.Im
 	return &depchase.Result{Resources: resources}, nil
 }
 
-type fakeTerraformRunner struct{}
+type fakeTerraformRunner struct {
+	importCount int
+}
 
 func (fakeTerraformRunner) Init(context.Context, string) error { return nil }
 
@@ -107,24 +214,61 @@ func (fakeTerraformRunner) Validate(context.Context, string) ([]byte, error) {
 
 func (fakeTerraformRunner) Plan(context.Context, string, string) error { return nil }
 
-func (fakeTerraformRunner) ShowPlanJSON(context.Context, string, string) ([]byte, error) {
-	return []byte(`{
-  "format_version": "1.2",
-  "terraform_version": "1.13.0",
-  "resource_changes": [
-    {
-      "address": "aws_sqs_queue.orders",
+func (r fakeTerraformRunner) ShowPlanJSON(context.Context, string, string) ([]byte, error) {
+	importCount := r.importCount
+	if importCount == 0 {
+		importCount = 1
+	}
+	var changes strings.Builder
+	for i := 0; i < importCount; i++ {
+		if i > 0 {
+			changes.WriteString(",")
+		}
+		fmt.Fprintf(&changes, `{
+      "address": "aws_sqs_queue.orders_%d",
       "mode": "managed",
       "type": "aws_sqs_queue",
-      "name": "orders",
+      "name": "orders_%d",
       "change": {
         "actions": ["no-op"],
         "before": null,
         "after": null,
         "after_unknown": {},
-        "importing": {"id": "https://sqs.us-east-1.amazonaws.com/123/orders"}
+        "importing": {"id": "https://sqs.us-east-1.amazonaws.com/123/orders_%d"}
       }
-    }
-  ]
-}`), nil
+    }`, i, i, i)
+	}
+	return []byte(fmt.Sprintf(`{
+  "format_version": "1.2",
+  "terraform_version": "1.13.0",
+  "resource_changes": [%s]
+}`, changes.String())), nil
+}
+
+type fakeClosureDiscoverer struct {
+	req       ClosureRequest
+	resources []imported.ImportedResource
+}
+
+func (f *fakeClosureDiscoverer) DiscoverClosure(_ context.Context, req ClosureRequest) ([]imported.ImportedResource, error) {
+	f.req = req
+	return f.resources, nil
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceResultByAddress(resources []job.ResourceResult, address string) (job.ResourceResult, bool) {
+	for _, resource := range resources {
+		if resource.Identity.Address == address {
+			return resource, true
+		}
+	}
+	return job.ResourceResult{}, false
 }

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -1,0 +1,130 @@
+package reverseimport
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+func TestRunEmitsArtifactsAndImportSummary(t *testing.T) {
+	dir := t.TempDir()
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	result, err := Run(context.Background(), req, Options{
+		OutputDir:       dir,
+		SkipDepChase:    true,
+		ImportProjectID: "io-test",
+		ImportSessionID: "sess-test",
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           fakeTerraformRunner{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Status != job.StatusSucceeded {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusSucceeded)
+	}
+	if result.PlanSummary.ImportCount != 1 {
+		t.Fatalf("ImportCount = %d, want 1", result.PlanSummary.ImportCount)
+	}
+	for _, name := range []string{"imported.json", "imported.tf", "providers-imported.tf", "validate.json", "tfplan.json", "plan-summary.json", "reverse-result.json"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Fatalf("%s not written: %v", name, err)
+		}
+	}
+	importedTF, err := os.ReadFile(filepath.Join(dir, "imported.tf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(importedTF), `import {`) {
+		t.Fatalf("imported.tf missing import block:\n%s", importedTF)
+	}
+	if !strings.Contains(string(importedTF), `resource "aws_sqs_queue" "orders"`) {
+		t.Fatalf("imported.tf missing queue resource:\n%s", importedTF)
+	}
+}
+
+func fakeGenconfig(_ context.Context, opts genconfig.Options, resources []imported.ImportedResource) (*genconfig.Result, error) {
+	if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
+		return nil, err
+	}
+	generatedPath := filepath.Join(opts.Workdir, "generated.tf")
+	if err := os.WriteFile(generatedPath, []byte(`resource "aws_sqs_queue" "orders" {
+  name = "orders"
+}
+`), 0o644); err != nil {
+		return nil, err
+	}
+	_ = os.WriteFile(filepath.Join(opts.Workdir, "imports.tf"), []byte("import {}\n"), 0o644)
+	_ = os.WriteFile(filepath.Join(opts.Workdir, "providers.tf"), []byte("terraform {}\n"), 0o644)
+
+	out := make([]imported.ImportedResource, len(resources))
+	copy(out, resources)
+	out[0].Attrs = []byte(`{"name":{"literal":"orders"}}`)
+	return &genconfig.Result{GeneratedPath: generatedPath, Resources: out}, nil
+}
+
+func fakeDriftfix(_ context.Context, opts driftfix.Options) (*driftfix.Result, error) {
+	return &driftfix.Result{GeneratedPath: filepath.Join(opts.Workdir, "generated.tf"), Iterations: 1}, nil
+}
+
+func fakeDepChase(_ context.Context, _ depchase.Options, resources []imported.ImportedResource) (*depchase.Result, error) {
+	return &depchase.Result{Resources: resources}, nil
+}
+
+type fakeTerraformRunner struct{}
+
+func (fakeTerraformRunner) Init(context.Context, string) error { return nil }
+
+func (fakeTerraformRunner) Validate(context.Context, string) ([]byte, error) {
+	return []byte(`{"valid":true,"diagnostics":[]}`), nil
+}
+
+func (fakeTerraformRunner) Plan(context.Context, string, string) error { return nil }
+
+func (fakeTerraformRunner) ShowPlanJSON(context.Context, string, string) ([]byte, error) {
+	return []byte(`{
+  "format_version": "1.2",
+  "terraform_version": "1.13.0",
+  "resource_changes": [
+    {
+      "address": "aws_sqs_queue.orders",
+      "mode": "managed",
+      "type": "aws_sqs_queue",
+      "name": "orders",
+      "change": {
+        "actions": ["no-op"],
+        "before": null,
+        "after": null,
+        "after_unknown": {},
+        "importing": {"id": "https://sqs.us-east-1.amazonaws.com/123/orders"}
+      }
+    }
+  ]
+}`), nil
+}

--- a/pkg/reverseimport/terraform.go
+++ b/pkg/reverseimport/terraform.go
@@ -1,0 +1,79 @@
+package reverseimport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+type terraformRunner interface {
+	Init(ctx context.Context, dir string) error
+	Validate(ctx context.Context, dir string) ([]byte, error)
+	Plan(ctx context.Context, dir, planPath string) error
+	ShowPlanJSON(ctx context.Context, dir, planPath string) ([]byte, error)
+}
+
+type execTerraformRunner struct {
+	binary string
+}
+
+func (r execTerraformRunner) bin() string {
+	if r.binary != "" {
+		return r.binary
+	}
+	return "terraform"
+}
+
+func (r execTerraformRunner) Init(ctx context.Context, dir string) error {
+	return r.run(ctx, dir, "init", "-input=false", "-no-color")
+}
+
+func (r execTerraformRunner) Validate(ctx context.Context, dir string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, r.bin(), "validate", "-json")
+	cmd.Dir = dir
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
+	out, err := cmd.Output()
+	if err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func (r execTerraformRunner) Plan(ctx context.Context, dir, planPath string) error {
+	err := r.run(ctx, dir, "plan", "-input=false", "-no-color", "-detailed-exitcode", "-out="+planPath)
+	if err == nil {
+		return nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) && ee.ExitCode() == 2 {
+		return nil
+	}
+	return err
+}
+
+func (r execTerraformRunner) ShowPlanJSON(ctx context.Context, dir, planPath string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, r.bin(), "show", "-json", planPath)
+	cmd.Dir = dir
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (r execTerraformRunner) run(ctx context.Context, dir string, args ...string) error {
+	cmd := exec.CommandContext(ctx, r.bin(), args...)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s %v: %w", r.bin(), args, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/reverseimport` and `pkg/reverseimport/job` as the shared SDK/job contract for provider-backed reverse import.
- Adds `insideout-import reverse` and wires `discover` to use the same SDK path by default.
- Adds parent-selection closure so selected top-level resources pull in provider-owned children/sidecars before HCL generation.
- Projects Terraform readback into typed `ImportedResource.Attrs`, regenerates `imported.tf`, runs `terraform validate -json`, and validates the final import-only plan.
- Hardens depchase/provider gaps: ARN-shaped Cloud Control lookup normalization, IAM role path/name handling, orphan pruning before cross-ref rewrites, and non-fatal warnings when Terraform omits a discovered dependency body.
- Documents the Mars/Reliable architecture and keeps Mars as a future Go SDK adapter, not a CLI reimplementation.

Closes #672

## Test plan

- [x] `git diff --check`
- [x] `go test ./cmd/insideout-import ./cmd/insideout-import/awsdiscover ./cmd/insideout-import/depchase ./cmd/insideout-import/genconfig ./pkg/reverseimport/...`
- [x] `go test ./...`
- [x] Live AWS S3 parent-only discover: 5 imports, 0 add, 0 change, 0 destroy
- [x] Live AWS S3 parent-only temp `terraform apply`: 5 imported, 0 added, 0 changed, 0 destroyed
- [x] Live AWS S3 parent-only post-import `terraform plan -detailed-exitcode`: exit 0, no changes
- [x] Live AWS broad smoke against Cust2 project `io-lh0sr6xgkosq`, `eu-west-2`, across 23 AWS resource types: 41 imports, 0 add, 0 change, 0 destroy
- [x] Live AWS broad temp `terraform apply`: 41 imported, 0 added, 0 changed, 0 destroyed
- [x] Live AWS broad post-import `terraform plan -detailed-exitcode`: exit 0, no changes
- [x] Standalone `insideout-import reverse` from `discover --no-hcl` S3 parent input: 5 imports, 0 add, 0 change, 0 destroy
- [x] Standalone reverse temp `terraform apply`: 5 imported, 0 added, 0 changed, 0 destroyed
- [x] Standalone reverse post-import `terraform plan -detailed-exitcode`: exit 0, no changes
- [x] Verified `validate.json`: valid true, zero errors/warnings for live runs

## Notes

- Rebases on the AWS v6 import-ID region suffix change from #674/#675; generated import IDs retain `@region`.
- The broad live run still reports an expected `depchase_warning` for the Lambda IAM role: the ARN now discovers correctly, but Terraform generated config omitted the role body, so the SDK leaves the literal ARN and converges instead of failing or creating a dangling `aws_iam_role` reference.

## Security review

- No new API endpoint or auth surface.
- Terraform execution stays in the local/Mars job context and uses argument-vector execution, not shell interpolation.
- Request/result JSON contains resource identities and artifact metadata; credentials are not added to the job contract.
- Live `terraform apply` calls were temp import-state applies only: they imported existing resources into local temp state and made 0 cloud creates/updates/deletes.

## QA review

- Added/updated tests cover JSON contract round trips, import count parsing, SDK artifact emission, closure expansion, CLI SDK wiring, multi-region reverse closure input, typed HCL list-object/null behavior, Secrets Manager default drift pinning, security group rule list restoration, Cognito fixups, orphan import filtering before cross refs, Cloud Control ARN normalization, IAM role path stripping, and depchase convergence when provider generated config drops a discovered dependency.
