### PR TITLE
fix(import): include region in AWS v6 import IDs

### DIFF
--- a/cmd/insideout-import/genconfig/emit.go
+++ b/cmd/insideout-import/genconfig/emit.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/importid"
 )
 
 const (
@@ -40,7 +41,7 @@ func emitImports(dir string, resources []imported.ImportedResource) error {
 			return fmt.Errorf("import block for %q: %w", ir.Identity.Address, err)
 		}
 		bb.SetAttributeTraversal("to", traversal)
-		bb.SetAttributeValue("id", cty.StringVal(ir.Identity.ImportID))
+		bb.SetAttributeValue("id", cty.StringVal(importid.ForResource(ir)))
 	}
 	return os.WriteFile(filepath.Join(dir, importsFile), f.Bytes(), 0o644)
 }

--- a/cmd/insideout-import/genconfig/emit_test.go
+++ b/cmd/insideout-import/genconfig/emit_test.go
@@ -14,8 +14,8 @@ func TestEmitImports_HappyPath(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	resources := []imported.ImportedResource{
-		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.alpha", ImportID: "https://example/alpha"}},
-		{Identity: imported.ResourceIdentity{Address: "aws_dynamodb_table.bravo", ImportID: "bravo"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.alpha", Region: "us-east-1", ImportID: "https://example/alpha"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.bravo", Region: "us-east-1", ImportID: "bravo"}},
 	}
 	if err := emitImports(dir, resources); err != nil {
 		t.Fatal(err)
@@ -27,13 +27,36 @@ func TestEmitImports_HappyPath(t *testing.T) {
 	got := string(body)
 	for _, want := range []string{
 		"to = aws_sqs_queue.alpha",
-		`id = "https://example/alpha"`,
+		`id = "https://example/alpha@us-east-1"`,
 		"to = aws_dynamodb_table.bravo",
-		`id = "bravo"`,
+		`id = "bravo@us-east-1"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("imports.tf missing %q\n--- got ---\n%s", want, got)
 		}
+	}
+}
+
+func TestEmitImports_DoesNotAppendRegionForGlobalAWSResource(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := emitImports(dir, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{
+			Type:     "aws_iam_policy",
+			Address:  "aws_iam_policy.readonly",
+			Region:   "us-east-1",
+			ImportID: "arn:aws:iam::123456789012:policy/readonly",
+		}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, importsFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	if want := `id = "arn:aws:iam::123456789012:policy/readonly"`; !strings.Contains(got, want) {
+		t.Errorf("imports.tf missing %q\n--- got ---\n%s", want, got)
 	}
 }
 

--- a/pkg/composer/imported/importid/importid.go
+++ b/pkg/composer/imported/importid/importid.go
@@ -1,0 +1,109 @@
+package importid
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// ForResource returns the Terraform import-block ID for ir.
+//
+// AWS provider v6 made most regional resources region-aware. For these
+// resources Terraform's import block expects the remote ID to be suffixed with
+// "@<region>"; using the bare ID can make the provider search the wrong
+// regional endpoint and report a live object as missing.
+func ForResource(ir imported.ImportedResource) string {
+	id := strings.TrimSpace(ir.Identity.ImportID)
+	if id == "" || !isAWSRegionAware(ir) {
+		return id
+	}
+	region := regionForImport(ir)
+	if region == "" || strings.HasSuffix(id, "@"+region) {
+		return id
+	}
+	return id + "@" + region
+}
+
+func isAWSRegionAware(ir imported.ImportedResource) bool {
+	cloud := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+	tfType := terraformType(ir.Identity)
+	if cloud != "" && cloud != "aws" {
+		return false
+	}
+	if !strings.HasPrefix(tfType, "aws_") {
+		return false
+	}
+	_, schema, ok := generated.Lookup(tfType)
+	if !ok {
+		return false
+	}
+	field, ok := schema["region"]
+	return ok && field.Configurable()
+}
+
+func terraformType(id imported.ResourceIdentity) string {
+	if typ := strings.TrimSpace(id.Type); typ != "" {
+		return typ
+	}
+	addr := strings.TrimSpace(id.Address)
+	if before, _, ok := strings.Cut(addr, "."); ok {
+		return before
+	}
+	return addr
+}
+
+func regionForImport(ir imported.ImportedResource) string {
+	for _, candidate := range []string{
+		typedLiteralString(ir.Attrs, "region"),
+		opaqueString(ir.Attributes["region"]),
+		mapString(ir.Identity.NativeIDs, "region"),
+		ir.Identity.Region,
+	} {
+		if candidate := strings.TrimSpace(candidate); candidate != "" {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func typedLiteralString(raw json.RawMessage, key string) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return ""
+	}
+	field, ok := obj[key]
+	if !ok {
+		return ""
+	}
+	var value struct {
+		Literal *string `json:"literal"`
+	}
+	if err := json.Unmarshal(field, &value); err != nil || value.Literal == nil {
+		return ""
+	}
+	return *value.Literal
+}
+
+func opaqueString(v any) string {
+	switch value := v.(type) {
+	case string:
+		return value
+	case map[string]any:
+		if literal, ok := value["literal"].(string); ok {
+			return literal
+		}
+	}
+	return ""
+}
+
+func mapString(m map[string]string, key string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	return m[key]
+}

--- a/pkg/composer/imported/importid/importid_test.go
+++ b/pkg/composer/imported/importid/importid_test.go
@@ -1,0 +1,118 @@
+package importid
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestForResource_AppendsRegionForAWSRegionAwareResource(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSS3Bucket{
+		Bucket: generated.LiteralOf("io-uploads"),
+		Region: generated.LiteralOf("us-west-2"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.io_uploads",
+			Region:   "us-east-1",
+			ImportID: "io-uploads",
+		},
+		Attrs: attrs,
+	}
+
+	if got, want := ForResource(ir), "io-uploads@us-west-2"; got != want {
+		t.Fatalf("ForResource() = %q, want %q", got, want)
+	}
+}
+
+func TestForResource_UsesIdentityRegionWhenAttrsDoNotCarryRegion(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.jobs",
+			Region:   "us-east-1",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123456789012/jobs",
+		},
+	}
+
+	if got, want := ForResource(ir), "https://sqs.us-east-1.amazonaws.com/123456789012/jobs@us-east-1"; got != want {
+		t.Fatalf("ForResource() = %q, want %q", got, want)
+	}
+}
+
+func TestForResource_KeepsRawIDWhenRegionUnknown(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.io_uploads",
+			ImportID: "io-uploads",
+		},
+	}
+
+	if got, want := ForResource(ir), "io-uploads"; got != want {
+		t.Fatalf("ForResource() = %q, want %q", got, want)
+	}
+}
+
+func TestForResource_DoesNotAppendRegionForAWSGlobalResource(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_iam_policy",
+			Address:  "aws_iam_policy.readonly",
+			Region:   "us-east-1",
+			ImportID: "arn:aws:iam::123456789012:policy/readonly",
+		},
+	}
+
+	if got, want := ForResource(ir), "arn:aws:iam::123456789012:policy/readonly"; got != want {
+		t.Fatalf("ForResource() = %q, want %q", got, want)
+	}
+}
+
+func TestForResource_DoesNotAppendRegionForGCP(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "gcp",
+			Type:     "google_pubsub_topic",
+			Address:  "google_pubsub_topic.events",
+			Region:   "us-central1",
+			ImportID: "projects/test/topics/events",
+		},
+	}
+
+	if got, want := ForResource(ir), "projects/test/topics/events"; got != want {
+		t.Fatalf("ForResource() = %q, want %q", got, want)
+	}
+}
+
+func TestForResource_KeepsExistingRegionSuffix(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.io_uploads",
+			Region:   "us-east-1",
+			ImportID: "io-uploads@us-east-1",
+		},
+	}
+
+	if got, want := ForResource(ir), "io-uploads@us-east-1"; got != want {
+		t.Fatalf("ForResource() = %q, want %q", got, want)
+	}
+}

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/importid"
 )
 
 // EmitImportedOpts bundles the provenance inputs threaded into EmitImportedTF
@@ -138,7 +139,7 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 			alias := providerAliasForResource(got, ir.Identity)
 			e.resource = wrapResourceBlock(ir.Identity.Type, addressLabel(addr), alias, body)
 			if mode == emitModeResourceImport {
-				e.imported = renderImportBlock(addr, ir.Identity.ImportID)
+				e.imported = renderImportBlock(addr, importid.ForResource(*ir))
 			}
 			providersUsed[got] = true
 			if alias == "google-beta.imported" {

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -38,6 +38,7 @@ func TestEmitImportedTF_TypedAWS(t *testing.T) {
 			Cloud:    "aws",
 			Type:     "aws_sqs_queue",
 			Address:  "aws_sqs_queue.orders_dlq",
+			Region:   "us-east-1",
 			ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ",
 		},
 		Tier:  imported.TierImportedFlat,
@@ -55,8 +56,37 @@ func TestEmitImportedTF_TypedAWS(t *testing.T) {
 	// import block paired with the resource.
 	assert.Contains(t, s, "import {")
 	assert.Contains(t, s, "to = aws_sqs_queue.orders_dlq")
-	assert.Contains(t, s, `id = "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ"`)
+	assert.Contains(t, s, `id = "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ@us-east-1"`)
 	// Output must parse as valid HCL.
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
+}
+
+func TestEmitImportedTF_S3ImportIDUsesResourceRegion(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSS3Bucket{
+		Bucket: generated.LiteralOf("io-uploads"),
+		Region: generated.LiteralOf("us-west-2"),
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.io_uploads",
+			Region:   "us-east-1",
+			ImportID: "io-uploads",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.Contains(t, s, "to = aws_s3_bucket.io_uploads")
+	assert.Contains(t, s, `id = "io-uploads@us-west-2"`)
+	assert.True(t, hasAttr(t, s, "region", `"us-west-2"`), "region attr missing in:\n%s", s)
 	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
 }

--- a/pkg/composer/noselfimport_test.go
+++ b/pkg/composer/noselfimport_test.go
@@ -38,6 +38,7 @@ func TestNoForeignLutherImportsInNonTestFiles(t *testing.T) {
 	allowedSubpackages := map[string]struct{}{
 		parentPkg + "/pkg/composer/imported":           {},
 		parentPkg + "/pkg/composer/imported/generated": {},
+		parentPkg + "/pkg/composer/imported/importid":  {},
 		parentPkg + "/pkg/composer/imported/policy":    {},
 	}
 


### PR DESCRIPTION
## Summary

- append @region to AWS provider v6 import IDs for region-aware resources
- share the import-ID formatter between composer imported.tf emission and genconfig imports.tf
- preserve raw IDs for IAM/global resources, GCP resources, and resources with no known region

Closes #674

## Verification

- go test ./pkg/composer/imported/importid ./pkg/composer ./cmd/insideout-import/genconfig -run 'TestForResource|TestEmitImportedTF_TypedAWS|TestEmitImportedTF_S3ImportIDUsesResourceRegion|TestNoForeignLutherImportsInNonTestFiles|TestEmitImports_HappyPath|TestEmitImports_DoesNotAppendRegionForGlobalAWSResource'