### PR TITLE
fix(import): keep S3 bucket import IDs bare

### DIFF
--- a/pkg/composer/imported/importid/importid.go
+++ b/pkg/composer/imported/importid/importid.go
@@ -16,7 +16,11 @@ import (
 // regional endpoint and report a live object as missing.
 func ForResource(ir imported.ImportedResource) string {
 	id := strings.TrimSpace(ir.Identity.ImportID)
-	if id == "" || !isAWSRegionAware(ir) {
+	if id == "" {
+		return id
+	}
+	tfType := terraformType(ir.Identity)
+	if !needsAWSRegionSuffix(ir, tfType) {
 		return id
 	}
 	region := regionForImport(ir)
@@ -26,9 +30,11 @@ func ForResource(ir imported.ImportedResource) string {
 	return id + "@" + region
 }
 
-func isAWSRegionAware(ir imported.ImportedResource) bool {
+func needsAWSRegionSuffix(ir imported.ImportedResource, tfType string) bool {
+	if usesBareImportID(tfType) {
+		return false
+	}
 	cloud := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
-	tfType := terraformType(ir.Identity)
 	if cloud != "" && cloud != "aws" {
 		return false
 	}
@@ -41,6 +47,15 @@ func isAWSRegionAware(ir imported.ImportedResource) bool {
 	}
 	field, ok := schema["region"]
 	return ok && field.Configurable()
+}
+
+func usesBareImportID(tfType string) bool {
+	switch tfType {
+	case "aws_s3_bucket":
+		return true
+	default:
+		return false
+	}
 }
 
 func terraformType(id imported.ResourceIdentity) string {

--- a/pkg/composer/imported/importid/importid_test.go
+++ b/pkg/composer/imported/importid/importid_test.go
@@ -10,6 +10,31 @@ import (
 
 func TestForResource_AppendsRegionForAWSRegionAwareResource(t *testing.T) {
 	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSSQSQueue{
+		URL:    generated.LiteralOf("https://sqs.us-west-2.amazonaws.com/123456789012/jobs"),
+		Region: generated.LiteralOf("us-west-2"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.jobs",
+			Region:   "us-east-1",
+			ImportID: "https://sqs.us-west-2.amazonaws.com/123456789012/jobs",
+		},
+		Attrs: attrs,
+	}
+
+	if got, want := ForResource(ir), "https://sqs.us-west-2.amazonaws.com/123456789012/jobs@us-west-2"; got != want {
+		t.Fatalf("ForResource() = %q, want %q", got, want)
+	}
+}
+
+func TestForResource_DoesNotAppendRegionForS3Bucket(t *testing.T) {
+	t.Parallel()
 	attrs, err := json.Marshal(&generated.AWSS3Bucket{
 		Bucket: generated.LiteralOf("io-uploads"),
 		Region: generated.LiteralOf("us-west-2"),
@@ -22,13 +47,13 @@ func TestForResource_AppendsRegionForAWSRegionAwareResource(t *testing.T) {
 			Cloud:    "aws",
 			Type:     "aws_s3_bucket",
 			Address:  "aws_s3_bucket.io_uploads",
-			Region:   "us-east-1",
+			Region:   "us-west-2",
 			ImportID: "io-uploads",
 		},
 		Attrs: attrs,
 	}
 
-	if got, want := ForResource(ir), "io-uploads@us-west-2"; got != want {
+	if got, want := ForResource(ir), "io-uploads"; got != want {
 		t.Fatalf("ForResource() = %q, want %q", got, want)
 	}
 }
@@ -105,14 +130,14 @@ func TestForResource_KeepsExistingRegionSuffix(t *testing.T) {
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{
 			Cloud:    "aws",
-			Type:     "aws_s3_bucket",
-			Address:  "aws_s3_bucket.io_uploads",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.jobs",
 			Region:   "us-east-1",
-			ImportID: "io-uploads@us-east-1",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123456789012/jobs@us-east-1",
 		},
 	}
 
-	if got, want := ForResource(ir), "io-uploads@us-east-1"; got != want {
+	if got, want := ForResource(ir), "https://sqs.us-east-1.amazonaws.com/123456789012/jobs@us-east-1"; got != want {
 		t.Fatalf("ForResource() = %q, want %q", got, want)
 	}
 }

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -91,7 +91,7 @@ func TestEmitImportedTF_TypedAWS(t *testing.T) {
 	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
 }
 
-func TestEmitImportedTF_S3ImportIDUsesResourceRegion(t *testing.T) {
+func TestEmitImportedTF_S3ImportIDUsesBareBucketName(t *testing.T) {
 	t.Parallel()
 	attrs, err := json.Marshal(&generated.AWSS3Bucket{
 		Bucket: generated.LiteralOf("io-uploads"),
@@ -114,7 +114,7 @@ func TestEmitImportedTF_S3ImportIDUsesResourceRegion(t *testing.T) {
 	require.NotNil(t, out)
 	s := string(out)
 	assert.Contains(t, s, "to = aws_s3_bucket.io_uploads")
-	assert.Contains(t, s, `id = "io-uploads@us-west-2"`)
+	assert.Contains(t, s, `id = "io-uploads"`)
 	assert.True(t, hasAttr(t, s, "region", `"us-west-2"`), "region attr missing in:\n%s", s)
 	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())


### PR DESCRIPTION
## Summary
- exclude aws_s3_bucket from AWS v6 @region import ID suffixing
- keep region suffix behavior for regional resources such as SQS
- update composer/importid tests to pin S3 bucket import IDs as bare bucket names

## Tests
- go test ./pkg/composer/imported/importid
- go test ./pkg/composer/...