### PR TITLE
feat(composer): export InsideOut import-provenance marker keys

### DIFF
--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -14,22 +14,10 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
 
-// Provenance tag/label key names emitted on every taggable imported resource.
-// Decision #46 in docs/managed-resource-tiers.md: the same logical
-// <import-project-id> is used across AWS+GCP for one InsideOut stack/session.
-const (
-	awsTagImportProject = "InsideOutImportProject"
-	awsTagImportSession = "InsideOutImportSession"
-	awsTagImported      = "InsideOutImported"
-	awsTagImportedAt    = "InsideOutImportedAt"
-	awsTagImportedTrue  = "true"
-
-	gcpLabelImportProject = "insideout-import-project"
-	gcpLabelImportSession = "insideout-import-session"
-	gcpLabelImported      = "insideout-imported"
-	gcpLabelImportedAt    = "insideout-imported-at"
-	gcpLabelImportedTrue  = "true"
-)
+// The provenance tag/label keys emitted on every taggable imported resource
+// are exported from marker_tags.go. Decision #46 in
+// docs/managed-resource-tiers.md: the same logical <import-project-id> is
+// used across AWS+GCP for one InsideOut stack/session.
 
 // untaggableAWS mirrors the canonical NON_TAGGABLE_AWS array in
 // tests/lint-project-tag.sh. Resource types in this set do NOT accept a tags
@@ -151,26 +139,26 @@ func provenanceKeysFor(cloud, projectID, sessionID string, importedAt time.Time)
 	switch strings.ToLower(strings.TrimSpace(cloud)) {
 	case "aws":
 		entries := []provenanceEntry{
-			{Key: awsTagImportProject, Value: projectID},
+			{Key: AWSTagKeyImportProject, Value: projectID},
 		}
 		if sessionID != "" {
-			entries = append(entries, provenanceEntry{Key: awsTagImportSession, Value: sessionID})
+			entries = append(entries, provenanceEntry{Key: AWSTagKeyImportSession, Value: sessionID})
 		}
 		entries = append(entries,
-			provenanceEntry{Key: awsTagImported, Value: awsTagImportedTrue},
-			provenanceEntry{Key: awsTagImportedAt, Value: importedAt.UTC().Format(time.RFC3339)},
+			provenanceEntry{Key: AWSTagKeyImported, Value: markerValueTrue},
+			provenanceEntry{Key: AWSTagKeyImportedAt, Value: importedAt.UTC().Format(time.RFC3339)},
 		)
 		return entries
 	case "gcp":
 		entries := []provenanceEntry{
-			{Key: gcpLabelImportProject, Value: projectID},
+			{Key: GCPLabelKeyImportProject, Value: projectID},
 		}
 		if sessionID != "" {
-			entries = append(entries, provenanceEntry{Key: gcpLabelImportSession, Value: sessionID})
+			entries = append(entries, provenanceEntry{Key: GCPLabelKeyImportSession, Value: sessionID})
 		}
 		entries = append(entries,
-			provenanceEntry{Key: gcpLabelImported, Value: gcpLabelImportedTrue},
-			provenanceEntry{Key: gcpLabelImportedAt, Value: gcpLabelTimestamp(importedAt)},
+			provenanceEntry{Key: GCPLabelKeyImported, Value: markerValueTrue},
+			provenanceEntry{Key: GCPLabelKeyImportedAt, Value: gcpLabelTimestamp(importedAt)},
 		)
 		return entries
 	}
@@ -199,9 +187,9 @@ func existingProvenanceProject(ir imported.ImportedResource) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	key := awsTagImportProject
+	key := AWSTagKeyImportProject
 	if attrName == "labels" {
-		key = gcpLabelImportProject
+		key = GCPLabelKeyImportProject
 	}
 
 	if len(ir.Attrs) > 0 {

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -86,6 +86,11 @@ func TestTaggable_AllowlistFallback(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestProvenanceKeysFor_AWS verifies provenanceKeysFor wiring (key set,
+// order, session omission). The literal values of the marker keys are
+// pinned in TestMarkerTagKeyValues_PinnedLiterals; here we use the
+// constants so a value rename caught there isn't silently masked by a
+// tautological assertion at this call site.
 func TestProvenanceKeysFor_AWS(t *testing.T) {
 	t.Parallel()
 	entries := provenanceKeysFor("aws", "io-stack-1", "sess-9", fixedTime())

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -90,13 +90,13 @@ func TestProvenanceKeysFor_AWS(t *testing.T) {
 	t.Parallel()
 	entries := provenanceKeysFor("aws", "io-stack-1", "sess-9", fixedTime())
 	require.Len(t, entries, 4)
-	assert.Equal(t, awsTagImportProject, entries[0].Key)
+	assert.Equal(t, AWSTagKeyImportProject, entries[0].Key)
 	assert.Equal(t, "io-stack-1", entries[0].Value)
-	assert.Equal(t, awsTagImportSession, entries[1].Key)
+	assert.Equal(t, AWSTagKeyImportSession, entries[1].Key)
 	assert.Equal(t, "sess-9", entries[1].Value)
-	assert.Equal(t, awsTagImported, entries[2].Key)
+	assert.Equal(t, AWSTagKeyImported, entries[2].Key)
 	assert.Equal(t, "true", entries[2].Value)
-	assert.Equal(t, awsTagImportedAt, entries[3].Key)
+	assert.Equal(t, AWSTagKeyImportedAt, entries[3].Key)
 	assert.Equal(t, "2026-04-29T14:30:00Z", entries[3].Value)
 }
 
@@ -104,13 +104,13 @@ func TestProvenanceKeysFor_GCP(t *testing.T) {
 	t.Parallel()
 	entries := provenanceKeysFor("gcp", "io-stack-1", "sess-9", fixedTime())
 	require.Len(t, entries, 4)
-	assert.Equal(t, gcpLabelImportProject, entries[0].Key)
+	assert.Equal(t, GCPLabelKeyImportProject, entries[0].Key)
 	assert.Equal(t, "io-stack-1", entries[0].Value)
-	assert.Equal(t, gcpLabelImportSession, entries[1].Key)
+	assert.Equal(t, GCPLabelKeyImportSession, entries[1].Key)
 	assert.Equal(t, "sess-9", entries[1].Value)
-	assert.Equal(t, gcpLabelImported, entries[2].Key)
+	assert.Equal(t, GCPLabelKeyImported, entries[2].Key)
 	assert.Equal(t, "true", entries[2].Value)
-	assert.Equal(t, gcpLabelImportedAt, entries[3].Key)
+	assert.Equal(t, GCPLabelKeyImportedAt, entries[3].Key)
 	assert.Equal(t, "2026-04-29t14-30-00z", entries[3].Value)
 }
 
@@ -119,7 +119,7 @@ func TestProvenanceKeysFor_OmitSession(t *testing.T) {
 	entries := provenanceKeysFor("aws", "io-stack-1", "", fixedTime())
 	require.Len(t, entries, 3)
 	for _, e := range entries {
-		assert.NotEqual(t, awsTagImportSession, e.Key, "session entry must be omitted when sessionID is empty")
+		assert.NotEqual(t, AWSTagKeyImportSession, e.Key, "session entry must be omitted when sessionID is empty")
 	}
 }
 

--- a/pkg/composer/marker_tags.go
+++ b/pkg/composer/marker_tags.go
@@ -1,0 +1,54 @@
+package composer
+
+// Exported InsideOut import-provenance marker tag/label keys.
+//
+// Every taggable resource adopted by `insideout-import` is stamped with these
+// keys on first apply. Downstream consumers (the reliable backend, the
+// imported-resource drift classifier, the UI) need the same literals to
+// classify plan diffs as "expected provenance write" vs. real drift. The
+// canonical source of truth lives here so a rename never has to land in
+// multiple repos by grep — see issue #679 for the duplication that prompted
+// this export.
+//
+// AWS uses CamelCase tag keys; GCP labels are restricted to lowercase letters,
+// digits, `-`, and `_`, so the GCP mirror uses kebab-case.
+const (
+	// AWSTagKeyImportProject identifies the InsideOut stack/import-project
+	// that owns this resource. Required on every adopted AWS resource.
+	AWSTagKeyImportProject = "InsideOutImportProject"
+
+	// AWSTagKeyImportSession identifies the specific import session that
+	// adopted this resource. Optional — omitted when the caller did not
+	// supply a session ID.
+	AWSTagKeyImportSession = "InsideOutImportSession"
+
+	// AWSTagKeyImported is the canonical boolean marker stamped on every
+	// adopted AWS resource. Its value is always "true".
+	AWSTagKeyImported = "InsideOutImported"
+
+	// AWSTagKeyImportedAt is the RFC3339 UTC timestamp recorded when the
+	// resource was first adopted.
+	AWSTagKeyImportedAt = "InsideOutImportedAt"
+
+	// GCPLabelKeyImportProject is the GCP-label mirror of
+	// AWSTagKeyImportProject.
+	GCPLabelKeyImportProject = "insideout-import-project"
+
+	// GCPLabelKeyImportSession is the GCP-label mirror of
+	// AWSTagKeyImportSession.
+	GCPLabelKeyImportSession = "insideout-import-session"
+
+	// GCPLabelKeyImported is the GCP-label mirror of AWSTagKeyImported.
+	GCPLabelKeyImported = "insideout-imported"
+
+	// GCPLabelKeyImportedAt is the GCP-label mirror of AWSTagKeyImportedAt.
+	// The value is RFC3339 UTC, downcased with `:` and `.` replaced by `-`
+	// to satisfy the GCP label charset.
+	GCPLabelKeyImportedAt = "insideout-imported-at"
+)
+
+// markerValueTrue is the canonical value of AWSTagKeyImported /
+// GCPLabelKeyImported. Kept unexported because it is the same literal in
+// both clouds and downstream classifiers only need to compare against the
+// constant `"true"`.
+const markerValueTrue = "true"

--- a/pkg/composer/marker_tags_test.go
+++ b/pkg/composer/marker_tags_test.go
@@ -6,29 +6,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestMarkerTagKeyValues pins the literal values of the exported provenance
-// keys. Downstream consumers (reliable2, ui-core) depend on these exact
-// strings to classify plan diffs as expected-provenance writes vs. real
-// drift — see issue #679. Any rename here is a breaking change for those
-// callers and must be coordinated.
-func TestMarkerTagKeyValues(t *testing.T) {
+// TestMarkerTagKeyValues_PinnedLiterals pins the literal values of the
+// exported provenance keys (and the unexported marker value). Downstream
+// consumers (reliable2, ui-core) depend on these exact strings to classify
+// plan diffs as expected-provenance writes vs. real drift — see issue #679.
+// Any rename here is a breaking change for those callers and must be
+// coordinated.
+//
+// markerValueTrue is unexported but still crosses the repo boundary via
+// the emitted Terraform — downstream classifiers compare against `"true"`
+// — so it is pinned here too.
+func TestMarkerTagKeyValues_PinnedLiterals(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name string
-		got  string
-		want string
-	}{
-		{"AWSTagKeyImportProject", AWSTagKeyImportProject, "InsideOutImportProject"},
-		{"AWSTagKeyImportSession", AWSTagKeyImportSession, "InsideOutImportSession"},
-		{"AWSTagKeyImported", AWSTagKeyImported, "InsideOutImported"},
-		{"AWSTagKeyImportedAt", AWSTagKeyImportedAt, "InsideOutImportedAt"},
-		{"GCPLabelKeyImportProject", GCPLabelKeyImportProject, "insideout-import-project"},
-		{"GCPLabelKeyImportSession", GCPLabelKeyImportSession, "insideout-import-session"},
-		{"GCPLabelKeyImported", GCPLabelKeyImported, "insideout-imported"},
-		{"GCPLabelKeyImportedAt", GCPLabelKeyImportedAt, "insideout-imported-at"},
-	}
-	for _, tc := range cases {
-		assert.Equalf(t, tc.want, tc.got, "marker key %s drifted from its pinned literal", tc.name)
-	}
+	assert.Equal(t, "InsideOutImportProject", AWSTagKeyImportProject)
+	assert.Equal(t, "InsideOutImportSession", AWSTagKeyImportSession)
+	assert.Equal(t, "InsideOutImported", AWSTagKeyImported)
+	assert.Equal(t, "InsideOutImportedAt", AWSTagKeyImportedAt)
+
+	assert.Equal(t, "insideout-import-project", GCPLabelKeyImportProject)
+	assert.Equal(t, "insideout-import-session", GCPLabelKeyImportSession)
+	assert.Equal(t, "insideout-imported", GCPLabelKeyImported)
+	assert.Equal(t, "insideout-imported-at", GCPLabelKeyImportedAt)
+
+	assert.Equal(t, "true", markerValueTrue)
 }

--- a/pkg/composer/marker_tags_test.go
+++ b/pkg/composer/marker_tags_test.go
@@ -1,0 +1,34 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMarkerTagKeyValues pins the literal values of the exported provenance
+// keys. Downstream consumers (reliable2, ui-core) depend on these exact
+// strings to classify plan diffs as expected-provenance writes vs. real
+// drift — see issue #679. Any rename here is a breaking change for those
+// callers and must be coordinated.
+func TestMarkerTagKeyValues(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"AWSTagKeyImportProject", AWSTagKeyImportProject, "InsideOutImportProject"},
+		{"AWSTagKeyImportSession", AWSTagKeyImportSession, "InsideOutImportSession"},
+		{"AWSTagKeyImported", AWSTagKeyImported, "InsideOutImported"},
+		{"AWSTagKeyImportedAt", AWSTagKeyImportedAt, "InsideOutImportedAt"},
+		{"GCPLabelKeyImportProject", GCPLabelKeyImportProject, "insideout-import-project"},
+		{"GCPLabelKeyImportSession", GCPLabelKeyImportSession, "insideout-import-session"},
+		{"GCPLabelKeyImported", GCPLabelKeyImported, "insideout-imported"},
+		{"GCPLabelKeyImportedAt", GCPLabelKeyImportedAt, "insideout-imported-at"},
+	}
+	for _, tc := range cases {
+		assert.Equalf(t, tc.want, tc.got, "marker key %s drifted from its pinned literal", tc.name)
+	}
+}

--- a/pkg/composer/plan_acceptance.go
+++ b/pkg/composer/plan_acceptance.go
@@ -53,8 +53,8 @@ func FirstImportProvenanceKeys(cloud string) []string {
 		var out []string
 		for _, parent := range []string{"tags", "tags_all"} {
 			for _, k := range []string{
-				awsTagImportProject, awsTagImportSession,
-				awsTagImported, awsTagImportedAt,
+				AWSTagKeyImportProject, AWSTagKeyImportSession,
+				AWSTagKeyImported, AWSTagKeyImportedAt,
 			} {
 				out = append(out, parent+"."+k)
 			}
@@ -64,8 +64,8 @@ func FirstImportProvenanceKeys(cloud string) []string {
 		var out []string
 		for _, parent := range []string{"labels", "effective_labels", "terraform_labels"} {
 			for _, k := range []string{
-				gcpLabelImportProject, gcpLabelImportSession,
-				gcpLabelImported, gcpLabelImportedAt,
+				GCPLabelKeyImportProject, GCPLabelKeyImportSession,
+				GCPLabelKeyImported, GCPLabelKeyImportedAt,
 			} {
 				out = append(out, parent+"."+k)
 			}


### PR DESCRIPTION
## Summary
- Export the four AWS tag keys and four GCP label keys that mark `insideout-import`-adopted resources as a stable API for downstream consumers — grouped in a new `pkg/composer/marker_tags.go`.
- Replace the unexported `awsTag*` / `gcpLabel*` package locals throughout `imported_provenance.go`, `plan_acceptance.go`, and their tests with the new exported names.
- Add `TestMarkerTagKeyValues_PinnedLiterals` so any future rename of a value (`"InsideOutImportProject"` → anything else) trips at PR review instead of silently breaking the downstream drift classifier.

Fixes [#679](https://github.com/luthersystems/insideout-terraform-presets/issues/679). Unblocks `reliable2` (three local copies today) and ui-core (per [reliable#1737](https://github.com/luthersystems/reliable/pull/1737)).

## Test plan
- [x] `go test ./pkg/composer/... -count=1` — 2195 pass.
- [x] `go test ./pkg/composer/ -run "TestMarkerTagKeyValues|TestProvenanceKeysFor|TestInjectProvenance|TestFirstImportProvenanceKeys" -count=1 -v` — 20 pass.
- [x] `go vet ./pkg/composer/...` clean.

## Review notes
- /review: no P0/P1 findings (Go-only refactor + new exports; no behavior change; rename-only).
- qa-professor findings addressed in the second commit:
  - Pinned `markerValueTrue` even though unexported (value crosses repo boundary).
  - Dropped the table's `name` field to remove the identifier-drift surface.
  - Renamed test to `_PinnedLiterals` for self-documenting intent.
  - Added a header comment on `TestProvenanceKeysFor_AWS` noting that the literal-value pin lives in the new pin test, so the existing wiring tests using symbols aren't mistaken for tautological pins.

## Downstream cleanup (separate PR after this lands)
- `reliable2` deletes the three duplicated literal blocks in `internal/agentapi/import_managed.go`, `internal/devtools/imported.go`, and `internal/agentapi/tf_plan_tag_only.go` in favor of `composer.AWSTagKey*` / `composer.GCPLabelKey*`.