### PR TITLE
Fix reverse-import AWS role and Route53 adoption

### DIFF
--- a/cmd/insideout-import/genconfig/emit.go
+++ b/cmd/insideout-import/genconfig/emit.go
@@ -65,6 +65,19 @@ var localstackEndpointServices = []string{
 	"sts",
 }
 
+type awsProviderAuth struct {
+	RoleARN    string
+	ExternalID string
+}
+
+type providerEmitOptions struct {
+	Provider       string
+	Region         string
+	GCPProjectID   string
+	AWSEndpointURL string
+	AWSAuth        awsProviderAuth
+}
+
 // emitProviders writes <dir>/providers.tf with the configured provider
 // pinned to the same major as the rest of the repo. The provider block is
 // unaliased — see emitImports for why.
@@ -74,6 +87,8 @@ var localstackEndpointServices = []string{
 //   - provider "aws" { region = ... }
 //   - When awsEndpointURL is non-empty (LocalStack CI gate #272),
 //     emits the LocalStack attribute set + endpoints {} map.
+//   - When AWSAuth.RoleARN is non-empty, emits assume_role so provider
+//     readback runs through the project Terraform role.
 //
 // On GCP (provider == ProviderGCP):
 //   - required_providers entry for hashicorp/google ~> 5.0
@@ -83,7 +98,7 @@ var localstackEndpointServices = []string{
 //   - awsEndpointURL is ignored. The Cloud Asset Inventory API has no
 //     emulator (issue #264) so the GCP gate is a manual smoke against a
 //     real project; there's no LocalStack-equivalent shape to emit.
-func emitProviders(dir, provider, region, gcpProjectID, awsEndpointURL string) error {
+func emitProviders(dir string, opts providerEmitOptions) error {
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 
@@ -92,16 +107,16 @@ func emitProviders(dir, provider, region, gcpProjectID, awsEndpointURL string) e
 
 	body.AppendNewline()
 
-	switch provider {
+	switch opts.Provider {
 	case ProviderGCP:
 		rp.Body().SetAttributeValue("google", cty.ObjectVal(map[string]cty.Value{
 			"source":  cty.StringVal("hashicorp/google"),
 			"version": cty.StringVal("~> 5.0"),
 		}))
 		prov := body.AppendNewBlock("provider", []string{"google"})
-		prov.Body().SetAttributeValue("project", cty.StringVal(gcpProjectID))
-		if region != "" {
-			prov.Body().SetAttributeValue("region", cty.StringVal(region))
+		prov.Body().SetAttributeValue("project", cty.StringVal(opts.GCPProjectID))
+		if opts.Region != "" {
+			prov.Body().SetAttributeValue("region", cty.StringVal(opts.Region))
 		}
 	default: // ProviderAWS
 		rp.Body().SetAttributeValue("aws", cty.ObjectVal(map[string]cty.Value{
@@ -109,9 +124,9 @@ func emitProviders(dir, provider, region, gcpProjectID, awsEndpointURL string) e
 			"version": cty.StringVal("~> 6.0"),
 		}))
 		prov := body.AppendNewBlock("provider", []string{"aws"})
-		prov.Body().SetAttributeValue("region", cty.StringVal(region))
+		prov.Body().SetAttributeValue("region", cty.StringVal(opts.Region))
 
-		if awsEndpointURL != "" {
+		if opts.AWSEndpointURL != "" {
 			prov.Body().SetAttributeValue("access_key", cty.StringVal("test"))
 			prov.Body().SetAttributeValue("secret_key", cty.StringVal("test"))
 			prov.Body().SetAttributeValue("skip_credentials_validation", cty.True)
@@ -120,12 +135,24 @@ func emitProviders(dir, provider, region, gcpProjectID, awsEndpointURL string) e
 			prov.Body().SetAttributeValue("s3_use_path_style", cty.True)
 			ep := prov.Body().AppendNewBlock("endpoints", nil)
 			for _, svc := range localstackEndpointServices {
-				ep.Body().SetAttributeValue(svc, cty.StringVal(awsEndpointURL))
+				ep.Body().SetAttributeValue(svc, cty.StringVal(opts.AWSEndpointURL))
 			}
 		}
+		appendAWSAssumeRole(prov.Body(), opts.AWSAuth)
 	}
 
 	return os.WriteFile(filepath.Join(dir, providersFile), f.Bytes(), 0o644)
+}
+
+func appendAWSAssumeRole(body *hclwrite.Body, auth awsProviderAuth) {
+	if strings.TrimSpace(auth.RoleARN) == "" {
+		return
+	}
+	assume := body.AppendNewBlock("assume_role", nil)
+	assume.Body().SetAttributeValue("role_arn", cty.StringVal(auth.RoleARN))
+	if strings.TrimSpace(auth.ExternalID) != "" {
+		assume.Body().SetAttributeValue("external_id", cty.StringVal(auth.ExternalID))
+	}
 }
 
 // addressTraversal converts a Terraform resource address like

--- a/cmd/insideout-import/genconfig/emit_test.go
+++ b/cmd/insideout-import/genconfig/emit_test.go
@@ -113,7 +113,10 @@ func TestEmitImports_RejectsBadAddress(t *testing.T) {
 func TestEmitProviders_HappyPath(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := emitProviders(dir, ProviderAWS, "us-west-2", "", ""); err != nil {
+	if err := emitProviders(dir, providerEmitOptions{
+		Provider: ProviderAWS,
+		Region:   "us-west-2",
+	}); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, providersFile))
@@ -137,6 +140,7 @@ func TestEmitProviders_HappyPath(t *testing.T) {
 	// words doesn't trip the check.
 	bannedPatterns := []string{
 		`(?m)^\s*endpoints\s*\{`,
+		`(?m)^\s*assume_role\s*\{`,
 		`(?m)^\s*access_key\s*=`,
 		`(?m)^\s*skip_credentials_validation\s*=`,
 		`(?m)^\s*s3_use_path_style\s*=`,
@@ -144,6 +148,37 @@ func TestEmitProviders_HappyPath(t *testing.T) {
 	for _, pat := range bannedPatterns {
 		if regexp.MustCompile(pat).MatchString(got) {
 			t.Errorf("providers.tf must not contain pattern %q when endpointURL is empty\n--- got ---\n%s", pat, got)
+		}
+	}
+}
+
+func TestEmitProviders_AWSAssumeRole(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := emitProviders(dir, providerEmitOptions{
+		Provider: ProviderAWS,
+		Region:   "us-west-2",
+		AWSAuth: awsProviderAuth{
+			RoleARN:    "arn:aws:iam::123456789012:role/io-terraform",
+			ExternalID: "external-123",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(filepath.Join(dir, providersFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	for _, pat := range []string{
+		`provider\s+"aws"\s+\{`,
+		`region\s*=\s*"us-west-2"`,
+		`assume_role\s*\{`,
+		`role_arn\s*=\s*"arn:aws:iam::123456789012:role/io-terraform"`,
+		`external_id\s*=\s*"external-123"`,
+	} {
+		if !regexp.MustCompile(pat).MatchString(got) {
+			t.Errorf("providers.tf missing pattern %q\n--- got ---\n%s", pat, got)
 		}
 	}
 }
@@ -159,7 +194,11 @@ func TestEmitProviders_HappyPath(t *testing.T) {
 func TestEmitProviders_LocalStackEndpoint(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := emitProviders(dir, ProviderAWS, "us-east-1", "", "http://localhost:4566"); err != nil {
+	if err := emitProviders(dir, providerEmitOptions{
+		Provider:       ProviderAWS,
+		Region:         "us-east-1",
+		AWSEndpointURL: "http://localhost:4566",
+	}); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, providersFile))
@@ -225,7 +264,11 @@ func TestEmitProviders_LocalStackEndpoint(t *testing.T) {
 func TestEmitProviders_GCPHappyPath(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := emitProviders(dir, ProviderGCP, "us-central1", "real-proj-12345", ""); err != nil {
+	if err := emitProviders(dir, providerEmitOptions{
+		Provider:     ProviderGCP,
+		Region:       "us-central1",
+		GCPProjectID: "real-proj-12345",
+	}); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, providersFile))
@@ -271,7 +314,10 @@ func TestEmitProviders_GCPHappyPath(t *testing.T) {
 func TestEmitProviders_GCPOmitsEmptyRegion(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := emitProviders(dir, ProviderGCP, "", "real-proj", ""); err != nil {
+	if err := emitProviders(dir, providerEmitOptions{
+		Provider:     ProviderGCP,
+		GCPProjectID: "real-proj",
+	}); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, providersFile))
@@ -292,13 +338,25 @@ func TestEmitProviders_GCPOmitsEmptyRegion(t *testing.T) {
 func TestEmitProviders_GCPIgnoresAWSEndpointURL(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	if err := emitProviders(dir, ProviderGCP, "us-central1", "real-proj", "http://localhost:4566"); err != nil {
+	if err := emitProviders(dir, providerEmitOptions{
+		Provider:       ProviderGCP,
+		Region:         "us-central1",
+		GCPProjectID:   "real-proj",
+		AWSEndpointURL: "http://localhost:4566",
+		AWSAuth: awsProviderAuth{
+			RoleARN:    "arn:aws:iam::123456789012:role/io-terraform",
+			ExternalID: "external-123",
+		},
+	}); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, providersFile))
 	got := string(body)
 	if regexp.MustCompile(`(?m)^\s*endpoints\s*\{`).MatchString(got) {
 		t.Errorf("providers.tf must not emit endpoints {} on GCP path even with awsEndpointURL set\n--- got ---\n%s", got)
+	}
+	if regexp.MustCompile(`(?m)^\s*assume_role\s*\{`).MatchString(got) {
+		t.Errorf("providers.tf must not emit AWS assume_role on GCP path\n--- got ---\n%s", got)
 	}
 }
 

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -48,6 +48,13 @@ type Options struct {
 	// no equivalent emulator (see issue #264 for the gap analysis).
 	AWSEndpointURL string
 
+	// AWSRoleARN and AWSExternalID configure the provider assume_role
+	// block used during readback. Reverse import runs inside the Oracle
+	// cluster but must read the user's AWS account through the project
+	// Terraform role, not the pod's IRSA role.
+	AWSRoleARN    string
+	AWSExternalID string
+
 	// Runner is optional. If nil, Run constructs an execRunner that shells
 	// out to the `terraform` binary on PATH. Tests inject a fake here to
 	// avoid the binary dependency.
@@ -131,7 +138,16 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	if err := emitImports(opts.Workdir, resources); err != nil {
 		return nil, fmt.Errorf("emit imports.tf: %w", err)
 	}
-	if err := emitProviders(opts.Workdir, provider, opts.Region, opts.GCPProjectID, opts.AWSEndpointURL); err != nil {
+	if err := emitProviders(opts.Workdir, providerEmitOptions{
+		Provider:       provider,
+		Region:         opts.Region,
+		GCPProjectID:   opts.GCPProjectID,
+		AWSEndpointURL: opts.AWSEndpointURL,
+		AWSAuth: awsProviderAuth{
+			RoleARN:    opts.AWSRoleARN,
+			ExternalID: opts.AWSExternalID,
+		},
+	}); err != nil {
 		return nil, fmt.Errorf("emit providers.tf: %w", err)
 	}
 

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -426,6 +426,11 @@ var importedLifecycleIgnoreChanges = map[string][]string{
 	// generate-config path pins them; the IR emitter must preserve that
 	// adoption behavior because lifecycle blocks are not stored in Attrs.
 	"aws_secretsmanager_secret": {"force_overwrite_replica_secret", "recovery_window_in_days"},
+	// aws_route53_zone: force_destroy is a Terraform-only destroy-time
+	// sentinel. AWS readback has no durable value for it, so first-import
+	// plans can surface false/null churn even when no hosted-zone setting
+	// would change.
+	"aws_route53_zone": {"force_destroy"},
 }
 
 // appendImportedLifecycle appends a `lifecycle { ignore_changes = [...] }`

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -120,6 +120,35 @@ func TestEmitImportedTF_S3ImportIDUsesBareBucketName(t *testing.T) {
 	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
 }
 
+func TestEmitImportedTF_Route53ZoneIgnoresForceDestroySentinel(t *testing.T) {
+	t.Parallel()
+
+	attrs, err := json.Marshal(&generated.AWSRoute53Zone{
+		Name:         generated.LiteralOf("apps.example.com"),
+		ForceDestroy: generated.NullOf[bool](),
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_route53_zone",
+			Address:  "aws_route53_zone.apps",
+			ImportID: "Z1234567890",
+			Region:   "us-west-2",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.True(t, hasAttr(t, s, "force_destroy", "null"), "fixture must exercise the provider sentinel:\n%s", s)
+	assert.ElementsMatch(t, []string{"force_destroy"}, lifecycleIgnoreChanges(t, out, "aws_route53_zone"))
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
+}
+
 func TestEmitImportedTF_TypedGCP(t *testing.T) {
 	t.Parallel()
 	ir := imported.ImportedResource{

--- a/pkg/reverseimport/aws_auth.go
+++ b/pkg/reverseimport/aws_auth.go
@@ -1,0 +1,151 @@
+package reverseimport
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	tfVarBootstrapRole = "bootstrap_role"
+	tfVarAWSExternalID = "aws_external_id"
+	tfEnvPrefix        = "TF_VAR_"
+)
+
+type awsProviderAuth struct {
+	RoleARN    string
+	ExternalID string
+}
+
+func resolveAWSProviderAuth(outputDir string) (awsProviderAuth, error) {
+	auth := awsProviderAuth{
+		RoleARN:    strings.TrimSpace(os.Getenv(tfEnvPrefix + tfVarBootstrapRole)),
+		ExternalID: strings.TrimSpace(os.Getenv(tfEnvPrefix + tfVarAWSExternalID)),
+	}
+
+	root := findProjectRoot(outputDir)
+	if root == "" {
+		return auth, nil
+	}
+
+	if auth.RoleARN == "" {
+		roleARN, err := terraformOutputString(filepath.Join(root, "outputs", "cloud-provision.json"), "terraform_role")
+		if err != nil {
+			return auth, err
+		}
+		auth.RoleARN = roleARN
+	}
+
+	autoVarsDir := filepath.Join(root, "tf", "auto-vars")
+	if auth.RoleARN == "" {
+		roleARN, err := autoVarString(autoVarsDir, tfVarBootstrapRole)
+		if err != nil {
+			return auth, err
+		}
+		auth.RoleARN = roleARN
+	}
+	if auth.ExternalID == "" {
+		externalID, err := autoVarString(autoVarsDir, tfVarAWSExternalID)
+		if err != nil {
+			return auth, err
+		}
+		auth.ExternalID = externalID
+	}
+
+	return auth, nil
+}
+
+func findProjectRoot(outputDir string) string {
+	if strings.TrimSpace(outputDir) == "" {
+		return ""
+	}
+	dir, err := filepath.Abs(outputDir)
+	if err != nil {
+		dir = outputDir
+	}
+	for {
+		if pathExists(filepath.Join(dir, "tf", "auto-vars")) ||
+			pathExists(filepath.Join(dir, "outputs", "cloud-provision.json")) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func pathExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func autoVarString(dir, key string) (string, error) {
+	paths, err := filepath.Glob(filepath.Join(dir, "*.json"))
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		value, ok, err := jsonFileString(path, key)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return value, nil
+		}
+	}
+	return "", nil
+}
+
+func terraformOutputString(path, key string) (string, error) {
+	if !pathExists(path) {
+		return "", nil
+	}
+	value, _, err := jsonFileString(path, key)
+	return value, err
+}
+
+func jsonFileString(path, key string) (string, bool, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return "", false, err
+	}
+	values := map[string]json.RawMessage{}
+	if err := json.Unmarshal(body, &values); err != nil {
+		return "", false, fmt.Errorf("parse %s: %w", path, err)
+	}
+	raw, ok := values[key]
+	if !ok || len(raw) == 0 {
+		return "", false, nil
+	}
+	value, ok, err := decodeStringValue(raw)
+	if err != nil {
+		return "", false, fmt.Errorf("decode %s %q: %w", path, key, err)
+	}
+	return value, ok, nil
+}
+
+func decodeStringValue(raw json.RawMessage) (string, bool, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return "", false, nil
+	}
+
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		s = strings.TrimSpace(s)
+		return s, s != "", nil
+	}
+
+	var wrapped struct {
+		Value json.RawMessage `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err != nil || len(wrapped.Value) == 0 {
+		return "", false, fmt.Errorf("expected string or Terraform output object")
+	}
+	return decodeStringValue(wrapped.Value)
+}

--- a/pkg/reverseimport/aws_auth_test.go
+++ b/pkg/reverseimport/aws_auth_test.go
@@ -1,0 +1,81 @@
+package reverseimport
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveAWSProviderAuthUsesProjectTerraformRoleOutput(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "outputs", "cloud-provision.json"), []byte(`{
+  "terraform_role": {
+    "value": "arn:aws:iam::123456789012:role/io-terraform",
+    "type": "string"
+  }
+}`))
+	mustWrite(t, filepath.Join(root, "tf", "auto-vars", "common.auto.tfvars.json"), []byte(`{
+  "bootstrap_role": "arn:aws:iam::999999999999:role/bootstrap",
+  "aws_external_id": "external-123"
+}`))
+
+	t.Setenv("TF_VAR_bootstrap_role", "")
+	t.Setenv("TF_VAR_aws_external_id", "")
+	auth, err := resolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
+	if err != nil {
+		t.Fatalf("resolveAWSProviderAuth() error = %v", err)
+	}
+	if auth.RoleARN != "arn:aws:iam::123456789012:role/io-terraform" {
+		t.Fatalf("RoleARN = %q, want project terraform_role output", auth.RoleARN)
+	}
+	if auth.ExternalID != "external-123" {
+		t.Fatalf("ExternalID = %q, want auto-var external ID", auth.ExternalID)
+	}
+}
+
+func TestResolveAWSProviderAuthAllowsEnvOverride(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "outputs", "cloud-provision.json"), []byte(`{
+  "terraform_role": {"value": "arn:aws:iam::123456789012:role/io-terraform", "type": "string"}
+}`))
+	t.Setenv("TF_VAR_bootstrap_role", "arn:aws:iam::222222222222:role/override")
+	t.Setenv("TF_VAR_aws_external_id", "override-external")
+
+	auth, err := resolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
+	if err != nil {
+		t.Fatalf("resolveAWSProviderAuth() error = %v", err)
+	}
+	if auth.RoleARN != "arn:aws:iam::222222222222:role/override" {
+		t.Fatalf("RoleARN = %q, want env override", auth.RoleARN)
+	}
+	if auth.ExternalID != "override-external" {
+		t.Fatalf("ExternalID = %q, want env override", auth.ExternalID)
+	}
+}
+
+func TestResolveAWSProviderAuthFallsBackToBootstrapRoleAutoVar(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "tf", "auto-vars", "common.auto.tfvars.json"), []byte(`{
+  "bootstrap_role": "arn:aws:iam::999999999999:role/bootstrap"
+}`))
+	t.Setenv("TF_VAR_bootstrap_role", "")
+	t.Setenv("TF_VAR_aws_external_id", "")
+
+	auth, err := resolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
+	if err != nil {
+		t.Fatalf("resolveAWSProviderAuth() error = %v", err)
+	}
+	if auth.RoleARN != "arn:aws:iam::999999999999:role/bootstrap" {
+		t.Fatalf("RoleARN = %q, want bootstrap_role fallback", auth.RoleARN)
+	}
+}
+
+func mustWrite(t *testing.T, path string, body []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/pkg/reverseimport/providers.go
+++ b/pkg/reverseimport/providers.go
@@ -22,20 +22,29 @@ var localstackEndpointServices = []string{
 	"sts",
 }
 
-func renderImportedProvidersTF(cloud, region, gcpProjectID, awsEndpointURL string, providersUsed map[string]bool) ([]byte, error) {
+type importedProviderRenderOptions struct {
+	Cloud          string
+	Region         string
+	GCPProjectID   string
+	AWSEndpointURL string
+	ProvidersUsed  map[string]bool
+	AWSAuth        awsProviderAuth
+}
+
+func renderImportedProvidersTF(opts importedProviderRenderOptions) ([]byte, error) {
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 	tfBlk := body.AppendNewBlock("terraform", nil)
 	rp := tfBlk.Body().AppendNewBlock("required_providers", nil)
 	body.AppendNewline()
 
-	switch strings.ToLower(strings.TrimSpace(cloud)) {
+	switch strings.ToLower(strings.TrimSpace(opts.Cloud)) {
 	case "gcp":
 		rp.Body().SetAttributeValue("google", cty.ObjectVal(map[string]cty.Value{
 			"source":  cty.StringVal("hashicorp/google"),
 			"version": cty.StringVal("~> 5.0"),
 		}))
-		if providersUsed[composer.ProvidersUsedKeyGCPBeta] {
+		if opts.ProvidersUsed[composer.ProvidersUsedKeyGCPBeta] {
 			rp.Body().SetAttributeValue("google-beta", cty.ObjectVal(map[string]cty.Value{
 				"source":  cty.StringVal("hashicorp/google-beta"),
 				"version": cty.StringVal("~> 5.0"),
@@ -43,16 +52,16 @@ func renderImportedProvidersTF(cloud, region, gcpProjectID, awsEndpointURL strin
 		}
 		prov := body.AppendNewBlock("provider", []string{"google"})
 		prov.Body().SetAttributeValue("alias", cty.StringVal("imported"))
-		prov.Body().SetAttributeValue("project", cty.StringVal(gcpProjectID))
-		if region != "" {
-			prov.Body().SetAttributeValue("region", cty.StringVal(region))
+		prov.Body().SetAttributeValue("project", cty.StringVal(opts.GCPProjectID))
+		if opts.Region != "" {
+			prov.Body().SetAttributeValue("region", cty.StringVal(opts.Region))
 		}
-		if providersUsed[composer.ProvidersUsedKeyGCPBeta] {
+		if opts.ProvidersUsed[composer.ProvidersUsedKeyGCPBeta] {
 			beta := body.AppendNewBlock("provider", []string{"google-beta"})
 			beta.Body().SetAttributeValue("alias", cty.StringVal("imported"))
-			beta.Body().SetAttributeValue("project", cty.StringVal(gcpProjectID))
-			if region != "" {
-				beta.Body().SetAttributeValue("region", cty.StringVal(region))
+			beta.Body().SetAttributeValue("project", cty.StringVal(opts.GCPProjectID))
+			if opts.Region != "" {
+				beta.Body().SetAttributeValue("region", cty.StringVal(opts.Region))
 			}
 		}
 	case "aws", "":
@@ -62,8 +71,8 @@ func renderImportedProvidersTF(cloud, region, gcpProjectID, awsEndpointURL strin
 		}))
 		prov := body.AppendNewBlock("provider", []string{"aws"})
 		prov.Body().SetAttributeValue("alias", cty.StringVal("imported"))
-		prov.Body().SetAttributeValue("region", cty.StringVal(region))
-		if awsEndpointURL != "" {
+		prov.Body().SetAttributeValue("region", cty.StringVal(opts.Region))
+		if opts.AWSEndpointURL != "" {
 			prov.Body().SetAttributeValue("access_key", cty.StringVal("test"))
 			prov.Body().SetAttributeValue("secret_key", cty.StringVal("test"))
 			prov.Body().SetAttributeValue("skip_credentials_validation", cty.True)
@@ -72,11 +81,23 @@ func renderImportedProvidersTF(cloud, region, gcpProjectID, awsEndpointURL strin
 			prov.Body().SetAttributeValue("s3_use_path_style", cty.True)
 			ep := prov.Body().AppendNewBlock("endpoints", nil)
 			for _, svc := range localstackEndpointServices {
-				ep.Body().SetAttributeValue(svc, cty.StringVal(awsEndpointURL))
+				ep.Body().SetAttributeValue(svc, cty.StringVal(opts.AWSEndpointURL))
 			}
 		}
+		appendAWSAssumeRole(prov.Body(), opts.AWSAuth)
 	default:
-		return nil, fmt.Errorf("unknown cloud %q", cloud)
+		return nil, fmt.Errorf("unknown cloud %q", opts.Cloud)
 	}
 	return f.Bytes(), nil
+}
+
+func appendAWSAssumeRole(body *hclwrite.Body, auth awsProviderAuth) {
+	if strings.TrimSpace(auth.RoleARN) == "" {
+		return
+	}
+	assume := body.AppendNewBlock("assume_role", nil)
+	assume.Body().SetAttributeValue("role_arn", cty.StringVal(auth.RoleARN))
+	if strings.TrimSpace(auth.ExternalID) != "" {
+		assume.Body().SetAttributeValue("external_id", cty.StringVal(auth.ExternalID))
+	}
 }

--- a/pkg/reverseimport/providers_test.go
+++ b/pkg/reverseimport/providers_test.go
@@ -1,0 +1,54 @@
+package reverseimport
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+)
+
+func TestRenderImportedProvidersTF_AWSAssumesProjectRole(t *testing.T) {
+	body, err := renderImportedProvidersTF(importedProviderRenderOptions{
+		Cloud:  "aws",
+		Region: "us-west-2",
+		ProvidersUsed: map[string]bool{
+			composer.ProvidersUsedKeyAWS: true,
+		},
+		AWSAuth: awsProviderAuth{
+			RoleARN:    "arn:aws:iam::123456789012:role/io-terraform",
+			ExternalID: "external-123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderImportedProvidersTF() error = %v", err)
+	}
+	s := string(body)
+	for _, want := range []string{
+		`provider "aws"`,
+		`alias  = "imported"`,
+		`region = "us-west-2"`,
+		`assume_role`,
+		`role_arn    = "arn:aws:iam::123456789012:role/io-terraform"`,
+		`external_id = "external-123"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("providers-imported.tf missing %q:\n%s", want, s)
+		}
+	}
+}
+
+func TestRenderImportedProvidersTF_AWSOmitsAssumeRoleWhenUnset(t *testing.T) {
+	body, err := renderImportedProvidersTF(importedProviderRenderOptions{
+		Cloud:  "aws",
+		Region: "us-west-2",
+		ProvidersUsed: map[string]bool{
+			composer.ProvidersUsedKeyAWS: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderImportedProvidersTF() error = %v", err)
+	}
+	if strings.Contains(string(body), "assume_role") {
+		t.Fatalf("providers-imported.tf must not emit assume_role without a role ARN:\n%s", body)
+	}
+}

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -63,6 +63,14 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	result.Diagnostics = append(result.Diagnostics, closure.diagnostics...)
 	dependenciesByAddress := closure.dependencies
 
+	var awsAuth awsProviderAuth
+	if cloud == "aws" {
+		awsAuth, err = resolveAWSProviderAuth(opts.OutputDir)
+		if err != nil {
+			return result, fmt.Errorf("resolve AWS provider auth: %w", err)
+		}
+	}
+
 	workdir := opts.Workdir
 	if workdir == "" {
 		workdir = filepath.Join(opts.OutputDir, "genconfig")
@@ -73,6 +81,8 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 		Region:         region,
 		GCPProjectID:   gcpProjectID,
 		AWSEndpointURL: opts.AWSEndpointURL,
+		AWSRoleARN:     awsAuth.RoleARN,
+		AWSExternalID:  awsAuth.ExternalID,
 	}
 
 	gcRes, err := opts.deps.runGenconfig(ctx, gcOpts, resources)
@@ -140,7 +150,14 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	if err := writeFileAtomic(importedTFPath, importedTF, 0o644); err != nil {
 		return result, fmt.Errorf("write imported.tf: %w", err)
 	}
-	providersTF, err := renderImportedProvidersTF(cloud, region, gcpProjectID, opts.AWSEndpointURL, providersUsed)
+	providersTF, err := renderImportedProvidersTF(importedProviderRenderOptions{
+		Cloud:          cloud,
+		Region:         region,
+		GCPProjectID:   gcpProjectID,
+		AWSEndpointURL: opts.AWSEndpointURL,
+		ProvidersUsed:  providersUsed,
+		AWSAuth:        awsAuth,
+	})
 	if err != nil {
 		return result, err
 	}

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -70,6 +70,72 @@ func TestRunEmitsArtifactsAndImportSummary(t *testing.T) {
 	}
 }
 
+func TestRunEmitsAWSAssumeRoleFromProjectBundle(t *testing.T) {
+	root := t.TempDir()
+	mustWrite(t, filepath.Join(root, "outputs", "cloud-provision.json"), []byte(`{
+  "terraform_role": {
+    "value": "arn:aws:iam::123456789012:role/io-terraform",
+    "type": "string"
+  }
+}`))
+	mustWrite(t, filepath.Join(root, "tf", "auto-vars", "common.auto.tfvars.json"), []byte(`{
+  "aws_external_id": "external-123"
+}`))
+	dir := filepath.Join(root, "outputs", "reverse-import")
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	var gotGenconfig genconfig.Options
+	_, err := Run(context.Background(), req, Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: func(ctx context.Context, opts genconfig.Options, resources []imported.ImportedResource) (*genconfig.Result, error) {
+				gotGenconfig = opts
+				return fakeGenconfig(ctx, opts, resources)
+			},
+			runDriftfix: fakeDriftfix,
+			runDepChase: fakeDepChase,
+			tf:          fakeTerraformRunner{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if gotGenconfig.AWSRoleARN != "arn:aws:iam::123456789012:role/io-terraform" {
+		t.Fatalf("genconfig AWSRoleARN = %q, want project Terraform role", gotGenconfig.AWSRoleARN)
+	}
+	if gotGenconfig.AWSExternalID != "external-123" {
+		t.Fatalf("genconfig AWSExternalID = %q, want external-123", gotGenconfig.AWSExternalID)
+	}
+	providersTF, err := os.ReadFile(filepath.Join(dir, "providers-imported.tf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(providersTF)
+	for _, want := range []string{
+		`assume_role`,
+		`role_arn    = "arn:aws:iam::123456789012:role/io-terraform"`,
+		`external_id = "external-123"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("providers-imported.tf missing %q:\n%s", want, s)
+		}
+	}
+}
+
 func TestRunExpandsSelectedParentClosure(t *testing.T) {
 	dir := t.TempDir()
 	discoverer := &fakeClosureDiscoverer{


### PR DESCRIPTION
## Summary
- make reverse-import genconfig and final imported providers assume the project Terraform role via bootstrap_role/aws_external_id
- resolve AWS provider auth from TF_VAR_*, project outputs/cloud-provision.json, then tf/auto-vars fallback
- ignore the Route53 force_destroy sentinel on first-import adoption plans

## Test plan
- [x] go test ./cmd/insideout-import/genconfig ./pkg/reverseimport ./pkg/composer -run 'TestEmitProviders_AWSAssumeRole|TestEmitProviders_HappyPath|TestEmitProviders_GCPIgnoresAWSEndpointURL|TestRunEmitsAWSAssumeRoleFromProjectBundle|TestResolveAWSProviderAuth|TestRenderImportedProvidersTF_AWS|TestEmitImportedTF_Route53ZoneIgnoresForceDestroySentinel|TestValidateFirstImportPlan'
- [x] git diff --check origin/main...HEAD
- [x] GitHub CI: go-test, go-vet, go-build, go-fmt, verify-gen, verify-supported-resources, tflint, preset/example matrix

## Reviews
- QA professor: PASS. Tests assert role-source precedence, genconfig wiring, final-provider HCL, empty/GCP non-emission cases, and Route53 lifecycle output.
- Security review: PASS. No credentials are logged; provider auth is read from existing Terraform env/project artifacts and only emits the role/external-id values into the generated Terraform artifact that needs them to run.

Fixes luthersystems/ui-core#358
Fixes luthersystems/ui-core#359
Related luthersystems/ui-core#360