### PR TITLE
Fix Lambda reverse-import provider default validation

### DIFF
--- a/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace.go
+++ b/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"sync"
@@ -109,9 +108,9 @@ func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) ResourceType() string {
 // bedrock_guardrail posture.
 //
 // Failure modes inside the per-namespace fan-out are fail-open at the
-// item level: a tag-fetch error skips that one namespace with a stderr
-// warn rather than aborting the region; a Route53 hop error emits the
-// namespace with vpc_id="UNKNOWN" and surfaces a ServiceWarn so the
+// item level: a tag-fetch error skips that one namespace with a
+// ServiceWarn rather than aborting the region; a Route53 hop error emits
+// the namespace with vpc_id="UNKNOWN" and surfaces a ServiceWarn so the
 // operator sees the gap. ListNamespaces / GetNamespace failures at the
 // region level abort that region and surface as the outer error.
 func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
@@ -210,7 +209,7 @@ func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) Discover(ctx context.Con
 					// skip this namespace, do not abort the region.
 					var nf *sdtypes.NamespaceNotFound
 					if !errors.As(err, &nf) {
-						fmt.Fprintf(os.Stderr, "discover: WARN: service_discovery_private_dns_namespace %s: GetNamespace (region=%s): %v\n", c.name, region, err)
+						args.Emitter.ServiceWarn(slug, region, fmt.Sprintf("%s: GetNamespace: %v", c.name, err))
 					}
 					return nil
 				}
@@ -231,7 +230,7 @@ func (d *serviceDiscoveryPrivateDNSNamespaceDiscoverer) Discover(ctx context.Con
 						if cerr := gctx.Err(); cerr != nil {
 							return cerr
 						}
-						fmt.Fprintf(os.Stderr, "discover: WARN: service_discovery_private_dns_namespace %s: ListTagsForResource (region=%s): %v\n", c.name, region, err)
+						args.Emitter.ServiceWarn(slug, region, fmt.Sprintf("%s: ListTagsForResource: %v", c.name, err))
 						// Skip this namespace — tag filter cannot
 						// be evaluated without tags.
 						return nil

--- a/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace_test.go
+++ b/cmd/insideout-import/awsdiscover/servicediscovery_private_dns_namespace_test.go
@@ -3,8 +3,6 @@ package awsdiscover
 import (
 	"context"
 	"errors"
-	"io"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -322,29 +320,22 @@ func TestSDPrivateDNSNSDiscover_TagsErrorSkipsNamespace(t *testing.T) {
 		newR53:         func() route53HostedZoneClient { return r53 },
 		maxConcurrency: 4,
 	}
-	// Capture stderr so we can pin that the tag-fetch failure surfaces
-	// as an operator-visible warn (the SUT writes to os.Stderr in the
-	// in-errgroup tag-error path; mutation that silently swallows the
-	// error would otherwise survive).
-	origStderr := os.Stderr
-	rPipe, wPipe, pipeErr := os.Pipe()
-	if pipeErr != nil {
-		t.Fatalf("os.Pipe: %v", pipeErr)
-	}
-	os.Stderr = wPipe
-	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123"})
-	wPipe.Close()
-	os.Stderr = origStderr
-	stderrBytes, _ := io.ReadAll(rPipe)
-	stderr := string(stderrBytes)
+	rec := &recordingEmitter{}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Project: "io-foo", Regions: []string{"us-east-1"}, AccountID: "123", Emitter: rec})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(got) != 1 || got[0].Identity.NameHint != "io-foo-good" {
 		t.Fatalf("got=%+v, want single io-foo-good", got)
 	}
-	if !strings.Contains(stderr, "io-foo-bad") || !strings.Contains(stderr, "ListTagsForResource") {
-		t.Errorf("stderr=%q, want warn naming the bad namespace + the failing SDK op", stderr)
+	var sawWarn bool
+	for _, ev := range rec.snapshot() {
+		if ev.Kind == "service_warn" && strings.Contains(ev.Message, "io-foo-bad") && strings.Contains(ev.Message, "ListTagsForResource") {
+			sawWarn = true
+		}
+	}
+	if !sawWarn {
+		t.Errorf("events=%+v, want warn naming the bad namespace + the failing SDK op", rec.snapshot())
 	}
 }
 

--- a/pkg/composer/plan_acceptance.go
+++ b/pkg/composer/plan_acceptance.go
@@ -8,6 +8,7 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
 
 // ValidateFirstImportPlanOpts configures the first-import contract per
@@ -115,7 +116,7 @@ func ValidateFirstImportPlan(plan *tfjson.Plan, opts ValidateFirstImportPlanOpts
 			// tags/labels. Any non-provenance attribute change fails.
 			if actions.Update() || actions.Replace() {
 				issues = append(issues,
-					unauthorizedChangeIssues(field, rc.Change, opts.ProvenanceLabelKeys)...)
+					unauthorizedChangeIssues(field, rc.Type, rc.Change, opts.ProvenanceLabelKeys)...)
 			}
 			continue
 		}
@@ -148,7 +149,7 @@ func ValidateFirstImportPlan(plan *tfjson.Plan, opts ValidateFirstImportPlanOpts
 			// A non-import update is only allowed if every changed
 			// attribute is in the provenance allowlist.
 			issues = append(issues,
-				unauthorizedChangeIssues(field, rc.Change, opts.ProvenanceLabelKeys)...)
+				unauthorizedChangeIssues(field, rc.Type, rc.Change, opts.ProvenanceLabelKeys)...)
 		}
 	}
 
@@ -269,12 +270,15 @@ func ValidateSubsequentApplyPlan(plan *tfjson.Plan, irs []imported.ImportedResou
 // change.Before vs change.After that is not in allowedKeys. Used by the
 // first-import contract where the only permitted updates are provenance
 // repair.
-func unauthorizedChangeIssues(field string, change *tfjson.Change, allowedKeys []string) []ValidationIssue {
+func unauthorizedChangeIssues(field, resourceType string, change *tfjson.Change, allowedKeys []string) []ValidationIssue {
 	allow := stringSet(allowedKeys)
 	bad := diffPaths(change.Before, change.After, "")
 	var issues []ValidationIssue
 	for _, p := range bad {
 		if _, ok := allow[p]; ok {
+			continue
+		}
+		if allowedFirstImportOptionalZeroDefault(resourceType, p, change.Before, change.After) {
 			continue
 		}
 		issues = append(issues, ValidationIssue{
@@ -284,6 +288,57 @@ func unauthorizedChangeIssues(field string, change *tfjson.Change, allowedKeys [
 		})
 	}
 	return issues
+}
+
+func allowedFirstImportOptionalZeroDefault(resourceType, path string, before, after any) bool {
+	_, schema, ok := generated.Lookup(resourceType)
+	if !ok {
+		return false
+	}
+	field, ok := schema[path]
+	if !ok || !field.Optional || field.Required {
+		return false
+	}
+	beforeValue, beforeOK := valueAtPath(before, path)
+	if beforeOK && beforeValue != nil {
+		return false
+	}
+	afterValue, afterOK := valueAtPath(after, path)
+	return afterOK && isZeroProviderDefault(afterValue)
+}
+
+func isZeroProviderDefault(v any) bool {
+	switch x := v.(type) {
+	case nil:
+		return true
+	case bool:
+		return !x
+	case string:
+		return x == ""
+	case float64:
+		return x == 0
+	case []any:
+		return len(x) == 0
+	case map[string]any:
+		return len(x) == 0
+	default:
+		return false
+	}
+}
+
+func valueAtPath(v any, path string) (any, bool) {
+	cur := v
+	for _, part := range strings.Split(path, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		cur, ok = m[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return cur, true
 }
 
 // unapprovedChangeIssues is the subsequent-apply variant: leaf paths

--- a/pkg/composer/plan_acceptance_test.go
+++ b/pkg/composer/plan_acceptance_test.go
@@ -28,6 +28,12 @@ func importChange(addr string, actions tfjson.Actions, before, after map[string]
 	}
 }
 
+func typedImportChange(tfType, addr string, actions tfjson.Actions, before, after map[string]any) *tfjson.ResourceChange {
+	rc := importChange(addr, actions, before, after)
+	rc.Type = tfType
+	return rc
+}
+
 // plainChange builds a tfjson.ResourceChange for a non-import action.
 func plainChange(addr string, actions tfjson.Actions, before, after map[string]any) *tfjson.ResourceChange {
 	return &tfjson.ResourceChange{
@@ -108,6 +114,56 @@ func TestValidateFirstImportPlan_Contract(t *testing.T) {
 				),
 			}},
 			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			name: "aws import provider optional bool default null to false passes",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_lambda_function", "aws_lambda_function.fn",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": nil, "tags": map[string]any{}},
+					map[string]any{"publish": false, "tags": map[string]any{
+						"InsideOutImported": "true",
+					}},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: nil,
+		},
+		{
+			name: "aws import provider optional bool default covers Route53 force destroy",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_route53_zone", "aws_route53_zone.zone",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"force_destroy": nil},
+					map[string]any{"force_destroy": false},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: nil,
+		},
+		{
+			name: "aws lambda import publish true still fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_lambda_function", "aws_lambda_function.fn",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": false},
+					map[string]any{"publish": true},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			name: "required field null to zero still fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_lambda_function", "aws_lambda_function.fn",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"function_name": nil},
+					map[string]any{"function_name": ""},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
 			wantCodes: []string{"imported_plan_unauthorized_change"},
 		},
 		{


### PR DESCRIPTION
## Summary
- Allow first-import plan validation to ignore provider-normalized optional zero defaults.
- Covers the Lambda publish null -> false issue found in live jobs CLI validation.
- Keeps real changes strict: publish false -> true and required-field zero changes still fail.
- Replace a race-prone Service Discovery warning assertion with the existing thread-safe progress emitter.

Closes #682
Closes #684

## Test plan
- go test ./pkg/composer -run 'TestValidateFirstImportPlan_Contract|TestValidateSubsequentApplyPlan_Contract|TestDiffPaths_LeafLevel'
- go test ./pkg/composer
- go test -race ./cmd/insideout-import/awsdiscover
