### PR TITLE
fix(composer): drill into tag/label maps for first-import diff validation

### DIFF
--- a/pkg/composer/plan_acceptance.go
+++ b/pkg/composer/plan_acceptance.go
@@ -270,9 +270,23 @@ func ValidateSubsequentApplyPlan(plan *tfjson.Plan, irs []imported.ImportedResou
 // change.Before vs change.After that is not in allowedKeys. Used by the
 // first-import contract where the only permitted updates are provenance
 // repair.
+//
+// Tag/label maps (AWS `tags`/`tags_all`, GCP `labels`/`effective_labels`/
+// `terraform_labels`) get special map-aware treatment: a leaf-key diff is
+// authorized iff every added key is in allowedKeys (i.e. a provenance
+// marker) and no pre-existing key is removed or modified. Pre-existing
+// keys that only appear in `after` because the before-side of the
+// computed mirror was nil/empty (the canonical `tags_all` shape on a
+// fresh import) are treated as discovered state, not as additions. This
+// closes the false-positive described in issue #685 where a clean
+// tag-only first-import plan got flagged as unauthorized drift purely
+// because `tags_all.Before` was nil while `tags_all.After` carried the
+// full user-tag union.
 func unauthorizedChangeIssues(field, resourceType string, change *tfjson.Change, allowedKeys []string) []ValidationIssue {
 	allow := stringSet(allowedKeys)
-	bad := diffPaths(change.Before, change.After, "")
+	tagParents := tagMapParents(allowedKeys)
+	bad := diffPathsExcludingTagMaps(change.Before, change.After, "", tagParents)
+
 	var issues []ValidationIssue
 	for _, p := range bad {
 		if _, ok := allow[p]; ok {
@@ -287,6 +301,12 @@ func unauthorizedChangeIssues(field, resourceType string, change *tfjson.Change,
 			Reason: fmt.Sprintf("first-import plan must only repair provenance tags/labels; path %q is not in the allowed set", p),
 		})
 	}
+
+	// Now run the tag-map-aware check for each known parent.
+	for parent := range tagParents {
+		issues = append(issues, tagMapIssues(field, parent, change.Before, change.After, allow)...)
+	}
+
 	return issues
 }
 
@@ -381,6 +401,14 @@ func changeCoveredByApproval(rc *tfjson.ResourceChange, approvedByAddr map[strin
 // a re-ordered list at the JSON level always indicates a real change to
 // the provider.
 func diffPaths(before, after any, prefix string) []string {
+	return diffPathsExcludingTagMaps(before, after, prefix, nil)
+}
+
+// diffPathsExcludingTagMaps is diffPaths plus an "exclude these top-level
+// keys" filter so the caller can handle tag/label parent maps with
+// map-aware semantics (see tagMapIssues). When skip is empty the
+// behaviour is identical to diffPaths.
+func diffPathsExcludingTagMaps(before, after any, prefix string, skip map[string]struct{}) []string {
 	if reflect.DeepEqual(before, after) {
 		return nil
 	}
@@ -394,7 +422,14 @@ func diffPaths(before, after any, prefix string) []string {
 			if prefix != "" {
 				child = prefix + "." + k
 			}
-			paths = append(paths, diffPaths(bMap[k], aMap[k], child)...)
+			// Only suppress at the top level — a key called `tags`
+			// nested inside another block is not a provenance parent.
+			if prefix == "" {
+				if _, ok := skip[k]; ok {
+					continue
+				}
+			}
+			paths = append(paths, diffPathsExcludingTagMaps(bMap[k], aMap[k], child, skip)...)
 		}
 		return paths
 	}
@@ -402,6 +437,110 @@ func diffPaths(before, after any, prefix string) []string {
 		return []string{"<root>"}
 	}
 	return []string{prefix}
+}
+
+// tagMapParents returns the set of top-level attribute names that the
+// caller passed as provenance-allowed parents. Derived from allowedKeys
+// (paths of the form `<parent>.<key>`) so the validator stays driven by
+// the FirstImportProvenanceKeys contract — adding a new cloud's tag
+// parent only requires updating that one builder.
+func tagMapParents(allowedKeys []string) map[string]struct{} {
+	parents := make(map[string]struct{})
+	for _, p := range allowedKeys {
+		idx := strings.Index(p, ".")
+		if idx <= 0 {
+			continue
+		}
+		parents[p[:idx]] = struct{}{}
+	}
+	return parents
+}
+
+// tagMapIssues validates a single tag/label parent map (e.g. `tags`,
+// `tags_all`, `labels`, `effective_labels`, `terraform_labels`) with
+// map-aware semantics:
+//
+//   - Pre-existing keys removed or modified → unauthorized change. The
+//     first-import contract forbids any user-tag touch beyond provenance
+//     writes.
+//   - Keys added when the before-side was present (even as `{}`): only
+//     allowed if the leaf path is in the provenance allowlist. An
+//     explicit empty map means the user genuinely had no tags, so any
+//     non-provenance addition is a real user-tag write.
+//   - Keys added when the before-side was NIL (the value was absent or
+//     literally null in the plan JSON): treated as "discovered state,
+//     not an InsideOut write". This is the canonical shape for AWS
+//     `tags_all` on a fresh import — terraform's pre-refresh state has
+//     it as null while the post-refresh `after` shows the union of user
+//     tags + provider defaults. Suppressing the noise here is the fix
+//     for issue #685.
+//
+// Values that aren't maps on both sides (e.g. one side is nil, both
+// scalar) are handled by the nil-before exception or by reporting the
+// leaf path as a single unauthorized change.
+func tagMapIssues(field, parent string, before, after any, allow map[string]struct{}) []ValidationIssue {
+	bMap, beforePresent := mapAtKey(before, parent)
+	aMap, _ := mapAtKey(after, parent)
+	if reflect.DeepEqual(bMap, aMap) {
+		return nil
+	}
+	var issues []ValidationIssue
+	emit := func(key, suffix string) {
+		path := parent + "." + key
+		issues = append(issues, ValidationIssue{
+			Field:  field + "." + path,
+			Code:   "imported_plan_unauthorized_change",
+			Reason: fmt.Sprintf("first-import plan must only repair provenance tags/labels; %s of %q is not permitted", suffix, path),
+		})
+	}
+	for _, k := range unionKeys(bMap, aMap) {
+		bVal, bHas := bMap[k]
+		aVal, aHas := aMap[k]
+		switch {
+		case bHas && aHas:
+			if !reflect.DeepEqual(bVal, aVal) {
+				emit(k, "modification")
+			}
+		case bHas && !aHas:
+			emit(k, "removal")
+		case !bHas && aHas:
+			if _, allowed := allow[parent+"."+k]; allowed {
+				continue
+			}
+			// Suppress discovered keys when the before-side of the
+			// parent was nil — covers the canonical fresh-import shape
+			// for computed mirrors (AWS `tags_all`, GCP
+			// `effective_labels`) where state has them as null until
+			// after the first refresh. A present-but-empty `{}` before
+			// is treated as user intent (no tags) so non-provenance
+			// adds still fail there.
+			if !beforePresent {
+				continue
+			}
+			emit(k, "addition")
+		}
+	}
+	return issues
+}
+
+// mapAtKey returns the map value at obj[key] when obj is a map. The
+// second return reports whether the key existed in the parent at all
+// (even as nil / non-map). Callers use that to distinguish "absent /
+// computed-mirror not yet refreshed" from "explicitly empty map".
+func mapAtKey(obj any, key string) (map[string]any, bool) {
+	m, ok := obj.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	v, present := m[key]
+	if !present {
+		return nil, false
+	}
+	if v == nil {
+		return nil, false
+	}
+	mv, _ := v.(map[string]any)
+	return mv, true
 }
 
 func stringSet(xs []string) map[string]struct{} {

--- a/pkg/composer/plan_acceptance_test.go
+++ b/pkg/composer/plan_acceptance_test.go
@@ -206,6 +206,221 @@ func TestValidateFirstImportPlan_Contract(t *testing.T) {
 			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: gcpProvenance},
 			wantCodes: nil,
 		},
+		{
+			// Real-world repro from issue #685 (sess_v2_CnqUJ6NRJnLC).
+			// `tags` carries 7 user keys before, those 7 + 4
+			// InsideOutImport* after; `tags_all` is the computed mirror
+			// whose before is nil (terraform state had not yet
+			// materialised it on a fresh import) and after carries the
+			// full union. All other attributes identical.
+			name: "aws kms tag-only first-import with computed tags_all mirror passes",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_kms_key", "aws_kms_key.r_0df0c214",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{
+						"description": "Luther tfstate KMS key",
+						"key_usage":   "ENCRYPT_DECRYPT",
+						"tags": map[string]any{
+							"Component":    "tfstate",
+							"Environment":  "default",
+							"ID":           "0",
+							"Name":         "647e1dd9-default-luther-tfstate-kms-0",
+							"Organization": "luther",
+							"Project":      "647e1dd9",
+							"Resource":     "kms",
+						},
+						// tags_all absent from before (fresh-import
+						// computed-mirror null shape).
+					},
+					map[string]any{
+						"description": "Luther tfstate KMS key",
+						"key_usage":   "ENCRYPT_DECRYPT",
+						"tags": map[string]any{
+							"Component":              "tfstate",
+							"Environment":            "default",
+							"ID":                     "0",
+							"InsideOutImportProject": "io-cnquj6nrjnlc",
+							"InsideOutImportSession": "sess_v2_CnqUJ6NRJnLC",
+							"InsideOutImported":      "true",
+							"InsideOutImportedAt":    "2026-05-25T03:46:14Z",
+							"Name":                   "647e1dd9-default-luther-tfstate-kms-0",
+							"Organization":           "luther",
+							"Project":                "647e1dd9",
+							"Resource":               "kms",
+						},
+						"tags_all": map[string]any{
+							"Component":              "tfstate",
+							"Environment":            "default",
+							"ID":                     "0",
+							"InsideOutImportProject": "io-cnquj6nrjnlc",
+							"InsideOutImportSession": "sess_v2_CnqUJ6NRJnLC",
+							"InsideOutImported":      "true",
+							"InsideOutImportedAt":    "2026-05-25T03:46:14Z",
+							"Name":                   "647e1dd9-default-luther-tfstate-kms-0",
+							"Organization":           "luther",
+							"Project":                "647e1dd9",
+							"Resource":               "kms",
+						},
+					},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: nil,
+		},
+		{
+			// AWS mirror where tags_all appears on both sides as the
+			// computed sum of user tags + provenance. Adding the
+			// provenance keys to both `tags` and `tags_all` (the
+			// natural shape once a single refresh has run) must not
+			// flag.
+			name: "aws tags_all mirrors tags clean provenance add passes",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_s3_bucket", "aws_s3_bucket.b",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{
+						"tags": map[string]any{
+							"Environment": "prod",
+						},
+						"tags_all": map[string]any{
+							"Environment": "prod",
+						},
+					},
+					map[string]any{
+						"tags": map[string]any{
+							"Environment":            "prod",
+							"InsideOutImportProject": "io-xyz",
+							"InsideOutImported":      "true",
+						},
+						"tags_all": map[string]any{
+							"Environment":            "prod",
+							"InsideOutImportProject": "io-xyz",
+							"InsideOutImported":      "true",
+						},
+					},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: nil,
+		},
+		{
+			// GCP mirror of the canonical first-import shape. labels
+			// before is nil (fresh-import computed-mirror absence),
+			// after carries the 4 insideout-import-* provenance keys
+			// and nothing else.
+			name: "gcp first-import labels add via nil-before mirror passes",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("google_storage_bucket", "google_storage_bucket.a",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"name": "a"},
+					map[string]any{
+						"name": "a",
+						"labels": map[string]any{
+							"insideout-import-project": "io-abc",
+							"insideout-import-session": "sess_v2_xyz",
+							"insideout-imported":       "true",
+							"insideout-imported-at":    "2026-05-25t03-46-14z",
+						},
+					},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: gcpProvenance},
+			wantCodes: nil,
+		},
+		{
+			// Negative — adding a user-owned tag (not in the
+			// provenance set) alongside the legitimate InsideOut
+			// writes is still real drift and must flag.
+			name: "aws import adds user-owned Environment tag fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_s3_bucket", "aws_s3_bucket.b",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{
+						"tags": map[string]any{
+							"Name": "b",
+						},
+					},
+					map[string]any{
+						"tags": map[string]any{
+							"Name":                   "b",
+							"InsideOutImportProject": "io-xyz",
+							"Environment":            "prod",
+						},
+					},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			// Negative — modifying a pre-existing user tag value flags
+			// even when the provenance set is also being added.
+			name: "aws import modifies user-owned Environment tag value fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_s3_bucket", "aws_s3_bucket.b",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{
+						"tags": map[string]any{
+							"Environment": "staging",
+						},
+					},
+					map[string]any{
+						"tags": map[string]any{
+							"Environment":            "prod",
+							"InsideOutImportProject": "io-xyz",
+						},
+					},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			// Negative — removing a pre-existing user tag flags even
+			// when provenance is also being added.
+			name: "aws import removes user-owned Environment tag fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_s3_bucket", "aws_s3_bucket.b",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{
+						"tags": map[string]any{
+							"Environment": "staging",
+							"Name":        "b",
+						},
+					},
+					map[string]any{
+						"tags": map[string]any{
+							"Name":                   "b",
+							"InsideOutImportProject": "io-xyz",
+						},
+					},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			// Negative — non-tag attribute change on the importing
+			// resource (force_destroy flipped) flags even when the
+			// tag diff is clean.
+			name: "aws import non-tag force_destroy change fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_s3_bucket", "aws_s3_bucket.b",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{
+						"force_destroy": false,
+						"tags":          map[string]any{},
+					},
+					map[string]any{
+						"force_destroy": true,
+						"tags": map[string]any{
+							"InsideOutImportProject": "io-xyz",
+						},
+					},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

`ValidateFirstImportPlan` was treating `tags` / `tags_all` (AWS) and `labels` / `effective_labels` / `terraform_labels` (GCP) as opaque values via `reflect.DeepEqual`, so any change to one of those parents — including the legitimate addition of the 4 `InsideOutImport*` provenance keys on a clean first-import plan — was flagged as an "unauthorized change" issue.

Surfaced once [luthersystems/ui-core#367](https://github.com/luthersystems/ui-core/pull/367)'s S3-backed `GetJobPlan` started serving the full plan JSON to reliable's classifier. Reliable consumed the plan, the validator returned the false-positive issue, and reliable persisted `expected_tag_changes_only = false` to plan_summary — gating the UI Apply button on legitimately-clean tag-only first-imports. The counts-only heuristic fallback added in [luthersystems/reliable#1761](https://github.com/luthersystems/reliable/pull/1761) returned the correct verdict for this case, but only fires when the full-plan path is unavailable; once ui-core#367 deployed the primary classifier wins and the wrong verdict gets persisted. This fix obsoletes that workaround.

## The fix

- `tagMapParents()` derives the tag/label parent attribute names from `allowedKeys` (paths of the form `<parent>.<key>`). Stays driven by `FirstImportProvenanceKeys` — adding a new cloud's parent set only requires updating that one builder.
- `diffPathsExcludingTagMaps()` is the existing `diffPaths` plus a per-parent skip filter, applied only at the top level so a nested `tags` inside another block is not mistakenly treated as a provenance parent.
- `tagMapIssues()` runs map-aware validation per tag/label parent:
  - pre-existing keys **removed or modified** → unauthorized
  - added keys must be a **subset of `allowedKeys`** for that parent
- A `null` `before` mirror (the canonical `tags_all` shape on a fresh import where terraform state had not yet materialised the computed attribute) is treated as discovered state, not as a forbidden removal — closes the exact false-positive from `sess_v2_CnqUJ6NRJnLC`.

`ValidateFirstImportPlan` / `ValidateFirstImportPlanOpts` signatures are unchanged.

## Tests

Added inside `TestValidateFirstImportPlan_Contract` (table-driven):

| Case | Expected |
|---|---|
| `aws kms tag-only first-import with computed tags_all mirror passes` — the **exact production repro from #685** | zero issues |
| `aws tags_all mirrors tags clean provenance add passes` — both-sides-present variant | zero issues |
| `gcp first-import labels add via nil-before mirror passes` | zero issues |
| `aws import adds user-owned Environment tag fails` | `imported_plan_unauthorized_change` |
| `aws import modifies user-owned Environment tag value fails` | `imported_plan_unauthorized_change` |
| `aws import removes user-owned Environment tag fails` | `imported_plan_unauthorized_change` |
| `aws import non-tag force_destroy change fails` | `imported_plan_unauthorized_change` |

Existing negative-case parity preserved:
- `create` / `destroy` / `replace` non-import actions still return issues.
- Import-count mismatch still returns issues.

## Test plan

- [x] `go test ./pkg/composer/...` — pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] `gofmt -l` — clean
- [ ] CI green

## Coordination

Upstream consumers waiting on this fix:
- [luthersystems/reliable#1761](https://github.com/luthersystems/reliable/pull/1761) — bump `go.mod` to the new `pkg/composer` tag after this lands; the counts-only fallback becomes redundant.
- [luthersystems/ui-core#367](https://github.com/luthersystems/ui-core/pull/367) — already merged; this PR closes the gap exposed by it.

After bump, a re-plan of `sess_v2_CnqUJ6NRJnLC` should write `expected_tag_changes_only = true`, unblocking the UI Apply button.

Closes [#685](https://github.com/luthersystems/insideout-terraform-presets/issues/685).