### PR TITLE
chore(compose): default /.terraform-version 1.7.5 → 1.9.8 (match mars bake)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -35,7 +35,13 @@ type Client struct {
 func New(opts ...Option) *Client {
 	c := &Client{
 		Mapper:           DefaultMapper{},
-		TerraformVersion: "1.7.5",
+		// Default TF version written to /.terraform-version in the
+		// composed customer archive. Pinned to match the version
+		// pre-installed in luthersystems/mars's /opt/tfenv/versions/
+		// so first-time `tfenv install` inside an Argo pod is a no-op
+		// instead of a ~30s download from releases.hashicorp.com.
+		// Bump this AND the mars TFENV_PREINSTALL_VERSIONS together.
+		TerraformVersion: "1.9.8",
 		presets:          terraformpresets.FS,
 	}
 	for _, o := range opts {

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -34,7 +34,7 @@ type Client struct {
 // alternate preset source (e.g. tests, custom preset distributions).
 func New(opts ...Option) *Client {
 	c := &Client{
-		Mapper:           DefaultMapper{},
+		Mapper: DefaultMapper{},
 		// Default TF version written to /.terraform-version in the
 		// composed customer archive. Pinned to match the version
 		// pre-installed in luthersystems/mars's /opt/tfenv/versions/


### PR DESCRIPTION
## Summary

Bumps the composer's default \`TerraformVersion\` from \`1.7.5\` to \`1.9.8\` — the version pre-installed in [mars v0.105.0](https://github.com/luthersystems/mars/releases/tag/v0.105.0)'s \`/opt/tfenv/versions/\`.

## Why

Composer writes \`/.terraform-version\` into every customer archive. tfenv reads the closer file first (workdir beats parent), so this composer default **overrides** sandbox-infra's per-stage \`.terraform-version=1.9.8\` ([sandbox-infrastructure-template#132](https://github.com/luthersystems/sandbox-infrastructure-template/pull/132), already merged). Net effect: customer plans were still requesting 1.7.5 and \`tfenv install\` was downloading from hashicorp.com (~30s per pod) despite all the upstream work to bake 1.9.8.

Confirmed via tflogs of \`pcs-647e1dd9-fj7bz\` (2026-05-25, post-fix run): \`terraform_1.7.5_linux_arm64.zip\` downloaded fresh in the prepare-custom-stack stage. The customer archive was the missing link.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./pkg/composer/ -run 'TerraformVersion|Version'\` — 16/16 pass
- [ ] CI
- [ ] After merge + reliable bumps composer go.mod: rerun staging e2e. Expect \`Terraform v1.9.8 is already installed\` from the start (no download).

## Required follow-up

After merge: bump \`insideout-terraform-presets\` in luthersystems/reliable's \`go.mod\`.