### PR TITLE
feat(awsdiscover): add DiscoverArgs.PerTypeTimeout for partial-result gather

### DIFF
--- a/cmd/insideout-import/awsdiscover/args.go
+++ b/cmd/insideout-import/awsdiscover/args.go
@@ -1,6 +1,10 @@
 package awsdiscover
 
-import "github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+import (
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+)
 
 // DiscoverArgs is the per-call input shape consumed by the aggregator's
 // DiscoverTypes and every per-service Discoverer.Discover. Bundling the
@@ -31,6 +35,23 @@ type DiscoverArgs struct {
 	TagSelectors []TagSelector
 	AccountID    string
 	Emitter      progress.Emitter
+
+	// PerTypeTimeout, when > 0, bounds the wall time a single per-type
+	// Discoverer.Discover call may consume inside DiscoverTypes's
+	// errgroup. On expiry the aggregator records a structured warn log
+	// (`reason=per_type_timeout type=<t> elapsed_ms=<n>`) and emits an
+	// empty result slice for that type — siblings keep running and the
+	// overall call returns a partial result rather than failing the
+	// whole gather. Zero means "no per-type bound" (back-compat: the
+	// pre-#1787 behavior where one slow / stalled SDK call held the
+	// whole gather hostage until the caller's outer deadline fired).
+	//
+	// Why an explicit bound rather than relying on the parent
+	// `ctx` deadline: a parent deadline cancels every sibling
+	// simultaneously, which throws away their work. A per-type bound
+	// fences off the slow type while letting siblings finish, which is
+	// the right shape for a best-effort discovery survey.
+	PerTypeTimeout time.Duration
 
 	// rgtCache is the package-internal RGT prefetch result threaded
 	// through DiscoverTypes (#406). Per-type discoverers that opt into

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"math/rand"
 	"sort"
 	"time"
@@ -578,8 +579,43 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 			if err := gctx.Err(); err != nil {
 				return err
 			}
-			entries, err := d.Discover(gctx, args)
+			// Per-type deadline (#1787 reliable). When
+			// args.PerTypeTimeout > 0, wrap the Discover call in a
+			// child context so one slow / stalled SDK call can't hold
+			// the whole gather hostage. On timeout we WARN-log and
+			// emit an empty slice for this type — partial result is
+			// strictly more useful than no result for a best-effort
+			// survey. The errgroup itself never sees the timeout
+			// error, so siblings keep running.
+			//
+			// Non-timeout errors still propagate through the errgroup
+			// so a genuine API failure (Throttling, invalid creds)
+			// continues to fail-fast as before.
+			callCtx := gctx
+			var cancel context.CancelFunc
+			if args.PerTypeTimeout > 0 {
+				callCtx, cancel = context.WithTimeout(gctx, args.PerTypeTimeout)
+				defer cancel()
+			}
+			callStart := time.Now()
+			entries, err := d.Discover(callCtx, args)
 			if err != nil {
+				// Distinguish "per-type budget expired" from "parent
+				// context cancelled" (a fail-fast sibling). Only the
+				// per-type case downgrades to a partial-result warn;
+				// parent cancellation must still propagate so the
+				// caller's deadline / fail-fast semantics work.
+				if args.PerTypeTimeout > 0 &&
+					errors.Is(err, context.DeadlineExceeded) &&
+					gctx.Err() == nil {
+					log.Printf("[awsdiscover] level=warn reason=per_type_timeout type=%s regions=%v elapsed_ms=%d budget_ms=%d",
+						d.ResourceType(),
+						args.Regions,
+						time.Since(callStart).Milliseconds(),
+						args.PerTypeTimeout.Milliseconds())
+					results[i] = nil
+					return nil
+				}
 				return fmt.Errorf("%s: %w", d.ResourceType(), err)
 			}
 			results[i] = entries

--- a/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
@@ -443,3 +443,124 @@ func TestNewAWSDiscoverer_DefaultsJitterFields(t *testing.T) {
 		t.Errorf("jitterSample is not d.defaultJitterSample (got pointer=%x, want %x)", gotSample, wantSample)
 	}
 }
+
+// TestDiscoverTypes_PerTypeTimeoutPartialResult pins the #1787 fix —
+// one stalled per-type Discover MUST NOT hold up its siblings or fail
+// the whole call. With args.PerTypeTimeout set, the aggregator wraps
+// each Discover in a child context-with-timeout; on expiry it emits an
+// empty slice for that type and lets siblings finish. The overall call
+// returns a partial result (the fast type's resources) without error.
+//
+// Why this matters: before #1787 a single slow S3 ListBuckets / EC2
+// DescribeInstances against a hot AWS quota could pin the broad scan
+// at the caller's outer Vercel deadline (300s), then fail the whole
+// gather. A best-effort survey should return what it has.
+func TestDiscoverTypes_PerTypeTimeoutPartialResult(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	// Slow type sleeps well past the per-type budget; fast type
+	// returns immediately. With PerTypeTimeout=50ms the slow type must
+	// be timed out (and emit nothing) while the fast type's "fast1"
+	// row survives in the returned slice.
+	slow := &sleepDiscoverer{
+		t:     "type_slow",
+		out:   []imported.ImportedResource{ir("slow1")},
+		sleep: 500 * time.Millisecond,
+	}
+	fast := &fakeDiscoverer{
+		t:   "type_fast",
+		out: []imported.ImportedResource{ir("fast1")},
+	}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{
+		"type_slow": slow,
+		"type_fast": fast,
+	}}
+
+	args := argsBasic()
+	args.PerTypeTimeout = 50 * time.Millisecond
+
+	start := time.Now()
+	got, err := agg.DiscoverTypes(context.Background(), []string{"type_slow", "type_fast"}, args)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("DiscoverTypes returned error on per-type timeout (partial result expected): %v", err)
+	}
+	// Wall time must be bounded by the timeout + a little overhead,
+	// NOT the slow sleeper's 500ms. The whole point of the per-type
+	// fence is to avoid waiting on the slow one.
+	if elapsed >= 400*time.Millisecond {
+		t.Errorf("DiscoverTypes elapsed=%v with PerTypeTimeout=50ms, want <400ms — the slow type was not fenced off", elapsed)
+	}
+	addrs := make([]string, 0, len(got))
+	for _, r := range got {
+		addrs = append(addrs, r.Identity.Address)
+	}
+	want := []string{"fast1"}
+	if !reflect.DeepEqual(addrs, want) {
+		t.Errorf("partial result = %v, want %v (slow type should emit nothing, fast type's row should survive)", addrs, want)
+	}
+}
+
+// TestDiscoverTypes_PerTypeTimeoutZeroDisablesFence pins the
+// back-compat default: PerTypeTimeout==0 means "no per-type bound".
+// A bare DiscoverArgs (the shape every existing test in the suite
+// uses) must behave exactly as it did pre-#1787: a slow per-type call
+// runs to completion and its results are included.
+func TestDiscoverTypes_PerTypeTimeoutZeroDisablesFence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	slow := &sleepDiscoverer{
+		t:     "type_slow",
+		out:   []imported.ImportedResource{ir("slow1")},
+		sleep: 60 * time.Millisecond,
+	}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_slow": slow}}
+
+	// argsBasic leaves PerTypeTimeout at the zero value.
+	got, err := agg.DiscoverTypes(context.Background(), []string{"type_slow"}, argsBasic())
+	if err != nil {
+		t.Fatalf("DiscoverTypes returned error with no per-type fence: %v", err)
+	}
+	if len(got) != 1 || got[0].Identity.Address != "slow1" {
+		t.Errorf("got=%v, want [slow1] — PerTypeTimeout==0 must NOT fence off the slow type", got)
+	}
+}
+
+// TestDiscoverTypes_PerTypeTimeoutParentCancelPropagates pins that the
+// timeout downgrade is scoped to per-type budget expiry. A parent
+// context cancellation (caller's outer deadline, fail-fast sibling)
+// must still propagate as an error — operators rely on the fail-fast
+// shape to surface real failures, and silently swallowing parent
+// cancellation would let the broad scan return success for a request
+// the caller already abandoned.
+func TestDiscoverTypes_PerTypeTimeoutParentCancelPropagates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	slow := &sleepDiscoverer{
+		t:     "type_slow",
+		out:   []imported.ImportedResource{ir("slow1")},
+		sleep: 500 * time.Millisecond,
+	}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_slow": slow}}
+
+	args := argsBasic()
+	// Per-type budget is generous; the parent ctx cancels first.
+	args.PerTypeTimeout = 1 * time.Second
+
+	parentCtx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := agg.DiscoverTypes(parentCtx, []string{"type_slow"}, args)
+	if err == nil {
+		t.Fatal("expected error from parent-ctx cancellation; got nil — the per-type timeout downgrade must NOT swallow parent cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

A single slow / stalled per-type SDK call (S3 ListBuckets in a region with a hot quota cap, EC2 DescribeInstances against a flaky AZ) could hold the whole `DiscoverTypes` errgroup hostage until the caller's outer deadline fired, then fail the entire gather. For a best-effort discovery survey that's the wrong shape — partial > nothing.

- Add `DiscoverArgs.PerTypeTimeout time.Duration`. When `> 0`, wrap each per-type `Discover` call in a child `context.WithTimeout`. On expiry: WARN-log (`reason=per_type_timeout type=<t> regions=<r> elapsed_ms=<n> budget_ms=<b>`) and emit nil for that type so siblings finish and the overall call returns a partial result.
- Zero (the default) preserves the pre-#1787 behavior so every existing caller is unaffected.
- Per-type expiry is distinguished from parent context cancellation (caller's outer deadline / fail-fast sibling) — the latter still propagates so real failures and abandoned requests surface correctly.

Consumed by [reliable#1787](https://github.com/luthersystems/reliable/issues/1787).

## Test plan

- [x] `go test ./cmd/insideout-import/awsdiscover/ -count=1` — full suite green (1231 tests)
- [x] New `TestDiscoverTypes_PerTypeTimeoutPartialResult` — one stalled type fences off, sibling's resources survive in the returned slice
- [x] New `TestDiscoverTypes_PerTypeTimeoutZeroDisablesFence` — back-compat: zero value behaves exactly as pre-#1787
- [x] New `TestDiscoverTypes_PerTypeTimeoutParentCancelPropagates` — parent ctx cancellation still propagates as an error, not silently swallowed
- [x] `go vet ./cmd/insideout-import/awsdiscover/`