### PR TITLE
fix(import): merge discover-time tags into provenance stamp (#690)

### DIFF
--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -302,9 +302,35 @@ func readOpaqueTagLiteral(attrs map[string]any, attrName, key string) (string, b
 
 // injectProvenance rewrites the tags/labels attribute in body so it carries
 // the provenance entries for the configured project/session. The resulting
-// attribute value is `merge({InsideOutImport... = "..."}, <existing>)`.
-// When body has no existing tags/labels attribute the second merge argument
-// becomes `{}`.
+// attribute value is:
+//
+//	merge({InsideOutImport... = "..."}, <discovered>, <existing>)
+//
+// where <discovered> is a literal map built from ir.Identity.Tags (the
+// discover-time cloud-side tag snapshot) and <existing> is whatever the
+// body emitter already wrote for the tags/labels attribute. Both extra
+// args are omitted when their source is empty, so the simplest call
+// remains `merge({InsideOut*}, {})` (no existing tags, no discover-time
+// tags) and the existing 2-arg shape is preserved for callers that
+// never populate Identity.Tags.
+//
+// Why we need the <discovered> arg: some AWS resource types (notably
+// aws_route53_zone — HostedZoneTags is a write-only CFN property and
+// CloudControl GetResource never returns it) lose their tags between
+// discover and Attrs-emit. Without the discover-time fallback the
+// emitted HCL would be `tags = merge({InsideOut*}, {})`, which the
+// first `terraform apply` resolves to ONLY the 4 InsideOut stamps —
+// silently deleting the customer's pre-existing tags on the live
+// resource. See #690.
+//
+// Terraform's `merge()` resolves conflicts in argument order, with later
+// arguments winning. The ordering chosen here is intentional:
+//
+//   - InsideOut* go first so the body-existing tags layer can override
+//     them on a re-import that already carries the project's stamps
+//     (matches the prior shape).
+//   - <discovered> sits in the middle: it backfills the keys the body
+//     dropped, but the body's typed values win when both are present.
 //
 // If ir's Terraform type is not taggable/labelable, body is returned
 // unchanged and ir.WeakLocked is set to true.
@@ -364,7 +390,17 @@ func injectProvenance(body []byte, ir *imported.ImportedResource, projectID, ses
 		bodyW.RemoveAttribute(attrName)
 	}
 
-	mergeExpr := buildMergeExpression(entries, existingExprText)
+	// Build the discover-time tags literal from ir.Identity.Tags. We
+	// only include keys that aren't InsideOut provenance markers — the
+	// first merge arg already carries those, so re-emitting them under
+	// <discovered> would just churn the merge in place. Identity.Tags
+	// is typically the cloud-side snapshot of the LIVE tags, including
+	// any prior-run InsideOut* stamps; dropping them here keeps the
+	// emitted HCL deterministic across re-imports without nudging
+	// InsideOutImportedAt.
+	discoveredExprText := buildDiscoveredTagsExpression(cloud, ir.Identity.Tags)
+
+	mergeExpr := buildMergeExpression(entries, discoveredExprText, existingExprText)
 	tokens, err := tokenizeExpression(mergeExpr)
 	if err != nil {
 		return nil, fmt.Errorf("tokenize provenance merge expression: %w", err)
@@ -374,19 +410,94 @@ func injectProvenance(body []byte, ir *imported.ImportedResource, projectID, ses
 	return f.Bytes(), nil
 }
 
-// buildMergeExpression formats `merge({ <provenance> }, <existingExpr>)` as
-// a string suitable for re-parsing via hclwrite. Provenance keys are emitted
-// in the order returned by provenanceKeysFor.
-func buildMergeExpression(entries []provenanceEntry, existingExpr string) string {
+// buildMergeExpression formats `merge({ <provenance> }, <discoveredExpr>,
+// <existingExpr>)` as a string suitable for re-parsing via hclwrite.
+// Provenance keys are emitted in the order returned by provenanceKeysFor.
+//
+// When discoveredExpr is empty (the resource's Identity.Tags was empty or
+// every entry was filtered as a provenance marker), the middle argument
+// is omitted so the call collapses to the historical 2-arg
+// `merge({InsideOut*}, <existing>)` shape.
+func buildMergeExpression(entries []provenanceEntry, discoveredExpr, existingExpr string) string {
 	var b strings.Builder
 	b.WriteString("merge(\n  {\n")
 	for _, e := range entries {
 		fmt.Fprintf(&b, "    %s = %q\n", quoteKeyIfNeeded(e.Key), e.Value)
 	}
-	b.WriteString("  },\n  ")
+	b.WriteString("  },\n")
+	if discoveredExpr != "" {
+		b.WriteString("  ")
+		b.WriteString(discoveredExpr)
+		b.WriteString(",\n")
+	}
+	b.WriteString("  ")
 	b.WriteString(existingExpr)
 	b.WriteString(",\n)")
 	return b.String()
+}
+
+// buildDiscoveredTagsExpression formats ir.Identity.Tags as an HCL object
+// literal suitable for an argument position inside a merge() call.
+// Returns "" when the map is empty or every entry is a provenance marker.
+//
+// Keys are emitted in sorted order so the output is deterministic
+// regardless of map iteration order. Provenance markers
+// (InsideOutImport* / insideout-import-* / insideout-imported* and
+// insideout-imported-at) are filtered out: the merge call already
+// emits the canonical values for the current pass in the first
+// argument, and re-emitting them under <discovered> would churn the
+// timestamp in place across re-imports while producing the same
+// effective `merge()` result.
+//
+// GCP label keys are emitted quoted (they may contain hyphens, which
+// HCL identifiers don't permit); AWS tag keys can contain arbitrary
+// characters and so are always quoted defensively via quoteKeyIfNeeded.
+func buildDiscoveredTagsExpression(cloud string, tags map[string]string) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	provenance := provenanceMarkerKeys(cloud)
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		if _, isMarker := provenance[k]; isMarker {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	if len(keys) == 0 {
+		return ""
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteString("{\n")
+	for _, k := range keys {
+		fmt.Fprintf(&b, "    %s = %q\n", quoteKeyIfNeeded(k), tags[k])
+	}
+	b.WriteString("  }")
+	return b.String()
+}
+
+// provenanceMarkerKeys returns the set of InsideOut marker keys for the
+// given cloud — the keys buildDiscoveredTagsExpression filters out so a
+// re-import doesn't shovel stale provenance values back into the merge.
+func provenanceMarkerKeys(cloud string) map[string]struct{} {
+	switch strings.ToLower(strings.TrimSpace(cloud)) {
+	case "aws":
+		return map[string]struct{}{
+			AWSTagKeyImportProject: {},
+			AWSTagKeyImportSession: {},
+			AWSTagKeyImported:      {},
+			AWSTagKeyImportedAt:    {},
+		}
+	case "gcp":
+		return map[string]struct{}{
+			GCPLabelKeyImportProject: {},
+			GCPLabelKeyImportSession: {},
+			GCPLabelKeyImported:      {},
+			GCPLabelKeyImportedAt:    {},
+		}
+	}
+	return nil
 }
 
 // quoteKeyIfNeeded wraps key in double quotes when it is not a legal HCL

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -154,6 +154,193 @@ func TestInjectProvenance_AWSTypedAttrsExisting(t *testing.T) {
 	assert.True(t, hasAttr(t, s, "Owner", `"team-payments"`), "user-supplied Owner tag missing in:\n%s", s)
 }
 
+// TestBuildDiscoveredTagsExpression_FiltersProvenanceMarkers pins that
+// InsideOut* / insideout-* markers are filtered out of the discover-time
+// arg of the merge() expression — otherwise a re-import would emit stale
+// timestamp values under <discovered> that would shadow the current
+// pass's fresh stamp at runtime when their literals happen to differ
+// (the merge resolves by position, and <existing> doesn't always carry
+// the markers post-first-apply on resources whose Attrs lose tags).
+func TestBuildDiscoveredTagsExpression_FiltersProvenanceMarkers(t *testing.T) {
+	t.Parallel()
+	t.Run("aws", func(t *testing.T) {
+		got := buildDiscoveredTagsExpression("aws", map[string]string{
+			"Component":              "dns",
+			"Name":                   "zone-0",
+			"InsideOutImportProject": "io-old", // must be filtered
+			"InsideOutImported":      "true",   // must be filtered
+			"InsideOutImportedAt":    "stale",  // must be filtered
+		})
+		require.NotEmpty(t, got)
+		assert.NotContains(t, got, "InsideOutImportProject", "provenance marker must not appear in discovered arg")
+		assert.NotContains(t, got, "InsideOutImported", "provenance marker must not appear in discovered arg")
+		assert.Contains(t, got, `Component = "dns"`)
+		assert.Contains(t, got, `Name = "zone-0"`)
+	})
+	t.Run("gcp", func(t *testing.T) {
+		got := buildDiscoveredTagsExpression("gcp", map[string]string{
+			"team":                     "docs",
+			"insideout-import-project": "io-old", // must be filtered
+			"insideout-imported":       "true",   // must be filtered
+		})
+		require.NotEmpty(t, got)
+		assert.NotContains(t, got, "insideout-import-project", "provenance marker must not appear in discovered arg")
+		assert.NotContains(t, got, "insideout-imported", "provenance marker must not appear in discovered arg")
+		assert.Contains(t, got, `team = "docs"`)
+	})
+	t.Run("only-markers-returns-empty", func(t *testing.T) {
+		got := buildDiscoveredTagsExpression("aws", map[string]string{
+			"InsideOutImportProject": "io-x",
+			"InsideOutImported":      "true",
+		})
+		assert.Empty(t, got, "if every entry is a marker, no discovered arg is emitted")
+	})
+	t.Run("nil-map-returns-empty", func(t *testing.T) {
+		assert.Empty(t, buildDiscoveredTagsExpression("aws", nil))
+	})
+	t.Run("empty-map-returns-empty", func(t *testing.T) {
+		assert.Empty(t, buildDiscoveredTagsExpression("aws", map[string]string{}))
+	})
+}
+
+// TestInjectProvenance_AWSDiscoveredTagsMergedWhenAttrsEmpty pins the #690
+// fix: when a resource's tags are not present in Attrs (because some AWS
+// CFN schemas mark Tags as write-only and Cloud Control GetResource never
+// returns them — aws_route53_zone is the lead repro), the discover-time
+// tags captured on Identity.Tags must still be merged into the emitted
+// tags expression so customer-set tags survive the first apply.
+//
+// Before the fix the emitted HCL was effectively `tags = merge({InsideOut*}, {})`,
+// which wiped Component / Environment / Name / Organization / Project /
+// Resource on the live resource. This test would have caught that.
+func TestInjectProvenance_AWSDiscoveredTagsMergedWhenAttrsEmpty(t *testing.T) {
+	t.Parallel()
+	// Mirror the route53_zone repro: typed Attrs do NOT carry the tags map
+	// (the Cloud Control GetResource for AWS::Route53::HostedZone never
+	// returns HostedZoneTags), but Identity.Tags is populated by the
+	// discoverer's TagsFromProperties extractor over the parallel
+	// resourcegroupstaggingapi / list path.
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_route53_zone",
+			Address:  "aws_route53_zone.apps",
+			ImportID: "Z1234567890",
+			Tags: map[string]string{
+				"Component":    "dns",
+				"Environment":  "default",
+				"ID":           "0",
+				"Name":         "252819b1-default-luther-dns-zone-0",
+				"Organization": "luther",
+				"Project":      "252819b1",
+				"Resource":     "zone",
+			},
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"apps.example.com"}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.False(t, ir.WeakLocked)
+	assert.Contains(t, s, "tags = merge(", "tags attribute must be a merge() call")
+	// InsideOut* provenance stamps must be present.
+	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`), "missing InsideOutImportProject in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "InsideOutImportSession", `"sess-9"`), "missing InsideOutImportSession in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "InsideOutImported", `"true"`), "missing InsideOutImported in:\n%s", s)
+	assert.True(t, hasAttr(t, s, "InsideOutImportedAt", `"2026-04-29T14:30:00Z"`), "missing InsideOutImportedAt in:\n%s", s)
+	// All seven customer-set tags from Identity.Tags must be preserved.
+	for _, kv := range []struct{ k, v string }{
+		{"Component", "dns"},
+		{"Environment", "default"},
+		{"ID", "0"},
+		{"Name", "252819b1-default-luther-dns-zone-0"},
+		{"Organization", "luther"},
+		{"Project", "252819b1"},
+		{"Resource", "zone"},
+	} {
+		assert.True(t, hasAttr(t, s, kv.k, `"`+kv.v+`"`),
+			"discover-time Identity.Tags[%q] = %q must survive the merge — silently wiping customer tags is data corruption (#690):\n%s",
+			kv.k, kv.v, s)
+	}
+}
+
+// TestInjectProvenance_AWSDiscoveredTagsPlusBodyTags pins that BOTH the
+// typed Attrs.Tags (when populated) AND Identity.Tags get merged into the
+// final expression. The body's tags win on key conflicts because Attrs is
+// the more authoritative state for the fields it actually carries; the
+// Identity.Tags layer is a backstop for shapes where Attrs lost tags in
+// transit (the #690 route53_zone case).
+func TestInjectProvenance_AWSDiscoveredTagsPlusBodyTags(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_sqs_queue",
+			Address: "aws_sqs_queue.q",
+			Tags: map[string]string{
+				"Component":   "queue",
+				"Environment": "prod",
+				// Conflicting key — body wins.
+				"Owner": "old-team",
+			},
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"q"},"tags":{"Owner":{"literal":"team-payments"}}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.False(t, ir.WeakLocked)
+	assert.Contains(t, s, "tags = merge(")
+	// Both Identity-only tags must be present.
+	assert.True(t, hasAttr(t, s, "Component", `"queue"`), "Identity.Tags[Component] missing:\n%s", s)
+	assert.True(t, hasAttr(t, s, "Environment", `"prod"`), "Identity.Tags[Environment] missing:\n%s", s)
+	// Body's Owner wins over Identity.Tags's Owner; the conflict is OK
+	// — the emitted HCL still resolves to the body's value at apply.
+	assert.True(t, hasAttr(t, s, "Owner", `"team-payments"`), "Attrs body Owner tag missing:\n%s", s)
+	// Provenance stamps still present.
+	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`), "missing InsideOutImportProject in:\n%s", s)
+}
+
+// TestInjectProvenance_GCPDiscoveredLabelsMergedWhenAttrsEmpty is the
+// GCP parallel to TestInjectProvenance_AWSDiscoveredTagsMergedWhenAttrsEmpty
+// — discover-time labels on Identity.Tags must survive into the merged
+// labels expression even when Attrs.Labels is empty.
+func TestInjectProvenance_GCPDiscoveredLabelsMergedWhenAttrsEmpty(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "gcp",
+			Type:    "google_storage_bucket",
+			Address: "google_storage_bucket.docs",
+			Tags: map[string]string{
+				"team":        "docs",
+				"environment": "prod",
+			},
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"docs"}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.False(t, ir.WeakLocked)
+	assert.Contains(t, s, "labels = merge(")
+	assert.True(t, hasAttr(t, s, "team", `"docs"`), "Identity.Tags[team] missing:\n%s", s)
+	assert.True(t, hasAttr(t, s, "environment", `"prod"`), "Identity.Tags[environment] missing:\n%s", s)
+	assert.True(t, hasAttr(t, s, `"insideout-import-project"`, `"io-stack-1"`), "missing insideout-import-project in:\n%s", s)
+}
+
 func TestInjectProvenance_GCPTypedAttrsExisting(t *testing.T) {
 	t.Parallel()
 	ir := imported.ImportedResource{


### PR DESCRIPTION
Closes #690.

## Summary

When importing an AWS resource via the InsideOut import flow, the composer's tag-stamping logic previously emitted

```hcl
tags = merge({InsideOut*}, {})
```

for any resource whose tags didn't survive the CloudControl `GetResource` round-trip — `aws_route53_zone` is the lead repro since CFN marks `HostedZoneTags` as write-only and `GetResource` never returns it. The first `terraform apply` then resolved that to ONLY the 4 `InsideOut*` stamps, **silently deleting** the customer's pre-existing tags (`Component`, `Environment`, `Name`, `Organization`, `Project`, `Resource` — used for billing / asset management / drift detection).

## Fix

Thread `ir.Identity.Tags` (the discover-time cloud-side tag snapshot — already populated by every Discoverer's `TagsFromProperties` extractor via the parallel resourcegroupstaggingapi/list path) into the merge as a middle argument:

```hcl
tags = merge({InsideOut*}, <discovered>, <existing>)
```

Merge ordering rationale:
- **InsideOut\* first** — the body-existing tags layer can still override them on a re-import that already carries the project's stamps; matches the prior 2-arg shape.
- **\<discovered\> in the middle** — backfills the keys the body emit dropped, but the body's typed values win on conflict (`Attrs` is more authoritative when populated).

`InsideOut*` / `insideout-*` markers are filtered out of \<discovered\> so a re-import doesn't shovel a stale `ImportedAt` back into the merge — the first arg already carries the canonical values for the current pass.

The 2-arg shape is preserved when `Identity.Tags` is empty, so no behavior change for any existing call site that doesn't populate the discover-time tag map.

## Tests

Four new tests in `pkg/composer/imported_provenance_test.go`:

- `TestInjectProvenance_AWSDiscoveredTagsMergedWhenAttrsEmpty` — the route53_zone repro. Asserts all 7 customer-set tags survive the merge alongside the 4 InsideOut\* stamps.
- `TestInjectProvenance_AWSDiscoveredTagsPlusBodyTags` — both layers populated; body wins on key conflict, Identity-only keys still emitted.
- `TestInjectProvenance_GCPDiscoveredLabelsMergedWhenAttrsEmpty` — GCP-side parity (labels rather than tags).
- `TestBuildDiscoveredTagsExpression_FiltersProvenanceMarkers` — confirms InsideOut\* markers are filtered out of the \<discovered\> arg so re-imports don't re-emit stale stamps.

Sample output for the route53_zone repro (post-fix):

```hcl
resource "aws_route53_zone" "apps" {
  provider = aws.imported
  name     = "apps.platform.luthersystemsapp.com"
  tags = merge(
    {
      InsideOutImportProject = "io-cnquj6nrjnlc"
      InsideOutImportSession = "sess_v2_CnqUJ6NRJnLC"
      InsideOutImported      = "true"
      InsideOutImportedAt    = "2026-05-26T21:22:04Z"
    },
    {
      Component    = "dns"
      Environment  = "default"
      ID           = "0"
      Name         = "252819b1-default-luther-dns-zone-0"
      Organization = "luther"
      Project      = "252819b1"
      Resource     = "zone"
    },
    {},
  )

  lifecycle {
    ignore_changes = [force_destroy]
  }
}
```

All 5332 tests across all 36 packages still pass.

## Test plan

- [x] `go test ./pkg/composer/ -run "TestInjectProvenance"` — 18 pass (15 pre-existing + 3 new bug-repro coverage)
- [x] `go test ./pkg/composer/ -run "TestBuildDiscoveredTagsExpression"` — new helper coverage
- [x] `go test ./pkg/...` — 4090 pass
- [x] `go test ./...` — 5332 pass
- [x] `go vet ./pkg/composer/...` — clean
- [x] `gofmt -l` — clean
- [x] End-to-end repro: emitted HCL for an `aws_route53_zone` with Identity.Tags populated now preserves all customer tags in the `merge()` call (verified by hand-running the emitter against the user's exact session shape).

## Follow-up

Once this lands, `reliable3` needs a `go.mod` bump to pull in the fix — separate PR there. The bug repros against any imported AWS resource whose CFN schema marks tags write-only or otherwise drops them on read; route53_zone is the one we have a customer repro on, but the same shape likely affects other types so the fix is intentionally generic across all taggable resources.
