### PR TITLE
fix(composer): dedupe discover-time tags against body emitter's existing map

### DIFF
--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -398,7 +399,18 @@ func injectProvenance(body []byte, ir *imported.ImportedResource, projectID, ses
 	// any prior-run InsideOut* stamps; dropping them here keeps the
 	// emitted HCL deterministic across re-imports without nudging
 	// InsideOutImportedAt.
-	discoveredExprText := buildDiscoveredTagsExpression(cloud, ir.Identity.Tags)
+	//
+	// We also drop keys already present in <existing>: when the body
+	// emitter wrote a tag from typed Attrs, Identity.Tags re-emitting
+	// the same key just duplicates the object literal in the merge()
+	// (visually noisy, semantically a no-op). The discover-time arg
+	// is conceptually a backfill for keys the body dropped — keys it
+	// already has don't need backfilling. When existingExprText is
+	// not a static object literal (a reference, another merge() call,
+	// etc.) we can't introspect the keys, so we keep every discovered
+	// entry — the safe direction is to over-include.
+	excludeKeys := parseObjectLiteralKeys(existingExprText)
+	discoveredExprText := buildDiscoveredTagsExpression(cloud, ir.Identity.Tags, excludeKeys)
 
 	mergeExpr := buildMergeExpression(entries, discoveredExprText, existingExprText)
 	tokens, err := tokenizeExpression(mergeExpr)
@@ -438,7 +450,8 @@ func buildMergeExpression(entries []provenanceEntry, discoveredExpr, existingExp
 
 // buildDiscoveredTagsExpression formats ir.Identity.Tags as an HCL object
 // literal suitable for an argument position inside a merge() call.
-// Returns "" when the map is empty or every entry is a provenance marker.
+// Returns "" when the map is empty or every entry is a provenance marker
+// or already present in excludeKeys.
 //
 // Keys are emitted in sorted order so the output is deterministic
 // regardless of map iteration order. Provenance markers
@@ -449,10 +462,20 @@ func buildMergeExpression(entries []provenanceEntry, discoveredExpr, existingExp
 // timestamp in place across re-imports while producing the same
 // effective `merge()` result.
 //
+// excludeKeys carries the set of keys already present in the body
+// emitter's <existing> tag map. Filtering them out avoids visually
+// duplicate object literals like
+// `merge({InsideOut*}, {Component=...}, {Component=...})` for the
+// common case where Identity.Tags is the same map the body just
+// emitted (any resource where CC GetResource returns tags — KMS keys,
+// log groups, SQS queues, etc.). Pass nil when the caller can't
+// introspect the existing map (a reference or a nested merge()),
+// in which case every discovered key is kept.
+//
 // GCP label keys are emitted quoted (they may contain hyphens, which
 // HCL identifiers don't permit); AWS tag keys can contain arbitrary
 // characters and so are always quoted defensively via quoteKeyIfNeeded.
-func buildDiscoveredTagsExpression(cloud string, tags map[string]string) string {
+func buildDiscoveredTagsExpression(cloud string, tags map[string]string, excludeKeys map[string]struct{}) string {
 	if len(tags) == 0 {
 		return ""
 	}
@@ -460,6 +483,9 @@ func buildDiscoveredTagsExpression(cloud string, tags map[string]string) string 
 	keys := make([]string, 0, len(tags))
 	for k := range tags {
 		if _, isMarker := provenance[k]; isMarker {
+			continue
+		}
+		if _, alreadyEmitted := excludeKeys[k]; alreadyEmitted {
 			continue
 		}
 		keys = append(keys, k)
@@ -475,6 +501,78 @@ func buildDiscoveredTagsExpression(cloud string, tags map[string]string) string 
 	}
 	b.WriteString("  }")
 	return b.String()
+}
+
+// parseObjectLiteralKeys returns the set of top-level keys when expr is
+// a static HCL object constructor (`{ Foo = "bar" }`). Returns nil when
+// expr is anything else — a reference like `var.tags`, a function call
+// like `merge(local.a, local.b)`, or any expression we can't statically
+// resolve. Callers treat nil as "don't filter" so the safe default is
+// to over-include discovered tags rather than under-include them.
+//
+// Both bare-identifier keys (`Foo = "..."`) and quoted-string keys
+// (`"Foo-Bar" = "..."`) are extracted; the former is the common AWS
+// shape and the latter is the common GCP-label shape.
+func parseObjectLiteralKeys(expr string) map[string]struct{} {
+	parsed, diags := hclsyntax.ParseExpression([]byte(expr), "expr.tf", hcl.InitialPos)
+	if diags.HasErrors() {
+		return nil
+	}
+	obj, ok := parsed.(*hclsyntax.ObjectConsExpr)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]struct{}, len(obj.Items))
+	for _, item := range obj.Items {
+		key, ok := objectConsKeyAsString(item.KeyExpr)
+		if !ok {
+			// A dynamic key (`(local.k) = "..."`) means we can't know
+			// statically what keys this literal carries. Bail to nil so
+			// the caller falls back to "don't filter".
+			return nil
+		}
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+// objectConsKeyAsString extracts the static string key from an HCL
+// object-cons key expression. HCL wraps the key in a ObjectConsKeyExpr;
+// the inner expression is either a single-segment ScopeTraversalExpr
+// (bare identifier) or a string-literal TemplateExpr (quoted key).
+// Returns ("", false) for anything else (parens-wrapped expressions
+// for dynamic keys, etc.).
+func objectConsKeyAsString(key hclsyntax.Expression) (string, bool) {
+	wrap, ok := key.(*hclsyntax.ObjectConsKeyExpr)
+	if !ok {
+		return "", false
+	}
+	// ForceNonLiteral is set when the source had `(expr)` parens around
+	// the key — that signals a dynamic key, which we can't resolve here.
+	if wrap.ForceNonLiteral {
+		return "", false
+	}
+	switch inner := wrap.Wrapped.(type) {
+	case *hclsyntax.ScopeTraversalExpr:
+		if len(inner.Traversal) != 1 {
+			return "", false
+		}
+		root, ok := inner.Traversal[0].(hcl.TraverseRoot)
+		if !ok {
+			return "", false
+		}
+		return root.Name, true
+	case *hclsyntax.TemplateExpr:
+		if !inner.IsStringLiteral() {
+			return "", false
+		}
+		val, vDiags := inner.Value(nil)
+		if vDiags.HasErrors() {
+			return "", false
+		}
+		return val.AsString(), true
+	}
+	return "", false
 }
 
 // provenanceMarkerKeys returns the set of InsideOut marker keys for the

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -170,7 +170,7 @@ func TestBuildDiscoveredTagsExpression_FiltersProvenanceMarkers(t *testing.T) {
 			"InsideOutImportProject": "io-old", // must be filtered
 			"InsideOutImported":      "true",   // must be filtered
 			"InsideOutImportedAt":    "stale",  // must be filtered
-		})
+		}, nil)
 		require.NotEmpty(t, got)
 		assert.NotContains(t, got, "InsideOutImportProject", "provenance marker must not appear in discovered arg")
 		assert.NotContains(t, got, "InsideOutImported", "provenance marker must not appear in discovered arg")
@@ -182,7 +182,7 @@ func TestBuildDiscoveredTagsExpression_FiltersProvenanceMarkers(t *testing.T) {
 			"team":                     "docs",
 			"insideout-import-project": "io-old", // must be filtered
 			"insideout-imported":       "true",   // must be filtered
-		})
+		}, nil)
 		require.NotEmpty(t, got)
 		assert.NotContains(t, got, "insideout-import-project", "provenance marker must not appear in discovered arg")
 		assert.NotContains(t, got, "insideout-imported", "provenance marker must not appear in discovered arg")
@@ -192,14 +192,35 @@ func TestBuildDiscoveredTagsExpression_FiltersProvenanceMarkers(t *testing.T) {
 		got := buildDiscoveredTagsExpression("aws", map[string]string{
 			"InsideOutImportProject": "io-x",
 			"InsideOutImported":      "true",
-		})
+		}, nil)
 		assert.Empty(t, got, "if every entry is a marker, no discovered arg is emitted")
 	})
 	t.Run("nil-map-returns-empty", func(t *testing.T) {
-		assert.Empty(t, buildDiscoveredTagsExpression("aws", nil))
+		assert.Empty(t, buildDiscoveredTagsExpression("aws", nil, nil))
 	})
 	t.Run("empty-map-returns-empty", func(t *testing.T) {
-		assert.Empty(t, buildDiscoveredTagsExpression("aws", map[string]string{}))
+		assert.Empty(t, buildDiscoveredTagsExpression("aws", map[string]string{}, nil))
+	})
+	t.Run("exclude-keys-drops-overlap", func(t *testing.T) {
+		// The injector passes the keys already present in <existing>
+		// here so the discovered arg doesn't duplicate them. Component
+		// is in the exclude set → filtered. Name is not → kept.
+		got := buildDiscoveredTagsExpression("aws", map[string]string{
+			"Component": "dns",
+			"Name":      "zone-0",
+		}, map[string]struct{}{"Component": {}})
+		require.NotEmpty(t, got)
+		assert.NotContains(t, got, "Component", "key already in <existing> must be filtered from <discovered>")
+		assert.Contains(t, got, `Name = "zone-0"`)
+	})
+	t.Run("exclude-keys-empties-out", func(t *testing.T) {
+		// When every discovered key is already in <existing>, the
+		// discovered arg collapses to empty so the caller can elide it.
+		got := buildDiscoveredTagsExpression("aws", map[string]string{
+			"Component": "dns",
+			"Name":      "zone-0",
+		}, map[string]struct{}{"Component": {}, "Name": {}})
+		assert.Empty(t, got, "every discovered key in <existing> → discovered arg empty")
 	})
 }
 
@@ -307,6 +328,126 @@ func TestInjectProvenance_AWSDiscoveredTagsPlusBodyTags(t *testing.T) {
 	assert.True(t, hasAttr(t, s, "Owner", `"team-payments"`), "Attrs body Owner tag missing:\n%s", s)
 	// Provenance stamps still present.
 	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`), "missing InsideOutImportProject in:\n%s", s)
+}
+
+// TestInjectProvenance_AWSDiscoveredTagsDeduped_AgainstBodyTags pins the
+// follow-up to #690: when ir.Identity.Tags and the body emitter's typed
+// Attrs.Tags carry the same keys (the common case for AWS resources whose
+// CloudControl GetResource returns tags — KMS keys, log groups, SQS
+// queues, the entire long tail), the emitted merge() must not contain
+// two object literals with identical keys. The discover-time arg only
+// makes sense as a *backfill* for keys the body dropped (route53_zone
+// repro); when every discovered key already appears in <existing>, the
+// middle arg has no work to do and must be elided to keep the HCL clean.
+//
+// Without dedupe the customer sees the duplicate-block output reported
+// against the v0.7.x KMS import in the field. The downstream merge()
+// still resolves to the right tags, but the visual duplication breaks
+// terraform fmt-style reviewability and confuses operators.
+func TestInjectProvenance_AWSDiscoveredTagsDeduped_AgainstBodyTags(t *testing.T) {
+	t.Parallel()
+	// Mirror the KMS repro: typed Attrs carries the full tag map AND
+	// Identity.Tags carries the same keys (CC GetResource returned them).
+	customer := map[string]string{
+		"Component":    "tfstate",
+		"Environment":  "default",
+		"ID":           "0",
+		"Name":         "252819b1-default-luther-tfstate-kms-0",
+		"Organization": "luther",
+		"Project":      "252819b1",
+		"Resource":     "kms",
+	}
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_kms_key",
+			Address: "aws_kms_key.c99a1dff_1b87_43a5_95a5_379e72e8046b",
+			Tags:    customer,
+		},
+		Tier: imported.TierImportedFlat,
+		Attrs: []byte(`{"description":{"literal":"tfstate encryption key"},` +
+			`"tags":{` +
+			`"Component":{"literal":"tfstate"},` +
+			`"Environment":{"literal":"default"},` +
+			`"ID":{"literal":"0"},` +
+			`"Name":{"literal":"252819b1-default-luther-tfstate-kms-0"},` +
+			`"Organization":{"literal":"luther"},` +
+			`"Project":{"literal":"252819b1"},` +
+			`"Resource":{"literal":"kms"}` +
+			`}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+
+	// Each customer tag value must appear exactly ONCE in the merged
+	// expression — the body emitter already wrote it under <existing>,
+	// so the <discovered> arg must not re-emit the same key.
+	for k, v := range customer {
+		count := strings.Count(s, `"`+v+`"`)
+		assert.Equalf(t, 1, count,
+			"customer tag %q=%q appears %d times in emitted HCL — discover-time arg duplicated the body's tags:\n%s",
+			k, v, count, s)
+	}
+
+	// And the merge() itself should be 2-arg (provenance + existing),
+	// since every discovered key was already in the body. Count object
+	// literals inside the merge() — should be exactly 2.
+	merge := strings.Index(s, "tags = merge(")
+	require.GreaterOrEqual(t, merge, 0)
+	openBraces := strings.Count(s[merge:], "{")
+	closeBraces := strings.Count(s[merge:], "}")
+	assert.Equalf(t, 2, openBraces, "expected 2 object literals in merge(), got %d:\n%s", openBraces, s)
+	assert.Equalf(t, 2, closeBraces, "expected 2 closing braces in merge(), got %d:\n%s", closeBraces, s)
+
+	// Sanity: provenance + all customer keys still present.
+	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`),
+		"missing InsideOutImportProject:\n%s", s)
+	for k, v := range customer {
+		assert.Truef(t, hasAttr(t, s, k, `"`+v+`"`),
+			"customer tag %q=%q missing after dedupe:\n%s", k, v, s)
+	}
+}
+
+// TestInjectProvenance_AWSDiscoveredTagsPartialOverlap pins that the
+// discovered arg keeps the keys NOT in <existing> (so the route53_zone
+// data-loss case from #690 still works) but drops keys already in
+// <existing> (so the KMS-style duplicate block doesn't ship).
+func TestInjectProvenance_AWSDiscoveredTagsPartialOverlap(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_sqs_queue",
+			Address: "aws_sqs_queue.q",
+			Tags: map[string]string{
+				// Overlaps the body — must be filtered out of <discovered>.
+				"Owner": "old-team",
+				// Not in body — must survive into <discovered>.
+				"Project": "io-stack-1",
+			},
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"q"},"tags":{"Owner":{"literal":"team-payments"}}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+
+	// Owner appears exactly once (body wrote it; <discovered> filtered).
+	assert.Equalf(t, 1, strings.Count(s, `"team-payments"`),
+		"Owner present once (body); old-team must NOT survive from discovered:\n%s", s)
+	assert.NotContains(t, s, `"old-team"`,
+		"discovered Owner=old-team must be filtered (key already in <existing>):\n%s", s)
+	// Project survives because it isn't in <existing>.
+	assert.True(t, hasAttr(t, s, "Project", `"io-stack-1"`),
+		"discovered Project must survive (key not in <existing>):\n%s", s)
 }
 
 // TestInjectProvenance_GCPDiscoveredLabelsMergedWhenAttrsEmpty is the

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -11,11 +11,36 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// mergeArgsForAttr extracts the argument expressions from a `merge(...)`
+// call assigned to attribute `attr` inside body. Fails the test (via
+// require) when body doesn't parse, attr isn't found, or attr's value
+// isn't a merge() call. Returns hclsyntax expressions so callers can
+// type-assert each arg's shape (e.g. *hclsyntax.ObjectConsExpr).
+func mergeArgsForAttr(t *testing.T, body []byte, attr string) []hclsyntax.Expression {
+	t.Helper()
+	// Wrap the attribute body in a synthetic resource block so the
+	// parser has a stable top-level shape; the body returned by
+	// emitImportedResourceBody is just attribute lines.
+	src := []byte("resource \"x\" \"y\" {\n" + string(body) + "\n}\n")
+	f, diags := hclsyntax.ParseConfig(src, "synthetic.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "parse synthetic resource: %s\nsource:\n%s", diags.Error(), src)
+	blocks := f.Body.(*hclsyntax.Body).Blocks
+	require.Lenf(t, blocks, 1, "expected one resource block, got %d", len(blocks))
+	a, ok := blocks[0].Body.Attributes[attr]
+	require.Truef(t, ok, "attribute %q not found in body:\n%s", attr, src)
+	call, ok := a.Expr.(*hclsyntax.FunctionCallExpr)
+	require.Truef(t, ok, "attr %q expression is %T, want FunctionCallExpr (merge call):\n%s", attr, a.Expr, src)
+	require.Equalf(t, "merge", call.Name, "attr %q calls %q, want merge:\n%s", attr, call.Name, src)
+	return call.Args
+}
 
 // fixedTime returns a stable timestamp used by the provenance tests so output
 // HCL is deterministic across runs.
@@ -394,14 +419,15 @@ func TestInjectProvenance_AWSDiscoveredTagsDeduped_AgainstBodyTags(t *testing.T)
 	}
 
 	// And the merge() itself should be 2-arg (provenance + existing),
-	// since every discovered key was already in the body. Count object
-	// literals inside the merge() — should be exactly 2.
-	merge := strings.Index(s, "tags = merge(")
-	require.GreaterOrEqual(t, merge, 0)
-	openBraces := strings.Count(s[merge:], "{")
-	closeBraces := strings.Count(s[merge:], "}")
-	assert.Equalf(t, 2, openBraces, "expected 2 object literals in merge(), got %d:\n%s", openBraces, s)
-	assert.Equalf(t, 2, closeBraces, "expected 2 closing braces in merge(), got %d:\n%s", closeBraces, s)
+	// since every discovered key was already in the body. Parse the
+	// emitted tags expression and assert structurally — counting raw
+	// braces is too tied to body-emitter formatting.
+	args := mergeArgsForAttr(t, got, "tags")
+	require.Lenf(t, args, 2, "expected 2-arg merge() after dedupe, got %d args:\n%s", len(args), s)
+	for i, a := range args {
+		_, ok := a.(*hclsyntax.ObjectConsExpr)
+		assert.Truef(t, ok, "merge() arg #%d is %T, want ObjectConsExpr:\n%s", i, a, s)
+	}
 
 	// Sanity: provenance + all customer keys still present.
 	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`),
@@ -448,6 +474,198 @@ func TestInjectProvenance_AWSDiscoveredTagsPartialOverlap(t *testing.T) {
 	// Project survives because it isn't in <existing>.
 	assert.True(t, hasAttr(t, s, "Project", `"io-stack-1"`),
 		"discovered Project must survive (key not in <existing>):\n%s", s)
+}
+
+// TestInjectProvenance_GCPDiscoveredLabelsDeduped_AgainstBodyLabels is
+// the GCP parallel to the AWS dedupe test. Critical because GCP label
+// keys are hyphenated and emit as quoted strings — this exercises the
+// TemplateExpr branch of objectConsKeyAsString end-to-end. If that
+// branch regressed to "always return false", excludeKeys would be
+// empty and we'd silently ship the duplicate-block bug on GCP only.
+func TestInjectProvenance_GCPDiscoveredLabelsDeduped_AgainstBodyLabels(t *testing.T) {
+	t.Parallel()
+	// Use label values that don't collide with the resource's `name`
+	// attribute (the body emitter writes `name = "..."` too, and we
+	// count value occurrences in the full body output).
+	customer := map[string]string{
+		"team":        "platform-team",
+		"environment": "prod-env",
+		// A hyphenated GCP-style label — the body emitter writes it
+		// as a quoted-string key, exercising the TemplateExpr branch.
+		"cost-center": "infra-cost",
+	}
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "gcp",
+			Type:    "google_storage_bucket",
+			Address: "google_storage_bucket.docs",
+			Tags:    customer,
+		},
+		Tier: imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"bucket-name"},"labels":{` +
+			`"team":{"literal":"platform-team"},` +
+			`"environment":{"literal":"prod-env"},` +
+			`"cost-center":{"literal":"infra-cost"}` +
+			`}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+
+	// Each customer label value must appear exactly once.
+	for k, v := range customer {
+		count := strings.Count(s, `"`+v+`"`)
+		assert.Equalf(t, 1, count,
+			"customer label %q=%q appears %d times — discover-time arg duplicated:\n%s",
+			k, v, count, s)
+	}
+
+	// Structural: merge() should be 2-arg after dedupe.
+	args := mergeArgsForAttr(t, got, "labels")
+	require.Lenf(t, args, 2, "expected 2-arg merge() after dedupe, got %d args:\n%s", len(args), s)
+}
+
+// TestInjectProvenance_AWSDiscoveredTagsDeduped_AgainstBodyTags_ReImport
+// pins re-import behavior: when both ir.Identity.Tags AND the body's
+// Attrs.Tags carry stale InsideOut* provenance markers from a prior
+// import pass, the discovered arg must STILL drop them (the marker
+// filter doesn't depend on excludeKeys — it has its own filter). And
+// the merge() must still resolve to the fresh project/session/timestamp
+// from the InsideOut* first arg, NOT the stale stamp from <existing>.
+//
+// Documenting the current behavior is the point: per the injector
+// docstring, "body-existing tags layer can override [the InsideOut
+// stamps] on a re-import that already carries the project's stamps."
+// That's the design from #690 — re-importing a previously-imported
+// resource doesn't churn the timestamp, because the live cloud-side
+// timestamp echoes back through <existing>. This test pins that
+// behavior so a future change to filter <existing>'s markers (which
+// the QA review flagged as ambiguous) doesn't silently regress it.
+func TestInjectProvenance_AWSDiscoveredTagsDeduped_AgainstBodyTags_ReImport(t *testing.T) {
+	t.Parallel()
+	staleTime := "2026-04-01T00:00:00Z"
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_sqs_queue",
+			Address: "aws_sqs_queue.q",
+			// Discovered carries stale markers — these must NOT appear
+			// in <discovered> (provenanceMarkerKeys filter), and they
+			// must not echo into the merge's customer-tag layer.
+			Tags: map[string]string{
+				"Component":              "queue",
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportedAt":    staleTime,
+				"InsideOutImported":      "true",
+			},
+		},
+		Tier: imported.TierImportedFlat,
+		// Body Attrs carries stale markers (re-import from a prior pass).
+		Attrs: []byte(`{"name":{"literal":"q"},"tags":{` +
+			`"InsideOutImportProject":{"literal":"io-stack-1"},` +
+			`"InsideOutImportedAt":{"literal":"` + staleTime + `"},` +
+			`"InsideOutImported":{"literal":"true"}` +
+			`}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+
+	// The fresh ImportProject stamp must be present (provenance first arg).
+	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`),
+		"missing fresh InsideOutImportProject:\n%s", s)
+	// Component (the only non-marker key in Identity.Tags) flows through
+	// <discovered>. Body has no Component → it's a genuine backfill.
+	assert.True(t, hasAttr(t, s, "Component", `"queue"`),
+		"non-marker Component from Identity.Tags missing:\n%s", s)
+
+	// Structural pin: 2-arg merge (no <discovered> middle arg, since
+	// every non-marker discovered key was filtered out — Component is
+	// not in <existing>, but the only other discovered keys are
+	// markers, so <discovered> has exactly one entry). Three args
+	// expected: {InsideOut*}, {Component}, <body with stale markers>.
+	args := mergeArgsForAttr(t, got, "tags")
+	require.Lenf(t, args, 3, "expected 3-arg merge() (prov, discovered backfill, existing with stale markers), got %d:\n%s", len(args), s)
+}
+
+// TestParseObjectLiteralKeys_NonIntrospectable_FallsBackToNil pins
+// the safe-default contract: when <existing> is a reference, function
+// call, or anything else we can't statically resolve, parseObjectLiteralKeys
+// must return nil so the caller falls back to "don't filter discovered"
+// — over-including is safe; under-including silently re-introduces the
+// #690 data-loss bug.
+func TestParseObjectLiteralKeys_NonIntrospectable_FallsBackToNil(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name, expr string
+		wantNil    bool
+	}{
+		{"variable reference", `var.tags`, true},
+		{"local reference", `local.tags`, true},
+		{"nested merge call", `merge(local.a, local.b)`, true},
+		{"toset call", `toset(["a","b"])`, true},
+		{"dynamic key via parens", `{ (local.k) = "v" }`, true},
+		{"malformed input", `{ unclosed`, true},
+		{"empty object literal", `{}`, false}, // returns empty map, NOT nil
+		{"single bare-id key", `{ Foo = "bar" }`, false},
+		{"single quoted key", `{ "cost-center" = "x" }`, false},
+		{"mixed keys", `{ Foo = "a", "b-c" = "d" }`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseObjectLiteralKeys(tc.expr)
+			if tc.wantNil {
+				assert.Nilf(t, got, "expected nil (don't-filter fallback) for %q, got %v", tc.expr, got)
+			} else {
+				assert.NotNilf(t, got, "expected non-nil map for %q", tc.expr)
+			}
+		})
+	}
+
+	t.Run("extracts both bare-id and quoted keys", func(t *testing.T) {
+		got := parseObjectLiteralKeys(`{ Foo = "a", "cost-center" = "b", Bar = "c" }`)
+		require.NotNil(t, got)
+		assert.Contains(t, got, "Foo")
+		assert.Contains(t, got, "Bar")
+		assert.Contains(t, got, "cost-center")
+		assert.Len(t, got, 3)
+	})
+}
+
+// TestBuildMergeExpression_ElidesDiscoveredWhenEmpty pins that the
+// emitter collapses to a 2-arg merge() when discoveredExpr is "".
+// Without this guard, the 3-arg shape would emit `merge({...},\n  ,\n  {...},\n)`
+// — invalid HCL. Caught at unit level so a refactor of buildMergeExpression
+// can't silently break the elision.
+func TestBuildMergeExpression_ElidesDiscoveredWhenEmpty(t *testing.T) {
+	t.Parallel()
+	entries := []provenanceEntry{{Key: "K", Value: "v"}}
+
+	t.Run("empty discovered → 2-arg merge", func(t *testing.T) {
+		got := buildMergeExpression(entries, "", "{}")
+		// Sanity-parse as HCL to catch invalid commas/newlines.
+		f, diags := hclsyntax.ParseExpression([]byte(got), "expr.tf", hcl.InitialPos)
+		require.Falsef(t, diags.HasErrors(), "elided merge() must parse: %s\n%s", diags.Error(), got)
+		call, ok := f.(*hclsyntax.FunctionCallExpr)
+		require.Truef(t, ok, "expected merge() call, got %T:\n%s", f, got)
+		assert.Equalf(t, "merge", call.Name, "wrong call name:\n%s", got)
+		assert.Lenf(t, call.Args, 2, "expected 2-arg merge() when discovered is empty:\n%s", got)
+	})
+
+	t.Run("non-empty discovered → 3-arg merge", func(t *testing.T) {
+		got := buildMergeExpression(entries, `{ Component = "x" }`, "{}")
+		f, diags := hclsyntax.ParseExpression([]byte(got), "expr.tf", hcl.InitialPos)
+		require.Falsef(t, diags.HasErrors(), "3-arg merge() must parse: %s\n%s", diags.Error(), got)
+		call, ok := f.(*hclsyntax.FunctionCallExpr)
+		require.True(t, ok)
+		assert.Lenf(t, call.Args, 3, "expected 3-arg merge() with discovered:\n%s", got)
+	})
 }
 
 // TestInjectProvenance_GCPDiscoveredLabelsMergedWhenAttrsEmpty is the


### PR DESCRIPTION
## Summary

- Follow-up to [#690](https://github.com/luthersystems/insideout-terraform-presets/pull/690). That PR added a 3-arg `merge({InsideOut*}, <discovered>, <existing>)` so resources whose CloudControl `GetResource` drops tags (the lead repro: `aws_route53_zone`) don't silently lose customer tags on first apply. It shipped without deduping: for the much more common case where CC GetResource _does_ return tags (KMS keys, log groups, SQS queues — most of the AWS long tail), `ir.Identity.Tags` and `Attrs.Tags` carry the same keys, so the injector emitted two visually identical object literals in the `merge()`. Semantically a no-op, but ugly in field reports and confusing to reviewers.
- This PR filters `<discovered>` against the keys actually present in `<existing>` (parsed via `hclsyntax` when `<existing>` is a static object literal; falls back to "keep every discovered key" when it isn't — the safe direction). The route53_zone backfill case still works because `<existing>` is `{}` for those, so `excludeKeys` is empty and every discovered key flows through.
- Reproduces the field report against KMS imports in a failing test, then fixes it. Adds GCP parallel coverage (hyphenated label keys exercise the quoted-key code path), a re-import scenario, structural HCL-parse assertions, and unit tests for the new helpers (`parseObjectLiteralKeys`, the 2-arg/3-arg `buildMergeExpression` elision).

Before (KMS import on v0.7.x):
```
tags = merge(
  { InsideOutImportProject = "...", ... },
  { Component = "tfstate", Environment = "default", ... },
  { Component = "tfstate", Environment = "default", ... },
)
```

After:
```
tags = merge(
  { InsideOutImportProject = "...", ... },
  { Component = "tfstate", Environment = "default", ... },
)
```

## Test plan

- [x] `go test ./pkg/composer/ -count=1` — 1525 passed (was 1508; +17 new tests including the failing repro)
- [x] `terraform fmt -check -recursive` — clean
- [x] All four lint scripts pass (`lint-project-tag.sh`, `lint-project-label.sh`, `lint-sensitive-for-each.sh`, `lint-foreach-unknown-keys.sh`)
- [ ] CI green

## Review notes

- `/review` findings: no P0/P1. P2 (brace-counting in dedupe test was fragile) and P3 nits addressed in the second commit.
- qa-professor findings: addressed in the second commit — replaced brace-count with `hclsyntax`-based structural assertion (reusable `mergeArgsForAttr` helper), added a GCP dedupe test with a hyphenated label key (exercises the `TemplateExpr` branch of `objectConsKeyAsString` end-to-end), added direct unit tests for `parseObjectLiteralKeys` non-introspectable fallback, and pinned the 2-arg-elision behavior of `buildMergeExpression`.

## Out-of-scope follow-up

- qa-professor flagged a design ambiguity inherited from [#690](https://github.com/luthersystems/insideout-terraform-presets/pull/690): when both `ir.Identity.Tags` AND `Attrs.Tags` carry stale `InsideOut*` markers on a re-import, the body's `<existing>` layer overrides the fresh stamps from the first merge arg (per the original docstring's merge-ordering rationale). This PR pins that behavior via `TestInjectProvenance_AWSDiscoveredTagsDeduped_AgainstBodyTags_ReImport` so a future change can't silently regress it. Whether that override _should_ happen on re-import is worth a separate decision, but it predates this PR and isn't changed here.