### PR TITLE
fix(composer): preserve InsideOutImportedAt on re-import to stop drift churn

### DIFF
--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -367,6 +367,13 @@ func injectProvenance(body []byte, ir *imported.ImportedResource, projectID, ses
 	if len(entries) == 0 {
 		return body, nil
 	}
+	// Preserve the existing InsideOutImportedAt timestamp when the resource
+	// was previously imported under the same project+session — every fresh
+	// stamp would otherwise show up as a tag-only diff on each subsequent
+	// compose pass and falsely register as drift on the carried-forward
+	// resource set (a CloudWatch log group that was imported on day 1
+	// shouldn't churn on day 2's flow if nothing else changed).
+	entries = preserveExistingImportedAt(entries, ir, cloud, projectID, sessionID)
 
 	// emitImportedResourceBody trims trailing newlines; without one, hclwrite
 	// appends a new attribute on the same line as the previous one. Restore
@@ -501,6 +508,87 @@ func buildDiscoveredTagsExpression(cloud string, tags map[string]string, exclude
 	}
 	b.WriteString("  }")
 	return b.String()
+}
+
+// preserveExistingImportedAt rewrites the InsideOutImportedAt entry's
+// value to the literal already present on the cloud-side resource
+// (ir.Identity.Tags) when the resource was previously imported under the
+// same project+session. Returns the entries slice unchanged when:
+//
+//   - the cloud is neither aws nor gcp (the entries slice is empty in
+//     that case anyway — defensive),
+//   - ir.Identity.Tags has no ImportProject marker (first import — fresh
+//     stamp is correct),
+//   - the existing ImportProject marker doesn't match projectID (a
+//     force-takeover or cross-project re-import — fresh stamp asserts
+//     the new ownership),
+//   - the session changed since the prior stamp (the session boundary is
+//     the natural place to refresh the timestamp),
+//   - or no existing ImportedAt literal is present (nothing to preserve).
+//
+// Why this lives at the entries layer rather than overriding importedAt
+// for the whole call: provenanceKeysFor's signature is small and
+// stateless, and the override is conditional on per-resource state. A
+// per-call mutation keeps the rest of injectProvenance's contract
+// intact and keeps the override visible to readers who scan
+// injectProvenance top-to-bottom.
+//
+// Idempotency contract: re-running the compose pass without any state
+// change must emit byte-identical HCL. Without this rewrite, the
+// timestamp churns on every pass and breaks that contract — visible as
+// a tag-only diff in `terraform plan` on every flow even when nothing
+// material changed.
+func preserveExistingImportedAt(entries []provenanceEntry, ir *imported.ImportedResource, cloud, projectID, sessionID string) []provenanceEntry {
+	if ir == nil || len(ir.Identity.Tags) == 0 {
+		return entries
+	}
+	var projectKey, sessionKey, importedAtKey string
+	switch strings.ToLower(strings.TrimSpace(cloud)) {
+	case "aws":
+		projectKey = AWSTagKeyImportProject
+		sessionKey = AWSTagKeyImportSession
+		importedAtKey = AWSTagKeyImportedAt
+	case "gcp":
+		projectKey = GCPLabelKeyImportProject
+		sessionKey = GCPLabelKeyImportSession
+		importedAtKey = GCPLabelKeyImportedAt
+	default:
+		return entries
+	}
+
+	if got, ok := ir.Identity.Tags[projectKey]; !ok || got != projectID {
+		return entries
+	}
+	// Session marker comparison: if the current pass has a session, it
+	// must match the prior stamp. If the current pass has no session,
+	// the prior stamp must also have no session — otherwise the prior
+	// belongs to a different temporal scope and a fresh stamp is the
+	// right signal.
+	if sessionID != "" {
+		if got, ok := ir.Identity.Tags[sessionKey]; !ok || got != sessionID {
+			return entries
+		}
+	} else if _, ok := ir.Identity.Tags[sessionKey]; ok {
+		return entries
+	}
+
+	existing, ok := ir.Identity.Tags[importedAtKey]
+	if !ok || strings.TrimSpace(existing) == "" {
+		return entries
+	}
+
+	// Copy on write so callers that share the entries slice across
+	// resources aren't mutated through. provenanceKeysFor allocates a
+	// fresh slice today, but the contract is cheap to keep.
+	out := make([]provenanceEntry, len(entries))
+	copy(out, entries)
+	for i := range out {
+		if out[i].Key == importedAtKey {
+			out[i].Value = existing
+			break
+		}
+	}
+	return out
 }
 
 // parseObjectLiteralKeys returns the set of top-level keys when expr is

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -179,6 +179,513 @@ func TestInjectProvenance_AWSTypedAttrsExisting(t *testing.T) {
 	assert.True(t, hasAttr(t, s, "Owner", `"team-payments"`), "user-supplied Owner tag missing in:\n%s", s)
 }
 
+// TestInjectProvenance_PreservesImportedAtOnReImport pins the core
+// re-import idempotency contract: when a resource was already imported
+// under the same project+session on a prior pass, the cloud-side
+// InsideOutImportedAt marker survives into the emitted HCL unchanged.
+//
+// Symptom this fixes (field report against PR #690 follow-up): every
+// subsequent compose pass re-stamped InsideOutImportedAt with `nowFn()`
+// even on resources that hadn't been touched, producing a tag-only
+// diff in `terraform plan` for the entire carried-forward set
+// (CloudWatch log groups, KMS keys, anything that came along through
+// reliable3's import-baseline carry-forward). That churn falsely reads
+// as drift to operators reviewing plans, and breaks the "byte-identical
+// HCL on a no-op compose pass" idempotency expectation.
+//
+// The trigger condition: ir.Identity.Tags carries the live cloud-side
+// tags (the discoverer's TagsFromProperties extractor captures them
+// post-apply), AND ImportProject + ImportSession match the current
+// pass. Mismatch on either falls back to fresh stamping — see the
+// adjacent table-driven test for the negative cases.
+func TestInjectProvenance_PreservesImportedAtOnReImport(t *testing.T) {
+	t.Parallel()
+	priorStamp := "2026-05-26T21:10:48Z"
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_cloudwatch_log_group",
+			Address: "aws_cloudwatch_log_group.rdsosmetrics",
+			Tags: map[string]string{
+				// Live cloud-side tags captured by re-discovery —
+				// includes the markers stamped by the prior apply.
+				"Component":              "logs",
+				"Environment":            "default",
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-9",
+				"InsideOutImported":      "true",
+				"InsideOutImportedAt":    priorStamp,
+			},
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"RDSOSMetrics"}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	// `fixedTime()` returns 2026-04-29T14:30:00Z. If preservation works,
+	// the emitted ImportedAt is priorStamp (May 26), NOT the fixed time
+	// (April 29).
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+
+	assert.True(t, hasAttr(t, s, "InsideOutImportedAt", `"`+priorStamp+`"`),
+		"prior cloud-side InsideOutImportedAt must be preserved (drift-flag fix):\n%s", s)
+	assert.False(t, hasAttr(t, s, "InsideOutImportedAt", `"2026-04-29T14:30:00Z"`),
+		"fresh nowFn timestamp must NOT appear when prior stamp matched project+session:\n%s", s)
+	// Other markers carry the fresh project/session values from the call
+	// args (they happen to match the prior stamp's values here — that's
+	// the precondition for preservation).
+	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`), "missing InsideOutImportProject:\n%s", s)
+	assert.True(t, hasAttr(t, s, "InsideOutImportSession", `"sess-9"`), "missing InsideOutImportSession:\n%s", s)
+	assert.True(t, hasAttr(t, s, "InsideOutImported", `"true"`), "missing InsideOutImported:\n%s", s)
+}
+
+// TestInjectProvenance_PreservesImportedAt_DoubleSource pins the
+// merge-arg-order contract in the presence of preservation: when BOTH
+// ir.Identity.Tags AND the body's typed Attrs.Tags carry the SAME prior
+// `InsideOutImportedAt`, the resulting `terraform apply` must resolve
+// to that prior value — not the fresh `nowFn()` stamp in the first
+// merge arg. Without this, a mutation that swapped `<existing>` and
+// `{InsideOut*}` in `buildMergeExpression` would silently flip the
+// preservation semantic on its head (apply would resolve to the stale
+// stamp in some flows and the fresh stamp in others). QA reviewer #2.
+func TestInjectProvenance_PreservesImportedAt_DoubleSource(t *testing.T) {
+	t.Parallel()
+	priorStamp := "2026-05-26T21:10:48Z"
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_cloudwatch_log_group",
+			Address: "aws_cloudwatch_log_group.rdsosmetrics",
+			// Live cloud-side tags carry the prior markers (matches the
+			// production carry-forward path post-apply re-discovery).
+			Tags: map[string]string{
+				"Component":              "logs",
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-9",
+				"InsideOutImported":      "true",
+				"InsideOutImportedAt":    priorStamp,
+			},
+		},
+		Tier: imported.TierImportedFlat,
+		// AND Attrs.Tags also carry them (so they appear in <existing>
+		// at merge-arg-3 position too). This is the worst-case shape
+		// for merge-ordering bugs.
+		Attrs: []byte(`{"name":{"literal":"RDSOSMetrics"},"tags":{` +
+			`"Component":{"literal":"logs"},` +
+			`"InsideOutImportProject":{"literal":"io-stack-1"},` +
+			`"InsideOutImportSession":{"literal":"sess-9"},` +
+			`"InsideOutImported":{"literal":"true"},` +
+			`"InsideOutImportedAt":{"literal":"` + priorStamp + `"}` +
+			`}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+
+	// The fresh `fixedTime` value must NOT appear anywhere — preservation
+	// rewrote the first merge arg, and Attrs.Tags (which feeds <existing>)
+	// also carries priorStamp.
+	assert.NotContainsf(t, s, "2026-04-29T14:30:00Z",
+		"fresh nowFn stamp must not appear when prior stamp matches:\n%s", s)
+	// priorStamp appears in BOTH the first merge arg (preservation) and
+	// the last merge arg (<existing> from Attrs.Tags). That's the
+	// expected shape — merge() resolves to the same value either way.
+	// Pin both occurrences explicitly via structural inspection so a
+	// mutation that swapped arg order (a real concern at the design
+	// level — see #690 comment) couldn't silently inject the fresh
+	// stamp into the surviving position.
+	args := mergeArgsForAttr(t, got, "tags")
+	require.GreaterOrEqualf(t, len(args), 2, "expected at least 2-arg merge():\n%s", s)
+	// First arg: provenance object literal — preserved stamp.
+	firstObj, ok := args[0].(*hclsyntax.ObjectConsExpr)
+	require.Truef(t, ok, "first merge arg is %T, want ObjectConsExpr", args[0])
+	assert.Equalf(t, priorStamp, objectLiteralStringValue(t, firstObj, "InsideOutImportedAt"),
+		"first merge arg must carry preserved priorStamp:\n%s", s)
+	// Last arg: <existing> from body — also carries priorStamp via Attrs.Tags.
+	lastObj, ok := args[len(args)-1].(*hclsyntax.ObjectConsExpr)
+	require.Truef(t, ok, "last merge arg is %T, want ObjectConsExpr", args[len(args)-1])
+	assert.Equalf(t, priorStamp, objectLiteralStringValue(t, lastObj, "InsideOutImportedAt"),
+		"last merge arg (<existing>) must carry priorStamp:\n%s", s)
+}
+
+// objectLiteralStringValue extracts the literal string value of `key`
+// from a static HCL object constructor. Fails the test if the key is
+// missing or the value isn't a static string literal — both are bugs
+// in the test setup (callers pass body-emitter output, which always
+// produces static literals).
+func objectLiteralStringValue(t *testing.T, obj *hclsyntax.ObjectConsExpr, key string) string {
+	t.Helper()
+	for _, item := range obj.Items {
+		k, ok := objectConsKeyAsString(item.KeyExpr)
+		if !ok || k != key {
+			continue
+		}
+		v, diags := item.ValueExpr.Value(nil)
+		require.Falsef(t, diags.HasErrors(), "value for %q: %s", key, diags.Error())
+		return v.AsString()
+	}
+	t.Fatalf("key %q not found in object literal", key)
+	return ""
+}
+
+// TestInjectProvenance_PreservesImportedAt_ForceTakeoverFreshStamps
+// pins the force-takeover interaction: when the current project differs
+// from the prior project AND a valid ForceTakeover authorizes the
+// rewrite, the emitted `InsideOutImportedAt` MUST be the fresh
+// `nowFn()` stamp — not the prior cloud-side value — because the
+// takeover is a re-assertion of ownership and the timestamp must
+// reflect THAT moment, not the prior owner's import time. QA reviewer #1.
+func TestInjectProvenance_PreservesImportedAt_ForceTakeoverFreshStamps(t *testing.T) {
+	t.Parallel()
+	priorStamp := "2026-05-26T21:10:48Z"
+	freshStamp := "2026-04-29T14:30:00Z" // fixedTime()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_sqs_queue",
+			Address: "aws_sqs_queue.q",
+			// Identity.Tags carries the OLD project + an old stamp —
+			// exactly the bait that a buggy preservation predicate
+			// reading from Identity.Tags alone could swallow.
+			Tags: map[string]string{
+				"InsideOutImportProject": "io-other",
+				"InsideOutImportSession": "sess-9",
+				"InsideOutImportedAt":    priorStamp,
+			},
+		},
+		Tier: imported.TierImportedFlat,
+		// Attrs.Tags also carries the old project so the existing-
+		// owner gate in injectProvenance reads it (existingProvenanceProject
+		// reads Attrs/Attributes, not Identity.Tags). Without a valid
+		// ForceTakeover, the injector would refuse to overwrite — see
+		// TestInjectProvenance_RefusesConflictingProject for that arm.
+		Attrs: []byte(`{"name":{"literal":"q"},"tags":{` +
+			`"InsideOutImportProject":{"literal":"io-other"}` +
+			`}}`),
+		ForceTakeover: &imported.ForceTakeover{
+			Actor:         "sam@luther",
+			Reason:        "test takeover",
+			PreviousOwner: "io-other",
+			ApprovedAt:    fixedTime(),
+		},
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+
+	assert.True(t, hasAttr(t, s, "InsideOutImportedAt", `"`+freshStamp+`"`),
+		"valid force-takeover must emit FRESH InsideOutImportedAt — the takeover is a re-assertion of ownership:\n%s", s)
+	assert.False(t, hasAttr(t, s, "InsideOutImportedAt", `"`+priorStamp+`"`),
+		"prior stamp must NOT be preserved when force-takeover changes the project:\n%s", s)
+	// The new project marker carries the new owner.
+	assert.True(t, hasAttr(t, s, "InsideOutImportProject", `"io-stack-1"`),
+		"force-takeover must emit new project marker:\n%s", s)
+}
+
+// TestInjectProvenance_Idempotent_OnReEmissionWithPriorStamp pins the
+// end-to-end byte-for-byte idempotency claim of this fix: if the
+// composer is run a second time with the prior emission's stamp echoed
+// back through ir.Identity.Tags (the production carry-forward path),
+// the output is byte-identical regardless of what `nowFn()` returns
+// during run #2. This is the "no tag-only diff on a no-op compose
+// pass" guarantee. QA reviewer #5.
+func TestInjectProvenance_Idempotent_OnReEmissionWithPriorStamp(t *testing.T) {
+	t.Parallel()
+	// Run 1: a fresh import — Identity.Tags has customer tags only, no
+	// InsideOut* markers (first-time discovery shape).
+	ir1 := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_cloudwatch_log_group",
+			Address: "aws_cloudwatch_log_group.rdsosmetrics",
+			Tags: map[string]string{
+				"Component": "logs",
+			},
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"RDSOSMetrics"}}`),
+	}
+	body1, _, err := emitTestBody(t, ir1)
+	require.NoError(t, err)
+	out1, err := injectProvenance(body1, &ir1, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+
+	// Run 2: same logical resource, but Identity.Tags now mirrors what
+	// the cloud-side resource would carry post-apply (the 4 InsideOut*
+	// markers stamped by run 1's apply, including run 1's ImportedAt).
+	// `nowFn()` returns a DIFFERENT time on this pass.
+	run2Time := fixedTime().Add(24 * 7 * time.Hour) // a week later
+	ir2 := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_cloudwatch_log_group",
+			Address: "aws_cloudwatch_log_group.rdsosmetrics",
+			Tags: map[string]string{
+				"Component":              "logs",
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-9",
+				"InsideOutImported":      "true",
+				// CRITICAL: this is the exact literal run 1 emitted —
+				// the RFC3339 form of fixedTime(), which preservation
+				// must echo back unchanged.
+				"InsideOutImportedAt": fixedTime().UTC().Format(time.RFC3339),
+			},
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"RDSOSMetrics"}}`),
+	}
+	body2, _, err := emitTestBody(t, ir2)
+	require.NoError(t, err)
+	out2, err := injectProvenance(body2, &ir2, "io-stack-1", "sess-9", run2Time)
+	require.NoError(t, err)
+
+	// Idempotency: byte-identical output. Note: out1's body does NOT
+	// have customer tags in <existing> beyond Component (we didn't put
+	// them in Attrs.Tags). Out2 has the markers in <discovered> via
+	// Identity.Tags, but the dedupe + preservation pipeline should
+	// produce the same final HCL — markers come from the first merge
+	// arg with the preserved stamp, customer tags from <existing>.
+	if !assert.Equal(t, string(out1), string(out2),
+		"second compose pass with prior stamp echoed via Identity.Tags must produce byte-identical HCL") {
+		t.Logf("--- out1 ---\n%s\n--- out2 ---\n%s", out1, out2)
+	}
+}
+
+// TestPreserveExistingImportedAt covers the negative arms of the
+// preservation predicate: each non-match case must fall back to the
+// fresh stamp from `entries` so the caller's intent (re-stamp on a
+// genuine state change) survives.
+//
+// Cases:
+//   - project mismatch (force-takeover / cross-project re-import) —
+//     fresh stamp asserts the new ownership.
+//   - session mismatch (a new flow started) — fresh stamp signals the
+//     temporal boundary.
+//   - new pass has session but prior didn't (or vice versa) — same
+//     temporal boundary signal.
+//   - prior ImportedAt absent — nothing to preserve.
+//   - Identity.Tags entirely empty — first-import case, fresh stamp.
+//   - unsupported cloud — no markers to parse, fall through.
+func TestPreserveExistingImportedAt(t *testing.T) {
+	t.Parallel()
+	freshStamp := fixedTime().UTC().Format(time.RFC3339)
+	freshGCPStamp := gcpLabelTimestamp(fixedTime())
+
+	awsFresh := func() []provenanceEntry {
+		return provenanceKeysFor("aws", "io-stack-1", "sess-9", fixedTime())
+	}
+	gcpFresh := func() []provenanceEntry {
+		return provenanceKeysFor("gcp", "io-stack-1", "sess-9", fixedTime())
+	}
+
+	importedAtValue := func(entries []provenanceEntry, key string) string {
+		for _, e := range entries {
+			if e.Key == key {
+				return e.Value
+			}
+		}
+		return ""
+	}
+
+	cases := []struct {
+		name      string
+		cloud     string
+		projectID string
+		sessionID string
+		tags      map[string]string
+		freshFn   func() []provenanceEntry
+		wantKey   string
+		wantValue string // expected ImportedAt value after preservation
+	}{
+		{
+			name:      "aws/preserves on full match",
+			cloud:     "aws",
+			projectID: "io-stack-1",
+			sessionID: "sess-9",
+			tags: map[string]string{
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-9",
+				"InsideOutImportedAt":    "2026-05-26T21:10:48Z",
+			},
+			freshFn:   awsFresh,
+			wantKey:   AWSTagKeyImportedAt,
+			wantValue: "2026-05-26T21:10:48Z",
+		},
+		{
+			name:      "aws/project mismatch → fresh stamp",
+			cloud:     "aws",
+			projectID: "io-stack-1",
+			sessionID: "sess-9",
+			tags: map[string]string{
+				"InsideOutImportProject": "io-other",
+				"InsideOutImportSession": "sess-9",
+				"InsideOutImportedAt":    "2026-05-26T21:10:48Z",
+			},
+			freshFn:   awsFresh,
+			wantKey:   AWSTagKeyImportedAt,
+			wantValue: freshStamp,
+		},
+		{
+			name:      "aws/session mismatch → fresh stamp",
+			cloud:     "aws",
+			projectID: "io-stack-1",
+			sessionID: "sess-9",
+			tags: map[string]string{
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-OLD",
+				"InsideOutImportedAt":    "2026-05-26T21:10:48Z",
+			},
+			freshFn:   awsFresh,
+			wantKey:   AWSTagKeyImportedAt,
+			wantValue: freshStamp,
+		},
+		{
+			name:      "aws/prior had session, current doesn't → fresh stamp",
+			cloud:     "aws",
+			projectID: "io-stack-1",
+			sessionID: "", // no session this pass
+			tags: map[string]string{
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-OLD",
+				"InsideOutImportedAt":    "2026-05-26T21:10:48Z",
+			},
+			freshFn: func() []provenanceEntry {
+				return provenanceKeysFor("aws", "io-stack-1", "", fixedTime())
+			},
+			wantKey:   AWSTagKeyImportedAt,
+			wantValue: freshStamp,
+		},
+		{
+			name:      "aws/no prior ImportedAt → fresh stamp",
+			cloud:     "aws",
+			projectID: "io-stack-1",
+			sessionID: "sess-9",
+			tags: map[string]string{
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-9",
+				// no InsideOutImportedAt
+			},
+			freshFn:   awsFresh,
+			wantKey:   AWSTagKeyImportedAt,
+			wantValue: freshStamp,
+		},
+		{
+			name:      "aws/Identity.Tags empty (first import) → fresh stamp",
+			cloud:     "aws",
+			projectID: "io-stack-1",
+			sessionID: "sess-9",
+			tags:      nil,
+			freshFn:   awsFresh,
+			wantKey:   AWSTagKeyImportedAt,
+			wantValue: freshStamp,
+		},
+		{
+			name:      "gcp/preserves on full match",
+			cloud:     "gcp",
+			projectID: "io-stack-1",
+			sessionID: "sess-9",
+			tags: map[string]string{
+				"insideout-import-project": "io-stack-1",
+				"insideout-import-session": "sess-9",
+				"insideout-imported-at":    "2026-05-26t21-10-48z",
+			},
+			freshFn:   gcpFresh,
+			wantKey:   GCPLabelKeyImportedAt,
+			wantValue: "2026-05-26t21-10-48z",
+		},
+		{
+			name:      "gcp/project mismatch → fresh stamp",
+			cloud:     "gcp",
+			projectID: "io-stack-1",
+			sessionID: "sess-9",
+			tags: map[string]string{
+				"insideout-import-project": "io-other",
+				"insideout-import-session": "sess-9",
+				"insideout-imported-at":    "2026-05-26t21-10-48z",
+			},
+			freshFn:   gcpFresh,
+			wantKey:   GCPLabelKeyImportedAt,
+			wantValue: freshGCPStamp,
+		},
+		{
+			// Identity.Tags carries a FULL AWS marker set matching the
+			// passed-in project+session+ImportedAt — if the predicate
+			// silently routed "azure" to the AWS key set, this would
+			// preserve "2026-05-26T21:10:48Z" instead of the fresh
+			// stamp. The test pins that the default branch returns the
+			// input slice untouched.
+			name:      "unsupported cloud → default branch, no preservation",
+			cloud:     "azure",
+			projectID: "io-stack-1",
+			sessionID: "sess-9",
+			tags: map[string]string{
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-9",
+				"InsideOutImportedAt":    "2026-05-26T21:10:48Z",
+			},
+			freshFn:   awsFresh,
+			wantKey:   AWSTagKeyImportedAt,
+			wantValue: freshStamp,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ir := &imported.ImportedResource{
+				Identity: imported.ResourceIdentity{
+					Cloud: tc.cloud,
+					Tags:  tc.tags,
+				},
+			}
+			got := preserveExistingImportedAt(tc.freshFn(), ir, tc.cloud, tc.projectID, tc.sessionID)
+			assert.Equalf(t, tc.wantValue, importedAtValue(got, tc.wantKey),
+				"unexpected ImportedAt value for case %q", tc.name)
+		})
+	}
+
+	t.Run("nil ir returns entries unchanged", func(t *testing.T) {
+		in := awsFresh()
+		got := preserveExistingImportedAt(in, nil, "aws", "io-stack-1", "sess-9")
+		assert.Equal(t, freshStamp, importedAtValue(got, AWSTagKeyImportedAt))
+	})
+	t.Run("copy-on-write: input slice + ir.Identity.Tags not mutated", func(t *testing.T) {
+		in := awsFresh()
+		inSnapshot := importedAtValue(in, AWSTagKeyImportedAt)
+		// Use a fresh map literal so we can detect any in-place mutation
+		// of ir.Identity.Tags (a future "optimization" that pops the
+		// markers out of the map to keep them out of <discovered> would
+		// silently leak across resources sharing the tag map).
+		tags := map[string]string{
+			"InsideOutImportProject": "io-stack-1",
+			"InsideOutImportSession": "sess-9",
+			"InsideOutImportedAt":    "2026-05-26T21:10:48Z",
+		}
+		tagsSnapshot := make(map[string]string, len(tags))
+		for k, v := range tags {
+			tagsSnapshot[k] = v
+		}
+		ir := &imported.ImportedResource{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Tags: tags},
+		}
+		out := preserveExistingImportedAt(in, ir, "aws", "io-stack-1", "sess-9")
+		// Out should have preserved value, in should still have fresh.
+		assert.Equal(t, "2026-05-26T21:10:48Z", importedAtValue(out, AWSTagKeyImportedAt))
+		assert.Equal(t, inSnapshot, importedAtValue(in, AWSTagKeyImportedAt),
+			"caller's entries slice must not be mutated")
+		assert.Equal(t, tagsSnapshot, tags,
+			"ir.Identity.Tags must not be mutated by the read-only preserve helper")
+	})
+}
+
 // TestBuildDiscoveredTagsExpression_FiltersProvenanceMarkers pins that
 // InsideOut* / insideout-* markers are filtered out of the discover-time
 // arg of the merge() expression — otherwise a re-import would emit stale


### PR DESCRIPTION
## Summary

- Field report on the v0.7.x flow that [#690](https://github.com/luthersystems/insideout-terraform-presets/pull/690) / [#692](https://github.com/luthersystems/insideout-terraform-presets/pull/692) partially addressed: every subsequent compose pass after the first import re-stamped `InsideOutImportedAt` with `nowFn()` on the entire carry-forward set, producing a tag-only diff in `terraform plan` that operators read as drift. Example from the reported KMS / log-group plan:
  ```
  ~ "InsideOutImportedAt" = "2026-05-26T21:10:48Z" -> "2026-05-27T16:16:29Z"
  ```
- This is the carry-forward side effect of [reliable3](https://github.com/luthersystems/reliable3)'s `mergeParentImported` (`import_apply.go` #1544): on a subsequent flow that imports a new resource, the prior applied imports get re-emitted alongside the new one, so the composer needs to re-stamp them — but should only refresh the timestamp when something material has changed.
- This PR teaches `injectProvenance` to read the cloud-side `InsideOutImportedAt` out of `ir.Identity.Tags` (populated by every Discoverer's `TagsFromProperties` extractor — see `cmd/insideout-import/awsdiscover/identity.go:49`) and reuse it when:
  - the cloud-side `InsideOutImportProject` matches the current `projectID`, AND
  - the cloud-side `InsideOutImportSession` matches the current `sessionID` (or both are empty), AND
  - a cloud-side `InsideOutImportedAt` literal is present.
  Mismatch on any of those falls back to fresh stamping — the natural signal for session boundaries, force-takeovers, and first imports.

Before (every compose pass):
```
~ "InsideOutImportedAt" = "<yesterday>" -> "<today>"
```

After (no-op compose pass produces byte-identical HCL): no tag diff.

## Test plan

- [x] `go test ./pkg/composer/ -count=1` — 1541 passed (1525 → 1541, +16 new tests covering the predicate's positive + negative arms, force-takeover edge, end-to-end idempotency, and merge-arg structural ordering)
- [x] `terraform fmt -check -recursive` clean
- [x] All four lint scripts pass
- [ ] CI green

## Review notes

- `/review`: P0/P1 clean. P3-only nits (table-driven case naming consistency) not addressed — they don't change behavior.
- **qa-professor** flagged 5 findings against the initial test suite; all addressed in the same commit:
  1. **MAJOR** Force-takeover + Identity.Tags interaction was uncovered → added `TestInjectProvenance_PreservesImportedAt_ForceTakeoverFreshStamps`.
  2. **MAJOR** Double-source merge-arg-order regression wasn't pinned → replaced raw `strings.Count` with `mergeArgsForAttr` structural inspection (reused from [#692](https://github.com/luthersystems/insideout-terraform-presets/pull/692)) plus a new `objectLiteralStringValue` helper that resolves the literal value of a specific key in a parsed `ObjectConsExpr`.
  3. **MAJOR** Read-only contract on `ir.Identity.Tags` wasn't asserted → strengthened the copy-on-write subtest with a tag-map snapshot.
  4. **MINOR** Unsupported-cloud table case was tautological → replaced with a full AWS-shape payload that would preserve if the cloud-key routing regressed.
  5. **MINOR** Recommended a byte-for-byte idempotency test → added `TestInjectProvenance_Idempotent_OnReEmissionWithPriorStamp` which runs the injector twice with a 7-day-different `nowFn` and asserts byte-identical HCL when the prior emission's stamp is echoed back through `Identity.Tags`. This is the end-to-end claim of the PR.

## Design notes

- The override lives at the entries layer in `preserveExistingImportedAt` (after `provenanceKeysFor`), not by mutating the `importedAt` argument across the whole call. `provenanceKeysFor` stays small and stateless; the per-resource override is locally visible to readers scanning `injectProvenance` top-to-bottom.
- Copy-on-write on the `entries` slice (the predicate allocates a fresh slice when it rewrites) — defensive against future call sites that share `entries` across resources.
- GCP timestamp format (`2026-05-26t21-10-48z` — label-safe lowercase with hyphens) is preserved as a literal pass-through; no parse/reformat round-trip that could lose precision or shift format.