### PR TITLE
feat(reverse-import): per-region provider aliases for multi-region import

### DIFF
--- a/cmd/insideout-import/genconfig/emit.go
+++ b/cmd/insideout-import/genconfig/emit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -20,14 +21,21 @@ const (
 )
 
 // emitImports writes <dir>/imports.tf — one `import { to = ADDR; id = "..." }`
-// block per ImportedResource. The block carries no `provider = aws.imported`
-// alias because this scratch stack is *not* an InsideOut composed root; it is
-// a throwaway directory whose only purpose is to feed `terraform plan
-// -generate-config-out` and produce HCL.
+// block per ImportedResource. The block carries no `provider` alias in the
+// single-region case because this scratch stack is *not* an InsideOut composed
+// root; it is a throwaway directory whose only purpose is to feed `terraform
+// plan -generate-config-out` and produce HCL.
+//
+// Multi-region (provider == "aws" and the resource set spans >1 region): a
+// resource whose region differs from primaryRegion gets a `provider =
+// aws.<region_alias>` meta-argument (Terraform 1.6+ import-block provider arg)
+// so generate-config-out reads it through that region's provider. Resources in
+// primaryRegion (or region-less globals like IAM) keep the default provider, so
+// a single-region stack emits byte-identical output.
 //
 // Address validation is light here — invalid addresses are surfaced earlier
 // by composer.ValidateImportedResources at writeManifest time.
-func emitImports(dir string, resources []imported.ImportedResource) error {
+func emitImports(dir string, resources []imported.ImportedResource, provider, primaryRegion string) error {
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 	for i, ir := range resources {
@@ -41,9 +49,63 @@ func emitImports(dir string, resources []imported.ImportedResource) error {
 			return fmt.Errorf("import block for %q: %w", ir.Identity.Address, err)
 		}
 		bb.SetAttributeTraversal("to", traversal)
+		if alias := importBlockProviderAlias(provider, ir.Identity.Region, primaryRegion); alias != "" {
+			bb.SetAttributeTraversal("provider", hcl.Traversal{
+				hcl.TraverseRoot{Name: "aws"},
+				hcl.TraverseAttr{Name: alias},
+			})
+		}
 		bb.SetAttributeValue("id", cty.StringVal(importid.ForResource(ir)))
 	}
 	return os.WriteFile(filepath.Join(dir, importsFile), f.Bytes(), 0o644)
+}
+
+// importBlockProviderAlias returns the provider-alias label for a resource's
+// import block, or "" when the default provider should be used. Only AWS
+// resources whose region is set and differs from primaryRegion route through
+// an aliased provider; everything else (GCP, region-less globals, resources in
+// the primary region) uses the default provider so output stays byte-stable
+// for single-region stacks.
+func importBlockProviderAlias(provider, resourceRegion, primaryRegion string) string {
+	if provider != ProviderAWS {
+		return ""
+	}
+	r := strings.TrimSpace(resourceRegion)
+	if r == "" || strings.EqualFold(r, strings.TrimSpace(primaryRegion)) {
+		return ""
+	}
+	return regionAlias(r)
+}
+
+// regionAlias converts a region id into a Terraform provider-alias label
+// (hyphens → underscores: "us-west-2" → "us_west_2"). Matches the
+// composer.RegionAlias convention used by the composed-root and final
+// reverse-import stacks.
+func regionAlias(region string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(region)), "-", "_")
+}
+
+// awsScratchAliasRegions returns the sorted, de-duplicated set of AWS regions
+// that need an aliased provider block in the scratch stack: every distinct
+// non-empty resource region that differs from primaryRegion. Empty when the
+// set is single-region (all resources in primaryRegion or region-less).
+func awsScratchAliasRegions(resources []imported.ImportedResource, primaryRegion string) []string {
+	primary := strings.TrimSpace(primaryRegion)
+	seen := map[string]struct{}{}
+	var out []string
+	for _, ir := range resources {
+		r := strings.TrimSpace(ir.Identity.Region)
+		if r == "" || strings.EqualFold(r, primary) {
+			continue
+		}
+		if _, ok := seen[r]; ok {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // localstackEndpointServices is the set of TF AWS provider `endpoints {}`
@@ -76,6 +138,13 @@ type providerEmitOptions struct {
 	GCPProjectID   string
 	AWSEndpointURL string
 	AWSAuth        awsProviderAuth
+
+	// AliasRegions is the set of AWS regions (excluding Region, the
+	// primary/default) that need an aliased `provider "aws" { alias =
+	// "<region_alias>" }` block so the multi-region import blocks'
+	// `provider = aws.<alias>` references resolve. Empty for single-region
+	// scratch stacks, leaving the providers.tf byte-identical to before.
+	AliasRegions []string
 }
 
 // emitProviders writes <dir>/providers.tf with the configured provider
@@ -123,25 +192,44 @@ func emitProviders(dir string, opts providerEmitOptions) error {
 			"source":  cty.StringVal("hashicorp/aws"),
 			"version": cty.StringVal("~> 6.0"),
 		}))
-		prov := body.AppendNewBlock("provider", []string{"aws"})
-		prov.Body().SetAttributeValue("region", cty.StringVal(opts.Region))
-
-		if opts.AWSEndpointURL != "" {
-			prov.Body().SetAttributeValue("access_key", cty.StringVal("test"))
-			prov.Body().SetAttributeValue("secret_key", cty.StringVal("test"))
-			prov.Body().SetAttributeValue("skip_credentials_validation", cty.True)
-			prov.Body().SetAttributeValue("skip_metadata_api_check", cty.True)
-			prov.Body().SetAttributeValue("skip_requesting_account_id", cty.True)
-			prov.Body().SetAttributeValue("s3_use_path_style", cty.True)
-			ep := prov.Body().AppendNewBlock("endpoints", nil)
-			for _, svc := range localstackEndpointServices {
-				ep.Body().SetAttributeValue(svc, cty.StringVal(opts.AWSEndpointURL))
-			}
+		// Default (unaliased) provider, pinned to the primary region.
+		// Resources in this region (and region-less globals) import
+		// through it.
+		configureAWSProviderBody(body.AppendNewBlock("provider", []string{"aws"}).Body(), opts.Region, opts)
+		// Multi-region: an aliased provider per non-primary region. The
+		// import blocks for those regions carry `provider = aws.<alias>`.
+		// Additive — single-region stacks pass no AliasRegions and emit
+		// only the default block above.
+		for _, r := range opts.AliasRegions {
+			ab := body.AppendNewBlock("provider", []string{"aws"}).Body()
+			ab.SetAttributeValue("alias", cty.StringVal(regionAlias(r)))
+			configureAWSProviderBody(ab, r, opts)
 		}
-		appendAWSAssumeRole(prov.Body(), opts.AWSAuth)
 	}
 
 	return os.WriteFile(filepath.Join(dir, providersFile), f.Bytes(), 0o644)
+}
+
+// configureAWSProviderBody fills an `aws` provider block body with the
+// region plus the shared LocalStack-endpoint and assume_role plumbing. Any
+// alias must be set on the body by the caller BEFORE calling this so the
+// attribute order (alias, region, …) stays stable. Factored out so the
+// default provider and every aliased per-region provider render identically.
+func configureAWSProviderBody(b *hclwrite.Body, region string, opts providerEmitOptions) {
+	b.SetAttributeValue("region", cty.StringVal(region))
+	if opts.AWSEndpointURL != "" {
+		b.SetAttributeValue("access_key", cty.StringVal("test"))
+		b.SetAttributeValue("secret_key", cty.StringVal("test"))
+		b.SetAttributeValue("skip_credentials_validation", cty.True)
+		b.SetAttributeValue("skip_metadata_api_check", cty.True)
+		b.SetAttributeValue("skip_requesting_account_id", cty.True)
+		b.SetAttributeValue("s3_use_path_style", cty.True)
+		ep := b.AppendNewBlock("endpoints", nil)
+		for _, svc := range localstackEndpointServices {
+			ep.Body().SetAttributeValue(svc, cty.StringVal(opts.AWSEndpointURL))
+		}
+	}
+	appendAWSAssumeRole(b, opts.AWSAuth)
 }
 
 func appendAWSAssumeRole(body *hclwrite.Body, auth awsProviderAuth) {

--- a/cmd/insideout-import/genconfig/emit_test.go
+++ b/cmd/insideout-import/genconfig/emit_test.go
@@ -17,7 +17,7 @@ func TestEmitImports_HappyPath(t *testing.T) {
 		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.alpha", Region: "us-east-1", ImportID: "https://example/alpha"}},
 		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.bravo", Region: "us-east-1", ImportID: "bravo"}},
 	}
-	if err := emitImports(dir, resources); err != nil {
+	if err := emitImports(dir, resources, ProviderAWS, "us-east-1"); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, importsFile))
@@ -47,7 +47,7 @@ func TestEmitImports_DoesNotAppendRegionForGlobalAWSResource(t *testing.T) {
 			Region:   "us-east-1",
 			ImportID: "arn:aws:iam::123456789012:policy/readonly",
 		}},
-	}); err != nil {
+	}, ProviderAWS, "us-east-1"); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, importsFile))
@@ -60,10 +60,12 @@ func TestEmitImports_DoesNotAppendRegionForGlobalAWSResource(t *testing.T) {
 	}
 }
 
-// TestEmitImports_NoProviderAlias pins that the scratch stack does NOT
-// emit `provider = aws.imported` on the import block. That alias is the
-// composer's job; the scratch directory is a standalone stack, so adding it
-// would force consumers to hand-emit a provider alias they don't have.
+// TestEmitImports_NoProviderAlias pins that a SINGLE-region scratch stack
+// does NOT emit `provider = aws.<alias>` on the import block — the default
+// provider handles every resource, so adding an alias would reference a
+// provider config that doesn't exist. (Multi-region stacks DO emit the
+// provider arg for non-primary regions; see
+// TestEmitImports_MultiRegionProviderAlias.)
 //
 // The regex matches only the `provider = ...` attribute form, not arbitrary
 // substrings — a future header comment that mentions "provider" must not
@@ -73,7 +75,7 @@ func TestEmitImports_NoProviderAlias(t *testing.T) {
 	dir := t.TempDir()
 	if err := emitImports(dir, []imported.ImportedResource{
 		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.x", ImportID: "id"}},
-	}); err != nil {
+	}, ProviderAWS, ""); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, importsFile))
@@ -102,12 +104,80 @@ func TestEmitImports_RejectsBadAddress(t *testing.T) {
 			dir := t.TempDir()
 			err := emitImports(dir, []imported.ImportedResource{
 				{Identity: imported.ResourceIdentity{Address: addr, ImportID: "x"}},
-			})
+			}, ProviderAWS, "")
 			if err == nil {
 				t.Errorf("expected error for address %q", addr)
 			}
 		})
 	}
+}
+
+// TestEmitImports_MultiRegionProviderAlias pins the multi-region scratch
+// stack: a resource whose region differs from the primary region gets a
+// `provider = aws.<region_alias>` meta-argument so generate-config-out reads
+// it through that region's aliased provider; a resource in the primary region
+// (and region-less globals) keeps the default provider (no provider arg).
+func TestEmitImports_MultiRegionProviderAlias(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	resources := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east", Region: "us-east-1", ImportID: "east"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.west", Region: "us-west-2", ImportID: "west"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_iam_role", Address: "aws_iam_role.global", Region: "", ImportID: "global"}},
+	}
+	if err := emitImports(dir, resources, ProviderAWS, "us-east-1"); err != nil {
+		t.Fatal(err)
+	}
+	got := mustReadFile(t, filepath.Join(dir, importsFile))
+	// The non-primary (us-west-2) resource routes through the aliased provider.
+	if want := "provider = aws.us_west_2"; !strings.Contains(got, want) {
+		t.Errorf("imports.tf missing %q\n--- got ---\n%s", want, got)
+	}
+	// The primary-region resource and the region-less global must NOT carry a
+	// provider arg — exactly one `provider = ...` line for three resources.
+	if n := strings.Count(got, "provider ="); n != 1 {
+		t.Errorf("expected exactly one provider= line (only the non-primary resource), got %d\n--- got ---\n%s", n, got)
+	}
+}
+
+// TestEmitProviders_MultiRegion pins that the scratch providers.tf declares
+// the default provider (primary region) plus one aliased provider per
+// non-primary region listed in AliasRegions.
+func TestEmitProviders_MultiRegion(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := emitProviders(dir, providerEmitOptions{
+		Provider:     ProviderAWS,
+		Region:       "us-east-1",
+		AliasRegions: []string{"us-west-2", "eu-west-1"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got := mustReadFile(t, filepath.Join(dir, providersFile))
+	for _, want := range []string{
+		`region = "us-east-1"`, // default provider
+		`alias  = "us_west_2"`, // aliased non-primary
+		`region = "us-west-2"`,
+		`alias  = "eu_west_1"`,
+		`region = "eu-west-1"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("providers.tf missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+	// Three provider blocks: default + 2 aliased.
+	if n := strings.Count(got, `provider "aws"`); n != 3 {
+		t.Errorf("expected 3 aws provider blocks (default + 2 aliased), got %d\n--- got ---\n%s", n, got)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }
 
 func TestEmitProviders_HappyPath(t *testing.T) {

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -135,7 +135,13 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	}
 	opts.Workdir = absWorkdir
 
-	if err := emitImports(opts.Workdir, resources); err != nil {
+	// Distinct non-primary AWS regions in THIS resource set drive the
+	// aliased provider blocks + import-block provider args. Computed from
+	// the resources arg (not Options) so each depchase iteration's expanded
+	// set re-derives its own region span. Empty for single-region stacks.
+	aliasRegions := awsScratchAliasRegions(resources, opts.Region)
+
+	if err := emitImports(opts.Workdir, resources, provider, opts.Region); err != nil {
 		return nil, fmt.Errorf("emit imports.tf: %w", err)
 	}
 	if err := emitProviders(opts.Workdir, providerEmitOptions{
@@ -147,6 +153,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 			RoleARN:    opts.AWSRoleARN,
 			ExternalID: opts.AWSExternalID,
 		},
+		AliasRegions: aliasRegions,
 	}); err != nil {
 		return nil, fmt.Errorf("emit providers.tf: %w", err)
 	}

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -722,12 +722,13 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	}
 
 	providersFiles := generateProvidersFiles(providersTFInput{
-		Cloud:          cloud,
-		Region:         reg,
-		GCPProjectID:   opts.GCPProjectID,
-		Selected:       selected,
-		Discovered:     discoveredProviders,
-		ImportedClouds: importedClouds,
+		Cloud:              cloud,
+		Region:             reg,
+		GCPProjectID:       opts.GCPProjectID,
+		Selected:           selected,
+		Discovered:         discoveredProviders,
+		ImportedClouds:     importedClouds,
+		ImportedAWSRegions: ImportedAWSRegions(composable),
 	})
 	// /providers.tf holds the terraform{} required_providers block, the
 	// default provider, and — on AWS — the `bootstrap_role` / `aws_external_id`
@@ -826,6 +827,19 @@ type providersTFInput struct {
 	// EmitImportedTF caller is responsible for populating this key based
 	// on per-type provider source lookups.
 	ImportedClouds map[string]bool
+
+	// ImportedAWSRegions is the sorted set of distinct AWS regions across
+	// the imported resource set (composer.ImportedAWSRegions). When it
+	// holds more than one region the imported resources are multi-region:
+	// EmitImportedTF routes each through a region-suffixed
+	// `aws.imported_<region>` alias, so the AWS branch declares one
+	// matching `provider "aws" { alias = "imported_<region>" }` block per
+	// region (in addition to the unconditional `aws.imported` block, which
+	// stays for the issue-#562 state-reference contract). Empty or
+	// single-region leaves the output byte-identical to prior composes.
+	// Must be derived from the SAME resource slice EmitImportedTF receives
+	// so the declared aliases match the referenced ones exactly.
+	ImportedAWSRegions []string
 }
 
 // providersTFFiles is the split-up output of generateProvidersFiles.
@@ -1112,6 +1126,17 @@ variable "aws_external_id" {
 		var imp strings.Builder
 		imp.WriteString("\n")
 		fmt.Fprintf(&imp, "provider \"aws\" {\n  alias  = \"imported\"\n  region = %q%s\n}\n", region, awsDynamicAssumeRole)
+
+		// Multi-region imported resources: declare one region-suffixed
+		// alias (`imported_<region>`) per distinct region so the
+		// `provider = aws.imported_<region>` references EmitImportedTF
+		// emits resolve. The plain `aws.imported` block above stays
+		// (issue #562 state-reference contract); these are additive, so a
+		// single-region or empty imported set leaves the file unchanged.
+		// Same region-id → alias mapping as the WAF `us_east_1` alias.
+		for _, r := range in.ImportedAWSRegions {
+			fmt.Fprintf(&imp, "\nprovider \"aws\" {\n  alias  = \"imported_%s\"\n  region = %q%s\n}\n", RegionAlias(r), r, awsDynamicAssumeRole)
+		}
 
 		return providersTFFiles{
 			Main:     []byte(main.String()),

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -103,6 +103,12 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 		removed  []byte // removed { from = ...; lifecycle { destroy = false } }
 	}
 
+	// Compute the distinct AWS region set once. len > 1 ⇒ multi-region:
+	// providerAliasForResource routes each AWS resource through a
+	// region-suffixed `aws.imported_<region>` alias. Single-region keeps
+	// the plain `aws.imported` alias (byte-identical to prior output).
+	awsRegions := ImportedAWSRegions(irs)
+
 	var entries []entry
 	for i := range irs {
 		ir := &irs[i]
@@ -136,7 +142,7 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 				}
 			}
 			body = appendImportedLifecycle(body, ir.Identity.Type)
-			alias := providerAliasForResource(got, ir.Identity)
+			alias := providerAliasForResource(got, ir.Identity, awsRegions)
 			e.resource = wrapResourceBlock(ir.Identity.Type, addressLabel(addr), alias, body)
 			if mode == emitModeResourceImport {
 				e.imported = renderImportBlock(addr, importid.ForResource(*ir))
@@ -578,13 +584,68 @@ func providerAliasFor(cloud string) string {
 // typed registry's recorded provider source — types that aren't
 // registered (the long tail still using the opaque-attr fallback) fall
 // back to the cloud's default alias, preserving historical behavior.
-func providerAliasForResource(cloud string, id imported.ResourceIdentity) string {
+//
+// awsRegions is the sorted set of distinct AWS regions in the emitted
+// batch (see ImportedAWSRegions). When it holds more than one region the
+// batch is multi-region: each AWS resource routes through a
+// region-suffixed alias (`aws.imported_us_west_2`) so terraform import /
+// plan hits the correct regional endpoint. A region-less AWS resource
+// (global services like IAM, after reliable's region backfill this is
+// rare) falls back to the first region's alias — that block is always
+// declared. Single-region batches keep the plain `aws.imported` alias so
+// the emitted HCL is byte-identical to the pre-multi-region output.
+func providerAliasForResource(cloud string, id imported.ResourceIdentity, awsRegions []string) string {
 	if cloud == "gcp" {
 		if source, ok := generated.LookupProviderSource(id.Type); ok && source == generated.GoogleBetaProviderSource {
 			return "google-beta.imported"
 		}
+		return providerAliasFor(cloud)
+	}
+	if cloud == "aws" && len(awsRegions) > 1 {
+		region := strings.TrimSpace(id.Region)
+		if region == "" {
+			region = awsRegions[0]
+		}
+		return "aws.imported_" + RegionAlias(region)
 	}
 	return providerAliasFor(cloud)
+}
+
+// RegionAlias converts a cloud region id into a Terraform provider-alias
+// label: hyphens become underscores ("us-west-2" → "us_west_2"). This
+// matches the existing `us_east_1` WAF alias convention in the composed
+// root (see generateProvidersFiles), so the multi-region imported aliases
+// read consistently alongside it.
+func RegionAlias(region string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(region)), "-", "_")
+}
+
+// ImportedAWSRegions returns the sorted, de-duplicated set of non-empty
+// AWS regions across the imported resource set. It is the single source
+// of truth for "is this batch multi-region?" — both EmitImportedTF (which
+// picks per-resource aliases) and the provider-block generators (which
+// declare the matching alias blocks) call it on the SAME resource slice,
+// so the references and declarations can never drift. GCP resources are
+// ignored: multi-region GCP import is a separate follow-up.
+func ImportedAWSRegions(irs []imported.ImportedResource) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for i := range irs {
+		if !strings.EqualFold(strings.TrimSpace(irs[i].Identity.Cloud), "aws") {
+			continue
+		}
+		region := strings.TrimSpace(irs[i].Identity.Region)
+		if region == "" {
+			continue
+		}
+		if _, ok := seen[region]; ok {
+			continue
+		}
+		seen[region] = struct{}{}
+		out = append(out, region)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // addressLabel extracts the Terraform label part of a fully-qualified address

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -710,6 +710,36 @@ func TestProviderAliasFor(t *testing.T) {
 	assert.Equal(t, "aws.imported", providerAliasFor("unknown"))
 }
 
+func TestRegionAlias(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "us_west_2", RegionAlias("us-west-2"))
+	assert.Equal(t, "eu_west_1", RegionAlias("EU-West-1"))
+	assert.Equal(t, "us_east_1", RegionAlias("  us-east-1  "))
+	assert.Equal(t, "", RegionAlias(""))
+}
+
+// TestImportedAWSRegions pins the multi-region detector: it collects the
+// sorted, de-duplicated set of non-empty AWS regions and ignores GCP and
+// region-less resources. len > 1 is the signal both the alias picker and the
+// provider-block generators key off.
+func TestImportedAWSRegions(t *testing.T) {
+	t.Parallel()
+	irs := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Cloud: "aws", Region: "us-west-2"}},
+		{Identity: imported.ResourceIdentity{Cloud: "aws", Region: "us-east-1"}},
+		{Identity: imported.ResourceIdentity{Cloud: "aws", Region: "us-west-2"}},   // dup
+		{Identity: imported.ResourceIdentity{Cloud: "aws", Region: ""}},            // region-less global
+		{Identity: imported.ResourceIdentity{Cloud: "gcp", Region: "us-central1"}}, // not AWS
+	}
+	assert.Equal(t, []string{"us-east-1", "us-west-2"}, ImportedAWSRegions(irs))
+
+	// Single region and empty are not multi-region.
+	assert.Len(t, ImportedAWSRegions([]imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Cloud: "aws", Region: "us-east-1"}},
+	}), 1)
+	assert.Empty(t, ImportedAWSRegions(nil))
+}
+
 // TestProviderAliasForResource pins the per-type routing decision for
 // imported GCP resources. The three API Gateway types live in
 // hashicorp/google-beta and must emit `provider = google-beta.imported`
@@ -721,11 +751,13 @@ func TestProviderAliasFor(t *testing.T) {
 func TestProviderAliasForResource(t *testing.T) {
 	t.Parallel()
 	cases := []struct {
-		name      string
-		cloud     string
-		idCloud   string // Identity.Cloud field; "" means leave zero
-		tfType    string
-		wantAlias string
+		name       string
+		cloud      string
+		idCloud    string // Identity.Cloud field; "" means leave zero
+		idRegion   string // Identity.Region field; "" means leave zero
+		tfType     string
+		awsRegions []string // distinct AWS regions in the batch
+		wantAlias  string
 	}{
 		{name: "google_pubsub_topic routes to google.imported", cloud: "gcp", tfType: "google_pubsub_topic", wantAlias: "google.imported"},
 		{name: "google_api_gateway_api routes to google-beta.imported", cloud: "gcp", tfType: "google_api_gateway_api", wantAlias: "google-beta.imported"},
@@ -739,12 +771,23 @@ func TestProviderAliasForResource(t *testing.T) {
 		// set both fields to the same value. Force them to disagree.
 		{name: "cloud arg dominates over id.Cloud for AWS-typed in gcp scope", cloud: "gcp", idCloud: "aws", tfType: "aws_sqs_queue", wantAlias: "google.imported"},
 		{name: "cloud arg dominates over id.Cloud for GCP-typed in aws scope", cloud: "aws", idCloud: "gcp", tfType: "google_api_gateway_api", wantAlias: "aws.imported"},
+		// Single-region AWS (one region in the batch) keeps the plain
+		// alias — no suffix — so output stays byte-identical to before.
+		{name: "single-region AWS keeps aws.imported", cloud: "aws", idRegion: "us-east-1", tfType: "aws_sqs_queue", awsRegions: []string{"us-east-1"}, wantAlias: "aws.imported"},
+		// Multi-region AWS: each resource routes through its region's
+		// suffixed alias (hyphens → underscores).
+		{name: "multi-region AWS routes to region-suffixed alias", cloud: "aws", idRegion: "us-west-2", tfType: "aws_sqs_queue", awsRegions: []string{"us-east-1", "us-west-2"}, wantAlias: "aws.imported_us_west_2"},
+		{name: "multi-region AWS other region", cloud: "aws", idRegion: "us-east-1", tfType: "aws_sqs_queue", awsRegions: []string{"us-east-1", "us-west-2"}, wantAlias: "aws.imported_us_east_1"},
+		// Region-less AWS resource (e.g. IAM global) in a multi-region
+		// batch falls back to the first region's alias — a block that
+		// is always declared.
+		{name: "multi-region region-less AWS falls back to first region alias", cloud: "aws", idRegion: "", tfType: "aws_iam_role", awsRegions: []string{"eu-west-1", "us-east-1"}, wantAlias: "aws.imported_eu_west_1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			id := imported.ResourceIdentity{Type: tc.tfType, Cloud: tc.idCloud}
-			got := providerAliasForResource(tc.cloud, id)
+			id := imported.ResourceIdentity{Type: tc.tfType, Cloud: tc.idCloud, Region: tc.idRegion}
+			got := providerAliasForResource(tc.cloud, id, tc.awsRegions)
 			assert.Equal(t, tc.wantAlias, got)
 		})
 	}

--- a/pkg/composer/providers_split_test.go
+++ b/pkg/composer/providers_split_test.go
@@ -152,6 +152,70 @@ func TestGenerateProvidersTF_WithImported(t *testing.T) {
 		"ProvidersUsed[gcp] must be false on an AWS-only compose: %v", res.ProvidersUsed)
 }
 
+// TestGenerateProvidersTF_MultiRegionImported drives an AWS compose with
+// imported resources in two regions and asserts the composed root declares
+// a region-suffixed `aws.imported_<region>` alias per region (additive — the
+// base `aws.imported` block stays) and that /imported.tf routes each resource
+// through its region's alias. This is the composed-root (deploy ladder) half
+// of multi-region reverse import.
+func TestGenerateProvidersTF_MultiRegionImported(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.east",
+					Region:   "us-east-1",
+					ImportID: "https://sqs.us-east-1.amazonaws.com/123/east",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"name":{"literal":"east"}}`),
+			},
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.west",
+					Region:   "us-west-2",
+					ImportID: "https://sqs.us-west-2.amazonaws.com/123/west",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"name":{"literal":"west"}}`),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	importedProviders := string(res.Files["/providers-imported.tf"])
+	// Base alias still emitted (issue #562 state-reference contract).
+	assert.Contains(t, importedProviders, `alias  = "imported"`)
+	// One region-suffixed alias per distinct region.
+	assert.Contains(t, importedProviders, `alias  = "imported_us_east_1"`)
+	assert.Contains(t, importedProviders, `region = "us-east-1"`)
+	assert.Contains(t, importedProviders, `alias  = "imported_us_west_2"`)
+	assert.Contains(t, importedProviders, `region = "us-west-2"`)
+
+	// /imported.tf routes each resource through its region's alias.
+	importedTF := string(res.Files["/imported.tf"])
+	assert.Contains(t, importedTF, "aws.imported_us_east_1")
+	assert.Contains(t, importedTF, "aws.imported_us_west_2")
+	// The plain `aws.imported` (no suffix) must NOT be referenced by any
+	// resource in multi-region mode — every AWS resource carries a region.
+	assert.NotRegexp(t, `provider = aws\.imported\b\s`, importedTF,
+		"multi-region resources must use region-suffixed aliases, not plain aws.imported")
+}
+
 // TestGenerateProvidersTF_WithImportedGCP mirrors the AWS case for GCP and
 // asserts ProvidersUsed records the gcp key. The google-beta.imported
 // block is emitted unconditionally for every GCP compose (#562), so its

--- a/pkg/reverseimport/providers.go
+++ b/pkg/reverseimport/providers.go
@@ -29,6 +29,16 @@ type importedProviderRenderOptions struct {
 	AWSEndpointURL string
 	ProvidersUsed  map[string]bool
 	AWSAuth        awsProviderAuth
+
+	// AWSRegions is the sorted set of distinct AWS regions across the
+	// imported resource set (composer.ImportedAWSRegions). When it holds
+	// more than one region, one aliased `provider "aws" { alias =
+	// "imported_<region>" }` block is emitted per region so the
+	// region-suffixed references EmitImportedTF produces resolve. The base
+	// `aws.imported` block is always emitted too (back-compat + the
+	// region-less fallback target). Empty/single-region is a no-op, so the
+	// emitted HCL stays byte-identical to the pre-multi-region output.
+	AWSRegions []string
 }
 
 func renderImportedProvidersTF(opts importedProviderRenderOptions) ([]byte, error) {
@@ -69,26 +79,45 @@ func renderImportedProvidersTF(opts importedProviderRenderOptions) ([]byte, erro
 			"source":  cty.StringVal("hashicorp/aws"),
 			"version": cty.StringVal("~> 6.0"),
 		}))
-		prov := body.AppendNewBlock("provider", []string{"aws"})
-		prov.Body().SetAttributeValue("alias", cty.StringVal("imported"))
-		prov.Body().SetAttributeValue("region", cty.StringVal(opts.Region))
-		if opts.AWSEndpointURL != "" {
-			prov.Body().SetAttributeValue("access_key", cty.StringVal("test"))
-			prov.Body().SetAttributeValue("secret_key", cty.StringVal("test"))
-			prov.Body().SetAttributeValue("skip_credentials_validation", cty.True)
-			prov.Body().SetAttributeValue("skip_metadata_api_check", cty.True)
-			prov.Body().SetAttributeValue("skip_requesting_account_id", cty.True)
-			prov.Body().SetAttributeValue("s3_use_path_style", cty.True)
-			ep := prov.Body().AppendNewBlock("endpoints", nil)
-			for _, svc := range localstackEndpointServices {
-				ep.Body().SetAttributeValue(svc, cty.StringVal(opts.AWSEndpointURL))
+		// Base `aws.imported` block (region = primary). Always emitted:
+		// back-compat with single-region stacks and the region-less
+		// fallback target for global resources in a multi-region batch.
+		appendAWSImportedProvider(body, "imported", opts.Region, opts)
+		// Multi-region: one aliased block per distinct region so the
+		// `aws.imported_<region>` references resolve. Additive — empty /
+		// single-region emits nothing here.
+		if len(opts.AWSRegions) > 1 {
+			for _, r := range opts.AWSRegions {
+				appendAWSImportedProvider(body, "imported_"+composer.RegionAlias(r), r, opts)
 			}
 		}
-		appendAWSAssumeRole(prov.Body(), opts.AWSAuth)
 	default:
 		return nil, fmt.Errorf("unknown cloud %q", opts.Cloud)
 	}
 	return f.Bytes(), nil
+}
+
+// appendAWSImportedProvider appends one `provider "aws" { alias = <alias>
+// region = <region> … }` block carrying the shared LocalStack-endpoint and
+// assume_role plumbing. Factored out so the base `imported` alias and every
+// per-region `imported_<region>` alias render identically bar alias+region.
+func appendAWSImportedProvider(body *hclwrite.Body, alias, region string, opts importedProviderRenderOptions) {
+	prov := body.AppendNewBlock("provider", []string{"aws"})
+	prov.Body().SetAttributeValue("alias", cty.StringVal(alias))
+	prov.Body().SetAttributeValue("region", cty.StringVal(region))
+	if opts.AWSEndpointURL != "" {
+		prov.Body().SetAttributeValue("access_key", cty.StringVal("test"))
+		prov.Body().SetAttributeValue("secret_key", cty.StringVal("test"))
+		prov.Body().SetAttributeValue("skip_credentials_validation", cty.True)
+		prov.Body().SetAttributeValue("skip_metadata_api_check", cty.True)
+		prov.Body().SetAttributeValue("skip_requesting_account_id", cty.True)
+		prov.Body().SetAttributeValue("s3_use_path_style", cty.True)
+		ep := prov.Body().AppendNewBlock("endpoints", nil)
+		for _, svc := range localstackEndpointServices {
+			ep.Body().SetAttributeValue(svc, cty.StringVal(opts.AWSEndpointURL))
+		}
+	}
+	appendAWSAssumeRole(prov.Body(), opts.AWSAuth)
 }
 
 func appendAWSAssumeRole(body *hclwrite.Body, auth awsProviderAuth) {

--- a/pkg/reverseimport/providers_test.go
+++ b/pkg/reverseimport/providers_test.go
@@ -37,6 +37,44 @@ func TestRenderImportedProvidersTF_AWSAssumesProjectRole(t *testing.T) {
 	}
 }
 
+// TestRenderImportedProvidersTF_MultiRegion pins that a multi-region batch
+// (AWSRegions holds >1 region) declares the base `aws.imported` block plus one
+// `aws.imported_<region>` block per region, each carrying the assume_role
+// plumbing. Single-region (covered by the cases above) emits only the base
+// block, so the output stays byte-identical to the pre-multi-region path.
+func TestRenderImportedProvidersTF_MultiRegion(t *testing.T) {
+	body, err := renderImportedProvidersTF(importedProviderRenderOptions{
+		Cloud:      "aws",
+		Region:     "us-east-1",
+		AWSRegions: []string{"us-east-1", "us-west-2"},
+		ProvidersUsed: map[string]bool{
+			composer.ProvidersUsedKeyAWS: true,
+		},
+		AWSAuth: awsProviderAuth{
+			RoleARN: "arn:aws:iam::123456789012:role/io-terraform",
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderImportedProvidersTF() error = %v", err)
+	}
+	s := string(body)
+	for _, want := range []string{
+		`alias  = "imported"`,           // base block (back-compat / fallback)
+		`alias  = "imported_us_east_1"`, // per-region
+		`region = "us-east-1"`,
+		`alias  = "imported_us_west_2"`,
+		`region = "us-west-2"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("providers-imported.tf missing %q:\n%s", want, s)
+		}
+	}
+	// base + 2 regional = 3 assume_role blocks (one per provider block).
+	if n := strings.Count(s, "assume_role"); n != 3 {
+		t.Fatalf("expected 3 assume_role blocks (base + 2 regional), got %d:\n%s", n, s)
+	}
+}
+
 func TestRenderImportedProvidersTF_AWSOmitsAssumeRoleWhenUnset(t *testing.T) {
 	body, err := renderImportedProvidersTF(importedProviderRenderOptions{
 		Cloud:  "aws",

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -157,6 +157,10 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 		AWSEndpointURL: opts.AWSEndpointURL,
 		ProvidersUsed:  providersUsed,
 		AWSAuth:        awsAuth,
+		// Same resource slice EmitImportedTF saw → the declared
+		// `aws.imported_<region>` alias blocks match the references it
+		// emitted. Single-region is a no-op (only `aws.imported`).
+		AWSRegions: composer.ImportedAWSRegions(resources),
 	})
 	if err != nil {
 		return result, err


### PR DESCRIPTION
## Summary

Makes reverse-Terraform import **multi-region**. Today the imported-provider rendering collapses every selected resource onto a single AWS provider/region, so a selection spanning more than one region targets the wrong regional endpoint for all but one resource and `terraform import`/`plan` fails.

This makes the imported-provider rendering region-aware across all three emit paths. When the imported resource set spans more than one AWS region, each resource routes through a region-suffixed alias (`aws.imported_<region>`) and one matching `provider "aws"` block is declared per region.

**Single-region (and all GCP) output is byte-identical to before** — every change is additive and gated on `len(distinct AWS regions) > 1`.

## What changed

| File | Change |
|---|---|
| `pkg/composer/imported_emit.go` | `ImportedAWSRegions` + `RegionAlias` helpers; `providerAliasForResource` returns `aws.imported_<region>` in multi-region mode. Region-less globals (IAM) fall back to the first region's alias — always declared. |
| `pkg/composer/compose.go` | Composed root (deploy ladder) declares one `aws.imported_<region>` alias per region, alongside the unconditional `aws.imported` block (issue #562 state-reference contract preserved). |
| `pkg/reverseimport/providers.go` + `run.go` | The reverse-import job's own final stack emits the per-region blocks, derived from the **same** resource slice `EmitImportedTF` sees → references and declarations can't drift. |
| `cmd/insideout-import/genconfig/emit.go` | The scratch `generate-config-out` stack emits a default provider (primary region) plus one aliased provider per non-primary region, and tags each non-primary import block with `provider = aws.<region_alias>`. |

### Terraform version

The genconfig scratch stack uses the **import-block `provider` meta-argument** (Terraform ≥ 1.6). mars v0.105.0 ships TF 1.9.8 (tfenv-managed) and this repo's CI runs 1.7.5 — both satisfy the requirement. No `required_version` bump needed (the scratch stack declares none).

### Example output (multi-region)

```hcl
# providers-imported.tf
provider "aws" { alias = "imported"          region = "us-east-1" ... }  # base (back-compat / fallback)
provider "aws" { alias = "imported_us_east_1" region = "us-east-1" ... }
provider "aws" { alias = "imported_us_west_2" region = "us-west-2" ... }

# imported.tf
resource "aws_instance" "web" { provider = aws.imported_us_west_2  ... }
import { to = aws_instance.web  provider = aws.imported_us_west_2  id = "i-0abc..." }
```

## Scope

AWS only. Multi-region **GCP** import is a separate follow-up (GCP imports mostly key off self-links/project, less region-sensitive).

## Test plan

- [x] New: per-region alias routing (`TestProviderAliasForResource` multi-region cases), `ImportedAWSRegions`/`RegionAlias` units, multi-region scratch stack (`TestEmitImports_MultiRegionProviderAlias`, `TestEmitProviders_MultiRegion`), final stack (`TestRenderImportedProvidersTF_MultiRegion`), composed root (`TestGenerateProvidersTF_MultiRegionImported`).
- [x] Single-region goldens unchanged.
- [x] `go test ./...` — 5099 pass.
- [x] `go vet ./...` — clean.

## Downstream

Consumed by luthersystems/reliable#1839 (reliable bumps this, relaxes its single-region backfill, threads the discovered region set through the reverse-import run path).