### PR TITLE
fix(reverse-import): per-region genconfig passes (fix #1839 region drop)

### DIFF
--- a/cmd/insideout-import/genconfig/emit.go
+++ b/cmd/insideout-import/genconfig/emit.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -21,21 +20,17 @@ const (
 )
 
 // emitImports writes <dir>/imports.tf — one `import { to = ADDR; id = "..." }`
-// block per ImportedResource. The block carries no `provider` alias in the
-// single-region case because this scratch stack is *not* an InsideOut composed
-// root; it is a throwaway directory whose only purpose is to feed `terraform
-// plan -generate-config-out` and produce HCL.
-//
-// Multi-region (provider == "aws" and the resource set spans >1 region): a
-// resource whose region differs from primaryRegion gets a `provider =
-// aws.<region_alias>` meta-argument (Terraform 1.6+ import-block provider arg)
-// so generate-config-out reads it through that region's provider. Resources in
-// primaryRegion (or region-less globals like IAM) keep the default provider, so
-// a single-region stack emits byte-identical output.
+// block per ImportedResource. The block carries no `provider` alias: this
+// scratch stack is a single-region throwaway whose only purpose is to feed
+// `terraform plan -generate-config-out`, and that command does NOT generate
+// config for import blocks bound to an aliased provider (it silently skips
+// them — the #1839 multi-region regression). Multi-region is handled by
+// genconfig.Run splitting the resource set into one single-region pass per
+// region (each with its own default provider), NOT by aliasing here.
 //
 // Address validation is light here — invalid addresses are surfaced earlier
 // by composer.ValidateImportedResources at writeManifest time.
-func emitImports(dir string, resources []imported.ImportedResource, provider, primaryRegion string) error {
+func emitImports(dir string, resources []imported.ImportedResource) error {
 	f := hclwrite.NewEmptyFile()
 	body := f.Body()
 	for i, ir := range resources {
@@ -49,63 +44,16 @@ func emitImports(dir string, resources []imported.ImportedResource, provider, pr
 			return fmt.Errorf("import block for %q: %w", ir.Identity.Address, err)
 		}
 		bb.SetAttributeTraversal("to", traversal)
-		if alias := importBlockProviderAlias(provider, ir.Identity.Region, primaryRegion); alias != "" {
-			bb.SetAttributeTraversal("provider", hcl.Traversal{
-				hcl.TraverseRoot{Name: "aws"},
-				hcl.TraverseAttr{Name: alias},
-			})
-		}
 		bb.SetAttributeValue("id", cty.StringVal(importid.ForResource(ir)))
 	}
 	return os.WriteFile(filepath.Join(dir, importsFile), f.Bytes(), 0o644)
 }
 
-// importBlockProviderAlias returns the provider-alias label for a resource's
-// import block, or "" when the default provider should be used. Only AWS
-// resources whose region is set and differs from primaryRegion route through
-// an aliased provider; everything else (GCP, region-less globals, resources in
-// the primary region) uses the default provider so output stays byte-stable
-// for single-region stacks.
-func importBlockProviderAlias(provider, resourceRegion, primaryRegion string) string {
-	if provider != ProviderAWS {
-		return ""
-	}
-	r := strings.TrimSpace(resourceRegion)
-	if r == "" || strings.EqualFold(r, strings.TrimSpace(primaryRegion)) {
-		return ""
-	}
-	return regionAlias(r)
-}
-
-// regionAlias converts a region id into a Terraform provider-alias label
-// (hyphens → underscores: "us-west-2" → "us_west_2"). Matches the
-// composer.RegionAlias convention used by the composed-root and final
-// reverse-import stacks.
+// regionAlias converts a region id into a filesystem-/label-safe token
+// (hyphens → underscores: "us-west-2" → "us_west_2"). Used to name the
+// per-region genconfig subdirectories.
 func regionAlias(region string) string {
 	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(region)), "-", "_")
-}
-
-// awsScratchAliasRegions returns the sorted, de-duplicated set of AWS regions
-// that need an aliased provider block in the scratch stack: every distinct
-// non-empty resource region that differs from primaryRegion. Empty when the
-// set is single-region (all resources in primaryRegion or region-less).
-func awsScratchAliasRegions(resources []imported.ImportedResource, primaryRegion string) []string {
-	primary := strings.TrimSpace(primaryRegion)
-	seen := map[string]struct{}{}
-	var out []string
-	for _, ir := range resources {
-		r := strings.TrimSpace(ir.Identity.Region)
-		if r == "" || strings.EqualFold(r, primary) {
-			continue
-		}
-		if _, ok := seen[r]; ok {
-			continue
-		}
-		seen[r] = struct{}{}
-		out = append(out, r)
-	}
-	sort.Strings(out)
-	return out
 }
 
 // localstackEndpointServices is the set of TF AWS provider `endpoints {}`
@@ -138,13 +86,6 @@ type providerEmitOptions struct {
 	GCPProjectID   string
 	AWSEndpointURL string
 	AWSAuth        awsProviderAuth
-
-	// AliasRegions is the set of AWS regions (excluding Region, the
-	// primary/default) that need an aliased `provider "aws" { alias =
-	// "<region_alias>" }` block so the multi-region import blocks'
-	// `provider = aws.<alias>` references resolve. Empty for single-region
-	// scratch stacks, leaving the providers.tf byte-identical to before.
-	AliasRegions []string
 }
 
 // emitProviders writes <dir>/providers.tf with the configured provider
@@ -192,19 +133,11 @@ func emitProviders(dir string, opts providerEmitOptions) error {
 			"source":  cty.StringVal("hashicorp/aws"),
 			"version": cty.StringVal("~> 6.0"),
 		}))
-		// Default (unaliased) provider, pinned to the primary region.
-		// Resources in this region (and region-less globals) import
-		// through it.
+		// Single default (unaliased) provider for this region. Each region
+		// in a multi-region import gets its own genconfig pass / workdir
+		// (see genconfig.Run), so this stack is always single-region and
+		// generate-config-out works against the default provider.
 		configureAWSProviderBody(body.AppendNewBlock("provider", []string{"aws"}).Body(), opts.Region, opts)
-		// Multi-region: an aliased provider per non-primary region. The
-		// import blocks for those regions carry `provider = aws.<alias>`.
-		// Additive — single-region stacks pass no AliasRegions and emit
-		// only the default block above.
-		for _, r := range opts.AliasRegions {
-			ab := body.AppendNewBlock("provider", []string{"aws"}).Body()
-			ab.SetAttributeValue("alias", cty.StringVal(regionAlias(r)))
-			configureAWSProviderBody(ab, r, opts)
-		}
 	}
 
 	return os.WriteFile(filepath.Join(dir, providersFile), f.Bytes(), 0o644)

--- a/cmd/insideout-import/genconfig/emit_test.go
+++ b/cmd/insideout-import/genconfig/emit_test.go
@@ -17,7 +17,7 @@ func TestEmitImports_HappyPath(t *testing.T) {
 		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.alpha", Region: "us-east-1", ImportID: "https://example/alpha"}},
 		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table", Address: "aws_dynamodb_table.bravo", Region: "us-east-1", ImportID: "bravo"}},
 	}
-	if err := emitImports(dir, resources, ProviderAWS, "us-east-1"); err != nil {
+	if err := emitImports(dir, resources); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, importsFile))
@@ -47,7 +47,7 @@ func TestEmitImports_DoesNotAppendRegionForGlobalAWSResource(t *testing.T) {
 			Region:   "us-east-1",
 			ImportID: "arn:aws:iam::123456789012:policy/readonly",
 		}},
-	}, ProviderAWS, "us-east-1"); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 	body, err := os.ReadFile(filepath.Join(dir, importsFile))
@@ -60,12 +60,11 @@ func TestEmitImports_DoesNotAppendRegionForGlobalAWSResource(t *testing.T) {
 	}
 }
 
-// TestEmitImports_NoProviderAlias pins that a SINGLE-region scratch stack
-// does NOT emit `provider = aws.<alias>` on the import block — the default
-// provider handles every resource, so adding an alias would reference a
-// provider config that doesn't exist. (Multi-region stacks DO emit the
-// provider arg for non-primary regions; see
-// TestEmitImports_MultiRegionProviderAlias.)
+// TestEmitImports_NoProviderAlias pins that the scratch stack NEVER emits a
+// `provider = aws.<alias>` arg on import blocks. `terraform plan
+// -generate-config-out` silently skips aliased-provider imports, so multi-
+// region is handled by genconfig.Run running one single-region pass per region
+// (each with its own default provider) — not by aliasing here (#1839).
 //
 // The regex matches only the `provider = ...` attribute form, not arbitrary
 // substrings — a future header comment that mentions "provider" must not
@@ -75,7 +74,7 @@ func TestEmitImports_NoProviderAlias(t *testing.T) {
 	dir := t.TempDir()
 	if err := emitImports(dir, []imported.ImportedResource{
 		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.x", ImportID: "id"}},
-	}, ProviderAWS, ""); err != nil {
+	}); err != nil {
 		t.Fatal(err)
 	}
 	body, _ := os.ReadFile(filepath.Join(dir, importsFile))
@@ -104,80 +103,12 @@ func TestEmitImports_RejectsBadAddress(t *testing.T) {
 			dir := t.TempDir()
 			err := emitImports(dir, []imported.ImportedResource{
 				{Identity: imported.ResourceIdentity{Address: addr, ImportID: "x"}},
-			}, ProviderAWS, "")
+			})
 			if err == nil {
 				t.Errorf("expected error for address %q", addr)
 			}
 		})
 	}
-}
-
-// TestEmitImports_MultiRegionProviderAlias pins the multi-region scratch
-// stack: a resource whose region differs from the primary region gets a
-// `provider = aws.<region_alias>` meta-argument so generate-config-out reads
-// it through that region's aliased provider; a resource in the primary region
-// (and region-less globals) keeps the default provider (no provider arg).
-func TestEmitImports_MultiRegionProviderAlias(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	resources := []imported.ImportedResource{
-		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east", Region: "us-east-1", ImportID: "east"}},
-		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.west", Region: "us-west-2", ImportID: "west"}},
-		{Identity: imported.ResourceIdentity{Type: "aws_iam_role", Address: "aws_iam_role.global", Region: "", ImportID: "global"}},
-	}
-	if err := emitImports(dir, resources, ProviderAWS, "us-east-1"); err != nil {
-		t.Fatal(err)
-	}
-	got := mustReadFile(t, filepath.Join(dir, importsFile))
-	// The non-primary (us-west-2) resource routes through the aliased provider.
-	if want := "provider = aws.us_west_2"; !strings.Contains(got, want) {
-		t.Errorf("imports.tf missing %q\n--- got ---\n%s", want, got)
-	}
-	// The primary-region resource and the region-less global must NOT carry a
-	// provider arg — exactly one `provider = ...` line for three resources.
-	if n := strings.Count(got, "provider ="); n != 1 {
-		t.Errorf("expected exactly one provider= line (only the non-primary resource), got %d\n--- got ---\n%s", n, got)
-	}
-}
-
-// TestEmitProviders_MultiRegion pins that the scratch providers.tf declares
-// the default provider (primary region) plus one aliased provider per
-// non-primary region listed in AliasRegions.
-func TestEmitProviders_MultiRegion(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	if err := emitProviders(dir, providerEmitOptions{
-		Provider:     ProviderAWS,
-		Region:       "us-east-1",
-		AliasRegions: []string{"us-west-2", "eu-west-1"},
-	}); err != nil {
-		t.Fatal(err)
-	}
-	got := mustReadFile(t, filepath.Join(dir, providersFile))
-	for _, want := range []string{
-		`region = "us-east-1"`, // default provider
-		`alias  = "us_west_2"`, // aliased non-primary
-		`region = "us-west-2"`,
-		`alias  = "eu_west_1"`,
-		`region = "eu-west-1"`,
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("providers.tf missing %q\n--- got ---\n%s", want, got)
-		}
-	}
-	// Three provider blocks: default + 2 aliased.
-	if n := strings.Count(got, `provider "aws"`); n != 3 {
-		t.Errorf("expected 3 aws provider blocks (default + 2 aliased), got %d\n--- got ---\n%s", n, got)
-	}
-}
-
-func mustReadFile(t *testing.T, path string) string {
-	t.Helper()
-	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(b)
 }
 
 func TestEmitProviders_HappyPath(t *testing.T) {

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -9,10 +9,13 @@
 package genconfig
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -121,9 +124,6 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		return nil, fmt.Errorf("genconfig: no resources to generate; nothing to do")
 	}
 
-	if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
-		return nil, fmt.Errorf("mkdir workdir: %w", err)
-	}
 	// terraform-exec runs the binary inside Workdir, so a relative
 	// generated-config-out path is resolved relative to Workdir — passing
 	// the same relative path twice (caller's CWD + workdir) produces a
@@ -135,13 +135,120 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	}
 	opts.Workdir = absWorkdir
 
-	// Distinct non-primary AWS regions in THIS resource set drive the
-	// aliased provider blocks + import-block provider args. Computed from
-	// the resources arg (not Options) so each depchase iteration's expanded
-	// set re-derives its own region span. Empty for single-region stacks.
-	aliasRegions := awsScratchAliasRegions(resources, opts.Region)
+	// Multi-region (AWS only): `terraform plan -generate-config-out` does NOT
+	// emit config for import blocks bound to an aliased provider — it silently
+	// skips them — so a single scratch stack with per-region provider aliases
+	// drops every non-primary region (the #1839 regression observed live:
+	// us-east-1 imported, us-west-2/eu-west-1 dropped to ~zero). Instead split
+	// the set into one single-region pass per distinct region, each in its own
+	// workdir with its own *default* provider (which generate-config-out
+	// handles), and merge the results. GCP import is project-global and never
+	// splits. The final imported.tf / providers-imported.tf the job emits
+	// downstream still carry per-region aliases — that path uses plain
+	// `terraform plan`, which handles aliased providers fine.
+	if provider == ProviderAWS {
+		if groups := groupResourcesByRegion(resources, opts.Region); len(groups) > 1 {
+			return runMultiRegion(ctx, opts, groups)
+		}
+	}
+	return runSingleRegion(ctx, opts, resources)
+}
 
-	if err := emitImports(opts.Workdir, resources, provider, opts.Region); err != nil {
+// regionGroup is one region's slice of a multi-region import set.
+type regionGroup struct {
+	region    string
+	resources []imported.ImportedResource
+}
+
+// groupResourcesByRegion partitions resources by AWS region, folding
+// region-less globals (IAM/Route53/CloudFront) into the primaryRegion group.
+// Returns groups sorted by region for deterministic subdir ordering. A set
+// that resolves to a single region yields one group (the caller then takes
+// the cheaper single-pass path).
+func groupResourcesByRegion(resources []imported.ImportedResource, primaryRegion string) []regionGroup {
+	byRegion := map[string][]imported.ImportedResource{}
+	for _, r := range resources {
+		region := strings.TrimSpace(r.Identity.Region)
+		if region == "" {
+			region = primaryRegion
+		}
+		byRegion[region] = append(byRegion[region], r)
+	}
+	regions := make([]string, 0, len(byRegion))
+	for region := range byRegion {
+		regions = append(regions, region)
+	}
+	sort.Strings(regions)
+	groups := make([]regionGroup, 0, len(regions))
+	for _, region := range regions {
+		groups = append(groups, regionGroup{region: region, resources: byRegion[region]})
+	}
+	return groups
+}
+
+// runMultiRegion runs one single-region genconfig pass per region group (each
+// in a region-<alias> subdir with its own default provider) and merges the
+// per-region resources. A combined generated.tf is written at the top level
+// for the debug artifact; the authoritative per-region configs live in the
+// subdirs.
+func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*Result, error) {
+	if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir workdir: %w", err)
+	}
+	merged := make([]imported.ImportedResource, 0)
+	subdirs := make([]string, 0, len(groups))
+	for _, g := range groups {
+		sub := opts
+		sub.Region = g.region
+		sub.Workdir = filepath.Join(opts.Workdir, "region-"+regionAlias(g.region))
+		res, err := runSingleRegion(ctx, sub, g.resources)
+		if err != nil {
+			return nil, fmt.Errorf("genconfig region %s: %w", g.region, err)
+		}
+		merged = append(merged, res.Resources...)
+		subdirs = append(subdirs, sub.Workdir)
+	}
+	genPath := filepath.Join(opts.Workdir, generatedFile)
+	if err := writeMergedGenerated(genPath, subdirs); err != nil {
+		// Best-effort: the merged top-level file is only for the debug
+		// artifact; the real per-region configs are in the subdirs.
+		fmt.Fprintf(os.Stderr, "genconfig: WARN: merged generated.tf: %v\n", err)
+	}
+	return &Result{GeneratedPath: genPath, Resources: merged}, nil
+}
+
+// writeMergedGenerated concatenates each region subdir's generated.tf into one
+// file (region-headed) for traceability / downstream artifact capture. A
+// region whose generated.tf is absent (e.g. all its imports were orphan-pruned)
+// is skipped. Errors only if nothing could be assembled.
+func writeMergedGenerated(destPath string, subdirs []string) error {
+	var buf bytes.Buffer
+	for _, d := range subdirs {
+		b, err := os.ReadFile(filepath.Join(d, generatedFile))
+		if err != nil {
+			continue
+		}
+		fmt.Fprintf(&buf, "# ===== %s =====\n", filepath.Base(d))
+		buf.Write(b)
+		buf.WriteString("\n")
+	}
+	if buf.Len() == 0 {
+		return fmt.Errorf("no per-region generated.tf produced")
+	}
+	return os.WriteFile(destPath, buf.Bytes(), 0o644)
+}
+
+// runSingleRegion is the single-region genconfig core: emit imports.tf +
+// providers.tf (one default provider), terraform init, plan -generate-config-out,
+// schema cleanup, fixups, orphan-prune, cross-ref, validate, attribute extract.
+// opts.Workdir must already be absolute (Run resolves it).
+func runSingleRegion(ctx context.Context, opts Options, resources []imported.ImportedResource) (*Result, error) {
+	provider := providerOrDefault(opts.Provider)
+	if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
+		return nil, fmt.Errorf("mkdir workdir: %w", err)
+	}
+
+	if err := emitImports(opts.Workdir, resources); err != nil {
 		return nil, fmt.Errorf("emit imports.tf: %w", err)
 	}
 	if err := emitProviders(opts.Workdir, providerEmitOptions{
@@ -153,7 +260,6 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 			RoleARN:    opts.AWSRoleARN,
 			ExternalID: opts.AWSExternalID,
 		},
-		AliasRegions: aliasRegions,
 	}); err != nil {
 		return nil, fmt.Errorf("emit providers.tf: %w", err)
 	}

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -459,3 +459,125 @@ func TestRun_StagedFailures(t *testing.T) {
 		})
 	}
 }
+
+// TestGroupResourcesByRegion pins the multi-region partitioner: resources
+// split by Identity.Region, region-less globals fold into primaryRegion, and
+// groups come back sorted for deterministic per-region subdir ordering.
+func TestGroupResourcesByRegion(t *testing.T) {
+	t.Parallel()
+	res := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.w", Region: "us-west-2"}},
+		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.e", Region: "us-east-1"}},
+		{Identity: imported.ResourceIdentity{Address: "aws_iam_role.g", Region: ""}}, // global → primary
+		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.e2", Region: "us-east-1"}},
+	}
+	groups := groupResourcesByRegion(res, "us-east-1")
+	if len(groups) != 2 {
+		t.Fatalf("want 2 groups, got %d: %+v", len(groups), groups)
+	}
+	// Sorted: us-east-1 first, us-west-2 second.
+	if groups[0].region != "us-east-1" || groups[1].region != "us-west-2" {
+		t.Fatalf("groups not sorted by region: %s, %s", groups[0].region, groups[1].region)
+	}
+	// us-east-1 holds e, e2, and the region-less global (folded into primary).
+	if len(groups[0].resources) != 3 {
+		t.Errorf("us-east-1 group: want 3 (incl. global), got %d", len(groups[0].resources))
+	}
+	if len(groups[1].resources) != 1 {
+		t.Errorf("us-west-2 group: want 1, got %d", len(groups[1].resources))
+	}
+
+	// Single region (incl. region-less folding) → one group, so Run takes the
+	// cheaper single-pass path.
+	one := groupResourcesByRegion([]imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.a", Region: "us-east-1"}},
+		{Identity: imported.ResourceIdentity{Address: "aws_iam_role.g", Region: ""}},
+	}, "us-east-1")
+	if len(one) != 1 {
+		t.Errorf("single-region set must yield 1 group, got %d", len(one))
+	}
+}
+
+// regionAwareRunner is a fakeRunner whose PlanGenerate synthesizes a resource
+// body per import block it finds in the pass's imports.tf — so a multi-region
+// Run, which feeds each region a different import set, produces region-correct
+// generated.tf without a real terraform. Only aws_sqs_queue is modeled (the
+// minimal schema covers it).
+type regionAwareRunner struct {
+	fakeRunner
+}
+
+func (r *regionAwareRunner) PlanGenerate(_ context.Context, generatedPath string) (bool, error) {
+	r.calls = append(r.calls, "plan")
+	r.planCalled++
+	r.generatedPath = generatedPath
+	importsTF, err := os.ReadFile(filepath.Join(filepath.Dir(generatedPath), importsFile))
+	if err != nil {
+		return false, err
+	}
+	var body strings.Builder
+	for _, m := range regexp.MustCompile(`to\s*=\s*aws_sqs_queue\.(\w+)`).FindAllStringSubmatch(string(importsTF), -1) {
+		body.WriteString("resource \"aws_sqs_queue\" \"" + m[1] + "\" {\n  name = \"" + m[1] + "\"\n}\n")
+	}
+	if err := os.WriteFile(generatedPath, []byte(body.String()), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// TestRun_MultiRegion pins the #1839 fix: a resource set spanning >1 AWS region
+// runs one single-region genconfig pass per region (each in its own
+// region-<alias> subdir with its own DEFAULT provider — no aliases, so
+// generate-config-out emits config for every region), and the per-region
+// resources merge. This is the regression guard for the live-observed drop
+// where only the primary region survived.
+func TestRun_MultiRegion(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	runner := &regionAwareRunner{fakeRunner: fakeRunner{schemas: minimalAWSSchema()}}
+	res, err := Run(context.Background(), Options{
+		Workdir: dir,
+		Region:  "us-east-1",
+		Runner:  runner,
+	}, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east1", Region: "us-east-1", ImportID: "e1"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east2", Region: "us-east-1", ImportID: "e2"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.west1", Region: "us-west-2", ImportID: "w1"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.euw1", Region: "eu-west-1", ImportID: "ew1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All four resources across all three regions must survive — NOT just the
+	// primary region's two (the bug dropped non-primary regions to ~zero).
+	if len(res.Resources) != 4 {
+		t.Fatalf("want 4 merged resources (2 us-east-1 + 1 us-west-2 + 1 eu-west-1), got %d", len(res.Resources))
+	}
+	byRegion := map[string]int{}
+	for _, r := range res.Resources {
+		byRegion[r.Identity.Region]++
+	}
+	if byRegion["us-east-1"] != 2 || byRegion["us-west-2"] != 1 || byRegion["eu-west-1"] != 1 {
+		t.Errorf("region distribution wrong: %v", byRegion)
+	}
+	// Each region ran in its own subdir with a single DEFAULT (unaliased)
+	// provider pinned to that region — no aliased providers in the scratch
+	// stack (the thing that broke generate-config-out).
+	for region, wantRegion := range map[string]string{"region-us_east_1": "us-east-1", "region-us_west_2": "us-west-2", "region-eu_west_1": "eu-west-1"} {
+		prov, err := os.ReadFile(filepath.Join(dir, region, providersFile))
+		if err != nil {
+			t.Errorf("missing per-region providers.tf for %s: %v", region, err)
+			continue
+		}
+		if !strings.Contains(string(prov), `region = "`+wantRegion+`"`) {
+			t.Errorf("%s providers.tf not pinned to %s:\n%s", region, wantRegion, prov)
+		}
+		if strings.Contains(string(prov), "alias") {
+			t.Errorf("%s scratch providers.tf must NOT use aliases (breaks generate-config-out):\n%s", region, prov)
+		}
+	}
+	// A combined generated.tf is assembled at the top level for the artifact.
+	if _, err := os.Stat(res.GeneratedPath); err != nil {
+		t.Errorf("merged top-level generated.tf missing: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a region-drop regression introduced by the multi-region work in #695, **caught by live testing** against a 3-region account.

#695 routed non-primary-region resources through aliased providers in the genconfig scratch stack. But **`terraform plan -generate-config-out` silently skips import blocks bound to an aliased provider** — so every non-primary region was dropped before `EmitImportedTF`. Live evidence on a 3-region S3 account (12 buckets/region selected):

| region | reliable sent | imported (old engine) | imported (#695, broken) |
|---|---|---|---|
| us-east-1 (primary, default provider) | 12 | 10 | 11 |
| us-west-2 (aliased) | 12 | 10 | **1** |
| eu-west-1 (aliased) | 12 | 10 | **0** |

Only the default-provider (primary) region survived.

## Fix

Stop aliasing in the scratch stack. `genconfig.Run` now **splits a multi-region AWS set into one single-region pass per distinct region** — each in its own `region-<alias>` workdir with its own *default* provider (which `generate-config-out` handles) — then merges the per-region results. Region-less globals fold into the primary region's pass. GCP is project-global and never splits.

`run.go` and the **depchase** pipeline are untouched: the per-region logic is fully encapsulated in `genconfig.Run`, so depchase (which calls it per iteration) gets correct multi-region behavior for free.

The final `imported.tf` / `providers-imported.tf` the job emits downstream **keep** their per-region `aws.imported_<region>` aliases — that path uses plain `terraform plan`, which handles aliased providers fine. Only `generate-config-out` has the limitation.

## Changes

- `genconfig/emit.go` — revert #695 aliasing: `emitImports` drops the import-block provider arg; `emitProviders` drops `AliasRegions`. One default provider per pass.
- `genconfig/genconfig.go` — `groupResourcesByRegion` + `runMultiRegion` + `runSingleRegion` (the former `Run` body) + `writeMergedGenerated` (combined debug artifact).
- tests — `groupResourcesByRegion` (partition/sort/global-fold) + multi-region `Run` (proves all resources across all regions survive; regression guard).

## Test plan

- [x] `go test ./...` — 4993 pass
- [x] `go vet ./...` + `gofmt` clean
- [x] `TestRun_MultiRegion` — 4 resources across 3 regions all survive; each region's scratch stack has a single default (unaliased) provider pinned to its region
- [ ] Post-merge: bake into mars → bump reliable → live 3-region plan shows even per-region imports (the table above, fixed)

## Rollout

Pairs with reliable#1839. After merge: new mars tag → bump `ReverseImportMarsVersion` in reliable.