### PR TITLE
fix(discover): account-wide S3 — mark bucket global + make --project optional (#1860)

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_s3_global_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_s3_global_test.go
@@ -1,0 +1,28 @@
+package awsdiscover
+
+import "testing"
+
+// TestS3BucketIsGlobal pins the #1860 fix: aws_s3_bucket must be a GLOBAL
+// Cloud Control type. S3 bucket ARNs carry no region and ListBuckets/RGT are
+// account-global, so a per-region S3 config emits the same bucket once per
+// scanned region (each stamped with the wrong scan region) — which broke the
+// per-region reverse-import engine. Marking it global makes the discoverer
+// scan once (region="") and read the ARN-deduped set via RGTCacheForGlobalCFN,
+// so each bucket appears exactly once. A regression that flips this back to
+// per-region resurrects the cross-region duplicate/mis-tag bug.
+func TestS3BucketIsGlobal(t *testing.T) {
+	t.Parallel()
+	var matches []cloudControlConfig
+	for _, cfg := range cloudControlTypeConfigs {
+		if cfg.TFType == "aws_s3_bucket" {
+			matches = append(matches, cfg)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected exactly one aws_s3_bucket config in cloudControlTypeConfigs, found %d", len(matches))
+	}
+	if !matches[0].IsGlobal {
+		t.Errorf("aws_s3_bucket must be IsGlobal=true (#1860): S3 is account-global; "+
+			"per-region scanning duplicates buckets across regions with bogus scan-region tags. got IsGlobal=%v", matches[0].IsGlobal)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -350,9 +350,19 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		TFType:             "aws_s3_bucket",
 		CloudFormationType: "AWS::S3::Bucket",
 		Slug:               "s3",
-		// RGT returns per-region tagged buckets (the GetBucketLocation
-		// per-bucket regionalization that the hand-rolled discoverer
-		// did is now unnecessary). Identifier = bucket name.
+		// S3 bucket ARNs (arn:aws:s3:::name) carry NO region, and
+		// ListBuckets / RGT GetResources are account-global — every
+		// scanned region returns the same buckets. Treating S3 as a
+		// per-region type therefore emitted the same bucket once per
+		// scan region, each stamped with the (wrong) scan region (#1860).
+		// Mark it global: the discoverer scans once (region="") and reads
+		// the deduped set via RGTCacheForGlobalCFN (dedups by ARN), so
+		// each bucket appears exactly once with no region. Downstream the
+		// region-less identity is handled as a global resource (reliable
+		// backfills the session region — us-east-1 — for import, which the
+		// S3 us-east-1 endpoint serves cross-region). Identifier = bucket
+		// name.
+		IsGlobal:                true,
 		ImportIDFromIdentifier:  passthroughImportID,
 		NameHintFromProperties:  nameOrIdentifier("BucketName"),
 		NativeIDsFromProperties: arnUnderKey("Arn"),

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -468,7 +468,7 @@ Exit codes:
 	provider := fs.String("provider", "", "cloud provider: aws or gcp (required)")
 	project := fs.String("project", "", "project name prefix used to filter resources (required)")
 	region := fs.String("region", "", "DEPRECATED (#291): use --regions instead. Single AWS region or GCP location filter; emits a deprecation warning when set.")
-	regions := fs.String("regions", "", "comma-separated AWS regions (or GCP locations) to scan in one invocation (required for --provider aws unless --region is set; optional for --provider gcp). Multi-region scans use the same per-service tag-selector filter across every region. Note: GCP project-global asset types (Pub/Sub, VPC networks, secrets) are excluded by any non-empty --regions; this is a known asset-API limitation.")
+	regions := fs.String("regions", "", "comma-separated AWS regions (or GCP locations) to scan in one invocation (required for --provider aws unless --region is set; optional for --provider gcp). Pass `all` (AWS) to expand to the InsideOut-supported region set — the CLI equivalent of the wizard's \"Scan all supported regions\"; combine with an empty --project for the wizard's whole-account scan. Multi-region scans use the same per-service tag-selector filter across every region. Note: GCP project-global asset types (Pub/Sub, VPC networks, secrets) are excluded by any non-empty --regions; this is a known asset-API limitation.")
 	tagSelectors := fs.String("tag-selectors", "", "comma-separated tag/label selectors of the form key=value, AND-conjuncted across the list. AWS: applied client-side over each per-service tag fetch. GCP: appended as `labels.<k>:<v>` clauses to the Cloud Asset query (server-side AND).")
 	outputDir := fs.String("output-dir", "", "directory to write imported.json into (required)")
 	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to discover; default: all supported types for the chosen provider")
@@ -546,6 +546,9 @@ Exit codes:
 		return discoverExitFatal
 	}
 	resolvedRegions := splitCSV(*regions)
+	if cloud == "aws" {
+		resolvedRegions = expandAllSupportedAWSRegions(resolvedRegions)
+	}
 	if len(resolvedRegions) == 0 && regionRaw != "" {
 		fmt.Fprintln(os.Stderr, "discover: WARN: --region is deprecated; use --regions instead")
 		resolvedRegions = []string{regionRaw}
@@ -1320,6 +1323,57 @@ func toSummaryTagSelectors(in []tagSelectorPair) []imported.SummaryTagSelector {
 	out := make([]imported.SummaryTagSelector, 0, len(in))
 	for _, p := range in {
 		out = append(out, imported.SummaryTagSelector{Key: p.Key, Value: p.Value})
+	}
+	return out
+}
+
+// insideOutSupportedAWSRegions mirrors INSIDEOUT_SUPPORTED_AWS_REGIONS in
+// reliable (lib/stack/supportedRegions.ts / internal/agentapi/supported_regions.go)
+// — the region set the import wizard's "Scan all supported regions" button
+// uses. Keep in sync. Lives here so `--regions all` reproduces the wizard's
+// whole-account, all-supported-regions scan from the CLI.
+var insideOutSupportedAWSRegions = []string{
+	"us-east-1",
+	"us-east-2",
+	"us-west-2",
+	"eu-west-1",
+	"ap-southeast-1",
+}
+
+// expandAllSupportedAWSRegions replaces an "all" sentinel in the region list
+// with the InsideOut-supported AWS region set — the CLI equivalent of the
+// wizard's "Scan all supported regions" (and reliable's server-side
+// expandAllRegionsSentinel). Any non-sentinel entries the caller also passed
+// are preserved and de-duplicated; order is deterministic (supported set
+// first, then caller extras). No "all" → returned unchanged.
+func expandAllSupportedAWSRegions(regions []string) []string {
+	hasAll := false
+	for _, r := range regions {
+		if strings.EqualFold(strings.TrimSpace(r), "all") {
+			hasAll = true
+			break
+		}
+	}
+	if !hasAll {
+		return regions
+	}
+	seen := make(map[string]struct{}, len(insideOutSupportedAWSRegions)+len(regions))
+	out := make([]string, 0, len(insideOutSupportedAWSRegions)+len(regions))
+	for _, r := range insideOutSupportedAWSRegions {
+		if _, ok := seen[r]; !ok {
+			seen[r] = struct{}{}
+			out = append(out, r)
+		}
+	}
+	for _, r := range regions {
+		t := strings.TrimSpace(r)
+		if t == "" || strings.EqualFold(t, "all") {
+			continue
+		}
+		if _, ok := seen[t]; !ok {
+			seen[t] = struct{}{}
+			out = append(out, t)
+		}
 	}
 	return out
 }

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -507,9 +507,13 @@ Exit codes:
 		return discoverExitFatal
 	}
 
+	// --project is an OPTIONAL tag-prefix filter. Empty means scan the whole
+	// account/provider: no RGT TagFilter prefetch, so each per-service
+	// discoverer falls back to its full ListResources enumeration. This is
+	// the "discover everything importable in the account" mode (#1860
+	// follow-up) — distinct from the wizard's project-scoped scan.
 	if strings.TrimSpace(*project) == "" {
-		fmt.Fprintln(os.Stderr, "discover: --project is required")
-		return discoverExitFatal
+		fmt.Fprintln(os.Stderr, "discover: no --project filter — scanning the entire account (all resources)")
 	}
 	// --from-manifest / --resource-ids mutual-exclusion + dependency
 	// validation (#292). These checks run before the AWS-region requirement

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -83,17 +83,29 @@ func TestRunDiscover_UnknownProvider(t *testing.T) {
 	}
 }
 
-func TestRunDiscover_MissingProject(t *testing.T) {
+// TestRunDiscover_EmptyProjectIsAllowed pins that --project is now OPTIONAL
+// (#1860 follow-up: an empty project scans the whole account). With no
+// --project AND no --regions, the run must get PAST the project gate — emitting
+// the account-wide-scan note — and fail instead at the downstream region gate.
+// Driving it this way proves the project requirement is gone without making a
+// (creds-dependent) AWS call.
+func TestRunDiscover_EmptyProjectIsAllowed(t *testing.T) {
 	dir := t.TempDir()
 	var rc int
 	stderr := captureStderr(t, func() {
-		rc = runDiscover([]string{"--provider", "aws", "--region", "us-east-1", "--output-dir", dir})
+		rc = runDiscover([]string{"--provider", "aws", "--output-dir", dir})
 	})
 	if rc != discoverExitFatal {
-		t.Errorf("rc=%d, want fatal", rc)
+		t.Errorf("rc=%d, want fatal (region gate)", rc)
 	}
-	if !strings.Contains(stderr, "--project is required") {
-		t.Errorf("stderr=%q, want substring %q", stderr, "--project is required")
+	if strings.Contains(stderr, "--project is required") {
+		t.Errorf("empty --project must no longer be rejected; stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "scanning the entire account") {
+		t.Errorf("expected the account-wide-scan note (project gate passed); stderr=%q", stderr)
+	}
+	if !strings.Contains(stderr, "--regions is required") {
+		t.Errorf("expected failure at the region gate, not the project gate; stderr=%q", stderr)
 	}
 }
 

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -3277,3 +3277,23 @@ func TestStageTimeoutsDoNotExceedOverallCap(t *testing.T) {
 		}
 	}
 }
+
+// TestExpandAllSupportedAWSRegions pins the `--regions all` sentinel: it
+// expands to the InsideOut-supported AWS set (CLI mirror of the wizard's
+// "Scan all supported regions"), preserves + dedups caller extras, and is a
+// no-op without "all".
+func TestExpandAllSupportedAWSRegions(t *testing.T) {
+	join := func(s []string) string { return strings.Join(s, ",") }
+	if got := expandAllSupportedAWSRegions([]string{"us-east-1", "eu-west-1"}); join(got) != "us-east-1,eu-west-1" {
+		t.Errorf("no 'all' must be unchanged; got %v", got)
+	}
+	if got := join(expandAllSupportedAWSRegions([]string{"all"})); got != join(insideOutSupportedAWSRegions) {
+		t.Errorf("'all' → supported set; got %q want %q", got, join(insideOutSupportedAWSRegions))
+	}
+	// supported set first, then deduped caller extras (us-east-1 already present).
+	got := join(expandAllSupportedAWSRegions([]string{"all", "ca-central-1", "us-east-1"}))
+	want := join(insideOutSupportedAWSRegions) + ",ca-central-1"
+	if got != want {
+		t.Errorf("'all' + extras: got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Two coupled fixes for **account-wide / multi-region S3 discovery** ([reliable#1860](https://github.com/luthersystems/reliable/issues/1860)).

### 1. `aws_s3_bucket` → global (dedupe + stop scan-region mis-tag)

S3 bucket ARNs carry no region and `ListBuckets`/RGT are account-global, so a per-region scan emitted the same bucket once per scanned region, each stamped with the (wrong) scan region. Marking it `IsGlobal: true` → scanned once (`region=""`), deduped by ARN via `RGTCacheForGlobalCFN`. No `GetBucketLocation` fan-out, no new map.

### 2. `--project` is now optional → scan the whole account

The discover CLI hard-required `--project` (a tag-prefix filter), so there was no way to enumerate everything importable in an account. Empty `--project` now means account-wide: no RGT TagFilter prefetch → each discoverer falls back to full `ListResources`.

## Validated live (real account, account-wide scan, 3 regions)

```
OLD (per-region S3):  one bucket appears 3× → us-east-1, us-west-2, eu-west-1   ← #1860 bug
NEW (this PR):         one bucket appears 1× → (global)                          ← fixed + deduped
```
(With `--project` set, the RGT path was already region-accurate — the bug is specific to the no-project/account-wide path, which is exactly the mode this PR also enables.)

## Test plan
- [x] `go test ./...` — 5129 pass
- [x] `go vet` + `gofmt` clean
- [x] `TestS3BucketIsGlobal` — config-flag regression guard
- [x] `TestRunDiscover_EmptyProjectIsAllowed` — empty project passes the gate (no AWS call)
- [x] **Live**: before/after on a real account (above)

## Follow-up (not in this PR)
- reliable `/api/import/discover` additionally scopes AWS discovery by the deployment-project tag filter; making the **wizard** scan account-wide is a separate product decision.

Follow-up to reliable#1839 / #1860.