### PR TITLE
feat(reverseimport): stream live phase progress through the whole pipeline

### DIFF
--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -97,6 +98,15 @@ type Options struct {
 	MaxIterations int
 	Discoverer    Discoverer
 	Pipeline      PipelineFns
+
+	// Stdout, when non-nil, receives a concise per-iteration progress
+	// line ("depchase: iteration k: discovered N resource(s)…") so a
+	// long-running caller — the Mars reverse-import job — can surface live
+	// progress through the chase loop instead of going silent while the
+	// nested genconfig/driftfix re-runs execute. Nil discards progress
+	// (the historical behavior). The nested terraform subprocess output
+	// is streamed separately by the Pipeline closures the caller wires.
+	Stdout io.Writer
 }
 
 // Result is what Run hands back. Resources is the final, expanded
@@ -297,6 +307,8 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 			return res, nil
 		}
 
+		progressf(opts.Stdout, "depchase: iteration %d: discovered %d dependency resource(s), regenerating config…\n", iter, len(added))
+
 		res.Resources = append(res.Resources, added...)
 
 		gcRes, err := opts.Pipeline.RunGenconfig(ctx, res.Resources)
@@ -473,6 +485,16 @@ func addWarning(res *Result, seen map[string]struct{}, msg string) {
 	}
 	seen[msg] = struct{}{}
 	res.Warnings = append(res.Warnings, msg)
+}
+
+// progressf writes a human-readable progress line to w when w is
+// non-nil. Best-effort: a write error to a progress sink must never
+// affect the chase result, so the error is intentionally ignored.
+func progressf(w io.Writer, format string, args ...any) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, format, args...)
 }
 
 // emitUnresolvedAsWarnings is called when the loop detects a stable

--- a/cmd/insideout-import/depchase/depchase_test.go
+++ b/cmd/insideout-import/depchase/depchase_test.go
@@ -185,6 +185,42 @@ resource "aws_iam_role" "io_foo_handler_role" {
 	}
 }
 
+// TestRun_StreamsIterationProgressToStdout is part of the
+// luthersystems/mars#178 fix: the chase loop must surface a per-iteration
+// progress line to Options.Stdout so the Mars reverse-import job's log
+// console shows live progress while the nested genconfig/driftfix re-runs
+// execute. A nil Stdout (the default) emits nothing.
+func TestRun_StreamsIterationProgressToStdout(t *testing.T) {
+	t.Parallel()
+	roleARN := "arn:aws:iam::123:role/io-foo-handler-role"
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  function_name = "io-foo-handler"
+  role          = "` + roleARN + `"
+}`
+	gen1 := gen0 + `
+resource "aws_iam_role" "io_foo_handler_role" {
+  name = "io-foo-handler-role"
+}`
+	dir := writeGen(t, gen0)
+	role := newRes("aws_iam_role.io_foo_handler_role", "io-foo-handler-role", roleARN, "aws_iam_role")
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_iam_role|" + roleARN: role,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen1}}
+
+	var progress strings.Builder
+	if _, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(), Stdout: &progress,
+	}, nil); err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if got := progress.String(); !strings.Contains(got, "iteration 1") || !strings.Contains(got, "discovered 1 dependency resource") {
+		t.Errorf("progress stream missing iteration line; got:\n%s", got)
+	}
+}
+
 func TestRun_DiscoveredResourceDroppedByPipelineWarnsAndConverges(t *testing.T) {
 	t.Parallel()
 	roleARN := "arn:aws:iam::123:role/io-foo-handler-role"

--- a/cmd/insideout-import/driftfix/driftfix.go
+++ b/cmd/insideout-import/driftfix/driftfix.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -41,6 +42,14 @@ type Options struct {
 	MaxIterations int
 	// Runner is optional; nil means "construct an execRunner from PATH."
 	Runner terraformRunner
+
+	// Stdout, when non-nil, receives the live stdout/stderr of the
+	// terraform subprocess (the per-iteration plan + validate) so a
+	// long-running caller — the Mars reverse-import job — can stream
+	// progress instead of going silent through the drift loop. Nil means
+	// "discard subprocess output" (the historical behavior). Ignored when
+	// Runner is injected.
+	Stdout io.Writer
 }
 
 // Result is what the orchestrator hands back to the caller. Iterations
@@ -79,7 +88,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 	runner := opts.Runner
 	if runner == nil {
-		r, err := newExecRunner(opts.Workdir)
+		r, err := newExecRunner(opts.Workdir, opts.Stdout)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/insideout-import/driftfix/runner.go
+++ b/cmd/insideout-import/driftfix/runner.go
@@ -3,6 +3,7 @@ package driftfix
 import (
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 	"strings"
 
@@ -41,7 +42,11 @@ type execRunner struct {
 	tf *tfexec.Terraform
 }
 
-func newExecRunner(workdir string) (*execRunner, error) {
+// newExecRunner constructs an execRunner for workdir. When stdout is
+// non-nil the terraform subprocess streams its stdout/stderr there so a
+// long-running caller can surface live progress; nil keeps the historical
+// "discard subprocess output" behavior.
+func newExecRunner(workdir string, stdout io.Writer) (*execRunner, error) {
 	bin, err := exec.LookPath("terraform")
 	if err != nil {
 		return nil, fmt.Errorf("terraform binary not found on PATH: %w", err)
@@ -49,6 +54,10 @@ func newExecRunner(workdir string) (*execRunner, error) {
 	tf, err := tfexec.NewTerraform(workdir, bin)
 	if err != nil {
 		return nil, fmt.Errorf("init terraform-exec: %w", err)
+	}
+	if stdout != nil {
+		tf.SetStdout(stdout)
+		tf.SetStderr(stdout)
 	}
 	return &execRunner{tf: tf}, nil
 }

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -62,6 +63,14 @@ type Options struct {
 	// out to the `terraform` binary on PATH. Tests inject a fake here to
 	// avoid the binary dependency.
 	Runner terraformRunner
+
+	// Stdout, when non-nil, receives the live stdout/stderr of the
+	// terraform subprocess (init, plan -generate-config-out, validate)
+	// so a long-running caller — the Mars reverse-import job — can stream
+	// progress to its own log console instead of going silent through
+	// this phase. Nil means "discard subprocess output" (the historical
+	// behavior). Ignored when Runner is injected.
+	Stdout io.Writer
 }
 
 const (
@@ -266,7 +275,7 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 
 	runner := opts.Runner
 	if runner == nil {
-		r, err := newExecRunner(opts.Workdir)
+		r, err := newExecRunner(opts.Workdir, opts.Stdout)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/insideout-import/genconfig/runner.go
+++ b/cmd/insideout-import/genconfig/runner.go
@@ -3,6 +3,7 @@ package genconfig
 import (
 	"context"
 	"fmt"
+	"io"
 	"os/exec"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -30,7 +31,11 @@ type execRunner struct {
 	tf *tfexec.Terraform
 }
 
-func newExecRunner(workdir string) (*execRunner, error) {
+// newExecRunner constructs an execRunner for workdir. When stdout is
+// non-nil the terraform subprocess streams its stdout/stderr there so a
+// long-running caller can surface live progress; nil keeps the historical
+// "discard subprocess output" behavior.
+func newExecRunner(workdir string, stdout io.Writer) (*execRunner, error) {
 	bin, err := exec.LookPath("terraform")
 	if err != nil {
 		return nil, fmt.Errorf("terraform binary not found on PATH: %w", err)
@@ -38,6 +43,10 @@ func newExecRunner(workdir string) (*execRunner, error) {
 	tf, err := tfexec.NewTerraform(workdir, bin)
 	if err != nil {
 		return nil, fmt.Errorf("init terraform-exec: %w", err)
+	}
+	if stdout != nil {
+		tf.SetStdout(stdout)
+		tf.SetStderr(stdout)
 	}
 	return &execRunner{tf: tf}, nil
 }

--- a/pkg/reverseimport/options.go
+++ b/pkg/reverseimport/options.go
@@ -4,6 +4,8 @@ package reverseimport
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"time"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
@@ -64,6 +66,17 @@ type Options struct {
 	Discoverer            Discoverer
 	ClosureDiscoverer     ClosureDiscoverer
 
+	// Stdout receives continuous human-readable progress as Run works
+	// through its phases — provider readback, genconfig, driftfix,
+	// dep-chase, and the final terraform init/validate/plan — plus the
+	// live stdout/stderr of the terraform subprocesses those phases
+	// drive. The Mars reverse-import job points this at its own stdout so
+	// Oracle's follow=1 stream (and the InsideOut import wizard's log
+	// console) shows live progress for the whole run rather than just the
+	// final plan. Nil defaults to io.Discard in withDefaults, so existing
+	// callers and tests stay silent and unaffected.
+	Stdout io.Writer
+
 	deps deps
 }
 
@@ -74,24 +87,43 @@ type deps struct {
 	tf           terraformRunner
 }
 
-func defaultDeps(terraformBinary string) deps {
+func defaultDeps(terraformBinary string, stdout io.Writer) deps {
 	return deps{
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
 		runDepChase:  depchase.Run,
-		tf:           execTerraformRunner{binary: terraformBinary},
+		tf:           execTerraformRunner{binary: terraformBinary, stdout: stdout},
 	}
+}
+
+// progressf writes a human-readable phase-progress line to o.Stdout.
+// withDefaults guarantees o.Stdout is non-nil (io.Discard at minimum), so
+// callers after withDefaults never need a nil check; the guard here keeps
+// a zero-value Options safe too. Best-effort: a write error to the
+// progress sink must never affect the run result, so it is ignored.
+func (o Options) progressf(format string, args ...any) {
+	if o.Stdout == nil {
+		return
+	}
+	fmt.Fprintf(o.Stdout, format, args...)
 }
 
 func (o Options) withDefaults() Options {
 	if o.MaxDepChaseIterations <= 0 {
 		o.MaxDepChaseIterations = depchase.DefaultMaxIterations
 	}
+	// Default the progress sink to io.Discard so progressf and the
+	// terraform subprocess streaming are always safe to call without a
+	// nil check, and existing callers/tests that pass no writer stay
+	// silent.
+	if o.Stdout == nil {
+		o.Stdout = io.Discard
+	}
 	if o.deps.runGenconfig == nil ||
 		o.deps.runDriftfix == nil ||
 		o.deps.runDepChase == nil ||
 		o.deps.tf == nil {
-		o.deps = defaultDeps(o.TerraformBinary)
+		o.deps = defaultDeps(o.TerraformBinary, o.Stdout)
 	}
 	return o
 }

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -49,6 +49,8 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			resources[i].Identity.Cloud = cloud
 		}
 	}
+	opts.progressf("reverse-import: starting %s run for %d selected resource(s)…\n", cloud, len(resources))
+	opts.progressf("reverse-import: expanding selection closure…\n")
 	closure, err := expandSelectionClosure(ctx, selectionClosureInput{
 		resources:    resources,
 		opts:         opts,
@@ -62,6 +64,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	resources = closure.resources
 	result.Diagnostics = append(result.Diagnostics, closure.diagnostics...)
 	dependenciesByAddress := closure.dependencies
+	opts.progressf("reverse-import: selection closure complete (%d resource(s))\n", len(resources))
 
 	var awsAuth awsProviderAuth
 	if cloud == "aws" {
@@ -83,18 +86,23 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 		AWSEndpointURL: opts.AWSEndpointURL,
 		AWSRoleARN:     awsAuth.RoleARN,
 		AWSExternalID:  awsAuth.ExternalID,
+		Stdout:         opts.Stdout,
 	}
 
+	opts.progressf("reverse-import: generating terraform config for %d resource(s)…\n", len(resources))
 	gcRes, err := opts.deps.runGenconfig(ctx, gcOpts, resources)
 	if err != nil {
 		return result, fmt.Errorf("genconfig: %w", err)
 	}
 	resources = gcRes.Resources
+	opts.progressf("reverse-import: terraform config generated\n")
 
 	if !opts.SkipDriftFix {
-		if _, err := opts.deps.runDriftfix(ctx, driftfix.Options{Workdir: workdir}); err != nil {
+		opts.progressf("reverse-import: running driftfix…\n")
+		if _, err := opts.deps.runDriftfix(ctx, driftfix.Options{Workdir: workdir, Stdout: opts.Stdout}); err != nil {
 			return result, fmt.Errorf("driftfix: %w", err)
 		}
+		opts.progressf("reverse-import: driftfix complete\n")
 	}
 
 	var dcRes *depchase.Result
@@ -108,13 +116,14 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 				return &depchase.GenconfigResult{GeneratedPath: r.GeneratedPath, Resources: r.Resources}, nil
 			},
 			RunDriftfix: func(ictx context.Context) (*depchase.DriftfixResult, error) {
-				r, err := opts.deps.runDriftfix(ictx, driftfix.Options{Workdir: workdir})
+				r, err := opts.deps.runDriftfix(ictx, driftfix.Options{Workdir: workdir, Stdout: opts.Stdout})
 				if err != nil {
 					return nil, err
 				}
 				return &depchase.DriftfixResult{GeneratedPath: r.GeneratedPath, Iterations: r.Iterations}, nil
 			},
 		}
+		opts.progressf("reverse-import: chasing resource dependencies…\n")
 		dcRes, err = opts.deps.runDepChase(ctx, depchase.Options{
 			Workdir:       workdir,
 			Region:        region,
@@ -122,6 +131,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			MaxIterations: opts.MaxDepChaseIterations,
 			Discoverer:    opts.Discoverer,
 			Pipeline:      pipeline,
+			Stdout:        opts.Stdout,
 		}, resources)
 		if err != nil {
 			return result, fmt.Errorf("depchase: %w", err)
@@ -130,6 +140,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			resources = dcRes.Resources
 			appendDepChaseDependencies(dependenciesByAddress, resources, dcRes.Edges)
 		}
+		opts.progressf("reverse-import: dependency chase complete (%d resource(s) total)\n", len(resources))
 	}
 
 	if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
@@ -176,9 +187,11 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	planPath := filepath.Join(opts.OutputDir, tfplanFile)
 	validateJSONPath := filepath.Join(opts.OutputDir, validateJSONFile)
 	tfplanJSONPath := filepath.Join(opts.OutputDir, tfplanJSONFile)
+	opts.progressf("reverse-import: terraform init…\n")
 	if err := opts.deps.tf.Init(ctx, opts.OutputDir); err != nil {
 		return result, fmt.Errorf("terraform init final: %w", err)
 	}
+	opts.progressf("reverse-import: terraform validate…\n")
 	validateJSON, err := opts.deps.tf.Validate(ctx, opts.OutputDir)
 	if len(validateJSON) > 0 {
 		if writeErr := writeFileAtomic(validateJSONPath, validateJSON, 0o644); writeErr != nil {
@@ -188,6 +201,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	if err != nil {
 		return result, fmt.Errorf("terraform validate final: %w", err)
 	}
+	opts.progressf("reverse-import: terraform plan…\n")
 	if err := opts.deps.tf.Plan(ctx, opts.OutputDir, planPath); err != nil {
 		return result, fmt.Errorf("terraform plan final: %w", err)
 	}
@@ -195,6 +209,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	if err != nil {
 		return result, fmt.Errorf("terraform show final plan: %w", err)
 	}
+	opts.progressf("reverse-import: plan complete\n")
 	if err := writeFileAtomic(tfplanJSONPath, planJSON, 0o644); err != nil {
 		return result, fmt.Errorf("write tfplan.json: %w", err)
 	}

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -1,6 +1,7 @@
 package reverseimport
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -67,6 +68,99 @@ func TestRunEmitsArtifactsAndImportSummary(t *testing.T) {
 	}
 	if !strings.Contains(string(importedTF), `resource "aws_sqs_queue" "orders"`) {
 		t.Fatalf("imported.tf missing queue resource:\n%s", importedTF)
+	}
+}
+
+// TestRunStreamsPhaseProgressToStdout is the regression guard for
+// luthersystems/mars#178: the reverse-import engine went silent through its
+// pre-plan phases, so the import wizard's live log console stalled until the
+// job ended. Run must now emit a human-readable progress line at each major
+// phase to the Options.Stdout writer the Mars job supplies.
+func TestRunStreamsPhaseProgressToStdout(t *testing.T) {
+	dir := t.TempDir()
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	var progress bytes.Buffer
+	_, err := Run(context.Background(), req, Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		Stdout:       &progress,
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           fakeTerraformRunner{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got := progress.String()
+	for _, want := range []string{
+		"expanding selection closure",
+		"generating terraform config",
+		"running driftfix",
+		"terraform init",
+		"terraform validate",
+		"terraform plan",
+		"plan complete",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("progress stream missing %q; got:\n%s", want, got)
+		}
+	}
+}
+
+// TestRunWithoutStdoutStaysSilent confirms the nil-Stdout default path is
+// inert: a caller (or existing test) that supplies no progress writer must
+// not panic and must not write to any global stream. The run still succeeds
+// and produces its artifacts.
+func TestRunWithoutStdoutStaysSilent(t *testing.T) {
+	dir := t.TempDir()
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	result, err := Run(context.Background(), req, Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           fakeTerraformRunner{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Status != job.StatusSucceeded {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusSucceeded)
 	}
 }
 

--- a/pkg/reverseimport/terraform.go
+++ b/pkg/reverseimport/terraform.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 )
@@ -17,6 +18,10 @@ type terraformRunner interface {
 
 type execTerraformRunner struct {
 	binary string
+	// stdout receives the live stdout of the streaming commands (init,
+	// plan) and the stderr of every command. nil falls back to os.Stdout
+	// / os.Stderr so a zero-value runner keeps the historical behavior.
+	stdout io.Writer
 }
 
 func (r execTerraformRunner) bin() string {
@@ -26,6 +31,16 @@ func (r execTerraformRunner) bin() string {
 	return "terraform"
 }
 
+// outW is the destination for streamed stdout/stderr. nil falls back to
+// the process stderr so a zero-value runner (and the historical
+// os.Stdout/os.Stderr behavior) still surfaces output somewhere.
+func (r execTerraformRunner) outW() io.Writer {
+	if r.stdout != nil {
+		return r.stdout
+	}
+	return os.Stderr
+}
+
 func (r execTerraformRunner) Init(ctx context.Context, dir string) error {
 	return r.run(ctx, dir, "init", "-input=false", "-no-color")
 }
@@ -33,7 +48,9 @@ func (r execTerraformRunner) Init(ctx context.Context, dir string) error {
 func (r execTerraformRunner) Validate(ctx context.Context, dir string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, r.bin(), "validate", "-json")
 	cmd.Dir = dir
-	cmd.Stderr = os.Stderr
+	// stdout is captured as the validate.json artifact, so only stderr
+	// streams to the progress sink here.
+	cmd.Stderr = r.outW()
 	cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
 	out, err := cmd.Output()
 	if err != nil {
@@ -57,7 +74,9 @@ func (r execTerraformRunner) Plan(ctx context.Context, dir, planPath string) err
 func (r execTerraformRunner) ShowPlanJSON(ctx context.Context, dir, planPath string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, r.bin(), "show", "-json", planPath)
 	cmd.Dir = dir
-	cmd.Stderr = os.Stderr
+	// stdout is captured as the tfplan.json artifact, so only stderr
+	// streams to the progress sink here.
+	cmd.Stderr = r.outW()
 	cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
 	out, err := cmd.Output()
 	if err != nil {
@@ -69,8 +88,8 @@ func (r execTerraformRunner) ShowPlanJSON(ctx context.Context, dir, planPath str
 func (r execTerraformRunner) run(ctx context.Context, dir string, args ...string) error {
 	cmd := exec.CommandContext(ctx, r.bin(), args...)
 	cmd.Dir = dir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = r.outW()
+	cmd.Stderr = r.outW()
 	cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("%s %v: %w", r.bin(), args, err)


### PR DESCRIPTION
## Problem

The `insideout-reverse-import` engine (`pkg/reverseimport.Run`) is silent on stdout through the phases that dominate runtime — provider readback (`expandSelectionClosure`), `genconfig`, `driftfix`, and `depchase` — emitting only the final `terraform init`/`plan` stream. Driven by the Mars job, that leaves the InsideOut import wizard's live log console showing early setup lines and then nothing until the job ends. Root cause: `reverseimport.Options` had no stdout/log-writer field, and the nested genconfig/driftfix/depchase phases ran terraform with captured or discarded output.

## Change

Add an opt-in progress sink so a long-running caller (the Mars reverse-import job) can surface continuous live progress for the whole run, matching the parity the final plan already had:

- **`reverseimport.Options`** gains a `Stdout io.Writer`, defaulted to `io.Discard` in `withDefaults()` so existing callers/tests stay silent and unaffected. `Run` emits a concise human-readable line at each major phase (selection closure, genconfig, driftfix, dep-chase, terraform init/validate/plan) via a `progressf` helper, and threads the writer into the genconfig/driftfix/depchase sub-options and the final terraform runner.
- **`execTerraformRunner`** streams `init`/`plan` stdout and every command's stderr to the configured writer instead of hardcoded `os.Stdout`/`os.Stderr`. `validate`/`show` still capture stdout for their JSON artifacts byte-identically (only their stderr now streams).
- **`genconfig.Options`** and **`driftfix.Options`** gain an optional `Stdout` that wires the terraform-exec subprocess output through `tfexec.SetStdout`/`SetStderr`, so the dominant pre-plan terraform output streams live. Ignored when a test `Runner` is injected.
- **`depchase.Options`** gains an optional `Stdout` and emits a per-iteration progress line so the chase loop is not silent while its nested genconfig/driftfix re-runs execute.

Artifact generation (`tfplan.json`, `validate.json`, `plan-summary.json`, `imported.tf`, etc.) is unchanged — this only **adds** streaming, never removes capture.

## Tests

- `TestRunStreamsPhaseProgressToStdout` — regression guard: asserts each phase line reaches the supplied writer.
- `TestRunWithoutStdoutStaysSilent` — the nil-`Stdout` default path stays inert and still succeeds.
- `TestRun_StreamsIterationProgressToStdout` (depchase) — asserts the per-iteration chase progress line.

`go build ./...`, `go vet`, and `go test ./pkg/reverseimport/... ./cmd/insideout-import/...` all pass (2887 tests).

Refs luthersystems/mars#178