### PR TITLE
fix(reverse-import): stream only stderr from genconfig/driftfix runners (reliable#1896)

### DIFF
--- a/cmd/insideout-import/driftfix/runner.go
+++ b/cmd/insideout-import/driftfix/runner.go
@@ -42,11 +42,20 @@ type execRunner struct {
 	tf *tfexec.Terraform
 }
 
-// newExecRunner constructs an execRunner for workdir. When stdout is
-// non-nil the terraform subprocess streams its stdout/stderr there so a
+// newExecRunner constructs an execRunner for workdir. When stream is
+// non-nil the terraform subprocess streams its *stderr* there so a
 // long-running caller can surface live progress; nil keeps the historical
 // "discard subprocess output" behavior.
-func newExecRunner(workdir string, stdout io.Writer) (*execRunner, error) {
+//
+// We deliberately do NOT call tf.SetStdout: ShowPlan (ShowPlanFile) and
+// Validate capture `-json` payloads on stdout, and terraform-exec merges
+// tf.stdout into that captured stream, so pointing tf.stdout at the live
+// log leaks the JSON into the user-facing log and blows the gRPC-limited
+// stream (reliable#1896). Leaving stdout unset lets tfexec discard it for
+// these commands while the JSON is still captured internally. Mirrors the
+// stderr-only discipline in genconfig.execRunner and
+// pkg/reverseimport/terraform.go.
+func newExecRunner(workdir string, stream io.Writer) (*execRunner, error) {
 	bin, err := exec.LookPath("terraform")
 	if err != nil {
 		return nil, fmt.Errorf("terraform binary not found on PATH: %w", err)
@@ -55,9 +64,8 @@ func newExecRunner(workdir string, stdout io.Writer) (*execRunner, error) {
 	if err != nil {
 		return nil, fmt.Errorf("init terraform-exec: %w", err)
 	}
-	if stdout != nil {
-		tf.SetStdout(stdout)
-		tf.SetStderr(stdout)
+	if stream != nil {
+		tf.SetStderr(stream)
 	}
 	return &execRunner{tf: tf}, nil
 }

--- a/cmd/insideout-import/driftfix/runner_test.go
+++ b/cmd/insideout-import/driftfix/runner_test.go
@@ -1,0 +1,99 @@
+package driftfix
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// builtinProviderStack uses only the builtin terraform_data resource
+// (terraform.io/builtin/terraform), so `terraform init` and `plan` both
+// succeed fully offline with no plugin download or cloud credentials — yet the
+// JSON-capture commands (validate -json, show -json) still emit real payloads.
+// A deterministic fixture for asserting those payloads don't leak into the
+// streamed log.
+const builtinProviderStack = `
+resource "terraform_data" "x" {
+  input = "hello"
+}
+`
+
+// TestExecRunner_JSONCaptureDoesNotLeakToStream is the driftfix-side
+// regression guard for reliable#1896. Like the genconfig runner, the driftfix
+// execRunner used to point tf.stdout at the live-log stream, so the
+// JSON-capture commands (Validate, ShowPlan) leaked their `-json` payload into
+// the user-facing log. The fix streams only stderr. This runs the real
+// Validate + Plan/Show path against an offline builtin-provider stack and
+// asserts the parsed results are populated while the streamed writer contains
+// none of the JSON-capture markers.
+func TestExecRunner_JSONCaptureDoesNotLeakToStream(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform CLI not available, skipping JSON-capture leak test")
+	}
+
+	workdir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "main.tf"), []byte(builtinProviderStack), 0o644))
+
+	// Driftfix runs after genconfig has already done init, so the runner has
+	// no Init method. Init the workdir externally to mirror that contract.
+	ctx := context.Background()
+	initCmd := exec.CommandContext(ctx, "terraform", "init", "-input=false", "-no-color")
+	initCmd.Dir = workdir
+	initCmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
+	out, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "terraform init (builtin provider, offline):\n%s", out)
+
+	var stream stringSink
+	runner, err := newExecRunner(workdir, &stream)
+	require.NoError(t, err)
+
+	// Validate captures `validate -json` on stdout internally.
+	require.NoError(t, runner.Validate(ctx), "builtin-provider stack validates clean")
+
+	// PlanTo writes a binary plan; ShowPlan decodes it via `show -json`, which
+	// captures its JSON payload on stdout internally.
+	planFile := filepath.Join(workdir, "tfplan.bin")
+	_, err = runner.PlanTo(ctx, planFile)
+	require.NoError(t, err)
+	plan, err := runner.ShowPlan(ctx, planFile)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	assert.NotEmpty(t, plan.FormatVersion, "parsed plan should carry a format version")
+
+	// None of the JSON-capture payload should have reached the stream.
+	// "format_version" appears in both validate and show JSON; "resource_changes"
+	// is a show-plan marker. If tf.stdout were wired to the stream (the bug),
+	// these would be present.
+	streamed := stream.String()
+	for _, marker := range []string{`"format_version"`, `"resource_changes"`, `"planned_values"`} {
+		assert.NotContainsf(t, streamed, marker,
+			"JSON-capture payload leaked to the streamed log (marker %q); reliable#1896 regression", marker)
+	}
+}
+
+// stringSink is a small mutex-guarded io.Writer for capturing streamed output
+// in tests. terraform-exec drains stderr from a goroutine that runs
+// concurrently with the command, so the writer must be safe under -race.
+type stringSink struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (s *stringSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf = append(s.buf, p...)
+	return len(p), nil
+}
+
+func (s *stringSink) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.buf)
+}

--- a/cmd/insideout-import/genconfig/runner.go
+++ b/cmd/insideout-import/genconfig/runner.go
@@ -31,11 +31,24 @@ type execRunner struct {
 	tf *tfexec.Terraform
 }
 
-// newExecRunner constructs an execRunner for workdir. When stdout is
-// non-nil the terraform subprocess streams its stdout/stderr there so a
-// long-running caller can surface live progress; nil keeps the historical
+// newExecRunner constructs an execRunner for workdir. When stream is
+// non-nil the terraform subprocess streams its *stderr* there so a
+// long-running caller can surface live progress (terraform's human
+// progress lines and the "Config generation is experimental" warning from
+// plan -generate-config-out both land on stderr); nil keeps the historical
 // "discard subprocess output" behavior.
-func newExecRunner(workdir string, stdout io.Writer) (*execRunner, error) {
+//
+// We deliberately do NOT call tf.SetStdout: the JSON-capture commands
+// (ProvidersSchema, Validate) write their giant `-json` payload to stdout,
+// and terraform-exec merges tf.stdout into the captured stream
+// (runTerraformCmdJSON → mergeWriters(cmd.Stdout, tf.stdout)). Pointing
+// tf.stdout at the live log therefore dumps the ~19MB provider schema /
+// validate JSON into the user-facing stream and blows the gRPC-limited log
+// (reliable#1896). Leaving stdout unset lets tfexec discard it for these
+// commands while the JSON is still captured internally — only the leak
+// stops. This mirrors pkg/reverseimport/terraform.go, which streams only
+// stderr for its `-json` capture commands.
+func newExecRunner(workdir string, stream io.Writer) (*execRunner, error) {
 	bin, err := exec.LookPath("terraform")
 	if err != nil {
 		return nil, fmt.Errorf("terraform binary not found on PATH: %w", err)
@@ -44,9 +57,8 @@ func newExecRunner(workdir string, stdout io.Writer) (*execRunner, error) {
 	if err != nil {
 		return nil, fmt.Errorf("init terraform-exec: %w", err)
 	}
-	if stdout != nil {
-		tf.SetStdout(stdout)
-		tf.SetStderr(stdout)
+	if stream != nil {
+		tf.SetStderr(stream)
 	}
 	return &execRunner{tf: tf}, nil
 }

--- a/cmd/insideout-import/genconfig/runner_test.go
+++ b/cmd/insideout-import/genconfig/runner_test.go
@@ -1,0 +1,98 @@
+package genconfig
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// builtinProviderStack is a terraform config that only uses the builtin
+// terraform_data resource (terraform.io/builtin/terraform). It needs no plugin
+// download and no cloud credentials, so `terraform init` succeeds fully
+// offline — yet `terraform providers schema -json` still emits a real,
+// non-trivial provider schema. That makes it a cheap, deterministic fixture
+// for asserting the JSON-capture commands don't leak their payload into the
+// streamed log.
+const builtinProviderStack = `
+resource "terraform_data" "x" {
+  input = "hello"
+}
+`
+
+// TestExecRunner_JSONCaptureDoesNotLeakToStream is the regression guard for
+// reliable#1896: the reverse-import genconfig phase dumped ~19MB of
+// `terraform providers schema -json` (and `terraform validate -json`) into
+// the user-facing live log because newExecRunner pointed tf.stdout at the
+// stream. terraform-exec merges tf.stdout into the JSON-capture stdout
+// (runTerraformCmdJSON → mergeWriters(cmd.Stdout, tf.stdout)), so the giant
+// schema JSON leaked.
+//
+// The fix streams only stderr. This test runs the real JSON-capture path
+// against an offline builtin-provider stack and asserts:
+//   - ProvidersSchema / Validate still return a populated, parsed result, and
+//   - the streamed writer contains NONE of the JSON markers that the leak
+//     would have dumped into it.
+func TestExecRunner_JSONCaptureDoesNotLeakToStream(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform CLI not available, skipping JSON-capture leak test")
+	}
+
+	workdir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "main.tf"), []byte(builtinProviderStack), 0o644))
+
+	// streamCapturingWriter stands in for the Mars live-log sink. Anything the
+	// runner streams here would, in the buggy version, contain the schema JSON.
+	var stream stringSink
+	runner, err := newExecRunner(workdir, &stream)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, runner.Init(ctx), "terraform init (builtin provider, offline)")
+
+	// ProvidersSchema captures ~3KB of `-json` on stdout internally. The
+	// builtin terraform provider always yields a non-empty schema set.
+	schemas, err := runner.ProvidersSchema(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, schemas)
+	assert.NotEmpty(t, schemas.Schemas, "parsed provider schema should be populated")
+
+	// Validate captures `validate -json` on stdout internally.
+	require.NoError(t, runner.Validate(ctx), "builtin-provider stack validates clean")
+
+	// The core assertion: none of the JSON-capture payload reached the stream.
+	// "provider_schemas" / "nesting_mode" are providers-schema-only markers;
+	// "format_version" appears in both schema and validate JSON. If tf.stdout
+	// were wired to the stream (the bug), all three would be present.
+	streamed := stream.String()
+	for _, marker := range []string{`"provider_schemas"`, `"nesting_mode"`, `"format_version"`} {
+		assert.NotContainsf(t, streamed, marker,
+			"JSON-capture payload leaked to the streamed log (marker %q); reliable#1896 regression", marker)
+	}
+}
+
+// stringSink is a small mutex-guarded io.Writer for capturing streamed
+// output in tests. terraform-exec drains stderr from a goroutine that runs
+// concurrently with the command, so the writer must be safe under -race.
+type stringSink struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (s *stringSink) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.buf = append(s.buf, p...)
+	return len(p), nil
+}
+
+func (s *stringSink) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return string(s.buf)
+}


### PR DESCRIPTION
## Problem

The mars v0.111.0 live-log streaming wiring (#698) made the reverse-import **genconfig** and **driftfix** exec runners call `tf.SetStdout(stream)` **unconditionally** on the terraform-exec handle.

The JSON-capture commands — `terraform providers schema -json` and `terraform validate -json` (plus `show -json` in driftfix) — write their payload to **stdout**, and terraform-exec merges `tf.stdout` into that captured stream:

```
runTerraformCmdJSON  → cmd.Stdout = mergeWriters(cmd.Stdout, &outbuf)
runTerraformCmd      → stdoutWriter = mergeWriters(cmd.Stdout, tf.stdout)
```

With `tf.stdout` pointed at the user-facing live log, the **~19MB provider schema JSON** leaked into the stream and **blew the gRPC-limited (4MB) log** on staging. Tracking issue: `luthersystems/reliable#1896`.

## Fix

Set **only** `tf.SetStderr(stream)` and leave `tf.stdout` unset — mirroring the stderr-only discipline already used in `pkg/reverseimport/terraform.go` for its `-json` capture commands ("stdout is captured as the validate.json artifact, so only stderr streams").

- terraform's human progress and the **"Config generation is experimental"** warning from `plan -generate-config-out` both land on **stderr**, so live progress still streams to the user.
- The JSON-capture commands (`ProvidersSchema` / `Validate` / `ShowPlan`) capture their payload **internally** regardless of `tf.stdout`, so functionality is unchanged — only the leak stops.
- Engine-level `progressf` lines (`pkg/reverseimport/run.go:98`, `:101`) write straight to `opts.Stdout` via `fmt.Fprintf` and are unaffected.

### Before / after (both runners)

```go
// before
if stdout != nil {
    tf.SetStdout(stdout)   // ← leaks JSON-capture payload into the live log
    tf.SetStderr(stdout)
}

// after
if stream != nil {
    tf.SetStderr(stream)   // stderr-only: progress + warnings stream, JSON stays internal
}
```

## Test plan

- Added offline regression guards: `cmd/insideout-import/genconfig/runner_test.go` and `cmd/insideout-import/driftfix/runner_test.go`. Each drives the **real** JSON-capture path against a builtin-provider stack (`terraform_data` — no plugin download, no cloud creds, fully offline) and asserts the streamed writer contains **none** of the schema/validate/plan JSON markers (`"provider_schemas"`, `"nesting_mode"`, `"format_version"`, `"resource_changes"`, `"planned_values"`) while the parsed `ProvidersSchema` / `Validate` / `ShowPlan` results are still populated. Tests skip gracefully if the `terraform` CLI is absent.
- **Test-first proof:** both new tests **fail** with the old `tf.SetStdout(stream)` wiring restored, **pass** with the fix.
- `go test -race ./cmd/insideout-import/... ./pkg/reverseimport/...` → all pass (2889 tests).
- `go build ./...`, `go vet`, `gofmt` all clean.

## Release chain (downstream)

This is the **start** of the release chain for `reliable#1896`. After merge:

1. **mars** bumps its presets `go.mod` pin to include this commit → cuts a mars release.
2. **reliable** bumps `ReverseImportMarsVersion` to that mars release.

The downstream mars bump needs the merge SHA of this PR.