### PR TITLE
feat(imported): expose per-type discovery progress sink (#699)

### DIFF
--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -545,6 +545,28 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 
 	stageStart := time.Now()
 	results := make([][]imported.ImportedResource, len(selected))
+
+	// Per-type progress (#699): when args.Emitter additionally
+	// implements TypeProgressEmitter (the pkg/imported facade's bridge
+	// does; the wire JSONEmitter / NopEmitter do not), fire one TypeDone
+	// per type as its parallel Discover lands so a facade consumer can
+	// stream a real "N of total types" progress signal instead of a
+	// cosmetic timer. The bridge serializes these concurrent calls under
+	// its own lock; a non-TypeProgressEmitter Emitter leaves typeSink nil
+	// and the path is skipped (byte-for-byte unchanged behavior).
+	typeSink, _ := args.Emitter.(progress.TypeProgressEmitter)
+	totalTypes := len(selected)
+	emitTypeDone := func(tfType string, found int) {
+		if typeSink != nil {
+			typeSink.TypeDone(progress.TypeProgress{
+				Phase:  "discover",
+				TFType: tfType,
+				Found:  found,
+				Total:  totalTypes,
+			})
+		}
+	}
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(defaultDiscoverTypesConcurrency)
 	// Per-goroutine startup jitter (#632). Without this, all N
@@ -614,11 +636,16 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 						time.Since(callStart).Milliseconds(),
 						args.PerTypeTimeout.Milliseconds())
 					results[i] = nil
+					// This type completed (with a partial / empty
+					// result); count it toward N-of-total so the
+					// progress denominator still reaches the total.
+					emitTypeDone(d.ResourceType(), 0)
 					return nil
 				}
 				return fmt.Errorf("%s: %w", d.ResourceType(), err)
 			}
 			results[i] = entries
+			emitTypeDone(d.ResourceType(), len(entries))
 			return nil
 		})
 	}

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -476,13 +476,50 @@ func (a *AWSDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 	}
 	_ = g.Wait()
 
+	// Per-type progress (#699): mirror the discover phase — when the
+	// emitter additionally implements TypeProgressEmitter (the
+	// pkg/imported facade's bridge does; the wire JSONEmitter /
+	// NopEmitter do not), fire one TypeDone per enriched type. idx is
+	// sorted by (type, address), so a type's resources are contiguous;
+	// emit when the type changes and once more after the loop for the
+	// final type. totalEnrichTypes is the count of distinct enrichable
+	// types — the stable N-of-total denominator. Found counts the
+	// resources of the type this pass covered (matching the discover
+	// phase's "resources found"), independent of per-resource enrich
+	// success so the value is deterministic.
+	typeSink, _ := emitter.(progress.TypeProgressEmitter)
+	totalEnrichTypes := 0
+	for pos := range idx {
+		if pos == 0 || irs[idx[pos-1]].Identity.Type != irs[idx[pos]].Identity.Type {
+			totalEnrichTypes++
+		}
+	}
+	emitTypeDone := func(tfType string, found int) {
+		if typeSink != nil {
+			typeSink.TypeDone(progress.TypeProgress{
+				Phase:  "enrich",
+				TFType: tfType,
+				Found:  found,
+				Total:  totalEnrichTypes,
+			})
+		}
+	}
+
 	// Second pass: walk idx in sorted order to inspect results,
 	// emit progress events, and aggregate errors. Doing this serially
 	// — and outside the goroutines — keeps emit order and error-join
 	// order deterministic (progress.Emitter is not documented as
 	// concurrency-safe) and identical to the old serial behaviour.
 	var errs []error
+	var curType string
+	curFound := 0
 	for pos, i := range idx {
+		if t := irs[i].Identity.Type; pos > 0 && t != curType {
+			emitTypeDone(curType, curFound)
+			curFound = 0
+		}
+		curType = irs[i].Identity.Type
+		curFound++
 		err := results[pos]
 		switch {
 		case err == nil:
@@ -520,6 +557,9 @@ func (a *AWSDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 			irs[i].Identity.EnrichErrors = append(irs[i].Identity.EnrichErrors, wrapped.Error())
 			errs = append(errs, wrapped)
 		}
+	}
+	if len(idx) > 0 {
+		emitTypeDone(curType, curFound)
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)

--- a/cmd/insideout-import/awsdiscover/progress_typeevents_test.go
+++ b/cmd/insideout-import/awsdiscover/progress_typeevents_test.go
@@ -1,0 +1,375 @@
+package awsdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+)
+
+// typeProgressRecorder is a recordingEmitter that ALSO implements
+// progress.TypeProgressEmitter, so it receives the per-type completion
+// events DiscoverTypes / EnrichAttributes fire for #699. Existing tests
+// use the bare recordingEmitter (which does NOT implement the extension)
+// — that they stay green proves the non-TypeProgressEmitter path is
+// byte-for-byte unchanged.
+type typeProgressRecorder struct {
+	*recordingEmitter
+	mu         sync.Mutex
+	typeEvents []progress.TypeProgress
+}
+
+func newTypeProgressRecorder() *typeProgressRecorder {
+	return &typeProgressRecorder{recordingEmitter: &recordingEmitter{}}
+}
+
+func (r *typeProgressRecorder) TypeDone(p progress.TypeProgress) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.typeEvents = append(r.typeEvents, p)
+}
+
+// byType returns the recorded per-type events keyed by TFType. The AWS
+// discover walk is concurrent, so callers index by type rather than
+// relying on slice order. NOTE: this map collapses any duplicate emit
+// for a type — double-emit regressions are caught by the separate
+// len(typeSnapshot()) assertions in each test, not here.
+func (r *typeProgressRecorder) byType() map[string]progress.TypeProgress {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]progress.TypeProgress, len(r.typeEvents))
+	for _, e := range r.typeEvents {
+		out[e.TFType] = e
+	}
+	return out
+}
+
+func (r *typeProgressRecorder) typeSnapshot() []progress.TypeProgress {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]progress.TypeProgress, len(r.typeEvents))
+	copy(out, r.typeEvents)
+	return out
+}
+
+// irType is like ir() but lets the test pin the Terraform type so the
+// enrich test can group by type.
+func irType(tfType, addr string) imported.ImportedResource {
+	return imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: tfType, Address: addr, ImportID: addr},
+		Tier:     imported.TierImportedFlat,
+		Source:   imported.SourceImporter,
+	}
+}
+
+// TestDiscoverTypes_EmitsPerTypeProgress pins the #699 discover-phase
+// contract: one TypeDone per selected type, carrying the type's
+// found-count and a stable Total == len(selected). A zero-result type
+// (type_c) must still emit (Found:0) so the N-of-total denominator
+// reaches the total.
+func TestDiscoverTypes_EmitsPerTypeProgress(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1"), ir("a2")}}
+	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
+	c := &fakeDiscoverer{t: "type_c"} // zero results
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b, "type_c": c}}
+
+	rec := newTypeProgressRecorder()
+	args := argsBasic()
+	args.Emitter = rec
+	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b", "type_c"}, args); err != nil {
+		t.Fatal(err)
+	}
+
+	events := rec.typeSnapshot()
+	if len(events) != 3 {
+		t.Fatalf("got %d per-type events, want 3 (one per selected type)", len(events))
+	}
+	byType := rec.byType()
+	for _, tc := range []struct {
+		tfType    string
+		wantFound int
+	}{
+		{"type_a", 2},
+		{"type_b", 1},
+		{"type_c", 0},
+	} {
+		got, ok := byType[tc.tfType]
+		if !ok {
+			t.Errorf("no TypeDone event for %s", tc.tfType)
+			continue
+		}
+		if got.Phase != "discover" {
+			t.Errorf("%s: Phase=%q, want discover", tc.tfType, got.Phase)
+		}
+		if got.Found != tc.wantFound {
+			t.Errorf("%s: Found=%d, want %d", tc.tfType, got.Found, tc.wantFound)
+		}
+		if got.Total != 3 {
+			t.Errorf("%s: Total=%d, want 3", tc.tfType, got.Total)
+		}
+	}
+}
+
+// TestDiscoverTypes_PlainEmitterSkipsPerTypePath confirms back-compat:
+// an Emitter that does NOT implement TypeProgressEmitter (the bare
+// recordingEmitter) runs DiscoverTypes without panicking and produces
+// the same result — the per-type path is simply skipped.
+func TestDiscoverTypes_PlainEmitterSkipsPerTypePath(t *testing.T) {
+	t.Parallel()
+	// Guard the design assumption the back-compat path relies on.
+	if _, ok := progress.Emitter(&recordingEmitter{}).(progress.TypeProgressEmitter); ok {
+		t.Fatal("recordingEmitter unexpectedly implements TypeProgressEmitter; this test no longer proves the plain-emitter path")
+	}
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1")}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a}}
+	args := argsBasic()
+	args.Emitter = &recordingEmitter{}
+	got, err := agg.DiscoverTypes(context.Background(), []string{"type_a"}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len(got)=%d, want 1", len(got))
+	}
+}
+
+// TestDiscoverTypes_PerTypeProgress_TimeoutCountsType pins that a
+// per-type-timeout partial (#1787) still counts toward the #699
+// progress denominator: the timed-out type emits a TypeDone with
+// Found:0 so the consumer's "N of total" reaches total even when a type
+// is fenced off.
+func TestDiscoverTypes_PerTypeProgress_TimeoutCountsType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+	slow := &sleepDiscoverer{t: "type_slow", out: []imported.ImportedResource{ir("slow1")}, sleep: 500 * time.Millisecond}
+	fast := &fakeDiscoverer{t: "type_fast", out: []imported.ImportedResource{ir("fast1")}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_slow": slow, "type_fast": fast}}
+
+	rec := newTypeProgressRecorder()
+	args := argsBasic()
+	args.Emitter = rec
+	args.PerTypeTimeout = 50 * time.Millisecond
+	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_slow", "type_fast"}, args); err != nil {
+		t.Fatalf("DiscoverTypes returned error on per-type timeout: %v", err)
+	}
+
+	byType := rec.byType()
+	if len(byType) != 2 {
+		t.Fatalf("got %d distinct per-type events, want 2 (both types complete)", len(byType))
+	}
+	if got := byType["type_slow"]; got.Found != 0 || got.Total != 2 {
+		t.Errorf("type_slow event = %+v, want Found:0 Total:2 (timed-out type still counts)", got)
+	}
+	if got := byType["type_fast"]; got.Found != 1 || got.Total != 2 {
+		t.Errorf("type_fast event = %+v, want Found:1 Total:2", got)
+	}
+}
+
+// TestEnrichAttributes_EmitsPerTypeProgress pins the #699 enrich-phase
+// contract: one TypeDone per enriched type with Phase="enrich",
+// Found == resources of that type covered, and Total == distinct
+// enrichable types. idx is sorted (type, address), so the serial
+// second pass emits in sorted type order — asserted here.
+func TestEnrichAttributes_EmitsPerTypeProgress(t *testing.T) {
+	t.Parallel()
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{
+		"aws_dynamodb_table": &fakeEnricher{tfType: "aws_dynamodb_table"},
+		"aws_s3_bucket":      &fakeEnricher{tfType: "aws_s3_bucket"},
+	}}
+	irs := []imported.ImportedResource{
+		irType("aws_s3_bucket", "b1"),
+		irType("aws_dynamodb_table", "t2"),
+		irType("aws_dynamodb_table", "t1"),
+		// A type with no registered enricher must NOT count toward Total
+		// or emit an event.
+		irType("aws_sqs_queue", "q1"),
+	}
+	rec := newTypeProgressRecorder()
+	if err := a.EnrichAttributes(context.Background(), irs, EnrichClients{}, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	events := rec.typeSnapshot()
+	if len(events) != 2 {
+		t.Fatalf("got %d per-type enrich events, want 2 (one per enrichable type)", len(events))
+	}
+	// Sorted (type, address): aws_dynamodb_table (2) precedes
+	// aws_s3_bucket (1).
+	want := []progress.TypeProgress{
+		{Phase: "enrich", TFType: "aws_dynamodb_table", Found: 2, Total: 2},
+		{Phase: "enrich", TFType: "aws_s3_bucket", Found: 1, Total: 2},
+	}
+	for i, w := range want {
+		if events[i] != w {
+			t.Errorf("enrich event[%d] = %+v, want %+v", i, events[i], w)
+		}
+	}
+}
+
+// TestEnrichAttributes_PerTypeProgress_CountsDespiteFailures pins the
+// documented enrich-phase determinism contract (enrich.go: "Found counts
+// the resources of the type this pass covered ... independent of
+// per-resource enrich success"): a type with one failing resource still
+// reports Found == the full type count, AND the TypeDone event is still
+// emitted even though EnrichAttributes returns a joined error.
+func TestEnrichAttributes_PerTypeProgress_CountsDespiteFailures(t *testing.T) {
+	t.Parallel()
+	// No shrinkEnrichRetryDelays needed: a generic error is not a
+	// throttle error, so enrichWithRetry returns immediately without
+	// backoff. (shrink mutates package globals and would race with the
+	// other parallel enrich tests under -race.)
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{
+		"aws_dynamodb_table": &fakeEnricher{tfType: "aws_dynamodb_table", result: func(ir *imported.ImportedResource) error {
+			if ir.Identity.ImportID == "t-bad" {
+				return errors.New("boom") // generic error → accumulated → joined return
+			}
+			ir.Attrs = json.RawMessage(`{}`)
+			return nil
+		}},
+	}}
+	irs := []imported.ImportedResource{
+		irType("aws_dynamodb_table", "t-bad"),
+		irType("aws_dynamodb_table", "t-good"),
+	}
+	rec := newTypeProgressRecorder()
+	if err := a.EnrichAttributes(context.Background(), irs, EnrichClients{}, rec); err == nil {
+		t.Fatal("expected a joined error from the failing resource")
+	}
+	events := rec.typeSnapshot()
+	if len(events) != 1 {
+		t.Fatalf("got %d per-type events, want 1 (TypeDone must fire even when EnrichAttributes returns an error)", len(events))
+	}
+	want := progress.TypeProgress{Phase: "enrich", TFType: "aws_dynamodb_table", Found: 2, Total: 1}
+	if events[0] != want {
+		t.Errorf("event = %+v, want %+v (Found counts all resources of the type regardless of per-resource success)", events[0], want)
+	}
+}
+
+// TestEnrichAttributes_PerTypeProgress_MidListFailureResetsCount hardens
+// the curType/curFound transition logic: with two enrichable types where
+// the NON-final type carries a failing resource, the transition emit must
+// carry the non-final type's full count (independent of the failure) AND
+// the counter must reset to 0 so the final type's count doesn't leak the
+// previous type's tail.
+func TestEnrichAttributes_PerTypeProgress_MidListFailureResetsCount(t *testing.T) {
+	t.Parallel()
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{
+		// Sorts first (non-final): 2 resources, one fails.
+		"aws_dynamodb_table": &fakeEnricher{tfType: "aws_dynamodb_table", result: func(ir *imported.ImportedResource) error {
+			if ir.Identity.ImportID == "t-bad" {
+				return errors.New("boom")
+			}
+			ir.Attrs = json.RawMessage(`{}`)
+			return nil
+		}},
+		// Sorts last (final): 1 resource, succeeds.
+		"aws_s3_bucket": &fakeEnricher{tfType: "aws_s3_bucket"},
+	}}
+	irs := []imported.ImportedResource{
+		irType("aws_dynamodb_table", "t-bad"),
+		irType("aws_dynamodb_table", "t-good"),
+		irType("aws_s3_bucket", "b1"),
+	}
+	rec := newTypeProgressRecorder()
+	if err := a.EnrichAttributes(context.Background(), irs, EnrichClients{}, rec); err == nil {
+		t.Fatal("expected a joined error from the failing resource")
+	}
+	events := rec.typeSnapshot()
+	want := []progress.TypeProgress{
+		{Phase: "enrich", TFType: "aws_dynamodb_table", Found: 2, Total: 2}, // full count despite the mid-list failure
+		{Phase: "enrich", TFType: "aws_s3_bucket", Found: 1, Total: 2},      // counter reset — not 3
+	}
+	if len(events) != len(want) {
+		t.Fatalf("got %d events, want %d: %+v", len(events), len(want), events)
+	}
+	for i, w := range want {
+		if events[i] != w {
+			t.Errorf("event[%d] = %+v, want %+v", i, events[i], w)
+		}
+	}
+}
+
+// TestDiscoverTypes_RealBridgeDeliversDiscoverProgress is the
+// orchestrator↔bridge integration test: it wires the REAL facade bridge
+// (imp.NewProgressEmitter) into a REAL DiscoverTypes run and asserts the
+// caller's DiscoverProgress sink receives correctly-translated events
+// with a monotonic CompletedTypes counter — the seam the provider-level
+// tests can't reach (AWSDiscoverer.byType is package-internal, so a
+// fake-backed Provider can't be built from the aws_test package). The
+// only hop left uncovered is the Provider's 6-line delegation that sets
+// Emitter: imp.NewProgressEmitter(opts.Progress), which is compile-
+// checked.
+func TestDiscoverTypes_RealBridgeDeliversDiscoverProgress(t *testing.T) {
+	t.Parallel()
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1"), ir("a2")}}
+	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b}}
+
+	var mu sync.Mutex
+	var got []imp.DiscoverProgress
+	sink := func(p imp.DiscoverProgress) {
+		mu.Lock()
+		got = append(got, p)
+		mu.Unlock()
+	}
+	args := argsBasic()
+	args.Emitter = imp.NewProgressEmitter(sink) // the real facade bridge
+	if _, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b"}, args); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(got) != 2 {
+		t.Fatalf("sink received %d DiscoverProgress events, want 2", len(got))
+	}
+	// CompletedTypes must cover 1..2 exactly once (bridge-owned counter),
+	// and each event carries the translated facade-shape fields.
+	completed := map[int]bool{}
+	foundByType := map[string]int{}
+	for _, p := range got {
+		if p.Phase != "discover" {
+			t.Errorf("Phase=%q, want discover", p.Phase)
+		}
+		if p.TotalTypes != 2 {
+			t.Errorf("TotalTypes=%d, want 2", p.TotalTypes)
+		}
+		completed[p.CompletedTypes] = true
+		foundByType[p.Type] = p.FoundCount
+	}
+	if !completed[1] || !completed[2] {
+		t.Errorf("CompletedTypes did not cover 1..2: %+v", got)
+	}
+	if foundByType["type_a"] != 2 || foundByType["type_b"] != 1 {
+		t.Errorf("FoundCount by type = %v, want type_a:2 type_b:1", foundByType)
+	}
+}
+
+// TestEnrichAttributes_NoEnrichableTypes_EmitsNoProgress pins the
+// len(idx)==0 guard: when no resource has a registered enricher, the
+// serial second pass never runs, so no TypeDone fires — in particular
+// no spurious trailing {Phase:"enrich", TFType:"", Found:0} event.
+func TestEnrichAttributes_NoEnrichableTypes_EmitsNoProgress(t *testing.T) {
+	t.Parallel()
+	a := &AWSDiscoverer{byTypeEnricher: map[string]AttributeEnricher{
+		"aws_dynamodb_table": &fakeEnricher{tfType: "aws_dynamodb_table"},
+	}}
+	// Only an unregistered type → idx is empty.
+	irs := []imported.ImportedResource{irType("aws_sqs_queue", "q1")}
+	rec := newTypeProgressRecorder()
+	if err := a.EnrichAttributes(context.Background(), irs, EnrichClients{}, rec); err != nil {
+		t.Fatal(err)
+	}
+	if events := rec.typeSnapshot(); len(events) != 0 {
+		t.Errorf("got %d per-type events, want 0 (no enrichable types → no TypeDone, no spurious empty-type event): %+v", len(events), events)
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -394,6 +394,35 @@ func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 	}
 	_ = grp.Wait()
 
+	// Per-type progress (#699): mirror the discover phase — when the
+	// emitter additionally implements TypeProgressEmitter (the
+	// pkg/imported facade's bridge does; the wire JSONEmitter /
+	// NopEmitter do not), fire one TypeDone per enriched type. idx is
+	// sorted by (type, address), so a type's resources are contiguous;
+	// emit when the type changes and once more after the loop for the
+	// final type. totalEnrichTypes is the count of distinct enrichable
+	// types — the stable N-of-total denominator. Found counts the
+	// resources of the type this pass covered (matching the discover
+	// phase's "resources found"), independent of per-resource enrich
+	// success so the value is deterministic.
+	typeSink, _ := emitter.(progress.TypeProgressEmitter)
+	totalEnrichTypes := 0
+	for pos := range idx {
+		if pos == 0 || irs[idx[pos-1]].Identity.Type != irs[idx[pos]].Identity.Type {
+			totalEnrichTypes++
+		}
+	}
+	emitTypeDone := func(tfType string, found int) {
+		if typeSink != nil {
+			typeSink.TypeDone(progress.TypeProgress{
+				Phase:  "enrich",
+				TFType: tfType,
+				Found:  found,
+				Total:  totalEnrichTypes,
+			})
+		}
+	}
+
 	// Second pass: walk idx in sorted order to inspect results, stamp
 	// the per-IR EnrichmentStatus/EnrichErrors, emit progress events,
 	// and aggregate errors. Doing this serially — and outside the
@@ -401,7 +430,15 @@ func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 	// (progress.Emitter is not documented as concurrency-safe) and
 	// identical to the old serial behaviour.
 	var errs []error
+	var curType string
+	curFound := 0
 	for pos, i := range idx {
+		if t := irs[i].Identity.Type; pos > 0 && t != curType {
+			emitTypeDone(curType, curFound)
+			curFound = 0
+		}
+		curType = irs[i].Identity.Type
+		curFound++
 		err := results[pos]
 		switch {
 		case err == nil:
@@ -427,6 +464,9 @@ func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 			irs[i].Identity.EnrichErrors = append(irs[i].Identity.EnrichErrors, wrapped.Error())
 			errs = append(errs, wrapped)
 		}
+	}
+	if len(idx) > 0 {
+		emitTypeDone(curType, curFound)
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -503,6 +503,27 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 
 	scope := fmt.Sprintf("projects/%s", g.projectID)
 
+	// Per-type progress (#699): when args.Emitter additionally implements
+	// TypeProgressEmitter (the pkg/imported facade's bridge does; the wire
+	// JSONEmitter / NopEmitter do not), fire one TypeDone per type so a
+	// facade consumer can stream a real "N of total types" signal. CAI is
+	// one bulk SearchAllResources, so its types all complete in a quick
+	// burst once translation runs; non-CAI types tick individually after.
+	// A non-TypeProgressEmitter Emitter leaves typeSink nil and the path
+	// is skipped (byte-for-byte unchanged behavior).
+	typeSink, _ := args.Emitter.(progress.TypeProgressEmitter)
+	totalTypes := len(selected)
+	emitTypeDone := func(tfType string, found int) {
+		if typeSink != nil {
+			typeSink.TypeDone(progress.TypeProgress{
+				Phase:  "discover",
+				TFType: tfType,
+				Found:  found,
+				Total:  totalTypes,
+			})
+		}
+	}
+
 	stageStart := time.Now()
 	args.Emitter.ServiceStart(gcpServiceSlug, "")
 	results, err := g.searchBuckets(ctx, scope, args, labelsBucket, namePrefixBucket, parentBucket)
@@ -524,6 +545,7 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	for _, d := range selected {
 		bucket := byAsset[d.AssetType()]
 		sort.SliceStable(bucket, func(i, j int) bool { return bucket[i].Name < bucket[j].Name })
+		typeFound := 0
 		for _, r := range bucket {
 			imp := d.FromAsset(book, r, g.projectID)
 			// A discoverer that returns a zero-valued ImportedResource
@@ -537,6 +559,14 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 			}
 			args.Emitter.ItemFound(gcpServiceSlug, r.Location, imp.Identity.Type, imp.Identity.ImportID)
 			out = append(out, imp)
+			typeFound++
+		}
+		// Per-type progress (#699): emit one event per CAI-backed type as
+		// its assets finish translating. Non-CAI types are handled in the
+		// dedicated phase below, so skip them here — that keeps each type
+		// emitting exactly once and the N-of-total count accurate.
+		if d.ScopeStyle() != ScopeStyleNonCAI {
+			emitTypeDone(d.ResourceType(), typeFound)
 		}
 	}
 	args.Emitter.ServiceFinish(gcpServiceSlug, "", len(out), time.Since(stageStart))
@@ -572,6 +602,7 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 				args.Emitter.ServiceFinish(nonCAIServiceSlug, "", len(nonCAIResults), time.Since(nonCAIStart))
 				return nil, fmt.Errorf("non-CAI list for %q: %w", d.ResourceType(), err)
 			}
+			typeFound := 0
 			for _, r := range rs {
 				if r.Identity.Type == "" {
 					continue
@@ -583,7 +614,11 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 				book.add(r.Identity.Address)
 				args.Emitter.ItemFound(nonCAIServiceSlug, r.Identity.Location, r.Identity.Type, r.Identity.ImportID)
 				nonCAIResults = append(nonCAIResults, r)
+				typeFound++
 			}
+			// Per-type progress (#699): non-CAI types complete one at a
+			// time after their service-specific lister returns.
+			emitTypeDone(d.ResourceType(), typeFound)
 		}
 		args.Emitter.ServiceFinish(nonCAIServiceSlug, "", len(nonCAIResults), time.Since(nonCAIStart))
 		out = append(out, nonCAIResults...)

--- a/cmd/insideout-import/gcpdiscover/progress_typeevents_test.go
+++ b/cmd/insideout-import/gcpdiscover/progress_typeevents_test.go
@@ -1,0 +1,325 @@
+package gcpdiscover
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+)
+
+// gcpIR builds a minimal ImportedResource for the enrich progress tests.
+func gcpIR(tfType, addr string) imported.ImportedResource {
+	return imported.ImportedResource{Identity: imported.ResourceIdentity{Cloud: "gcp", Type: tfType, Address: addr, ImportID: addr}}
+}
+
+// typeProgressRecorder is a recordingEmitter that ALSO implements
+// progress.TypeProgressEmitter, capturing the per-type completion events
+// DiscoverTypes / EnrichAttributes fire for #699. Mirrors the
+// awsdiscover-package helper. Existing GCP tests use the bare
+// recordingEmitter (which does NOT implement the extension), so their
+// staying green proves the non-TypeProgressEmitter path is unchanged.
+type typeProgressRecorder struct {
+	*recordingEmitter
+	mu         sync.Mutex
+	typeEvents []progress.TypeProgress
+}
+
+func newTypeProgressRecorder() *typeProgressRecorder {
+	return &typeProgressRecorder{recordingEmitter: &recordingEmitter{}}
+}
+
+func (r *typeProgressRecorder) TypeDone(p progress.TypeProgress) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.typeEvents = append(r.typeEvents, p)
+}
+
+// byType returns the recorded per-type events keyed by TFType. NOTE:
+// this map collapses any duplicate emit for a type — double-emit
+// regressions are caught by the separate len(typeSnapshot()) assertions
+// in each test, not here.
+func (r *typeProgressRecorder) byType() map[string]progress.TypeProgress {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]progress.TypeProgress, len(r.typeEvents))
+	for _, e := range r.typeEvents {
+		out[e.TFType] = e
+	}
+	return out
+}
+
+func (r *typeProgressRecorder) typeSnapshot() []progress.TypeProgress {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]progress.TypeProgress, len(r.typeEvents))
+	copy(out, r.typeEvents)
+	return out
+}
+
+// TestDiscoverTypes_EmitsPerTypeProgress pins the #699 discover-phase
+// contract for GCP across BOTH dispatch paths: the CAI-backed types
+// (translated from one bulk SearchAllResources) and a non-CAI type
+// (listed separately). Each selected type emits exactly one TypeDone
+// with Phase="discover" and a stable Total == len(selected); the
+// non-CAI type with no lister still emits (Found:0) so the denominator
+// reaches the total.
+func TestDiscoverTypes_EmitsPerTypeProgress(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+			{Name: "//pubsub.googleapis.com/projects/real-proj/topics/zeta", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+			{Name: "//storage.googleapis.com/io-foo-bucket", AssetType: "storage.googleapis.com/Bucket", Project: "real-proj", Location: "us-central1"},
+		},
+	}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+	rec := newTypeProgressRecorder()
+	// google_logging_project_sink is ScopeStyleNonCAI; with the default
+	// (nil) SinkLister its ListNonCAI returns empty, exercising the
+	// non-CAI emission branch with Found:0.
+	types := []string{"google_pubsub_topic", "google_storage_bucket", "google_logging_project_sink"}
+	if _, err := g.DiscoverTypes(context.Background(), types, DiscoverArgs{Project: "io-foo", Emitter: rec}); err != nil {
+		t.Fatal(err)
+	}
+
+	events := rec.typeSnapshot()
+	if len(events) != 3 {
+		t.Fatalf("got %d per-type events, want 3 (one per selected type): %+v", len(events), events)
+	}
+	byType := rec.byType()
+	for _, tc := range []struct {
+		tfType    string
+		wantFound int
+	}{
+		{"google_pubsub_topic", 2},
+		{"google_storage_bucket", 1},
+		{"google_logging_project_sink", 0},
+	} {
+		got, ok := byType[tc.tfType]
+		if !ok {
+			t.Errorf("no TypeDone event for %s", tc.tfType)
+			continue
+		}
+		if got.Phase != "discover" {
+			t.Errorf("%s: Phase=%q, want discover", tc.tfType, got.Phase)
+		}
+		if got.Found != tc.wantFound {
+			t.Errorf("%s: Found=%d, want %d", tc.tfType, got.Found, tc.wantFound)
+		}
+		if got.Total != 3 {
+			t.Errorf("%s: Total=%d, want 3", tc.tfType, got.Total)
+		}
+	}
+}
+
+// TestDiscoverTypes_PlainEmitterSkipsPerTypePath confirms back-compat:
+// the bare recordingEmitter (not a TypeProgressEmitter) runs
+// DiscoverTypes without panicking and produces results — the per-type
+// path is simply skipped.
+func TestDiscoverTypes_PlainEmitterSkipsPerTypePath(t *testing.T) {
+	t.Parallel()
+	if _, ok := progress.Emitter(&recordingEmitter{}).(progress.TypeProgressEmitter); ok {
+		t.Fatal("recordingEmitter unexpectedly implements TypeProgressEmitter; this test no longer proves the plain-emitter path")
+	}
+	fake := &fakeAssetSearcher{results: []gcpAssetResult{
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+	}}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, DiscoverArgs{Emitter: &recordingEmitter{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len(got)=%d, want 1", len(got))
+	}
+}
+
+// TestEnrichAttributes_EmitsPerTypeProgress pins the #699 enrich-phase
+// contract for GCP: one TypeDone per enriched type, Phase="enrich",
+// Found == resources of that type covered, Total == distinct enrichable
+// types, in sorted type order (idx is sorted by (type, address)).
+func TestEnrichAttributes_EmitsPerTypeProgress(t *testing.T) {
+	t.Parallel()
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{
+		"google_pubsub_topic":   &fakeEnricher{tfType: "google_pubsub_topic"},
+		"google_storage_bucket": &fakeEnricher{tfType: "google_storage_bucket"},
+	}}
+	irs := []imported.ImportedResource{
+		gcpIR("google_storage_bucket", "b2"),
+		gcpIR("google_storage_bucket", "b1"),
+		gcpIR("google_pubsub_topic", "t1"),
+		// No enricher registered → excluded from Total and emits nothing.
+		gcpIR("google_compute_network", "n1"),
+	}
+	rec := newTypeProgressRecorder()
+	if err := g.EnrichAttributes(context.Background(), irs, EnrichClients{}, rec); err != nil {
+		t.Fatal(err)
+	}
+
+	events := rec.typeSnapshot()
+	if len(events) != 2 {
+		t.Fatalf("got %d per-type enrich events, want 2 (one per enrichable type): %+v", len(events), events)
+	}
+	// Sorted (type, address): google_pubsub_topic (1) precedes
+	// google_storage_bucket (2).
+	want := []progress.TypeProgress{
+		{Phase: "enrich", TFType: "google_pubsub_topic", Found: 1, Total: 2},
+		{Phase: "enrich", TFType: "google_storage_bucket", Found: 2, Total: 2},
+	}
+	for i, w := range want {
+		if events[i] != w {
+			t.Errorf("enrich event[%d] = %+v, want %+v", i, events[i], w)
+		}
+	}
+}
+
+// TestDiscoverTypes_NonCAIPerTypeProgress_PopulatedLister exercises the
+// non-CAI per-type accumulator (gcpdiscover.go: typeFound++ in the
+// non-CAI phase) with a real lister returning multiple rows — the
+// earlier discover test only covered the Found:0 nil-lister case. It
+// also confirms the non-CAI type emits exactly once (no double-emit
+// across the CAI-translation loop and the non-CAI phase).
+func TestDiscoverTypes_NonCAIPerTypeProgress_PopulatedLister(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{results: []gcpAssetResult{
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+	}}
+	sinkLister := &fakeLoggingSinkLister{sinks: []gcpLoggingSink{
+		{Name: "io-foo-audit-sink", FullName: "projects/real-proj/sinks/io-foo-audit-sink", Destination: "storage.googleapis.com/io-foo-audit"},
+		{Name: "io-foo-flow-sink", FullName: "projects/real-proj/sinks/io-foo-flow-sink", Destination: "storage.googleapis.com/io-foo-flow"},
+		// Builtin + non-stack sinks are filtered out by ListNonCAI, so
+		// they must NOT inflate Found.
+		{Name: "_Default", FullName: "projects/real-proj/sinks/_Default"},
+		{Name: "other-stack-sink", FullName: "projects/real-proj/sinks/other-stack-sink"},
+	}}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{SinkLister: sinkLister})
+	rec := newTypeProgressRecorder()
+	types := []string{"google_pubsub_topic", "google_logging_project_sink"}
+	if _, err := g.DiscoverTypes(context.Background(), types, DiscoverArgs{Project: "io-foo", Emitter: rec}); err != nil {
+		t.Fatal(err)
+	}
+
+	events := rec.typeSnapshot()
+	if len(events) != 2 {
+		t.Fatalf("got %d per-type events, want 2 (one per selected type, no double-emit): %+v", len(events), events)
+	}
+	byType := rec.byType()
+	if got := byType["google_pubsub_topic"]; got.Found != 1 || got.Total != 2 || got.Phase != "discover" {
+		t.Errorf("google_pubsub_topic event = %+v, want {discover,_,1,2}", got)
+	}
+	// Two stack-scoped sinks survive ListNonCAI's builtin + name-prefix
+	// filter; Found must reflect only those.
+	if got := byType["google_logging_project_sink"]; got.Found != 2 || got.Total != 2 || got.Phase != "discover" {
+		t.Errorf("google_logging_project_sink event = %+v, want {discover,_,2,2}", got)
+	}
+}
+
+// TestEnrichAttributes_PerTypeProgress_CountsDespiteFailures pins the
+// GCP enrich determinism contract: Found counts all resources of a type
+// regardless of per-resource enrich success, and TypeDone fires even
+// when EnrichAttributes returns a joined error.
+func TestEnrichAttributes_PerTypeProgress_CountsDespiteFailures(t *testing.T) {
+	t.Parallel()
+	// No shrinkEnrichRetryDelays needed: a generic error is not a
+	// throttle error, so enrichWithRetry returns immediately without
+	// backoff. (shrink mutates package globals and would race with the
+	// other parallel enrich tests under -race.)
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{
+		"google_storage_bucket": &fakeEnricher{tfType: "google_storage_bucket", result: func(ir *imported.ImportedResource) error {
+			if ir.Identity.ImportID == "b-bad" {
+				return errors.New("boom")
+			}
+			ir.Attrs = json.RawMessage(`{}`)
+			return nil
+		}},
+	}}
+	irs := []imported.ImportedResource{
+		gcpIR("google_storage_bucket", "b-bad"),
+		gcpIR("google_storage_bucket", "b-good"),
+	}
+	rec := newTypeProgressRecorder()
+	if err := g.EnrichAttributes(context.Background(), irs, EnrichClients{}, rec); err == nil {
+		t.Fatal("expected a joined error from the failing resource")
+	}
+	events := rec.typeSnapshot()
+	if len(events) != 1 {
+		t.Fatalf("got %d per-type events, want 1 (TypeDone must fire even when EnrichAttributes returns an error)", len(events))
+	}
+	want := progress.TypeProgress{Phase: "enrich", TFType: "google_storage_bucket", Found: 2, Total: 1}
+	if events[0] != want {
+		t.Errorf("event = %+v, want %+v (Found counts all resources of the type regardless of per-resource success)", events[0], want)
+	}
+}
+
+// TestEnrichAttributes_NoEnrichableTypes_EmitsNoProgress pins the
+// len(idx)==0 guard for GCP: no enrichable resources → no TypeDone, no
+// spurious empty-type event.
+func TestEnrichAttributes_NoEnrichableTypes_EmitsNoProgress(t *testing.T) {
+	t.Parallel()
+	g := &GCPDiscoverer{byTypeEnricher: map[string]AttributeEnricher{
+		"google_storage_bucket": &fakeEnricher{tfType: "google_storage_bucket"},
+	}}
+	irs := []imported.ImportedResource{gcpIR("google_compute_network", "n1")} // no enricher
+	rec := newTypeProgressRecorder()
+	if err := g.EnrichAttributes(context.Background(), irs, EnrichClients{}, rec); err != nil {
+		t.Fatal(err)
+	}
+	if events := rec.typeSnapshot(); len(events) != 0 {
+		t.Errorf("got %d per-type events, want 0 (no enrichable types → no TypeDone): %+v", len(events), events)
+	}
+}
+
+// TestDiscoverTypes_RealBridgeDeliversDiscoverProgress is the
+// orchestrator↔bridge integration test: it wires the REAL facade bridge
+// (imp.NewProgressEmitter) into a REAL DiscoverTypes run and asserts the
+// caller's DiscoverProgress sink receives correctly-translated events
+// with a monotonic CompletedTypes counter. GCP discovers sequentially,
+// so CompletedTypes arrives strictly in order. This covers the seam the
+// gcp_test provider tests can't reach (gcpAssetSearcher is package-
+// internal); only the Provider's compile-checked delegation remains.
+func TestDiscoverTypes_RealBridgeDeliversDiscoverProgress(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{results: []gcpAssetResult{
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/zeta", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+		{Name: "//storage.googleapis.com/io-foo-bucket", AssetType: "storage.googleapis.com/Bucket", Project: "real-proj", Location: "us-central1"},
+	}}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+
+	var got []imp.DiscoverProgress
+	sink := func(p imp.DiscoverProgress) { got = append(got, p) }
+	if _, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic", "google_storage_bucket"}, DiscoverArgs{
+		Project: "io-foo",
+		Emitter: imp.NewProgressEmitter(sink), // the real facade bridge
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("sink received %d DiscoverProgress events, want 2: %+v", len(got), got)
+	}
+	// Sequential discovery → CompletedTypes is strictly 1 then 2.
+	for i, p := range got {
+		if p.Phase != "discover" {
+			t.Errorf("event[%d].Phase=%q, want discover", i, p.Phase)
+		}
+		if p.TotalTypes != 2 {
+			t.Errorf("event[%d].TotalTypes=%d, want 2", i, p.TotalTypes)
+		}
+		if p.CompletedTypes != i+1 {
+			t.Errorf("event[%d].CompletedTypes=%d, want %d (monotonic)", i, p.CompletedTypes, i+1)
+		}
+	}
+	foundByType := map[string]int{}
+	for _, p := range got {
+		foundByType[p.Type] = p.FoundCount
+	}
+	if foundByType["google_pubsub_topic"] != 2 || foundByType["google_storage_bucket"] != 1 {
+		t.Errorf("FoundCount by type = %v, want google_pubsub_topic:2 google_storage_bucket:1", foundByType)
+	}
+}

--- a/cmd/insideout-import/progress/progress.go
+++ b/cmd/insideout-import/progress/progress.go
@@ -211,10 +211,67 @@ type Emitter interface {
 	ServiceWarn(service, region, msg string)
 }
 
+// TypeProgress reports the completion of one Terraform resource type's
+// discovery (or enrichment) scope. It is the per-Terraform-type
+// counterpart to the per-(service,region) Emitter events: where
+// ServiceFinish brackets a service/region scope, TypeProgress fires once
+// per Terraform type as that type's resources finish being discovered or
+// enriched, carrying the type's found-count and the stage's type total so
+// a facade consumer can render a real "N of total types" progress bar
+// instead of a cosmetic timer. See issue #699.
+//
+// Completed (the running count of types done so far) is intentionally
+// NOT carried here: the producer (orchestrator) emits one event per type
+// without tracking a global running count under concurrency, and the
+// receiving TypeProgressEmitter — which accumulates state across calls —
+// is the natural owner of the monotonic counter. pkg/imported's bridge
+// derives DiscoverProgress.CompletedTypes by counting invocations under
+// its own lock.
+type TypeProgress struct {
+	// Phase is "discover" (Provider.Discover) or "enrich"
+	// (Provider.EnrichAttributes) — mirrors the Stage discriminator on
+	// the wire Event and lets a single sink distinguish the two passes.
+	Phase string
+	// TFType is the Terraform resource type that just completed, e.g.
+	// "aws_s3_bucket".
+	TFType string
+	// Found is the number of resources discovered (discover phase) or
+	// enriched (enrich phase) for this type. Zero is a valid value — a
+	// type whose scope yielded nothing still completes.
+	Found int
+	// Total is the number of types in this call's scope: len(selected)
+	// for discover, the count of distinct enrichable types for enrich.
+	// Stable across every event of a single call so the consumer's
+	// denominator never moves.
+	Total int
+}
+
+// TypeProgressEmitter is an OPTIONAL extension interface an Emitter may
+// implement to receive per-Terraform-type completion events. The
+// discovery / enrichment orchestrators type-assert their Emitter to this
+// interface and call TypeDone only when it is satisfied — so the wire
+// JSONEmitter and NopEmitter (which do not implement it) are entirely
+// unaffected and the per-service event stream / CLI --progress=json
+// output is byte-for-byte unchanged. Only the pkg/imported.Provider
+// facade supplies an Emitter implementing this interface, to bridge
+// per-type progress onto its DiscoverOpts.Progress / EnrichOpts.Progress
+// sink (issue #699).
+//
+// TypeDone may be invoked concurrently — the AWS discover walk fans its
+// per-type Discover calls out across an errgroup — so implementations
+// MUST be safe for concurrent use.
+type TypeProgressEmitter interface {
+	TypeDone(TypeProgress)
+}
+
 // NopEmitter is a zero-overhead Emitter that swallows every call. The
 // orchestrator substitutes NopEmitter{} when the operator did not pass
 // --progress=json, so per-service discoverers always have a non-nil
 // Emitter to call.
+//
+// NopEmitter deliberately does NOT implement TypeProgressEmitter: the
+// orchestrators' type-assertion fails for it, so the per-type emission
+// path is skipped entirely under the default (no-sink) configuration.
 type NopEmitter struct{}
 
 // ServiceStart is a no-op.

--- a/cmd/insideout-import/progress/typeprogress_test.go
+++ b/cmd/insideout-import/progress/typeprogress_test.go
@@ -1,0 +1,62 @@
+package progress
+
+import "testing"
+
+// fakeTypeSink is a minimal TypeProgressEmitter — it satisfies the base
+// Emitter contract (no-ops) plus the optional per-type extension.
+type fakeTypeSink struct {
+	NopEmitter
+	got []TypeProgress
+}
+
+func (f *fakeTypeSink) TypeDone(p TypeProgress) { f.got = append(f.got, p) }
+
+// TestNopEmitterIsNotTypeProgressEmitter pins the load-bearing design
+// property of #699: the per-type extension interface is OPTIONAL, and
+// the default (no-sink) Emitter — NopEmitter — must NOT satisfy it. The
+// orchestrators type-assert their Emitter to TypeProgressEmitter and
+// skip the per-type path when the assertion fails; if NopEmitter ever
+// grew a TypeDone method, that path would fire under the default config
+// and the "byte-for-byte unchanged" back-compat guarantee would break.
+func TestNopEmitterIsNotTypeProgressEmitter(t *testing.T) {
+	t.Parallel()
+	var e Emitter = NopEmitter{}
+	if _, ok := e.(TypeProgressEmitter); ok {
+		t.Error("NopEmitter must NOT implement TypeProgressEmitter — the default no-sink path would otherwise emit per-type events")
+	}
+}
+
+// TestJSONEmitterIsNotTypeProgressEmitter pins that the wire
+// (--progress=json / SSE) Emitter does not implement the per-type
+// extension either: per-type events are a facade-only concern (#699),
+// so the CLI event stream and its golden tests stay untouched. A
+// regression that added TypeDone to JSONEmitter would silently inject a
+// new event type into the wire stream.
+func TestJSONEmitterIsNotTypeProgressEmitter(t *testing.T) {
+	t.Parallel()
+	var e Emitter = NewJSONEmitter(nil)
+	if _, ok := e.(TypeProgressEmitter); ok {
+		t.Error("JSONEmitter must NOT implement TypeProgressEmitter — per-type events are facade-only and must not enter the wire stream")
+	}
+}
+
+// TestTypeProgressEmitter_OptInWorks confirms the positive half: an
+// Emitter that DOES implement the extension is reachable via the same
+// type assertion the orchestrators use, and TypeDone delivers the event.
+func TestTypeProgressEmitter_OptInWorks(t *testing.T) {
+	t.Parallel()
+	var e Emitter = &fakeTypeSink{}
+	tp, ok := e.(TypeProgressEmitter)
+	if !ok {
+		t.Fatal("fakeTypeSink should satisfy TypeProgressEmitter")
+	}
+	tp.TypeDone(TypeProgress{Phase: "discover", TFType: "aws_s3_bucket", Found: 3, Total: 7})
+	got := e.(*fakeTypeSink).got
+	if len(got) != 1 {
+		t.Fatalf("TypeDone recorded %d events, want 1", len(got))
+	}
+	want := TypeProgress{Phase: "discover", TFType: "aws_s3_bucket", Found: 3, Total: 7}
+	if got[0] != want {
+		t.Errorf("TypeDone event = %+v, want %+v", got[0], want)
+	}
+}

--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
-	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
 	driftimp "github.com/luthersystems/insideout-terraform-presets/pkg/drift/imported"
@@ -175,12 +174,15 @@ func (p *Provider) CanonicalAddress(identity *imported.ResourceIdentity) string 
 //   - Regions    → Regions
 //   - TagSelectors → TagSelectors (translated to awsdiscover.TagSelector)
 //   - AccountID  → AccountID
+//   - Progress   → a per-type progress bridge on Emitter (#699)
 //
-// Progress emission is suppressed (NopEmitter) — consumers that want
-// streaming progress construct AWSDiscoverer directly and call
-// DiscoverTypes with their own Emitter. The Provider's job is
-// per-type static introspection plus one-shot live calls; streaming
-// belongs on the caller.
+// Per-type progress: when opts.Progress is non-nil, the Emitter handed
+// to DiscoverTypes is a bridge (imp.NewProgressEmitter) that forwards
+// one per-Terraform-type completion event to opts.Progress as the
+// parallel walk lands each type, serialized and with a monotonic
+// N-of-total count. A nil sink resolves to progress.NopEmitter{}, which
+// also disables the per-(service,region) wire stream — so the no-sink
+// path is byte-for-byte the pre-#699 behavior.
 func (p *Provider) Discover(ctx context.Context, types []string, clients imp.Clients, opts imp.DiscoverOpts) ([]imported.ImportedResource, error) {
 	if p.d == nil {
 		return nil, imp.ErrEnrichClientUnavailable
@@ -190,7 +192,7 @@ func (p *Provider) Discover(ctx context.Context, types []string, clients imp.Cli
 		Regions:      opts.Regions,
 		TagSelectors: toAWSTagSelectors(opts.TagSelectors),
 		AccountID:    opts.AccountID,
-		Emitter:      progress.NopEmitter{},
+		Emitter:      imp.NewProgressEmitter(opts.Progress),
 	}
 	return p.d.DiscoverTypes(ctx, types, args)
 }
@@ -211,7 +213,14 @@ func toAWSTagSelectors(in []imp.TagSelector) []awsdiscover.TagSelector {
 // EnrichAttributes delegates to AWSDiscoverer.EnrichAttributes. The
 // clients union must carry clients.AWS as a *Clients; absent bundle
 // returns ErrEnrichClientUnavailable.
-func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients imp.Clients) error {
+//
+// opts is variadic for back-compat (three-argument callers are
+// unaffected). When the first EnrichOpts carries a non-nil Progress, a
+// per-type bridge (imp.NewProgressEmitter) forwards one completion event
+// per enriched Terraform type with Phase="enrich" (#699); otherwise the
+// bridge resolves to progress.NopEmitter{} — byte-for-byte the pre-#699
+// behavior.
+func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients imp.Clients, opts ...imp.EnrichOpts) error {
 	if p.d == nil {
 		return imp.ErrEnrichClientUnavailable
 	}
@@ -219,7 +228,11 @@ func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.Imported
 	if err != nil {
 		return err
 	}
-	return p.d.EnrichAttributes(ctx, irs, aws, progress.NopEmitter{})
+	var sink func(imp.DiscoverProgress)
+	if len(opts) > 0 {
+		sink = opts[0].Progress
+	}
+	return p.d.EnrichAttributes(ctx, irs, aws, imp.NewProgressEmitter(sink))
 }
 
 // EnrichByID delegates to AWSDiscoverer.EnrichByID, mapping the

--- a/pkg/imported/aws/provider_test.go
+++ b/pkg/imported/aws/provider_test.go
@@ -55,6 +55,43 @@ func TestNewProvider_NilDiscoverer_StaticIntrospection(t *testing.T) {
 	}
 }
 
+// TestProvider_ProgressOpts_AcceptedAndShortCircuitOnNilDiscoverer pins
+// the #699 signatures on the AWS Provider: Discover accepts
+// DiscoverOpts.Progress and EnrichAttributes accepts both the legacy
+// three-argument form (back-compat) and the variadic EnrichOpts{Progress}
+// form. With a nil discoverer every path short-circuits to
+// ErrEnrichClientUnavailable before the sink is read, so the sink is
+// never invoked.
+//
+// This does NOT prove the sink reaches the discoverer — the nil
+// discoverer returns before opts is consulted. Real end-to-end delivery
+// of the caller's sink (real bridge wired into a real discover run) is
+// covered by TestDiscoverTypes_RealBridgeDeliversDiscoverProgress in the
+// awsdiscover package; AWSDiscoverer.byType is package-internal, so a
+// fake-backed Provider cannot be constructed here.
+func TestProvider_ProgressOpts_AcceptedAndShortCircuitOnNilDiscoverer(t *testing.T) {
+	t.Parallel()
+	p := awsprov.NewProvider(nil, nil)
+
+	sinkCalls := 0
+	sink := func(imp.DiscoverProgress) { sinkCalls++ }
+
+	if _, err := p.Discover(context.Background(), nil, imp.Clients{}, imp.DiscoverOpts{Progress: sink}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("Discover with Progress + nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	// Legacy three-argument form must still compile and behave.
+	if err := p.EnrichAttributes(context.Background(), nil, imp.Clients{}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("EnrichAttributes (3-arg) with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	// Variadic EnrichOpts{Progress} form.
+	if err := p.EnrichAttributes(context.Background(), nil, imp.Clients{}, imp.EnrichOpts{Progress: sink}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("EnrichAttributes (EnrichOpts) with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	if sinkCalls != 0 {
+		t.Errorf("sink invoked %d times on the nil-discoverer short-circuit, want 0", sinkCalls)
+	}
+}
+
 func TestProvider_Capabilities_Enrichable(t *testing.T) {
 	t.Parallel()
 	d := awsdiscover.NewAWSDiscoverer(awssdk.Config{})

--- a/pkg/imported/gcp/provider.go
+++ b/pkg/imported/gcp/provider.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
-	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/policy"
 	driftimp "github.com/luthersystems/insideout-terraform-presets/pkg/drift/imported"
@@ -133,6 +132,12 @@ func (p *Provider) CanonicalAddress(identity *imported.ResourceIdentity) string 
 // the real GCP project ID lives on the GCPDiscoverer itself, set at
 // construction time). opts.ProjectID is ignored when the underlying
 // discoverer was constructed with one — see NewGCPDiscoverer.
+//
+// Per-type progress: when opts.Progress is non-nil, the Emitter handed
+// to DiscoverTypes is a bridge (imp.NewProgressEmitter) that forwards
+// one per-Terraform-type completion event to opts.Progress with a
+// monotonic N-of-total count (#699). A nil sink resolves to
+// progress.NopEmitter{}, byte-for-byte the pre-#699 behavior.
 func (p *Provider) Discover(ctx context.Context, types []string, clients imp.Clients, opts imp.DiscoverOpts) ([]imported.ImportedResource, error) {
 	if p.d == nil {
 		return nil, imp.ErrEnrichClientUnavailable
@@ -141,7 +146,7 @@ func (p *Provider) Discover(ctx context.Context, types []string, clients imp.Cli
 		Project:      opts.Project,
 		Regions:      opts.Regions,
 		TagSelectors: toGCPTagSelectors(opts.TagSelectors),
-		Emitter:      progress.NopEmitter{},
+		Emitter:      imp.NewProgressEmitter(opts.Progress),
 	}
 	return p.d.DiscoverTypes(ctx, types, args)
 }
@@ -158,7 +163,14 @@ func toGCPTagSelectors(in []imp.TagSelector) []gcpdiscover.TagSelector {
 }
 
 // EnrichAttributes delegates to GCPDiscoverer.EnrichAttributes.
-func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients imp.Clients) error {
+//
+// opts is variadic for back-compat (three-argument callers are
+// unaffected). When the first EnrichOpts carries a non-nil Progress, a
+// per-type bridge (imp.NewProgressEmitter) forwards one completion event
+// per enriched Terraform type with Phase="enrich" (#699); otherwise the
+// bridge resolves to progress.NopEmitter{} — byte-for-byte the pre-#699
+// behavior.
+func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients imp.Clients, opts ...imp.EnrichOpts) error {
 	if p.d == nil {
 		return imp.ErrEnrichClientUnavailable
 	}
@@ -166,7 +178,11 @@ func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.Imported
 	if err != nil {
 		return err
 	}
-	return p.d.EnrichAttributes(ctx, irs, gcp, progress.NopEmitter{})
+	var sink func(imp.DiscoverProgress)
+	if len(opts) > 0 {
+		sink = opts[0].Progress
+	}
+	return p.d.EnrichAttributes(ctx, irs, gcp, imp.NewProgressEmitter(sink))
 }
 
 // EnrichByID delegates to GCPDiscoverer.EnrichByID, mapping the

--- a/pkg/imported/gcp/provider_test.go
+++ b/pkg/imported/gcp/provider_test.go
@@ -47,6 +47,39 @@ func TestNewProvider_NilDiscoverer_StaticIntrospection(t *testing.T) {
 	}
 }
 
+// TestProvider_ProgressOpts_AcceptedAndShortCircuitOnNilDiscoverer pins
+// the #699 signatures on the GCP Provider: Discover accepts
+// DiscoverOpts.Progress and EnrichAttributes accepts both the legacy
+// three-argument form (back-compat) and the variadic EnrichOpts{Progress}
+// form. With a nil discoverer every path short-circuits to
+// ErrEnrichClientUnavailable before the sink is read, so the sink is
+// never invoked.
+//
+// This does NOT prove the sink reaches the discoverer. Real end-to-end
+// delivery is covered by TestDiscoverTypes_RealBridgeDeliversDiscoverProgress
+// in the gcpdiscover package; gcpAssetSearcher is package-internal, so a
+// fake-backed Provider cannot be constructed here.
+func TestProvider_ProgressOpts_AcceptedAndShortCircuitOnNilDiscoverer(t *testing.T) {
+	t.Parallel()
+	p := gcpprov.NewProvider(nil, nil)
+
+	sinkCalls := 0
+	sink := func(imp.DiscoverProgress) { sinkCalls++ }
+
+	if _, err := p.Discover(context.Background(), nil, imp.Clients{}, imp.DiscoverOpts{Progress: sink}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("Discover with Progress + nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	if err := p.EnrichAttributes(context.Background(), nil, imp.Clients{}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("EnrichAttributes (3-arg) with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	if err := p.EnrichAttributes(context.Background(), nil, imp.Clients{}, imp.EnrichOpts{Progress: sink}); !errors.Is(err, imp.ErrEnrichClientUnavailable) {
+		t.Errorf("EnrichAttributes (EnrichOpts) with nil discoverer: err = %v, want ErrEnrichClientUnavailable", err)
+	}
+	if sinkCalls != 0 {
+		t.Errorf("sink invoked %d times on the nil-discoverer short-circuit, want 0", sinkCalls)
+	}
+}
+
 func TestProvider_Capabilities_Enrichable(t *testing.T) {
 	t.Parallel()
 	d := gcpdiscover.NewGCPDiscoverer(nil, "test-project", gcpdiscover.GCPDiscovererOpts{})

--- a/pkg/imported/progress.go
+++ b/pkg/imported/progress.go
@@ -1,0 +1,85 @@
+package imported
+
+import (
+	"sync"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+)
+
+// NewProgressEmitter returns the progress.Emitter that the per-cloud
+// Provider implementations hand to the underlying discoverer for a
+// Discover / EnrichAttributes call, bridging the cloud-agnostic
+// DiscoverProgress sink onto the discoverer's per-type completion events
+// (#699).
+//
+//   - sink == nil → progress.NopEmitter{}: zero-overhead, and the
+//     orchestrators' TypeProgressEmitter type-assertion fails, so the
+//     per-type emission path is skipped entirely. This is the today's-
+//     behavior, byte-for-byte path.
+//   - sink != nil → a bridge that no-ops the per-(service,region) Emitter
+//     events (not part of the facade contract) and forwards each per-type
+//     TypeDone to sink as a DiscoverProgress.
+//
+// The bridge serializes sink invocations under a mutex and owns the
+// monotonic CompletedTypes counter, so a sink is safe to call from the
+// AWS discover path's parallel per-type walk and always observes
+// CompletedTypes incrementing 1..TotalTypes in order.
+//
+// Exported because pkg/imported/aws and pkg/imported/gcp are distinct
+// packages that both need to construct it; facade consumers (e.g.
+// reliable's importer wizard) never call it directly — they set
+// DiscoverOpts.Progress / EnrichOpts.Progress and let the Provider wire
+// it up.
+func NewProgressEmitter(sink func(DiscoverProgress)) progress.Emitter {
+	if sink == nil {
+		return progress.NopEmitter{}
+	}
+	return &progressBridge{sink: sink}
+}
+
+// progressBridge adapts a per-type DiscoverProgress sink onto the
+// progress.Emitter contract the discover / enrich orchestrators consume.
+// It implements the base Emitter as no-ops (the facade's progress
+// contract is per-type, not per-(service,region)) and the optional
+// progress.TypeProgressEmitter to receive and forward the per-type
+// completion events.
+type progressBridge struct {
+	sink func(DiscoverProgress)
+
+	mu        sync.Mutex
+	completed int // running count of types done; guarded by mu
+}
+
+// Compile-time checks: *progressBridge satisfies both the base Emitter
+// and the optional per-type extension interface.
+var (
+	_ progress.Emitter             = (*progressBridge)(nil)
+	_ progress.TypeProgressEmitter = (*progressBridge)(nil)
+)
+
+// The per-(service,region) Emitter events are not part of the facade's
+// per-type progress contract, so the bridge swallows them.
+func (b *progressBridge) ServiceStart(string, string)                      {}
+func (b *progressBridge) ServiceFinish(string, string, int, time.Duration) {}
+func (b *progressBridge) ItemFound(string, string, string, string)         {}
+func (b *progressBridge) StageFinish(string, int, time.Duration)           {}
+func (b *progressBridge) ServiceWarn(string, string, string)               {}
+
+// TypeDone increments the running completed-type counter and forwards a
+// DiscoverProgress to the sink. The lock both serializes concurrent
+// callers (the AWS discover walk fans out per-type goroutines) and makes
+// the increment-then-deliver atomic, so the sink observes CompletedTypes
+// as a strictly monotonic 1..Total sequence.
+func (b *progressBridge) TypeDone(p progress.TypeProgress) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.completed++
+	b.sink(DiscoverProgress{
+		Phase:          p.Phase,
+		Type:           p.TFType,
+		FoundCount:     p.Found,
+		CompletedTypes: b.completed,
+		TotalTypes:     p.Total,
+	})
+}

--- a/pkg/imported/progress_test.go
+++ b/pkg/imported/progress_test.go
@@ -1,0 +1,117 @@
+package imported_test
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+)
+
+// TestNewProgressEmitter_NilSinkIsNop pins the back-compat path: a nil
+// sink resolves to progress.NopEmitter{}, which (a) is the zero-overhead
+// default and (b) does NOT implement TypeProgressEmitter — so the
+// orchestrators' per-type emission path is skipped entirely, byte-for-
+// byte the pre-#699 behavior.
+func TestNewProgressEmitter_NilSinkIsNop(t *testing.T) {
+	t.Parallel()
+	e := imp.NewProgressEmitter(nil)
+	if e != (progress.NopEmitter{}) {
+		t.Errorf("NewProgressEmitter(nil) = %#v, want progress.NopEmitter{}", e)
+	}
+	if _, ok := e.(progress.TypeProgressEmitter); ok {
+		t.Error("nil-sink emitter must NOT implement TypeProgressEmitter (would re-enable per-type emission under the default config)")
+	}
+}
+
+// TestNewProgressEmitter_BridgeTranslatesAndCounts pins the field
+// mapping (progress.TypeProgress → imp.DiscoverProgress) and that the
+// bridge owns the monotonic CompletedTypes counter: successive TypeDone
+// calls deliver CompletedTypes 1, 2, 3 while Phase/Type/FoundCount/
+// TotalTypes pass through verbatim.
+func TestNewProgressEmitter_BridgeTranslatesAndCounts(t *testing.T) {
+	t.Parallel()
+	var got []imp.DiscoverProgress
+	e := imp.NewProgressEmitter(func(p imp.DiscoverProgress) { got = append(got, p) })
+
+	tp, ok := e.(progress.TypeProgressEmitter)
+	if !ok {
+		t.Fatal("non-nil-sink emitter must implement TypeProgressEmitter")
+	}
+	tp.TypeDone(progress.TypeProgress{Phase: "discover", TFType: "aws_s3_bucket", Found: 3, Total: 3})
+	tp.TypeDone(progress.TypeProgress{Phase: "discover", TFType: "aws_sqs_queue", Found: 0, Total: 3})
+	tp.TypeDone(progress.TypeProgress{Phase: "enrich", TFType: "aws_iam_role", Found: 5, Total: 3})
+
+	want := []imp.DiscoverProgress{
+		{Phase: "discover", Type: "aws_s3_bucket", FoundCount: 3, CompletedTypes: 1, TotalTypes: 3},
+		{Phase: "discover", Type: "aws_sqs_queue", FoundCount: 0, CompletedTypes: 2, TotalTypes: 3},
+		{Phase: "enrich", Type: "aws_iam_role", FoundCount: 5, CompletedTypes: 3, TotalTypes: 3},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d events, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("event[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestNewProgressEmitter_ServiceEventsAreNoops confirms the bridge
+// swallows the per-(service,region) Emitter events — only per-type
+// completion reaches the facade sink.
+func TestNewProgressEmitter_ServiceEventsAreNoops(t *testing.T) {
+	t.Parallel()
+	calls := 0
+	e := imp.NewProgressEmitter(func(imp.DiscoverProgress) { calls++ })
+	e.ServiceStart("svc", "r")
+	e.ServiceFinish("svc", "r", 9, 0)
+	e.ItemFound("svc", "r", "aws_s3_bucket", "id")
+	e.StageFinish("discover", 9, 0)
+	e.ServiceWarn("svc", "r", "warn")
+	if calls != 0 {
+		t.Errorf("service-level events invoked the sink %d times, want 0", calls)
+	}
+}
+
+// TestProgressBridge_ConcurrentTypeDoneIsSafe is the #699 concurrency
+// contract: the AWS discover walk fans out per-type goroutines, so
+// TypeDone may be called concurrently. The bridge must serialize the
+// sink and hand out each CompletedTypes value exactly once across
+// 1..N. Run under -race to catch unsynchronized access.
+func TestProgressBridge_ConcurrentTypeDoneIsSafe(t *testing.T) {
+	t.Parallel()
+	const n = 64
+
+	var mu sync.Mutex
+	seen := make([]int, 0, n)
+	e := imp.NewProgressEmitter(func(p imp.DiscoverProgress) {
+		mu.Lock()
+		seen = append(seen, p.CompletedTypes)
+		mu.Unlock()
+	})
+	tp := e.(progress.TypeProgressEmitter)
+
+	var wg sync.WaitGroup
+	for range n {
+		wg.Go(func() {
+			tp.TypeDone(progress.TypeProgress{Phase: "discover", TFType: "t", Found: 1, Total: n})
+		})
+	}
+	wg.Wait()
+
+	if len(seen) != n {
+		t.Fatalf("sink invoked %d times, want %d", len(seen), n)
+	}
+	// CompletedTypes must cover exactly 1..n, each once — proving the
+	// counter increments under the lock without lost updates.
+	counts := make(map[int]int, n)
+	for _, c := range seen {
+		counts[c]++
+	}
+	for i := 1; i <= n; i++ {
+		if counts[i] != 1 {
+			t.Errorf("CompletedTypes=%d appeared %d times, want exactly 1 (1..%d each once)", i, counts[i], n)
+		}
+	}
+}

--- a/pkg/imported/provider.go
+++ b/pkg/imported/provider.go
@@ -75,6 +75,11 @@ type Provider interface {
 	// ImportedResource per matched cloud resource, with
 	// Identity populated and Tier=TierImportedFlat,
 	// Source=SourceImporter.
+	//
+	// When opts.Progress is non-nil it fires once per Terraform type
+	// as that type's resources finish discovering, carrying a running
+	// N-of-total type count (#699); a nil sink is byte-for-byte the
+	// pre-existing behavior.
 	Discover(ctx context.Context, types []string, clients Clients, opts DiscoverOpts) ([]composerimported.ImportedResource, error)
 
 	// EnrichAttributes populates ir.Attrs in place for every
@@ -84,7 +89,13 @@ type Provider interface {
 	// joined error; ErrEnrichClientUnavailable failures are
 	// downgraded internally (the per-cloud impls surface them as
 	// progress warnings without failing the batch).
-	EnrichAttributes(ctx context.Context, irs []composerimported.ImportedResource, clients Clients) error
+	//
+	// opts is variadic for back-compat: existing three-argument
+	// callers are unaffected. When the first EnrichOpts carries a
+	// non-nil Progress, it fires once per Terraform type as that
+	// type's resources finish enriching (Phase="enrich"), mirroring
+	// the Discover progress contract (#699).
+	EnrichAttributes(ctx context.Context, irs []composerimported.ImportedResource, clients Clients, opts ...EnrichOpts) error
 
 	// EnrichByID fetches the typed Layer-1 Attrs payload for a
 	// single resource named by identity. Used by the per-IR drift

--- a/pkg/imported/provider_test.go
+++ b/pkg/imported/provider_test.go
@@ -34,7 +34,7 @@ func (s *stubProvider) CanonicalAddress(*composerimported.ResourceIdentity) stri
 func (s *stubProvider) Discover(context.Context, []string, imp.Clients, imp.DiscoverOpts) ([]composerimported.ImportedResource, error) {
 	return nil, nil
 }
-func (s *stubProvider) EnrichAttributes(context.Context, []composerimported.ImportedResource, imp.Clients) error {
+func (s *stubProvider) EnrichAttributes(context.Context, []composerimported.ImportedResource, imp.Clients, ...imp.EnrichOpts) error {
 	return nil
 }
 func (s *stubProvider) EnrichByID(context.Context, *composerimported.ResourceIdentity, imp.Clients) (imp.Attrs, error) {

--- a/pkg/imported/types.go
+++ b/pkg/imported/types.go
@@ -120,12 +120,65 @@ type Clients struct {
 //     Ignored on GCP.
 //   - ProjectID: GCP project ID (the real project ID, not the
 //     stack project name). Ignored on AWS.
+//   - Progress: optional per-Terraform-type completion sink (#699).
+//     Nil = no progress (today's behavior, byte-for-byte). When set,
+//     it fires once per Terraform type as that type's resources finish
+//     being discovered, carrying a running N-of-total type counter so
+//     a streaming consumer (reliable's reverse-import "Scan" step) can
+//     render real progress instead of a cosmetic timer. Invocations are
+//     serialized — safe to call from the AWS path's parallel walk — and
+//     CompletedTypes is monotonic 1..TotalTypes.
 type DiscoverOpts struct {
 	Project      string
 	Regions      []string
 	TagSelectors []TagSelector
 	AccountID    string
 	ProjectID    string
+	Progress     func(DiscoverProgress)
+}
+
+// DiscoverProgress is one per-Terraform-type completion event delivered
+// to DiscoverOpts.Progress (discover phase) or EnrichOpts.Progress
+// (enrich phase). It is emitted once per type as that type's resources
+// finish being discovered or enriched — the incremental signal the
+// reverse-import UI needs to stream a per-service / per-type count
+// instead of painting a local-timer animation (#699).
+//
+// Back-compat: a nil sink means no events are produced and the discover
+// / enrich return values are unchanged. Existing callers that never set
+// a sink are unaffected.
+type DiscoverProgress struct {
+	// Phase is "discover" (Provider.Discover) or "enrich"
+	// (Provider.EnrichAttributes). A single sink can serve both and
+	// branch on this field.
+	Phase string
+	// Type is the Terraform type that just completed, e.g.
+	// "aws_s3_bucket".
+	Type string
+	// FoundCount is the number of resources discovered (discover) or
+	// covered (enrich) for this type. Zero is valid.
+	FoundCount int
+	// CompletedTypes is the running count of types completed so far,
+	// inclusive of this one — monotonic 1..TotalTypes across a single
+	// Discover / EnrichAttributes call.
+	CompletedTypes int
+	// TotalTypes is the number of types in this call's scope: the
+	// requested type count for discover, the count of distinct
+	// enrichable types for enrich. Stable across every event of the
+	// call so the consumer's denominator never moves.
+	TotalTypes int
+}
+
+// EnrichOpts carries optional inputs to Provider.EnrichAttributes. It is
+// passed variadically so existing three-argument callers
+// (EnrichAttributes(ctx, irs, clients)) keep compiling and behaving
+// exactly as before — the zero-opts path is byte-for-byte unchanged.
+//
+//   - Progress: optional per-Terraform-type completion sink, the enrich
+//     counterpart to DiscoverOpts.Progress. Events carry Phase="enrich".
+//     Nil = no progress.
+type EnrichOpts struct {
+	Progress func(DiscoverProgress)
 }
 
 // TagSelector is a single operator-supplied tag/label equality


### PR DESCRIPTION
## Summary
- `imported.Provider.Discover` / `EnrichAttributes` were blocking, all-at-once calls — the per-cloud facade hard-coded `progress.NopEmitter{}`, so reliable's reverse-import "Scan" step had no incremental signal and the import UI could only paint a cosmetic timer.
- Adds an **optional per-Terraform-type progress sink** to the facade, threaded through the existing emitter plumbing **without touching the per-service wire event stream** (CLI `--progress=json` / SSE / goldens are untouched).
- Implemented via an **optional extension interface** (`progress.TypeProgressEmitter`) — the base `Emitter` interface is unchanged, so the ~16 emitter spies and `JSONEmitter`/`NopEmitter` are unaffected. nil sink ⇒ `NopEmitter` ⇒ byte-for-byte the pre-#699 behavior.

### What's new
- `progress.TypeProgress` + optional `TypeProgressEmitter{TypeDone(TypeProgress)}`.
- AWS & GCP `DiscoverTypes` fire one `TypeDone` per type at each per-type completion boundary (AWS per-goroutine return incl. the per-type-timeout partial; GCP per CAI-bucket translation guarded against non-CAI double-count, plus the non-CAI list phase).
- Both `EnrichAttributes` second passes emit one `TypeDone` per enriched type (`Phase:"enrich"`).
- Facade: `DiscoverProgress{Phase,Type,FoundCount,CompletedTypes,TotalTypes}` (the issue's contract shape), `DiscoverOpts.Progress`, and variadic `EnrichOpts{Progress}` on `Provider.EnrichAttributes` (existing 3-arg callers unaffected). `NewProgressEmitter` bridges the sink: no-ops service events, owns a mutex-guarded **monotonic** `CompletedTypes` counter (safe under the AWS parallel walk).

Downstream (reliable) consumes the sink to convert `/agent-api/import/discover` into an SSE stream — separate follow-up.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `make go-fmt-check` — clean
- [x] `go test -race ./...` — full module green
- [x] New unit + integration tests: optional-interface negative pins (NopEmitter/JSONEmitter are not `TypeProgressEmitter`); per-type emission (AWS parallel + timeout, GCP CAI + non-CAI, both enrich phases incl. mid-list-failure determinism); bridge translation + monotonic counter + 64-goroutine concurrency under `-race`; and orchestrator↔bridge integration (real `NewProgressEmitter` wired into a real `DiscoverTypes` run).

## Review notes
- Ran an adversarial multi-agent review (correctness/concurrency/back-compat/edge/tests, each finding verified): **no production defects**; the 3 confirmed test-coverage gaps were fixed.
- qa-professor: flagged that the provider-level tests only exercise the nil-discoverer short-circuit; added real-bridge integration tests in the `awsdiscover`/`gcpdiscover` packages to cover the orchestrator↔bridge seam end-to-end (the per-cloud `Provider` can't be fake-backed from its `_test` package because `AWSDiscoverer.byType` / `gcpAssetSearcher` are unexported — only the 6-line, compile-checked `Provider` delegation remains uncovered). Also added a mid-list-failure enrich case and renamed the provider test to match what it asserts.

Closes #699