### PR TITLE
feat(reverse-import): heartbeat during silent phases + wire progress sink (#702)

### DIFF
--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -1028,6 +1028,13 @@ Exit codes:
 			AccountID:             accountID,
 			MaxDepChaseIterations: *maxDepChaseIter,
 			Discoverer:            d,
+			// Stream the engine's live phase progress + silent-phase
+			// heartbeat (#702) to summaryOut, which is os.Stdout in
+			// human-readable mode and os.Stderr under --progress=json — so
+			// the human progress rides the same writer as the rest of the
+			// summary and never corrupts the newline-delimited JSON event
+			// stream that machine consumers read on stdout.
+			Stdout: summaryOut,
 		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "discover: reverse import SDK: %v\n", err)

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -758,6 +759,12 @@ func TestRunDiscoverWithDeps_DefaultHCLUsesReverseSDK(t *testing.T) {
 		if opts.OutputDir != dir {
 			t.Fatalf("OutputDir = %q, want %q", opts.OutputDir, dir)
 		}
+		// Regression guard for #702: the discover→reverse path must wire a
+		// progress sink, otherwise the engine's live phase progress and the
+		// silent-phase heartbeat are discarded and the job log looks frozen.
+		if opts.Stdout == nil {
+			t.Fatal("runReverse opts.Stdout is nil; engine progress would be discarded")
+		}
 		return reversejob.Result{
 			Version:     reversejob.Version,
 			Status:      reversejob.StatusSucceeded,
@@ -777,6 +784,52 @@ func TestRunDiscoverWithDeps_DefaultHCLUsesReverseSDK(t *testing.T) {
 	}
 	if called != 1 {
 		t.Fatalf("runReverse called %d times, want 1", called)
+	}
+}
+
+// TestRunDiscoverWithDeps_ReverseProgressRoutedToStderrUnderJSON pins the
+// #702 output contract: under --progress=json the reverse engine's
+// human-readable progress + heartbeat must ride os.Stderr (= summaryOut),
+// never os.Stdout, so the newline-delimited JSON event stream machine
+// consumers read on stdout stays pure. In the default (human) mode the same
+// progress rides os.Stdout. Asserting non-nil alone (as the sibling test
+// does) would not catch a regression that mixed the heartbeat into the JSON
+// stream.
+func TestRunDiscoverWithDeps_ReverseProgressRoutedToStderrUnderJSON(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		progress string
+		want     *os.File
+	}{
+		{name: "human mode → stdout", progress: "", want: os.Stdout},
+		{name: "json mode → stderr", progress: "json", want: os.Stderr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			agg := &fakeAggregator{out: []imported.ImportedResource{validResource("aws_sqs_queue.orders")}}
+			deps := okDeps(agg)
+			var gotStdout io.Writer
+			deps.runReverse = func(_ context.Context, req reversejob.Request, opts reverseimport.Options) (reversejob.Result, error) {
+				gotStdout = opts.Stdout
+				return reversejob.Result{
+					Version:     reversejob.Version,
+					Status:      reversejob.StatusSucceeded,
+					Imported:    req.ImportedResources(),
+					PlanSummary: reversejob.PlanSummary{ImportCount: 1},
+				}, nil
+			}
+
+			args := []string{"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir}
+			if tc.progress != "" {
+				args = append(args, "--progress", tc.progress)
+			}
+			if rc := runDiscoverWithDeps(args, deps); rc != discoverExitOK {
+				t.Fatalf("exit = %d, want %d", rc, discoverExitOK)
+			}
+			if gotStdout != tc.want {
+				t.Fatalf("reverse engine Stdout = %v, want %v (progress=%q)", gotStdout, tc.want, tc.progress)
+			}
+		})
 	}
 }
 

--- a/cmd/insideout-import/reverse.go
+++ b/cmd/insideout-import/reverse.go
@@ -125,6 +125,12 @@ Flags:`)
 		SkipDepChase:          *noDepChase,
 		MaxDepChaseIterations: *maxDepChaseIter,
 		Discoverer:            discoverer,
+		// Stream live phase progress + heartbeat to the process stdout the
+		// Mars reverse-import job follows (Oracle follow=1 → reliable's
+		// import plan-preview). Without this the engine's progress plumbing
+		// (PR #698) and the silent-phase heartbeat (#702) write to
+		// io.Discard and the job log looks frozen for minutes.
+		Stdout: os.Stdout,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "reverse: %v\n", err)

--- a/pkg/reverseimport/heartbeat.go
+++ b/pkg/reverseimport/heartbeat.go
@@ -1,0 +1,99 @@
+package reverseimport
+
+import (
+	"io"
+	"sync"
+	"time"
+)
+
+// defaultHeartbeatInterval is how often a long-running phase emits a
+// "still running" liveness line to the progress sink. Chosen at the
+// responsive end of issue #702's "~15-30s" window: a 2-5 minute
+// terraform-init (provider download + GPG verify) or driftfix phase then
+// produces ~8-20 heartbeat lines, so a consumer streaming the job log
+// (reliable's onboard import plan-preview) never sees more than ~15s of
+// apparent silence and can't mistake the run for stuck/broken.
+const defaultHeartbeatInterval = 15 * time.Second
+
+// runPhase executes fn while a background goroutine emits a periodic
+// heartbeat line to o.Stdout, so a consumer streaming the job log sees
+// forward motion even through phases whose subprocess output is buffered
+// or fully silent for minutes (issue #702). terraform's own provider
+// download/GPG-verify during init, and driftfix's plan-refresh cycles, are
+// the worst offenders: terraform buffers that output and the engine has no
+// other line to print until the phase returns.
+//
+// The first heartbeat fires only after o.heartbeatEvery elapses, so a fast
+// phase stays quiet and produces zero extra lines; the ticker stops the
+// moment fn returns. fn's own error is returned unchanged — runPhase is a
+// transparent wrapper. label names the phase in the heartbeat line and
+// should echo the human-readable phase name progressf prints at the phase
+// boundary (e.g. "terraform init", "driftfix") — close enough that the
+// heartbeat reads as a continuation of the same phase.
+//
+// o.Stdout is serialized by withDefaults (see syncWriter), so the heartbeat
+// goroutine, the per-phase progress lines, and the streamed terraform
+// subprocess output never corrupt each other on the shared writer.
+func (o Options) runPhase(label string, fn func() error) error {
+	if o.heartbeatEvery <= 0 {
+		return fn()
+	}
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(o.heartbeatEvery)
+		defer ticker.Stop()
+		start := time.Now()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				// Re-check done so a tick that races phase completion
+				// doesn't print a spurious heartbeat after the phase has
+				// already finished.
+				select {
+				case <-done:
+					return
+				default:
+				}
+				o.progressf("reverse-import: %s still running (%s elapsed)…\n", label, time.Since(start).Round(time.Second))
+			}
+		}
+	}()
+	// Stop and join the heartbeat on every exit path — including a panic
+	// unwinding out of fn — so the goroutine is reaped rather than left
+	// blocked in its select.
+	defer func() {
+		close(done)
+		<-stopped
+	}()
+	return fn()
+}
+
+// syncWriter serializes concurrent writes to an underlying sink. The
+// reverse-import engine shares one Options.Stdout across three concurrent
+// producers — the heartbeat goroutine, the per-phase progress lines, and
+// the streamed terraform subprocess output — and many real sinks (a
+// bufio.Writer, a custom log writer) are not safe for concurrent use, so
+// the engine guarantees serialization itself rather than assuming the
+// caller's writer is goroutine-safe.
+//
+// Each Write is atomic with respect to every other Write. The engine's own
+// progress and heartbeat lines are emitted one whole line per Write, so
+// they are never split or interleaved mid-line. The streamed terraform
+// output, by contrast, reaches this writer via os/exec's io.Copy in
+// ~32KB chunks that are not newline-aligned, so a heartbeat line can land
+// between two chunks of a terraform line — cosmetic only (never a race or
+// data corruption), and acceptable given heartbeats are seconds apart.
+type syncWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}

--- a/pkg/reverseimport/heartbeat_test.go
+++ b/pkg/reverseimport/heartbeat_test.go
@@ -1,0 +1,306 @@
+package reverseimport
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+// safeBuffer is a bytes.Buffer guarded for concurrent Write/String so a
+// test can read the progress stream from one goroutine while the heartbeat
+// goroutine writes from another, under -race.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// waitForContains blocks until b contains sub or within elapses. Returning
+// on the condition (rather than a fixed sleep) keeps the heartbeat tests
+// bounded by the tiny test interval, not by a worst-case wait; the timeout
+// is only a failure backstop so a regression fails fast instead of hanging.
+func waitForContains(b *safeBuffer, sub string, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if strings.Contains(b.String(), sub) {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return strings.Contains(b.String(), sub)
+}
+
+// TestRunPhaseEmitsHeartbeatDuringSlowPhase is the core regression guard
+// for issue #702: a phase that runs longer than the heartbeat interval must
+// emit a "still running" liveness line so a consumer streaming the job log
+// sees forward motion instead of a frozen stream.
+func TestRunPhaseEmitsHeartbeatDuringSlowPhase(t *testing.T) {
+	var buf safeBuffer
+	opts := Options{Stdout: &buf, heartbeatEvery: 2 * time.Millisecond}
+
+	release := make(chan struct{})
+	go func() {
+		// End the phase as soon as the first heartbeat is observed, so the
+		// test is bounded by the 2ms interval; the 2s ceiling is a backstop.
+		waitForContains(&buf, "still running", 2*time.Second)
+		close(release)
+	}()
+
+	called := false
+	err := opts.runPhase("terraform init", func() error {
+		called = true
+		<-release
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("runPhase returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("phase fn was never called")
+	}
+	got := buf.String()
+	if !strings.Contains(got, "terraform init still running") {
+		t.Fatalf("missing heartbeat for slow phase; got:\n%s", got)
+	}
+	if !strings.Contains(got, "elapsed") {
+		t.Fatalf("heartbeat missing elapsed marker; got:\n%s", got)
+	}
+}
+
+// TestRunPhaseStaysSilentForFastPhase pins the no-noise side: a phase that
+// returns before the first tick must emit nothing, so fast phases (validate,
+// show on a small plan) don't spam the log with heartbeats.
+func TestRunPhaseStaysSilentForFastPhase(t *testing.T) {
+	var buf safeBuffer
+	opts := Options{Stdout: &buf, heartbeatEvery: time.Hour}
+	if err := opts.runPhase("terraform validate", func() error { return nil }); err != nil {
+		t.Fatalf("runPhase returned error: %v", err)
+	}
+	if got := buf.String(); got != "" {
+		t.Fatalf("fast phase emitted unexpected output: %q", got)
+	}
+}
+
+// TestRunPhasePropagatesError confirms runPhase is a transparent wrapper:
+// fn's error is returned unchanged, so wrapping a phase never swallows or
+// rewrites its failure.
+func TestRunPhasePropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	opts := Options{Stdout: &safeBuffer{}, heartbeatEvery: time.Hour}
+	err := opts.runPhase("driftfix", func() error { return wantErr })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runPhase err = %v, want %v", err, wantErr)
+	}
+}
+
+// TestRunPhaseDisabledWhenIntervalNonPositive pins the passthrough: a
+// non-positive interval disables the heartbeat entirely (no goroutine, no
+// output), so a caller can opt out cleanly.
+func TestRunPhaseDisabledWhenIntervalNonPositive(t *testing.T) {
+	var buf safeBuffer
+	opts := Options{Stdout: &buf, heartbeatEvery: 0}
+	ran := false
+	if err := opts.runPhase("terraform init", func() error { ran = true; return nil }); err != nil {
+		t.Fatalf("runPhase returned error: %v", err)
+	}
+	if !ran {
+		t.Fatal("phase fn was never called")
+	}
+	if got := buf.String(); got != "" {
+		t.Fatalf("disabled heartbeat emitted output: %q", got)
+	}
+}
+
+// TestRunPhaseHeartbeatIsPeriodicAndLabeled pins two things the single-tick
+// slow-phase test leaves open: the heartbeat fires repeatedly (not just once
+// before the ticker is mistakenly stopped), and the line carries the caller's
+// label rather than a hardcoded phase name — here "driftfix", distinct from
+// the "terraform init" the other tests use.
+func TestRunPhaseHeartbeatIsPeriodicAndLabeled(t *testing.T) {
+	var buf safeBuffer
+	opts := Options{Stdout: &buf, heartbeatEvery: 2 * time.Millisecond}
+
+	release := make(chan struct{})
+	go func() {
+		// Hold the phase open until at least two heartbeats have fired, so
+		// "periodic" is actually proven; 2s is a failure backstop only.
+		deadline := time.Now().Add(2 * time.Second)
+		for time.Now().Before(deadline) {
+			if strings.Count(buf.String(), "still running") >= 2 {
+				break
+			}
+			time.Sleep(time.Millisecond)
+		}
+		close(release)
+	}()
+
+	if err := opts.runPhase("driftfix", func() error {
+		<-release
+		return nil
+	}); err != nil {
+		t.Fatalf("runPhase returned error: %v", err)
+	}
+	got := buf.String()
+	if n := strings.Count(got, "still running"); n < 2 {
+		t.Fatalf("expected >=2 periodic heartbeats, got %d:\n%s", n, got)
+	}
+	if !strings.Contains(got, "driftfix still running") {
+		t.Fatalf("heartbeat did not carry the provided label %q:\n%s", "driftfix", got)
+	}
+	if strings.Contains(got, "terraform init") {
+		t.Fatalf("heartbeat label looks hardcoded, not threaded from the caller:\n%s", got)
+	}
+}
+
+// TestRunPhasePanicReapsHeartbeatGoroutine guards the panic-cleanup path that
+// the production comment promises: runPhase joins the heartbeat goroutine via
+// a deferred close(done)+<-stopped, so a panic out of fn re-surfaces AND the
+// goroutine is reaped rather than left ticking. The regression this kills is
+// moving the cleanup out of the defer — then a panicking fn would leak the
+// goroutine, which keeps emitting "still running" lines after the unwind.
+func TestRunPhasePanicReapsHeartbeatGoroutine(t *testing.T) {
+	var buf safeBuffer
+	opts := Options{Stdout: &buf, heartbeatEvery: time.Millisecond}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic to propagate out of runPhase")
+			}
+		}()
+		_ = opts.runPhase("terraform init", func() error {
+			waitForContains(&buf, "still running", 2*time.Second)
+			panic("boom")
+		})
+	}()
+
+	// runPhase's deferred close(done)+<-stopped runs during the panic unwind
+	// and blocks until the goroutine exits, so the goroutine is already
+	// joined by the time recover() returns above. A leaked goroutine (the
+	// regression) would keep ticking at ~1ms; assert the stream is now
+	// quiescent across many would-be ticks.
+	afterPanic := buf.String()
+	settle := time.Now().Add(60 * time.Millisecond)
+	for time.Now().Before(settle) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := buf.String(); got != afterPanic {
+		t.Fatalf("heartbeat goroutine kept emitting after panic — not reaped:\nbefore=%q\nafter=%q", afterPanic, got)
+	}
+}
+
+// TestSyncWriterSerializesConcurrentWrites proves the engine's shared
+// progress sink stays line-atomic under concurrent producers — the
+// guarantee that lets the heartbeat goroutine and the streamed terraform
+// output share one Options.Stdout without interleaving mid-line.
+func TestSyncWriterSerializesConcurrentWrites(t *testing.T) {
+	var underlying bytes.Buffer
+	sw := &syncWriter{w: &underlying}
+
+	const writers, perWriter = 8, 64
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			line := fmt.Appendf(nil, "line-from-%d\n", id)
+			for range perWriter {
+				if _, err := sw.Write(line); err != nil {
+					t.Errorf("write: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Safe to read underlying directly now: all writers have joined.
+	lines := strings.Split(strings.TrimRight(underlying.String(), "\n"), "\n")
+	if len(lines) != writers*perWriter {
+		t.Fatalf("got %d lines, want %d", len(lines), writers*perWriter)
+	}
+	for _, ln := range lines {
+		if !strings.HasPrefix(ln, "line-from-") {
+			t.Fatalf("interleaved/garbled line: %q", ln)
+		}
+	}
+}
+
+// blockingInitRunner wraps the fake terraform runner but holds Init open
+// until release is closed, so a test can keep the init phase running long
+// enough to observe the heartbeat the engine emits during a slow init.
+type blockingInitRunner struct {
+	fakeTerraformRunner
+	release <-chan struct{}
+}
+
+func (r blockingInitRunner) Init(context.Context, string) error {
+	<-r.release
+	return nil
+}
+
+// TestRunEmitsHeartbeatDuringSlowInit is the end-to-end guard that the
+// heartbeat is actually wired into Run's terraform-init phase and reaches
+// the Options.Stdout the Mars job supplies — not just exercised in isolation.
+func TestRunEmitsHeartbeatDuringSlowInit(t *testing.T) {
+	dir := t.TempDir()
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	var buf safeBuffer
+	release := make(chan struct{})
+	go func() {
+		waitForContains(&buf, "terraform init still running", 3*time.Second)
+		close(release)
+	}()
+
+	_, err := Run(context.Background(), req, Options{
+		OutputDir:      dir,
+		SkipDepChase:   true,
+		Stdout:         &buf,
+		heartbeatEvery: 2 * time.Millisecond,
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           blockingInitRunner{release: release},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := buf.String(); !strings.Contains(got, "terraform init still running") {
+		t.Fatalf("expected terraform-init heartbeat in progress stream; got:\n%s", got)
+	}
+}

--- a/pkg/reverseimport/options.go
+++ b/pkg/reverseimport/options.go
@@ -70,12 +70,21 @@ type Options struct {
 	// through its phases — provider readback, genconfig, driftfix,
 	// dep-chase, and the final terraform init/validate/plan — plus the
 	// live stdout/stderr of the terraform subprocesses those phases
-	// drive. The Mars reverse-import job points this at its own stdout so
-	// Oracle's follow=1 stream (and the InsideOut import wizard's log
-	// console) shows live progress for the whole run rather than just the
-	// final plan. Nil defaults to io.Discard in withDefaults, so existing
-	// callers and tests stay silent and unaffected.
+	// drive and a periodic per-phase heartbeat during the silent stretches
+	// (terraform init provider download/GPG-verify, driftfix plan refresh).
+	// The Mars reverse-import job points this at its own stdout so Oracle's
+	// follow=1 stream (and the InsideOut import wizard's log console) shows
+	// live progress for the whole run rather than just the final plan. Nil
+	// defaults to io.Discard in withDefaults, so existing callers and tests
+	// stay silent and unaffected.
 	Stdout io.Writer
+
+	// heartbeatEvery is the interval between "still running" liveness lines
+	// emitted during a long phase (see runPhase). withDefaults sets it to
+	// defaultHeartbeatInterval; tests override it to a tiny value to assert
+	// heartbeat behavior deterministically. A non-positive value disables
+	// the heartbeat entirely (runPhase becomes a transparent passthrough).
+	heartbeatEvery time.Duration
 
 	deps deps
 }
@@ -112,12 +121,23 @@ func (o Options) withDefaults() Options {
 	if o.MaxDepChaseIterations <= 0 {
 		o.MaxDepChaseIterations = depchase.DefaultMaxIterations
 	}
+	if o.heartbeatEvery <= 0 {
+		o.heartbeatEvery = defaultHeartbeatInterval
+	}
 	// Default the progress sink to io.Discard so progressf and the
 	// terraform subprocess streaming are always safe to call without a
 	// nil check, and existing callers/tests that pass no writer stay
 	// silent.
 	if o.Stdout == nil {
 		o.Stdout = io.Discard
+	}
+	// Serialize the shared progress sink: the heartbeat goroutine, the
+	// per-phase progress lines, and the streamed terraform subprocess
+	// output all write to o.Stdout concurrently, and the caller's writer is
+	// not assumed goroutine-safe. io.Discard needs no guarding and the
+	// wrap would only add a pointless mutex, so skip it.
+	if o.Stdout != io.Discard {
+		o.Stdout = &syncWriter{w: o.Stdout}
 	}
 	if o.deps.runGenconfig == nil ||
 		o.deps.runDriftfix == nil ||

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -90,8 +90,12 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	}
 
 	opts.progressf("reverse-import: generating terraform config for %d resource(s)…\n", len(resources))
-	gcRes, err := opts.deps.runGenconfig(ctx, gcOpts, resources)
-	if err != nil {
+	var gcRes *genconfig.Result
+	if err := opts.runPhase("generating terraform config", func() error {
+		var genErr error
+		gcRes, genErr = opts.deps.runGenconfig(ctx, gcOpts, resources)
+		return genErr
+	}); err != nil {
 		return result, fmt.Errorf("genconfig: %w", err)
 	}
 	resources = gcRes.Resources
@@ -99,7 +103,10 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 
 	if !opts.SkipDriftFix {
 		opts.progressf("reverse-import: running driftfix…\n")
-		if _, err := opts.deps.runDriftfix(ctx, driftfix.Options{Workdir: workdir, Stdout: opts.Stdout}); err != nil {
+		if err := opts.runPhase("driftfix", func() error {
+			_, driftErr := opts.deps.runDriftfix(ctx, driftfix.Options{Workdir: workdir, Stdout: opts.Stdout})
+			return driftErr
+		}); err != nil {
 			return result, fmt.Errorf("driftfix: %w", err)
 		}
 		opts.progressf("reverse-import: driftfix complete\n")
@@ -124,16 +131,19 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			},
 		}
 		opts.progressf("reverse-import: chasing resource dependencies…\n")
-		dcRes, err = opts.deps.runDepChase(ctx, depchase.Options{
-			Workdir:       workdir,
-			Region:        region,
-			AccountID:     firstResourceField(resources, func(id imported.ResourceIdentity) string { return id.AccountID }),
-			MaxIterations: opts.MaxDepChaseIterations,
-			Discoverer:    opts.Discoverer,
-			Pipeline:      pipeline,
-			Stdout:        opts.Stdout,
-		}, resources)
-		if err != nil {
+		if err := opts.runPhase("chasing resource dependencies", func() error {
+			var chaseErr error
+			dcRes, chaseErr = opts.deps.runDepChase(ctx, depchase.Options{
+				Workdir:       workdir,
+				Region:        region,
+				AccountID:     firstResourceField(resources, func(id imported.ResourceIdentity) string { return id.AccountID }),
+				MaxIterations: opts.MaxDepChaseIterations,
+				Discoverer:    opts.Discoverer,
+				Pipeline:      pipeline,
+				Stdout:        opts.Stdout,
+			}, resources)
+			return chaseErr
+		}); err != nil {
 			return result, fmt.Errorf("depchase: %w", err)
 		}
 		if dcRes != nil {
@@ -188,25 +198,38 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	validateJSONPath := filepath.Join(opts.OutputDir, validateJSONFile)
 	tfplanJSONPath := filepath.Join(opts.OutputDir, tfplanJSONFile)
 	opts.progressf("reverse-import: terraform init…\n")
-	if err := opts.deps.tf.Init(ctx, opts.OutputDir); err != nil {
+	if err := opts.runPhase("terraform init", func() error {
+		return opts.deps.tf.Init(ctx, opts.OutputDir)
+	}); err != nil {
 		return result, fmt.Errorf("terraform init final: %w", err)
 	}
 	opts.progressf("reverse-import: terraform validate…\n")
-	validateJSON, err := opts.deps.tf.Validate(ctx, opts.OutputDir)
+	var validateJSON []byte
+	validateErr := opts.runPhase("terraform validate", func() error {
+		var verr error
+		validateJSON, verr = opts.deps.tf.Validate(ctx, opts.OutputDir)
+		return verr
+	})
 	if len(validateJSON) > 0 {
 		if writeErr := writeFileAtomic(validateJSONPath, validateJSON, 0o644); writeErr != nil {
 			return result, fmt.Errorf("write validate.json: %w", writeErr)
 		}
 	}
-	if err != nil {
-		return result, fmt.Errorf("terraform validate final: %w", err)
+	if validateErr != nil {
+		return result, fmt.Errorf("terraform validate final: %w", validateErr)
 	}
 	opts.progressf("reverse-import: terraform plan…\n")
-	if err := opts.deps.tf.Plan(ctx, opts.OutputDir, planPath); err != nil {
+	if err := opts.runPhase("terraform plan", func() error {
+		return opts.deps.tf.Plan(ctx, opts.OutputDir, planPath)
+	}); err != nil {
 		return result, fmt.Errorf("terraform plan final: %w", err)
 	}
-	planJSON, err := opts.deps.tf.ShowPlanJSON(ctx, opts.OutputDir, planPath)
-	if err != nil {
+	var planJSON []byte
+	if err := opts.runPhase("terraform show plan", func() error {
+		var showErr error
+		planJSON, showErr = opts.deps.tf.ShowPlanJSON(ctx, opts.OutputDir, planPath)
+		return showErr
+	}); err != nil {
 		return result, fmt.Errorf("terraform show final plan: %w", err)
 	}
 	opts.progressf("reverse-import: plan complete\n")


### PR DESCRIPTION
## Summary

Fixes the "frozen log" problem in reverse-import (`ri-*`) jobs. Two parts:

1. **Wiring fix (latent bug):** PR #698 plumbed an `Options.Stdout` progress sink through the whole engine but **never set it at either CLI entrypoint**, so all live phase progress and streamed terraform output defaulted to `io.Discard` — the job log was almost entirely silent during a run. Now `reverse.go` → `os.Stdout` and `discover.go` → `summaryOut` (so `--progress=json` keeps a pure JSON stdout stream and the human progress rides stderr).

2. **Heartbeat (the feature):** `terraform init` (provider download + GPG verify) and `driftfix` can run 2–5 min producing no output. Each long phase (genconfig, driftfix, dep-chase, terraform init/validate/plan/show) is now wrapped in `runPhase`, which emits a `… still running (Ns elapsed)…` liveness line every 15s. Fast phases finish before the first tick and stay silent (self-tuning). A `syncWriter` serializes the shared sink so the heartbeat, per-phase progress, and streamed terraform output never corrupt each other; the heartbeat goroutine is joined on every exit path including a panic.

Local proof — slow silent init produces forward motion:
```
reverse-import: terraform init…
reverse-import: terraform init still running (15s elapsed)…
reverse-import: terraform init still running (30s elapsed)…
reverse-import: terraform validate…
```

This is the source-side durable fix; reliable's client-side "Waiting for Terraform output" hint (luthersystems/reliable#1906) was the band-aid.

## Test plan
- [x] `go test -race ./pkg/reverseimport/... ./cmd/insideout-import/` (235 pass)
- [x] `go test -race ./...` (5081 pass, 36 packages)
- [x] `go vet ./...`, `gofmt -l` clean
- [x] New: heartbeat fires on slow phase / stays silent on fast phase / periodic / label-threaded / panic-reaps-goroutine / syncWriter atomicity / Run-level end-to-end init heartbeat
- [x] New: discover routes engine Stdout to stdout (human) vs stderr (`--progress=json`)
- [x] Commit 1 builds + tests pass standalone (clean bisect)

## Review notes
- Multi-agent adversarial review (concurrency/correctness/contract/conventions): all P0/P1/P2 resolved; the only P2 (json-mode routing coverage) got a dedicated test. P3s addressed (panic-safe defer, softened over-claiming comments).
- qa-professor: PASS; added panic-reaping, periodicity, and label-threading tests per its P2 recommendations.

Refs #702
Closes #702