### PR TITLE
feat(reverse-import): add genconfig driftfix progress

### DIFF
--- a/cmd/insideout-import/driftfix/driftfix.go
+++ b/cmd/insideout-import/driftfix/driftfix.go
@@ -79,6 +79,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	if opts.MaxIterations <= 0 {
 		opts.MaxIterations = defaultMaxIterations
 	}
+	progressf(opts.Stdout, "driftfix: starting drift convergence (max %d iteration(s))…\n", opts.MaxIterations)
 
 	abs, err := filepath.Abs(opts.Workdir)
 	if err != nil {
@@ -106,14 +107,17 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	alreadyEscalated := map[string]map[string]struct{}{}
 
 	for iter := 1; iter <= opts.MaxIterations; iter++ {
+		progressf(opts.Stdout, "driftfix: iteration %d: running terraform plan…\n", iter)
 		hasChanges, err := runner.PlanTo(ctx, planPath)
 		if err != nil {
 			return nil, fmt.Errorf("driftfix iter %d: terraform plan: %w", iter, err)
 		}
 		if !hasChanges {
+			progressf(opts.Stdout, "driftfix: converged after %d iteration(s)\n", iter)
 			return &Result{GeneratedPath: generatedPath, Iterations: iter}, nil
 		}
 
+		progressf(opts.Stdout, "driftfix: iteration %d: reading plan details…\n", iter)
 		plan, err := runner.ShowPlan(ctx, planPath)
 		if err != nil {
 			return nil, fmt.Errorf("driftfix iter %d: show plan: %w", iter, err)
@@ -128,6 +132,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		// out via the no-op check; if nothing actionable remains, the
 		// plan is functionally clean and the loop is done.
 		if len(classifications) == 0 {
+			progressf(opts.Stdout, "driftfix: iteration %d: plan has no actionable drift; converged\n", iter)
 			return &Result{GeneratedPath: generatedPath, Iterations: iter}, nil
 		}
 
@@ -147,6 +152,8 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 			if everyDriftAttrAlreadyEscalated(curDrift, alreadyEscalated) {
 				return nil, fmt.Errorf("driftfix iter %d: %w", iter, errStableUnresolved(curDrift))
 			}
+			progressf(opts.Stdout, "driftfix: iteration %d: escalating %d drift attribute(s) across %d resource(s) to ignore_changes…\n",
+				iter, driftAttrCount(curDrift), len(curDrift))
 			patched, err := applyIgnoreChangesEscalation(raw, classifications)
 			if err != nil {
 				return nil, fmt.Errorf("driftfix iter %d: ignore_changes escalation: %w", iter, err)
@@ -155,6 +162,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 				return nil, fmt.Errorf("driftfix iter %d: write generated.tf: %w", iter, err)
 			}
 			markEscalated(curDrift, alreadyEscalated)
+			progressf(opts.Stdout, "driftfix: iteration %d: validating ignore_changes patch…\n", iter)
 			if err := runner.Validate(ctx); err != nil {
 				return nil, fmt.Errorf("driftfix iter %d: validate after ignore_changes: %w", iter, err)
 			}
@@ -163,6 +171,8 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		}
 		prevDrift = curDrift
 
+		progressf(opts.Stdout, "driftfix: iteration %d: patching %d drift attribute(s) across %d resource(s)…\n",
+			iter, driftAttrCount(curDrift), len(curDrift))
 		patched, err := applyDriftPatches(raw, classifications)
 		if err != nil {
 			return nil, fmt.Errorf("driftfix iter %d: patch: %w", iter, err)
@@ -170,6 +180,7 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		if err := os.WriteFile(generatedPath, patched, 0o644); err != nil {
 			return nil, fmt.Errorf("driftfix iter %d: write generated.tf: %w", iter, err)
 		}
+		progressf(opts.Stdout, "driftfix: iteration %d: validating patch…\n", iter)
 		if err := runner.Validate(ctx); err != nil {
 			return nil, fmt.Errorf("driftfix iter %d: validate after patch: %w", iter, err)
 		}
@@ -208,6 +219,23 @@ func markEscalated(cur map[string][]string, dst map[string]map[string]struct{}) 
 			dst[addr][a] = struct{}{}
 		}
 	}
+}
+
+func driftAttrCount(drift map[string][]string) int {
+	var n int
+	for _, attrs := range drift {
+		n += len(attrs)
+	}
+	return n
+}
+
+// progressf writes a human-readable progress line to w when w is non-nil.
+// Best-effort: progress sink failures must never affect drift convergence.
+func progressf(w io.Writer, format string, args ...any) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, format, args...)
 }
 
 // classificationFatal returns the first fatal condition (delete or

--- a/cmd/insideout-import/driftfix/driftfix_test.go
+++ b/cmd/insideout-import/driftfix/driftfix_test.go
@@ -3,6 +3,7 @@ package driftfix
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -219,6 +220,92 @@ func TestRun_DriftThenCleanConverges(t *testing.T) {
 	}
 }
 
+func TestRun_StreamsIterationProgressToStdout(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{
+		updatePlan("aws_sqs_queue.x",
+			map[string]any{"name": "alpha", "delay_seconds": float64(30)},
+			map[string]any{"name": "alpha", "delay_seconds": float64(0)}),
+		emptyPlan(),
+	}}
+	var progress strings.Builder
+
+	_, err := Run(context.Background(), Options{
+		Workdir: dir,
+		Runner:  runner,
+		Stdout:  &progress,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := progress.String()
+	assertContainsInOrder(t, got, []string{
+		"driftfix: starting drift convergence",
+		"driftfix: iteration 1: running terraform plan",
+		"driftfix: iteration 1: reading plan details",
+		"driftfix: iteration 1: patching 1 drift attribute(s) across 1 resource(s)",
+		"driftfix: iteration 1: validating patch",
+		"driftfix: iteration 2: running terraform plan",
+		"driftfix: converged after 2 iteration(s)",
+	})
+}
+
+func TestRun_NilStdoutDoesNotWriteProgressToProcessStdout(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir)
+	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{emptyPlan()}}
+
+	stdout := captureStdout(t, func() {
+		_, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("nil Stdout wrote to process stdout; got:\n%s", stdout)
+	}
+}
+
+func assertContainsInOrder(t *testing.T, got string, wants []string) {
+	t.Helper()
+	pos := 0
+	for _, want := range wants {
+		idx := strings.Index(got[pos:], want)
+		if idx < 0 {
+			t.Fatalf("progress stream missing %q after byte %d; got:\n%s", want, pos, got)
+		}
+		pos += idx + len(want)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
 // hclResourceHasAttr parses raw HCL and reports whether the named
 // resource address has the named top-level attribute. Robust to
 // formatter whitespace and comments.
@@ -258,7 +345,8 @@ func TestRun_RecurringDriftEscalatesToIgnoreChanges(t *testing.T) {
 	// iter1=drift → drop; iter2=same drift → escalate to ignore_changes;
 	// iter3=empty → converge.
 	runner := &scriptedRunner{plansByCall: []*tfjson.Plan{driftP, driftP, emptyPlan()}}
-	res, err := Run(context.Background(), Options{Workdir: dir, Runner: runner})
+	var progress strings.Builder
+	res, err := Run(context.Background(), Options{Workdir: dir, Runner: runner, Stdout: &progress})
 	if err != nil {
 		t.Fatalf("expected escalation+convergence; got: %v", err)
 	}
@@ -283,6 +371,16 @@ func TestRun_RecurringDriftEscalatesToIgnoreChanges(t *testing.T) {
 	if !equalStringSlices(runner.calls, wantOrder) {
 		t.Errorf("call order = %v, want %v", runner.calls, wantOrder)
 	}
+	assertContainsInOrder(t, progress.String(), []string{
+		"driftfix: iteration 1: patching 1 drift attribute(s) across 1 resource(s)",
+		"driftfix: iteration 1: validating patch",
+		"driftfix: iteration 2: running terraform plan",
+		"driftfix: iteration 2: reading plan details",
+		"driftfix: iteration 2: escalating 1 drift attribute(s) across 1 resource(s) to ignore_changes",
+		"driftfix: iteration 2: validating ignore_changes patch",
+		"driftfix: iteration 3: running terraform plan",
+		"driftfix: converged after 3 iteration(s)",
+	})
 }
 
 // TestRun_DriftStableAfterEscalationFatal pins the truly-stuck case:

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -132,6 +132,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	if len(resources) == 0 {
 		return nil, fmt.Errorf("genconfig: no resources to generate; nothing to do")
 	}
+	progressf(opts.Stdout, "genconfig: preparing %d %s resource(s)…\n", len(resources), provider)
 
 	// terraform-exec runs the binary inside Workdir, so a relative
 	// generated-config-out path is resolved relative to Workdir — passing
@@ -204,9 +205,11 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 	if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir workdir: %w", err)
 	}
+	progressf(opts.Stdout, "genconfig: split into %d regional pass(es)…\n", len(groups))
 	merged := make([]imported.ImportedResource, 0)
 	subdirs := make([]string, 0, len(groups))
 	for _, g := range groups {
+		progressf(opts.Stdout, "genconfig: region %s: generating config for %d resource(s)…\n", g.region, len(g.resources))
 		sub := opts
 		sub.Region = g.region
 		sub.Workdir = filepath.Join(opts.Workdir, "region-"+regionAlias(g.region))
@@ -257,6 +260,8 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 		return nil, fmt.Errorf("mkdir workdir: %w", err)
 	}
 
+	scope := progressScope(opts)
+	progressf(opts.Stdout, "genconfig: %s: writing terraform import/provider files for %d resource(s)…\n", scope, len(resources))
 	if err := emitImports(opts.Workdir, resources); err != nil {
 		return nil, fmt.Errorf("emit imports.tf: %w", err)
 	}
@@ -282,11 +287,13 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 		runner = r
 	}
 
+	progressf(opts.Stdout, "genconfig: %s: terraform init…\n", scope)
 	if err := runner.Init(ctx); err != nil {
 		return nil, fmt.Errorf("terraform init: %w", err)
 	}
 
 	generatedPath := filepath.Join(opts.Workdir, generatedFile)
+	progressf(opts.Stdout, "genconfig: %s: terraform plan -generate-config-out…\n", scope)
 	if _, err := runner.PlanGenerate(ctx, generatedPath); err != nil {
 		// `terraform plan -generate-config-out` writes generated.tf and
 		// then immediately validates the result. For resource types like
@@ -299,18 +306,22 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 		if _, statErr := os.Stat(generatedPath); os.IsNotExist(statErr) {
 			return nil, fmt.Errorf("terraform plan -generate-config-out: %w", err)
 		}
+		progressf(opts.Stdout, "genconfig: %s: generate-config-out wrote partial config after an error; continuing cleanup…\n", scope)
 	}
 
+	progressf(opts.Stdout, "genconfig: %s: loading provider schema…\n", scope)
 	schemas, err := runner.ProvidersSchema(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("terraform providers schema: %w", err)
 	}
 
+	progressf(opts.Stdout, "genconfig: %s: reading generated terraform config…\n", scope)
 	raw, err := os.ReadFile(generatedPath)
 	if err != nil {
 		return nil, fmt.Errorf("read generated.tf: %w", err)
 	}
 
+	progressf(opts.Stdout, "genconfig: %s: cleaning generated terraform config…\n", scope)
 	cleaned, err := cleanGenerated(raw, schemas, provider)
 	if err != nil {
 		return nil, fmt.Errorf("schema cleanup: %w", err)
@@ -320,6 +331,7 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 	// — today, only injecting a placeholder source + ignore_changes for
 	// aws_lambda_function so it survives `terraform validate` without
 	// real code on disk. See fixups.go.
+	progressf(opts.Stdout, "genconfig: %s: applying resource type fixups…\n", scope)
 	cleaned, err = applyResourceTypeFixups(cleaned)
 	if err != nil {
 		return nil, fmt.Errorf("resource-type fixups: %w", err)
@@ -339,6 +351,7 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 	// resource remains in the cross-ref index, a surviving resource can
 	// be rewritten to reference a block that was just pruned from
 	// imports.tf and never existed in generated.tf.
+	progressf(opts.Stdout, "genconfig: %s: pruning orphan imports…\n", scope)
 	skipped, err := pruneOrphanImports(opts.Workdir, cleaned)
 	if err != nil {
 		return nil, fmt.Errorf("orphan-import safety net: %w", err)
@@ -354,9 +367,11 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 			fmt.Fprintf(os.Stderr, "genconfig: WARN: dropped orphan import %s (id=%q, reason=%s) — terraform plan -generate-config-out produced no resource body\n",
 				s.Address, s.ImportID, s.Reason)
 		}
+		progressf(opts.Stdout, "genconfig: %s: pruned %d orphan import(s)…\n", scope, len(skipped))
 		resources = filterSkippedResources(resources, skipped)
 	}
 
+	progressf(opts.Stdout, "genconfig: %s: rewriting in-batch references…\n", scope)
 	cleaned, err = applyCrossRefs(cleaned, resources, provider)
 	if err != nil {
 		return nil, fmt.Errorf("cross-ref: %w", err)
@@ -366,15 +381,38 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 		return nil, fmt.Errorf("rewrite generated.tf: %w", err)
 	}
 
+	progressf(opts.Stdout, "genconfig: %s: validating generated terraform config…\n", scope)
 	if err := runner.Validate(ctx); err != nil {
 		return nil, fmt.Errorf("terraform validate: %w", err)
 	}
 
+	progressf(opts.Stdout, "genconfig: %s: extracting generated attributes…\n", scope)
 	out, err := extractAttributes(cleaned, resources)
 	if err != nil {
 		return nil, fmt.Errorf("extract attributes: %w", err)
 	}
+	progressf(opts.Stdout, "genconfig: %s: complete (%d resource(s) retained)\n", scope, len(out))
 	return &Result{GeneratedPath: generatedPath, Resources: out}, nil
+}
+
+func progressScope(opts Options) string {
+	switch providerOrDefault(opts.Provider) {
+	case ProviderAWS:
+		return "region " + opts.Region
+	case ProviderGCP:
+		return "project " + opts.GCPProjectID
+	default:
+		return "provider " + providerOrDefault(opts.Provider)
+	}
+}
+
+// progressf writes a human-readable progress line to w when w is non-nil.
+// Best-effort: progress sink failures must never affect config generation.
+func progressf(w io.Writer, format string, args ...any) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintf(w, format, args...)
 }
 
 func filterSkippedResources(resources []imported.ImportedResource, skipped []OrphanImport) []imported.ImportedResource {

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -3,6 +3,7 @@ package genconfig
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -175,6 +176,112 @@ func TestRun_HappyPath(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, providersFile)); err != nil {
 		t.Errorf("providers.tf missing: %v", err)
 	}
+}
+
+func TestRun_StreamsMilestoneProgressToStdout(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	runner := &fakeRunner{
+		planBody: `resource "aws_sqs_queue" "x" {
+  name = "alpha"
+}
+`,
+		schemas: minimalAWSSchema(),
+	}
+	var progress strings.Builder
+
+	_, err := Run(context.Background(), Options{
+		Workdir: dir,
+		Region:  "us-east-1",
+		Runner:  runner,
+		Stdout:  &progress,
+	}, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.x", ImportID: "id-x"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := progress.String()
+	assertContainsInOrder(t, got, []string{
+		"genconfig: preparing 1 aws resource",
+		"genconfig: region us-east-1: writing terraform import/provider files",
+		"genconfig: region us-east-1: terraform init",
+		"genconfig: region us-east-1: terraform plan -generate-config-out",
+		"genconfig: region us-east-1: loading provider schema",
+		"genconfig: region us-east-1: reading generated terraform config",
+		"genconfig: region us-east-1: cleaning generated terraform config",
+		"genconfig: region us-east-1: applying resource type fixups",
+		"genconfig: region us-east-1: pruning orphan imports",
+		"genconfig: region us-east-1: rewriting in-batch references",
+		"genconfig: region us-east-1: validating generated terraform config",
+		"genconfig: region us-east-1: extracting generated attributes",
+		"genconfig: region us-east-1: complete (1 resource(s) retained)",
+	})
+}
+
+func TestRun_NilStdoutDoesNotWriteProgressToProcessStdout(t *testing.T) {
+	dir := t.TempDir()
+	runner := &fakeRunner{
+		planBody: `resource "aws_sqs_queue" "x" {
+  name = "alpha"
+}
+`,
+		schemas: minimalAWSSchema(),
+	}
+
+	stdout := captureStdout(t, func() {
+		_, err := Run(context.Background(), Options{
+			Workdir: dir,
+			Region:  "us-east-1",
+			Runner:  runner,
+		}, []imported.ImportedResource{
+			{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.x", ImportID: "id-x"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	if stdout != "" {
+		t.Fatalf("nil Stdout wrote to process stdout; got:\n%s", stdout)
+	}
+}
+
+func assertContainsInOrder(t *testing.T, got string, wants []string) {
+	t.Helper()
+	pos := 0
+	for _, want := range wants {
+		idx := strings.Index(got[pos:], want)
+		if idx < 0 {
+			t.Fatalf("progress stream missing %q after byte %d; got:\n%s", want, pos, got)
+		}
+		pos += idx + len(want)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
 }
 
 func equalStrings(a, b []string) bool {


### PR DESCRIPTION
## Summary

- Add milestone progress lines inside genconfig for import/provider file emit, terraform init, generate-config-out, schema load/cleanup, orphan pruning, cross-ref rewrite, validation, and attribute extraction.
- Add driftfix per-iteration progress for plan, show, patch/escalation, validation, and convergence.
- Cover both progress streams with focused regression tests while keeping nil Stdout behavior best-effort and silent.

## Test plan

- [x] go test ./cmd/insideout-import/genconfig ./cmd/insideout-import/driftfix
- [x] go test ./pkg/reverseimport/... ./cmd/insideout-import/...
- [x] git diff --check

Security review: low risk. No auth, credentials, command construction, or trust-boundary changes; this only writes static progress messages to the existing caller-supplied writer.

Closes #704
Refs luthersystems/reliable#1928