### PR TITLE
Backfill reverse-import attrs from final Terraform plan

### DIFF
--- a/pkg/reverseimport/plan_attrs.go
+++ b/pkg/reverseimport/plan_attrs.go
@@ -1,0 +1,294 @@
+package reverseimport
+
+import (
+	"encoding/json"
+	"fmt"
+
+	tfjson "github.com/hashicorp/terraform-json"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+type plannedResourceAttrs struct {
+	tfType    string
+	values    map[string]any
+	sensitive any
+}
+
+// BackfillImportedAttrsFromPlan fills missing desired-state fields on imported
+// resources from Terraform's final plan. The genconfig HCL path remains the
+// source of truth for fields it captured; this pass only fills gaps with
+// provider-read values that Terraform already proved in the plan.
+func BackfillImportedAttrsFromPlan(resources []imported.ImportedResource, plan *tfjson.Plan) ([]imported.ImportedResource, bool, error) {
+	if len(resources) == 0 || plan == nil {
+		return resources, false, nil
+	}
+	planned := plannedAttrsByAddress(plan)
+	if len(planned) == 0 {
+		return resources, false, nil
+	}
+
+	out := make([]imported.ImportedResource, len(resources))
+	copy(out, resources)
+	changed := false
+	for i := range out {
+		addr := out[i].Identity.Address
+		if addr == "" {
+			continue
+		}
+		pa, ok := planned[addr]
+		if !ok || len(pa.values) == 0 {
+			continue
+		}
+		tfType := out[i].Identity.Type
+		if tfType == "" {
+			tfType = pa.tfType
+		}
+		filtered := configurablePlanValues(tfType, pa.values, pa.sensitive)
+		if len(filtered) == 0 {
+			continue
+		}
+		resourceChanged, err := backfillResourceAttrs(&out[i], tfType, filtered)
+		if err != nil {
+			return resources, false, err
+		}
+		changed = changed || resourceChanged
+	}
+	return out, changed, nil
+}
+
+func plannedAttrsByAddress(plan *tfjson.Plan) map[string]plannedResourceAttrs {
+	out := map[string]plannedResourceAttrs{}
+	if plan.PlannedValues != nil {
+		collectStateModuleAttrs(plan.PlannedValues.RootModule, out)
+	}
+	for _, rc := range plan.ResourceChanges {
+		if rc == nil || rc.Mode != tfjson.ManagedResourceMode || rc.Address == "" || rc.Change == nil {
+			continue
+		}
+		current := out[rc.Address]
+		if len(current.values) == 0 {
+			if values, ok := rc.Change.After.(map[string]any); ok {
+				current.values = values
+			}
+		}
+		if current.sensitive == nil {
+			current.sensitive = rc.Change.AfterSensitive
+		}
+		if current.tfType == "" {
+			current.tfType = rc.Type
+		}
+		if len(current.values) > 0 {
+			out[rc.Address] = current
+		}
+	}
+	return out
+}
+
+func collectStateModuleAttrs(mod *tfjson.StateModule, out map[string]plannedResourceAttrs) {
+	if mod == nil {
+		return
+	}
+	for _, res := range mod.Resources {
+		if res == nil || res.Mode != tfjson.ManagedResourceMode || res.Address == "" || len(res.AttributeValues) == 0 {
+			continue
+		}
+		out[res.Address] = plannedResourceAttrs{
+			tfType:    res.Type,
+			values:    res.AttributeValues,
+			sensitive: decodeSensitiveValues(res.SensitiveValues),
+		}
+	}
+	for _, child := range mod.ChildModules {
+		collectStateModuleAttrs(child, out)
+	}
+}
+
+func decodeSensitiveValues(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+func configurablePlanValues(tfType string, values map[string]any, sensitive any) map[string]any {
+	_, schema, ok := generated.Lookup(tfType)
+	if !ok {
+		return nil
+	}
+	out := map[string]any{}
+	for key, value := range values {
+		field, ok := schema[key]
+		if !ok || !field.Configurable() || field.Sensitive {
+			continue
+		}
+		if !field.Required && !isCompoundPlanValue(value) {
+			continue
+		}
+		pruned, keep := pruneSensitiveValue(value, childSensitive(sensitive, key))
+		if !keep {
+			continue
+		}
+		out[key] = pruned
+	}
+	return out
+}
+
+func backfillResourceAttrs(resource *imported.ImportedResource, tfType string, values map[string]any) (bool, error) {
+	typed, err := decodeAttrsObject(resource.Attrs)
+	if err != nil {
+		return false, fmt.Errorf("resource %q: decode typed attrs: %w", resource.Identity.Address, err)
+	}
+	legacy := resource.Attributes
+	if legacy == nil {
+		legacy = map[string]any{}
+	}
+	changed := false
+	for key, value := range values {
+		if _, ok := typed[key]; !ok {
+			rawValue, err := json.Marshal(wrapPlanAttrValue(value))
+			if err != nil {
+				return false, fmt.Errorf("resource %q: marshal plan value %q: %w", resource.Identity.Address, key, err)
+			}
+			candidate := cloneRawObject(typed)
+			candidate[key] = rawValue
+			candidateRaw, err := json.Marshal(candidate)
+			if err != nil {
+				return false, fmt.Errorf("resource %q: marshal typed attrs candidate: %w", resource.Identity.Address, err)
+			}
+			if _, err := generated.UnmarshalAttrs(tfType, candidateRaw); err != nil {
+				continue
+			}
+			typed = candidate
+			changed = true
+			if _, legacyHasKey := legacy[key]; !legacyHasKey {
+				legacy[key] = value
+			}
+			continue
+		}
+	}
+	if !changed {
+		return false, nil
+	}
+	raw, err := json.Marshal(typed)
+	if err != nil {
+		return false, fmt.Errorf("resource %q: marshal typed attrs: %w", resource.Identity.Address, err)
+	}
+	if _, err := generated.UnmarshalAttrs(tfType, raw); err != nil {
+		return false, fmt.Errorf("resource %q: validate typed attrs: %w", resource.Identity.Address, err)
+	}
+	resource.Attrs = raw
+	if len(legacy) > 0 {
+		resource.Attributes = legacy
+	}
+	return true, nil
+}
+
+func decodeAttrsObject(raw json.RawMessage) (map[string]json.RawMessage, error) {
+	if len(raw) == 0 {
+		return map[string]json.RawMessage{}, nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, err
+	}
+	if obj == nil {
+		return map[string]json.RawMessage{}, nil
+	}
+	return obj, nil
+}
+
+func cloneRawObject(in map[string]json.RawMessage) map[string]json.RawMessage {
+	out := make(map[string]json.RawMessage, len(in)+1)
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func wrapPlanAttrValue(value any) any {
+	switch v := value.(type) {
+	case nil:
+		return map[string]any{"null": true}
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		for key, child := range v {
+			out[key] = wrapPlanAttrValue(child)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(v))
+		for _, child := range v {
+			out = append(out, wrapPlanAttrValue(child))
+		}
+		return out
+	default:
+		return map[string]any{"literal": v}
+	}
+}
+
+func isCompoundPlanValue(value any) bool {
+	switch value.(type) {
+	case map[string]any, []any:
+		return true
+	default:
+		return false
+	}
+}
+
+func childSensitive(sensitive any, key string) any {
+	if m, ok := sensitive.(map[string]any); ok {
+		return m[key]
+	}
+	return nil
+}
+
+func pruneSensitiveValue(value any, sensitive any) (any, bool) {
+	if isSensitiveLeaf(sensitive) || value == nil {
+		return nil, false
+	}
+	switch v := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(v))
+		sensitiveMap, _ := sensitive.(map[string]any)
+		for key, child := range v {
+			pruned, keep := pruneSensitiveValue(child, sensitiveMap[key])
+			if keep {
+				out[key] = pruned
+			}
+		}
+		if len(v) > 0 && len(out) == 0 {
+			return nil, false
+		}
+		return out, true
+	case []any:
+		out := make([]any, 0, len(v))
+		sensitiveList, _ := sensitive.([]any)
+		for i, child := range v {
+			var childSensitive any
+			if i < len(sensitiveList) {
+				childSensitive = sensitiveList[i]
+			}
+			pruned, keep := pruneSensitiveValue(child, childSensitive)
+			if keep {
+				out = append(out, pruned)
+			}
+		}
+		if len(v) > 0 && len(out) == 0 {
+			return nil, false
+		}
+		return out, true
+	default:
+		return v, true
+	}
+}
+
+func isSensitiveLeaf(value any) bool {
+	sensitive, ok := value.(bool)
+	return ok && sensitive
+}

--- a/pkg/reverseimport/plan_attrs_test.go
+++ b/pkg/reverseimport/plan_attrs_test.go
@@ -1,0 +1,130 @@
+package reverseimport
+
+import (
+	"encoding/json"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+func TestBackfillImportedAttrsFromPlanFillsMissingTypedBlocks(t *testing.T) {
+	resources := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.state",
+			ImportID: "luther-state",
+			Region:   "us-east-1",
+		},
+		Tier:       imported.TierImportedFlat,
+		Source:     imported.SourceImporter,
+		Attributes: map[string]any{"bucket": "luther-state", "tags": map[string]any{"Project": "core"}},
+		Attrs:      json.RawMessage(`{"bucket":{"literal":"luther-state"},"tags":{"Project":{"literal":"core"}}}`),
+	}}
+	plan := &tfjson.Plan{
+		PlannedValues: &tfjson.StateValues{RootModule: &tfjson.StateModule{Resources: []*tfjson.StateResource{{
+			Address: "aws_s3_bucket.state",
+			Mode:    tfjson.ManagedResourceMode,
+			Type:    "aws_s3_bucket",
+			Name:    "state",
+			AttributeValues: map[string]any{
+				"arn":    "arn:aws:s3:::luther-state",
+				"bucket": "luther-state",
+				"tags": map[string]any{
+					"InsideOutImported": "true",
+					"Project":           "core",
+				},
+				"versioning": []any{map[string]any{
+					"enabled":    true,
+					"mfa_delete": false,
+				}},
+				"server_side_encryption_configuration": []any{map[string]any{
+					"rule": []any{map[string]any{
+						"bucket_key_enabled": false,
+						"apply_server_side_encryption_by_default": []any{map[string]any{
+							"kms_master_key_id": "arn:aws:kms:us-east-1:123:key/abc",
+							"sse_algorithm":     "aws:kms",
+						}},
+					}},
+				}},
+			},
+		}}}},
+	}
+
+	got, changed, err := BackfillImportedAttrsFromPlan(resources, plan)
+	if err != nil {
+		t.Fatalf("BackfillImportedAttrsFromPlan: %v", err)
+	}
+	if !changed {
+		t.Fatal("BackfillImportedAttrsFromPlan changed=false, want true")
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got)=%d, want 1", len(got))
+	}
+	if _, ok := got[0].Attributes["arn"]; ok {
+		t.Fatalf("computed-only arn must not be backfilled into legacy Attributes: %#v", got[0].Attributes)
+	}
+	tags, ok := got[0].Attributes["tags"].(map[string]any)
+	if !ok {
+		t.Fatalf("legacy tags = %#v, want map[string]any", got[0].Attributes["tags"])
+	}
+	if tags["InsideOutImported"] != nil {
+		t.Fatalf("existing tags must not be overwritten by plan/provenance tags: %#v", tags)
+	}
+	versioning, ok := got[0].Attributes["versioning"].([]any)
+	if !ok || len(versioning) != 1 {
+		t.Fatalf("legacy versioning = %#v, want one block", got[0].Attributes["versioning"])
+	}
+
+	decoded, err := generated.UnmarshalAttrs("aws_s3_bucket", got[0].Attrs)
+	if err != nil {
+		t.Fatalf("typed attrs did not decode: %v\n%s", err, got[0].Attrs)
+	}
+	bucket := decoded.(*generated.AWSS3Bucket)
+	if len(bucket.Versioning) != 1 || bucket.Versioning[0].Enabled == nil || bucket.Versioning[0].Enabled.Literal == nil || !*bucket.Versioning[0].Enabled.Literal {
+		t.Fatalf("typed versioning not backfilled: %#v", bucket.Versioning)
+	}
+	if len(bucket.ServerSideEncryptionConfiguration) != 1 {
+		t.Fatalf("typed server_side_encryption_configuration not backfilled: %#v", bucket.ServerSideEncryptionConfiguration)
+	}
+	if _, ok := bucket.Tags["InsideOutImported"]; ok {
+		t.Fatalf("typed tags must preserve the generated config value, got %#v", bucket.Tags)
+	}
+}
+
+func TestBackfillImportedAttrsFromPlanSkipsSensitivePlanValues(t *testing.T) {
+	resources := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.orders",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+			Region:   "us-east-1",
+		},
+		Attrs: json.RawMessage(`{"name":{"literal":"orders"}}`),
+	}}
+	plan := &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{{
+		Address: "aws_sqs_queue.orders",
+		Mode:    tfjson.ManagedResourceMode,
+		Type:    "aws_sqs_queue",
+		Name:    "orders",
+		Change: &tfjson.Change{
+			After:          map[string]any{"name": "orders", "kms_master_key_id": "secret-key"},
+			AfterSensitive: map[string]any{"kms_master_key_id": true},
+		},
+	}}}
+
+	got, changed, err := BackfillImportedAttrsFromPlan(resources, plan)
+	if err != nil {
+		t.Fatalf("BackfillImportedAttrsFromPlan: %v", err)
+	}
+	if changed {
+		t.Fatalf("sensitive-only plan value should not change resource: %#v", got[0].Attributes)
+	}
+	if string(got[0].Attrs) != `{"name":{"literal":"orders"}}` {
+		t.Fatalf("Attrs changed despite only sensitive missing fields: %s", got[0].Attrs)
+	}
+}

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -159,86 +159,49 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	result.Imported = resources
 	result.Resources = resourceResults(resources, dependenciesByAddress)
 
-	importedTF, providersUsed := composer.EmitImportedTF(cloud, resources, composer.EmitImportedOpts{
+	emitOpts := composer.EmitImportedOpts{
 		ImportProjectID: opts.ImportProjectID,
 		ImportSessionID: opts.ImportSessionID,
 		ImportedAt:      importedAtOrNow(opts.ImportedAt),
-	})
-	if len(importedTF) == 0 {
-		return result, fmt.Errorf("reverseimport: EmitImportedTF produced no HCL")
 	}
-	importedTFPath := filepath.Join(opts.OutputDir, importedTFFile)
-	if err := writeFileAtomic(importedTFPath, importedTF, 0o644); err != nil {
-		return result, fmt.Errorf("write imported.tf: %w", err)
-	}
-	providersTF, err := renderImportedProvidersTF(importedProviderRenderOptions{
-		Cloud:          cloud,
-		Region:         region,
-		GCPProjectID:   gcpProjectID,
-		AWSEndpointURL: opts.AWSEndpointURL,
-		ProvidersUsed:  providersUsed,
-		AWSAuth:        awsAuth,
-		// Same resource slice EmitImportedTF saw → the declared
-		// `aws.imported_<region>` alias blocks match the references it
-		// emitted. Single-region is a no-op (only `aws.imported`).
-		AWSRegions: composer.ImportedAWSRegions(resources),
-	})
-	if err != nil {
-		return result, err
-	}
-	providersTFPath := filepath.Join(opts.OutputDir, importedProvidersTF)
-	if err := writeFileAtomic(providersTFPath, providersTF, 0o644); err != nil {
-		return result, fmt.Errorf("write providers-imported.tf: %w", err)
-	}
-	if err := ensurePlaceholderFiles(opts.OutputDir, resources); err != nil {
+	if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
 		return result, err
 	}
 
 	planPath := filepath.Join(opts.OutputDir, tfplanFile)
 	validateJSONPath := filepath.Join(opts.OutputDir, validateJSONFile)
 	tfplanJSONPath := filepath.Join(opts.OutputDir, tfplanJSONFile)
-	opts.progressf("reverse-import: terraform init…\n")
-	if err := opts.runPhase("terraform init", func() error {
-		return opts.deps.tf.Init(ctx, opts.OutputDir)
-	}); err != nil {
-		return result, fmt.Errorf("terraform init final: %w", err)
-	}
-	opts.progressf("reverse-import: terraform validate…\n")
-	var validateJSON []byte
-	validateErr := opts.runPhase("terraform validate", func() error {
-		var verr error
-		validateJSON, verr = opts.deps.tf.Validate(ctx, opts.OutputDir)
-		return verr
-	})
-	if len(validateJSON) > 0 {
-		if writeErr := writeFileAtomic(validateJSONPath, validateJSON, 0o644); writeErr != nil {
-			return result, fmt.Errorf("write validate.json: %w", writeErr)
-		}
-	}
-	if validateErr != nil {
-		return result, fmt.Errorf("terraform validate final: %w", validateErr)
-	}
-	opts.progressf("reverse-import: terraform plan…\n")
-	if err := opts.runPhase("terraform plan", func() error {
-		return opts.deps.tf.Plan(ctx, opts.OutputDir, planPath)
-	}); err != nil {
-		return result, fmt.Errorf("terraform plan final: %w", err)
-	}
-	var planJSON []byte
-	if err := opts.runPhase("terraform show plan", func() error {
-		var showErr error
-		planJSON, showErr = opts.deps.tf.ShowPlanJSON(ctx, opts.OutputDir, planPath)
-		return showErr
-	}); err != nil {
-		return result, fmt.Errorf("terraform show final plan: %w", err)
-	}
-	opts.progressf("reverse-import: plan complete\n")
-	if err := writeFileAtomic(tfplanJSONPath, planJSON, 0o644); err != nil {
-		return result, fmt.Errorf("write tfplan.json: %w", err)
+	planJSON, err := runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
+	if err != nil {
+		return result, err
 	}
 	plan, err := job.DecodeTerraformPlan(bytes.NewReader(planJSON))
 	if err != nil {
 		return result, err
+	}
+	backfilled, changed, err := BackfillImportedAttrsFromPlan(resources, plan)
+	if err != nil {
+		return result, err
+	}
+	if changed {
+		opts.progressf("reverse-import: enriching imported attributes from final plan…\n")
+		resources = backfilled
+		if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
+			return result, err
+		}
+		result.Imported = resources
+		result.Resources = resourceResults(resources, dependenciesByAddress)
+		if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
+			return result, err
+		}
+		planJSON, err = runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
+		if err != nil {
+			return result, err
+		}
+		plan, err = job.DecodeTerraformPlan(bytes.NewReader(planJSON))
+		if err != nil {
+			return result, err
+		}
 	}
 	result.PlanSummary = job.PlanSummaryFromTerraformPlan(plan)
 	result.ValidationIssues = issuesFromComposer(composer.ValidateFirstImportPlan(plan, composer.ValidateFirstImportPlanOpts{
@@ -291,6 +254,83 @@ func writeResult(outputDir string, result *job.Result) error {
 		return err
 	}
 	return nil
+}
+
+func writeImportedTerraformArtifacts(outputDir, cloud, region, gcpProjectID, awsEndpointURL string, awsAuth awsProviderAuth, resources []imported.ImportedResource, emitOpts composer.EmitImportedOpts) error {
+	importedTF, providersUsed := composer.EmitImportedTF(cloud, resources, emitOpts)
+	if len(importedTF) == 0 {
+		return fmt.Errorf("reverseimport: EmitImportedTF produced no HCL")
+	}
+	importedTFPath := filepath.Join(outputDir, importedTFFile)
+	if err := writeFileAtomic(importedTFPath, importedTF, 0o644); err != nil {
+		return fmt.Errorf("write imported.tf: %w", err)
+	}
+	providersTF, err := renderImportedProvidersTF(importedProviderRenderOptions{
+		Cloud:          cloud,
+		Region:         region,
+		GCPProjectID:   gcpProjectID,
+		AWSEndpointURL: awsEndpointURL,
+		ProvidersUsed:  providersUsed,
+		AWSAuth:        awsAuth,
+		// Same resource slice EmitImportedTF saw → the declared
+		// `aws.imported_<region>` alias blocks match the references it
+		// emitted. Single-region is a no-op (only `aws.imported`).
+		AWSRegions: composer.ImportedAWSRegions(resources),
+	})
+	if err != nil {
+		return err
+	}
+	providersTFPath := filepath.Join(outputDir, importedProvidersTF)
+	if err := writeFileAtomic(providersTFPath, providersTF, 0o644); err != nil {
+		return fmt.Errorf("write providers-imported.tf: %w", err)
+	}
+	if err := ensurePlaceholderFiles(outputDir, resources); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runFinalPlanJSON(ctx context.Context, opts Options, planPath, validateJSONPath, tfplanJSONPath string) ([]byte, error) {
+	opts.progressf("reverse-import: terraform init…\n")
+	if err := opts.runPhase("terraform init", func() error {
+		return opts.deps.tf.Init(ctx, opts.OutputDir)
+	}); err != nil {
+		return nil, fmt.Errorf("terraform init final: %w", err)
+	}
+	opts.progressf("reverse-import: terraform validate…\n")
+	var validateJSON []byte
+	validateErr := opts.runPhase("terraform validate", func() error {
+		var verr error
+		validateJSON, verr = opts.deps.tf.Validate(ctx, opts.OutputDir)
+		return verr
+	})
+	if len(validateJSON) > 0 {
+		if writeErr := writeFileAtomic(validateJSONPath, validateJSON, 0o644); writeErr != nil {
+			return nil, fmt.Errorf("write validate.json: %w", writeErr)
+		}
+	}
+	if validateErr != nil {
+		return nil, fmt.Errorf("terraform validate final: %w", validateErr)
+	}
+	opts.progressf("reverse-import: terraform plan…\n")
+	if err := opts.runPhase("terraform plan", func() error {
+		return opts.deps.tf.Plan(ctx, opts.OutputDir, planPath)
+	}); err != nil {
+		return nil, fmt.Errorf("terraform plan final: %w", err)
+	}
+	var planJSON []byte
+	if err := opts.runPhase("terraform show plan", func() error {
+		var showErr error
+		planJSON, showErr = opts.deps.tf.ShowPlanJSON(ctx, opts.OutputDir, planPath)
+		return showErr
+	}); err != nil {
+		return nil, fmt.Errorf("terraform show final plan: %w", err)
+	}
+	opts.progressf("reverse-import: plan complete\n")
+	if err := writeFileAtomic(tfplanJSONPath, planJSON, 0o644); err != nil {
+		return nil, fmt.Errorf("write tfplan.json: %w", err)
+	}
+	return planJSON, nil
 }
 
 func populateArtifacts(result *job.Result, outputDir, generatedPath string, dcRes *depchase.Result) error {

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -3,6 +3,7 @@ package reverseimport
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -13,6 +14,7 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
 )
 
@@ -325,6 +327,71 @@ func TestRunExpandsSelectedParentClosure(t *testing.T) {
 	}
 }
 
+func TestRunBackfillsImportedAttrsFromFinalPlan(t *testing.T) {
+	dir := t.TempDir()
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.uploads",
+				ImportID: "io-uploads",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	result, err := Run(context.Background(), req, Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           s3VersioningPlanRunner{},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.PlanSummary.ImportCount != 1 {
+		t.Fatalf("ImportCount = %d, want 1", result.PlanSummary.ImportCount)
+	}
+	if len(result.Imported) != 1 {
+		t.Fatalf("Imported len = %d, want 1", len(result.Imported))
+	}
+	decoded, err := generated.UnmarshalAttrs("aws_s3_bucket", result.Imported[0].Attrs)
+	if err != nil {
+		t.Fatalf("result imported attrs did not decode: %v\n%s", err, result.Imported[0].Attrs)
+	}
+	bucket := decoded.(*generated.AWSS3Bucket)
+	if len(bucket.Versioning) != 1 || bucket.Versioning[0].Enabled == nil || bucket.Versioning[0].Enabled.Literal == nil || !*bucket.Versioning[0].Enabled.Literal {
+		t.Fatalf("result typed versioning not backfilled: %#v", bucket.Versioning)
+	}
+
+	var persisted []imported.ImportedResource
+	raw, err := os.ReadFile(filepath.Join(dir, "imported.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(raw, &persisted); err != nil {
+		t.Fatal(err)
+	}
+	if len(persisted) != 1 || len(persisted[0].Attrs) == 0 {
+		t.Fatalf("persisted imported resources missing attrs: %#v", persisted)
+	}
+	importedTF, err := os.ReadFile(filepath.Join(dir, "imported.tf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(importedTF), "versioning {") {
+		t.Fatalf("imported.tf missing plan-backed versioning block:\n%s", importedTF)
+	}
+}
+
 func fakeGenconfig(_ context.Context, opts genconfig.Options, resources []imported.ImportedResource) (*genconfig.Result, error) {
 	if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
 		return nil, err
@@ -403,6 +470,61 @@ func (r fakeTerraformRunner) ShowPlanJSON(context.Context, string, string) ([]by
   "terraform_version": "1.13.0",
   "resource_changes": [%s]
 }`, changes.String())), nil
+}
+
+type s3VersioningPlanRunner struct{}
+
+func (s3VersioningPlanRunner) Init(context.Context, string) error { return nil }
+
+func (s3VersioningPlanRunner) Validate(context.Context, string) ([]byte, error) {
+	return []byte(`{"valid":true,"diagnostics":[]}`), nil
+}
+
+func (s3VersioningPlanRunner) Plan(context.Context, string, string) error { return nil }
+
+func (s3VersioningPlanRunner) ShowPlanJSON(context.Context, string, string) ([]byte, error) {
+	return []byte(`{
+  "format_version": "1.2",
+  "terraform_version": "1.13.0",
+  "planned_values": {
+    "root_module": {
+      "resources": [{
+        "address": "aws_s3_bucket.uploads",
+        "mode": "managed",
+        "type": "aws_s3_bucket",
+        "name": "uploads",
+        "values": {
+          "bucket": "io-uploads",
+          "region": "us-east-1",
+          "versioning": [{
+            "enabled": true,
+            "mfa_delete": false
+          }]
+        }
+      }]
+    }
+  },
+  "resource_changes": [{
+    "address": "aws_s3_bucket.uploads",
+    "mode": "managed",
+    "type": "aws_s3_bucket",
+    "name": "uploads",
+    "change": {
+      "actions": ["no-op"],
+      "before": null,
+      "after": {
+        "bucket": "io-uploads",
+        "region": "us-east-1",
+        "versioning": [{
+          "enabled": true,
+          "mfa_delete": false
+        }]
+      },
+      "after_unknown": {},
+      "importing": {"id": "io-uploads"}
+    }
+  }]
+}`), nil
 }
 
 type fakeClosureDiscoverer struct {


### PR DESCRIPTION
Closes #706

## Summary
- add a generic final-plan backfill pass for imported resource typed attrs
- filter plan values through generated provider schema, skipping computed-only and sensitive fields
- preserve fields captured by generated config and re-emit imported.tf from the enriched snapshot

## Tests
- go test ./pkg/reverseimport -run 'TestRunBackfillsImportedAttrsFromFinalPlan|TestBackfillImportedAttrsFromPlan'
- go test ./pkg/reverseimport ./pkg/composer/imported/generated
- go test ./pkg/reverseimport ./pkg/composer ./pkg/composer/imported/generated