### PR TITLE
feat(discover): gate AWS-managed / non-importable instances as unsupported (#709)

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -3543,3 +3543,47 @@ func TestVPCSecurityGroupEgressRuleConfig(t *testing.T) {
 		t.Errorf("Tags: got %+v, want empty map (untaggable)", tags)
 	}
 }
+
+// TestNetworkInterfaceConfig pins the aws_network_interface NativeIDs
+// extractor added in #709: it must surface interface_type into
+// NativeIDs["interface_type"] when CloudControl returns it (so the
+// instance-level importability classifier can grey out service-managed ENIs in
+// the wizard) and must be absent-safe — omitting the key entirely when the
+// payload has no InterfaceType, so a standard ENI is left importable and the
+// genconfig prune remains the backstop.
+func TestNetworkInterfaceConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_network_interface")
+	if cfg.CloudFormationType != "AWS::EC2::NetworkInterface" {
+		t.Errorf("CloudFormationType=%q, want AWS::EC2::NetworkInterface", cfg.CloudFormationType)
+	}
+	if cfg.NativeIDsFromProperties == nil {
+		t.Fatal("aws_network_interface must declare NativeIDsFromProperties to surface interface_type (#709)")
+	}
+
+	// Service-managed ENI: InterfaceType present → surfaced.
+	managed := cfg.NativeIDsFromProperties("eni-1", map[string]any{"InterfaceType": "nat_gateway"})
+	want := map[string]string{"id": "eni-1", "interface_type": "nat_gateway"}
+	if !reflect.DeepEqual(managed, want) {
+		t.Errorf("managed ENI NativeIDs: got %+v, want %+v", managed, want)
+	}
+
+	// Standard ENI: InterfaceType absent → key omitted (absent-safe).
+	plain := cfg.NativeIDsFromProperties("eni-2", map[string]any{})
+	if _, ok := plain["interface_type"]; ok {
+		t.Errorf("absent InterfaceType must omit the key, got %+v", plain)
+	}
+	if plain["id"] != "eni-2" {
+		t.Errorf("id: got %q, want eni-2", plain["id"])
+	}
+
+	// Importable-but-present InterfaceType ("interface") is surfaced verbatim,
+	// not filtered — the extractor surfaces whatever CloudControl returns and
+	// the classifier (imported.UnimportableReason) owns the importable/managed
+	// decision. A regression that filtered to only managed types here would
+	// wrongly split that responsibility across two layers.
+	std := cfg.NativeIDsFromProperties("eni-3", map[string]any{"InterfaceType": "interface"})
+	if std["interface_type"] != "interface" {
+		t.Errorf("importable InterfaceType must pass through verbatim, got %+v", std)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -577,6 +577,20 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		ImportIDFromIdentifier: passthroughImportID,
 		NameHintFromProperties: passthroughIdentifierName,
 		TagsFromProperties:     tagsFromKey("Tags"),
+		// Surface interface_type so the instance-level importability
+		// classifier (imported.UnimportableReason, #709) can grey out
+		// service/parent-managed ENIs (nat_gateway, vpc_endpoint, …) in the
+		// wizard instead of offering them as importable. Absent-safe: when the
+		// CloudControl payload omits InterfaceType the key is simply not set
+		// and the ENI is treated as importable, with the genconfig prune (#708)
+		// as the backstop.
+		NativeIDsFromProperties: func(identifier string, props map[string]any) map[string]string {
+			out := map[string]string{"id": identifier}
+			if it := extractString(props, "InterfaceType"); it != "" {
+				out["interface_type"] = it
+			}
+			return out
+		},
 	},
 
 	// =====================================================================

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -911,6 +911,22 @@ Exit codes:
 		}
 	}
 
+	// #709: route instance-level un-importables (AWS-managed alias/aws/* KMS
+	// aliases, service/parent-managed ENIs) out of imported.json before it is
+	// written. They are supported *types* but un-importable *instances*; left
+	// in a selection they fail `terraform plan -generate-config-out` for the
+	// whole import (#708). The dropped rows are merged into unsupported.json
+	// below (when --include-unsupported) so the wizard can grey them out with a
+	// reason; either way they are excluded from imported.json and reported.
+	resources, unimportableRows := partitionUnimportable(resources)
+	if len(unimportableRows) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"discover: excluded %d un-importable resource(s) from imported.json "+
+				"(supported type, un-importable instance — e.g. AWS-managed alias/aws/* "+
+				"KMS aliases, service-managed ENIs): %s\n",
+			len(unimportableRows), unimportableReasonsSummary(unimportableRows))
+	}
+
 	out, n, err := writeManifest(*outputDir, cloud, resources)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "discover: %v\n", err)
@@ -988,6 +1004,12 @@ Exit codes:
 					"discover: WARN: --include-unsupported: cap fired (max_results=%d); unsupported.json contains the first %d resources sorted by (Type, Region, ID); truncated=true marker set.\n",
 					*maxUnsupportedResults, len(unsupported))
 			}
+			// Merge the instance-level un-importables partitioned out of
+			// imported.json above (#709) with the type-level enumerator
+			// output so the wizard renders both, each greyed-out with its
+			// reason. writeUnsupportedManifest re-sorts by (Type, Region, ID),
+			// so merge order does not affect the on-disk shape.
+			unsupported = append(unsupported, unimportableRows...)
 			uout, un, werr := writeUnsupportedManifest(*outputDir, unsupported, truncated, *maxUnsupportedResults)
 			if werr != nil {
 				fmt.Fprintf(os.Stderr, "discover: WARN: --include-unsupported: write manifest: %v; imported.json was written; continuing without unsupported.json\n", werr)

--- a/cmd/insideout-import/genconfig/unimportable.go
+++ b/cmd/insideout-import/genconfig/unimportable.go
@@ -5,72 +5,41 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
-// Reason codes for the imports-skipped.json sibling. The orphan-import
-// safety net (#362) was the first producer ("no_generated_config"); the
-// un-importable prune (#708) adds the two below for resources that DO get a
-// generated body but can never be adopted into customer Terraform state.
+// Reason codes for the imports-skipped.json sibling. The orphan-import safety
+// net (#362) was the first producer ("no_generated_config"); the un-importable
+// prune (#708) adds the two below for resources that DO get a generated body
+// but can never be adopted into customer Terraform state. The codes + the
+// per-type predicates live in pkg/composer/imported (#709) so discovery, this
+// genconfig prune, and reliable's wizard all classify identically; these
+// package-local aliases keep the genconfig call sites and tests terse.
 const (
-	// reasonAWSManagedKMSAlias marks an aws_kms_alias whose name carries
-	// the reserved `alias/aws/` prefix — an AWS-managed default alias
-	// (alias/aws/rds, alias/aws/ebs, …). The provider rejects creating or
-	// importing any alias with that prefix, so it can never be adopted.
-	reasonAWSManagedKMSAlias = "aws_managed_kms_alias"
-
-	// reasonServiceManagedENI marks an aws_network_interface whose
-	// interface_type is owned by an AWS service (nat_gateway, vpc_endpoint,
-	// …) rather than a customer. These ENIs are managed by their parent
-	// resource (the NAT gateway, the VPC endpoint, …) and cannot be adopted
-	// as a standalone aws_network_interface.
-	reasonServiceManagedENI = "service_managed_eni"
+	reasonAWSManagedKMSAlias = imported.ReasonAWSManagedKMSAlias
+	reasonServiceManagedENI  = imported.ReasonServiceManagedENI
 )
-
-// importableENIInterfaceTypes is the set of interface_type values that an
-// aws_network_interface can legitimately carry for a customer-managed,
-// importable ENI. The empty string means the attribute is absent (the
-// standard case once fixupNetworkInterfaceProviderQuirks drops the
-// non-settable literal "interface"). efa/efa-only/branch/trunk are the only
-// values the provider's interface_type argument actually accepts on create.
-// Every OTHER describe-only value (nat_gateway, vpc_endpoint,
-// network_load_balancer, lambda, …) signals a service-managed ENI that is
-// owned by its parent resource and is not standalone-importable.
-var importableENIInterfaceTypes = map[string]struct{}{
-	"":          {},
-	"interface": {}, // standard ENI; fixup normally drops the literal first
-	"efa":       {},
-	"efa-only":  {},
-	"branch":    {},
-	"trunk":     {},
-}
-
-// isServiceManagedENIInterfaceType reports whether an interface_type value
-// denotes an AWS-service-managed ENI (and therefore an un-importable one).
-// Forward-compatible: any interface_type AWS introduces for a managed ENI
-// family is treated as service-managed without a code change here.
-func isServiceManagedENIInterfaceType(v string) bool {
-	_, importable := importableENIInterfaceTypes[v]
-	return !importable
-}
 
 // unimportableReason classifies a generated resource block as inherently
 // un-importable, returning the reason code (one of the reason* consts) or ""
 // when the block is importable. It inspects only the post-cleanup HCL body,
-// never live schema — the same constraint the resource-type fixups obey.
+// never live schema — the same constraint the resource-type fixups obey — and
+// delegates the actual rules to the shared pkg/composer/imported predicates so
+// the genconfig prune and discovery-time gating never drift.
 func unimportableReason(tfType string, body *hclwrite.Body) string {
 	switch tfType {
 	case "aws_kms_alias":
-		if name := stringLitFromAttr(body.GetAttribute("name")); strings.HasPrefix(name, "alias/aws/") {
+		if imported.IsAWSManagedKMSAliasName(stringLitFromAttr(body.GetAttribute("name"))) {
 			return reasonAWSManagedKMSAlias
 		}
 	case "aws_network_interface":
-		// isServiceManagedENIInterfaceType already returns false for "" (the
-		// absent / standard case), so no separate empty check is needed.
-		if it := stringLitFromAttr(body.GetAttribute("interface_type")); isServiceManagedENIInterfaceType(it) {
+		// IsServiceManagedENIInterfaceType returns false for "" (the absent /
+		// standard case), so no separate empty check is needed.
+		if imported.IsServiceManagedENIInterfaceType(stringLitFromAttr(body.GetAttribute("interface_type"))) {
 			return reasonServiceManagedENI
 		}
 	}

--- a/cmd/insideout-import/imported_unsupported.go
+++ b/cmd/insideout-import/imported_unsupported.go
@@ -72,6 +72,18 @@ type UnsupportedResource struct {
 	// gcpdiscover/unsupported.go). The picker falls back to "Other" when
 	// Category returns the empty string for an unknown type.
 	Group string `json:"group,omitempty"`
+
+	// Reason is the machine-readable code explaining why this row is
+	// unsupported, present only for instance-level un-importables that the
+	// discovery partition routed here — a *supported type* whose specific
+	// instance can't be adopted into Terraform state (#709). One of the
+	// imported.Reason* codes (e.g. "aws_managed_kms_alias",
+	// "service_managed_eni"). Empty for type-level unsupported rows (a type
+	// with no discoverer at all), where the absence of a Terraform mapping is
+	// itself the reason and the picker shows its generic "coming soon"
+	// tooltip. reliable (reliable#1967) maps this code to the greyed-out row's
+	// explanation via imported.ReasonDescription.
+	Reason string `json:"reason,omitempty"`
 }
 
 // UnsupportedManifest is the on-disk wrapper-object shape of

--- a/cmd/insideout-import/unsupported_partition.go
+++ b/cmd/insideout-import/unsupported_partition.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// partitionUnimportable splits a freshly-discovered resource slice into the
+// importable rows (which stay in imported.json) and the instance-level
+// un-importable rows — a *supported type* whose specific instance can never be
+// adopted into customer Terraform state (AWS-managed alias/aws/* KMS aliases,
+// service/parent-managed ENIs). The dropped rows are returned as
+// UnsupportedResource carriers (with a reason code) so the caller can route
+// them into unsupported.json alongside the type-level enumerator output (#709).
+//
+// Removing them from imported.json is the root-cause fix for #708: left in, a
+// broad selection that includes one fails `terraform plan
+// -generate-config-out` for the whole import. The reverse-import genconfig
+// prune (#708) remains as defense-in-depth for selections built outside this
+// path. Classification is delegated to imported.UnimportableReason so discovery
+// here, the genconfig prune, and reliable's wizard all agree.
+//
+// keep and dropped both preserve input order and are always non-nil.
+func partitionUnimportable(resources []imported.ImportedResource) (keep []imported.ImportedResource, dropped []UnsupportedResource) {
+	keep = make([]imported.ImportedResource, 0, len(resources))
+	dropped = []UnsupportedResource{}
+	for _, ir := range resources {
+		reason := imported.UnimportableReason(ir)
+		if reason == "" {
+			keep = append(keep, ir)
+			continue
+		}
+		dropped = append(dropped, unsupportedFromImported(ir, reason))
+	}
+	return keep, dropped
+}
+
+// unsupportedFromImported projects an un-importable ImportedResource into the
+// unsupported.json wire shape, carrying the reason code that explains the
+// grey-out. ID falls back through the most stable native identifiers the
+// discoverer stamped when ImportID is empty so the picker always has a key.
+func unsupportedFromImported(ir imported.ImportedResource, reason string) UnsupportedResource {
+	id := ir.Identity.ImportID
+	if id == "" {
+		for _, k := range []string{"arn", "id", "name", "self_link"} {
+			if v := ir.Identity.NativeIDs[k]; v != "" {
+				id = v
+				break
+			}
+		}
+	}
+	name := ir.Identity.NameHint
+	if name == "" {
+		name = id
+	}
+	return UnsupportedResource{
+		Type:     ir.Identity.Type,
+		ID:       id,
+		Name:     name,
+		Region:   ir.Identity.Region,
+		Location: ir.Identity.Location,
+		Tags:     ir.Identity.Tags,
+		Group:    imported.Category(ir.Identity.Type),
+		Reason:   reason,
+	}
+}
+
+// unimportableReasonsSummary renders a compact, deterministic
+// "<count> <reason>" breakdown (e.g. "5 aws_managed_kms_alias, 1
+// service_managed_eni") for the stderr exclusion line. Sorted by reason code
+// so the message is stable across runs.
+func unimportableReasonsSummary(rows []UnsupportedResource) string {
+	counts := map[string]int{}
+	for _, r := range rows {
+		counts[r.Reason]++
+	}
+	reasons := make([]string, 0, len(counts))
+	for reason := range counts {
+		reasons = append(reasons, reason)
+	}
+	sort.Strings(reasons)
+	parts := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		parts = append(parts, fmt.Sprintf("%d %s", counts[reason], reason))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cmd/insideout-import/unsupported_partition_test.go
+++ b/cmd/insideout-import/unsupported_partition_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+func ir(typ, address string, nativeIDs map[string]string) imported.ImportedResource {
+	return imported.ImportedResource{Identity: imported.ResourceIdentity{
+		Type:      typ,
+		Address:   address,
+		NameHint:  address,
+		NativeIDs: nativeIDs,
+	}}
+}
+
+func TestPartitionUnimportable(t *testing.T) {
+	in := []imported.ImportedResource{
+		ir("aws_vpc", "vpc-1", map[string]string{"id": "vpc-1"}),
+		ir("aws_kms_alias", "alias/aws/rds", map[string]string{"name": "alias/aws/rds"}),
+		ir("aws_kms_alias", "alias/my-app", map[string]string{"name": "alias/my-app"}),
+		ir("aws_network_interface", "eni-managed", map[string]string{"id": "eni-managed", "interface_type": "nat_gateway"}),
+		ir("aws_network_interface", "eni-plain", map[string]string{"id": "eni-plain", "interface_type": "interface"}),
+	}
+
+	keep, dropped := partitionUnimportable(in)
+
+	// Assert input-order preservation on the slice directly (the doc contract),
+	// not just set membership — a regression that sorts/reverses either slice
+	// must fail here.
+	if len(keep) != 3 {
+		t.Fatalf("keep: got %d, want 3 (vpc, customer alias, standard eni)", len(keep))
+	}
+	wantKeep := []string{"vpc-1", "alias/my-app", "eni-plain"}
+	for i, want := range wantKeep {
+		if keep[i].Identity.Address != want {
+			t.Errorf("keep[%d] = %q, want %q (input order must be preserved)", i, keep[i].Identity.Address, want)
+		}
+	}
+
+	if len(dropped) != 2 {
+		t.Fatalf("dropped: got %d, want 2 (managed alias + managed eni)", len(dropped))
+	}
+	// dropped preserves input order: managed alias precedes managed eni.
+	if dropped[0].ID != "alias/aws/rds" || dropped[0].Reason != imported.ReasonAWSManagedKMSAlias {
+		t.Errorf("dropped[0] = {ID:%q Reason:%q}, want {alias/aws/rds, %q}", dropped[0].ID, dropped[0].Reason, imported.ReasonAWSManagedKMSAlias)
+	}
+	if dropped[1].ID != "eni-managed" || dropped[1].Reason != imported.ReasonServiceManagedENI {
+		t.Errorf("dropped[1] = {ID:%q Reason:%q}, want {eni-managed, %q}", dropped[1].ID, dropped[1].Reason, imported.ReasonServiceManagedENI)
+	}
+}
+
+// TestUnsupportedResource_ReasonWireFormat pins the cross-repo JSON contract on
+// the `reason` field (#709 → reliable#1967): the key is literally "reason", the
+// value round-trips, and an empty Reason is omitted (omitempty) so type-level
+// unsupported rows don't emit reason:"". This is the headline contract the
+// change exists to deliver, so it is pinned at the wire boundary, not just the
+// Go field.
+func TestUnsupportedResource_ReasonWireFormat(t *testing.T) {
+	t.Parallel()
+
+	withReason, err := json.Marshal(UnsupportedResource{
+		Type:   "aws_kms_alias",
+		ID:     "alias/aws/rds",
+		Name:   "alias/aws/rds",
+		Reason: imported.ReasonAWSManagedKMSAlias,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(withReason), `"reason":"aws_managed_kms_alias"`) {
+		t.Errorf("expected `\"reason\":\"aws_managed_kms_alias\"` in JSON, got %s", withReason)
+	}
+
+	// A type-level row (no reason) must omit the key entirely.
+	noReason, err := json.Marshal(UnsupportedResource{Type: "aws_lb", ID: "arn:...", Name: "my-lb"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(noReason), "reason") {
+		t.Errorf("empty Reason must be omitted (omitempty), got %s", noReason)
+	}
+
+	// Round-trip: the code survives decode unchanged.
+	var rt UnsupportedResource
+	if err := json.Unmarshal(withReason, &rt); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if rt.Reason != imported.ReasonAWSManagedKMSAlias {
+		t.Errorf("round-trip reason = %q, want %q", rt.Reason, imported.ReasonAWSManagedKMSAlias)
+	}
+}
+
+func TestPartitionUnimportable_StampsWizardFields(t *testing.T) {
+	in := []imported.ImportedResource{{Identity: imported.ResourceIdentity{
+		Type:      "aws_kms_alias",
+		Address:   "aws_kms_alias.rds",
+		NameHint:  "alias/aws/rds",
+		ImportID:  "alias/aws/rds",
+		Region:    "us-east-1",
+		NativeIDs: map[string]string{"name": "alias/aws/rds"},
+		Tags:      map[string]string{"Project": "io-abc"},
+	}}}
+
+	_, dropped := partitionUnimportable(in)
+	if len(dropped) != 1 {
+		t.Fatalf("dropped: got %d, want 1", len(dropped))
+	}
+	d := dropped[0]
+	if d.Type != "aws_kms_alias" || d.ID != "alias/aws/rds" || d.Name != "alias/aws/rds" {
+		t.Errorf("unexpected wire fields: %+v", d)
+	}
+	if d.Region != "us-east-1" {
+		t.Errorf("region = %q, want us-east-1", d.Region)
+	}
+	// Pin the literal category (not imported.Category("aws_kms_alias"), which
+	// would tautologically re-invoke the function under test and pass vacuously
+	// if the type were missing from the category map).
+	if d.Group != "Security" {
+		t.Errorf("group = %q, want Security", d.Group)
+	}
+	if d.Tags["Project"] != "io-abc" {
+		t.Errorf("tags not carried through: %+v", d.Tags)
+	}
+}
+
+func TestPartitionUnimportable_Empty(t *testing.T) {
+	keep, dropped := partitionUnimportable(nil)
+	if keep == nil || dropped == nil {
+		t.Fatalf("keep and dropped must be non-nil; got keep=%v dropped=%v", keep, dropped)
+	}
+	if len(keep) != 0 || len(dropped) != 0 {
+		t.Fatalf("expected empty slices, got keep=%d dropped=%d", len(keep), len(dropped))
+	}
+}
+
+func TestUnimportableReasonsSummary(t *testing.T) {
+	rows := []UnsupportedResource{
+		{Reason: imported.ReasonAWSManagedKMSAlias},
+		{Reason: imported.ReasonAWSManagedKMSAlias},
+		{Reason: imported.ReasonServiceManagedENI},
+	}
+	got := unimportableReasonsSummary(rows)
+	// Sorted by reason code: aws_managed_kms_alias < service_managed_eni.
+	want := "2 aws_managed_kms_alias, 1 service_managed_eni"
+	if got != want {
+		t.Errorf("summary = %q, want %q", got, want)
+	}
+}

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -1,0 +1,149 @@
+package imported
+
+import "strings"
+
+// Instance-level un-importability classification (#709).
+//
+// Some AWS resources are *supported types* (they appear in
+// registry.SupportedDiscoverTypes and have discoverers) but whose *specific
+// instances* can never be adopted into customer Terraform state — the AWS
+// provider rejects the import. The two known families:
+//
+//   - AWS-managed default KMS aliases (alias/aws/rds, alias/aws/ebs, …): the
+//     provider refuses any aws_kms_alias under the reserved `alias/aws/`
+//     prefix.
+//   - Service/parent-managed ENIs (NAT gateway, VPC endpoint, load balancer,
+//     Lambda, …): owned by their parent resource, not standalone-importable
+//     as aws_network_interface.
+//
+// This predicate is the single source of truth shared across the pipeline so
+// the reason codes never drift:
+//
+//   - discovery (cmd/insideout-import): route these instances into the
+//     unsupported set with a reason so the wizard greys them out instead of
+//     offering them (#709);
+//   - reverse-import genconfig (cmd/insideout-import/genconfig): the
+//     defense-in-depth prune that drops them from a selection so a stale
+//     selection still imports cleanly (#708);
+//   - reliable's importer wizard + reverse-run persist gate (reliable#1967):
+//     stamp support=unsupported on the DTO and reject the run path.
+//
+// It inspects only the ResourceIdentity surface populated at discovery time —
+// never live provider schema or rendered HCL — so it produces the same verdict
+// everywhere it runs.
+
+// Reason codes for instance-level un-importability. Stable wire identifiers
+// carried in the unsupported.json `reason` field (#709), the reverse-import
+// imports-skipped.json `reason` field (#708), and consumed by reliable
+// (reliable#1967). Adding a code is additive; renaming one is a wire-format
+// break — bump the reliable consumer in lockstep.
+const (
+	// ReasonAWSManagedKMSAlias marks an aws_kms_alias whose name carries the
+	// reserved `alias/aws/` prefix — an AWS-managed default alias
+	// (alias/aws/rds, alias/aws/ebs, …). The provider rejects creating or
+	// importing any alias with that prefix.
+	ReasonAWSManagedKMSAlias = "aws_managed_kms_alias"
+
+	// ReasonServiceManagedENI marks an aws_network_interface whose
+	// interface_type is owned by an AWS service (nat_gateway, vpc_endpoint,
+	// network_load_balancer, lambda, …) rather than a customer. These ENIs
+	// are managed by their parent resource and cannot be adopted as a
+	// standalone aws_network_interface.
+	ReasonServiceManagedENI = "service_managed_eni"
+)
+
+// awsManagedKMSAliasPrefix is the reserved alias prefix the AWS provider
+// refuses to create or import an aws_kms_alias under.
+const awsManagedKMSAliasPrefix = "alias/aws/"
+
+// importableENIInterfaceTypes is the set of interface_type values an
+// aws_network_interface can legitimately carry for a customer-managed,
+// importable ENI. The empty string means the attribute is absent (the standard
+// case). "interface" is the default standard ENI; efa/efa-only/branch/trunk
+// are the only other values the provider's interface_type argument accepts on
+// create. Every OTHER value (nat_gateway, vpc_endpoint, network_load_balancer,
+// lambda, …) denotes a service-managed ENI owned by its parent resource and is
+// not standalone-importable.
+var importableENIInterfaceTypes = map[string]struct{}{
+	"":          {},
+	"interface": {},
+	"efa":       {},
+	"efa-only":  {},
+	"branch":    {},
+	"trunk":     {},
+}
+
+// IsAWSManagedKMSAliasName reports whether an aws_kms_alias name is an
+// AWS-managed default alias (reserved `alias/aws/` prefix), which the provider
+// cannot import.
+func IsAWSManagedKMSAliasName(name string) bool {
+	return strings.HasPrefix(name, awsManagedKMSAliasPrefix)
+}
+
+// IsServiceManagedENIInterfaceType reports whether an interface_type value
+// denotes an AWS-service-managed ENI (and therefore an un-importable one).
+// Forward-compatible: any interface_type AWS introduces for a managed ENI
+// family is treated as service-managed without a code change here. The empty
+// string (attribute absent / standard ENI) is importable.
+func IsServiceManagedENIInterfaceType(interfaceType string) bool {
+	_, importable := importableENIInterfaceTypes[interfaceType]
+	return !importable
+}
+
+// UnimportableReason classifies a discovered resource as inherently
+// un-importable into customer Terraform state, returning the reason code (one
+// of the Reason* consts) or "" when the resource is importable.
+//
+// KMS aliases are always classifiable — the alias name is the import ID /
+// native ID stamped by every discoverer. Service-managed ENIs are classifiable
+// only when the discoverer surfaced interface_type into
+// NativeIDs["interface_type"]; when it is absent the ENI is treated as
+// importable here and the genconfig prune (#708) remains the backstop.
+func UnimportableReason(ir ImportedResource) string {
+	switch ir.Identity.Type {
+	case "aws_kms_alias":
+		if IsAWSManagedKMSAliasName(kmsAliasName(ir.Identity)) {
+			return ReasonAWSManagedKMSAlias
+		}
+	case "aws_network_interface":
+		if IsServiceManagedENIInterfaceType(eniInterfaceType(ir.Identity)) {
+			return ReasonServiceManagedENI
+		}
+	}
+	return ""
+}
+
+// ReasonDescription returns a short, operator-facing explanation for an
+// un-importability reason code, suitable for a wizard tooltip or a CLI / 422
+// message. Returns "" for an unknown code so callers can fall back to a generic
+// message.
+func ReasonDescription(reason string) string {
+	switch reason {
+	case ReasonAWSManagedKMSAlias:
+		return "AWS-managed KMS alias (reserved alias/aws/* prefix) — cannot be imported into Terraform."
+	case ReasonServiceManagedENI:
+		return "Service-managed network interface (owned by its parent NAT gateway / VPC endpoint / load balancer) — cannot be imported as a standalone network interface."
+	default:
+		return ""
+	}
+}
+
+// kmsAliasName resolves the alias name from the identity surface the KMS-alias
+// discoverer populates: NativeIDs["name"], then ImportID, then NameHint — all
+// three carry the bare alias name (e.g. "alias/aws/rds") for this type.
+func kmsAliasName(id ResourceIdentity) string {
+	if n := id.NativeIDs["name"]; n != "" {
+		return n
+	}
+	if id.ImportID != "" {
+		return id.ImportID
+	}
+	return id.NameHint
+}
+
+// eniInterfaceType resolves an ENI's interface_type from
+// NativeIDs["interface_type"] (populated by the network-interface discoverer's
+// property extractor). Empty when the discoverer did not surface it.
+func eniInterfaceType(id ResourceIdentity) string {
+	return id.NativeIDs["interface_type"]
+}

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -1,0 +1,129 @@
+package imported
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReasonCodes_WireStable pins the literal reason-code strings. These are
+// cross-repo wire identifiers (carried in unsupported.json's `reason` field and
+// consumed by reliable#1967); renaming one is a wire-format break that must
+// surface as a deliberate test diff per the "bump the reliable consumer in
+// lockstep" contract, not slip through because every comparison reads the const
+// symbol on both sides.
+func TestReasonCodes_WireStable(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "aws_managed_kms_alias", ReasonAWSManagedKMSAlias)
+	assert.Equal(t, "service_managed_eni", ReasonServiceManagedENI)
+}
+
+func TestIsAWSManagedKMSAliasName(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"alias/aws/rds":      true,
+		"alias/aws/ebs":      true,
+		"alias/aws/dynamodb": true,
+		"alias/my-app-key":   false,
+		"alias/aws":          false, // no trailing slash — not the reserved namespace
+		"":                   false,
+		"aws/rds":            false,
+	}
+	for name, want := range cases {
+		assert.Equalf(t, want, IsAWSManagedKMSAliasName(name), "IsAWSManagedKMSAliasName(%q)", name)
+	}
+}
+
+func TestIsServiceManagedENIInterfaceType(t *testing.T) {
+	t.Parallel()
+	// Importable (customer-owned / absent) interface types.
+	for _, it := range []string{"", "interface", "efa", "efa-only", "branch", "trunk"} {
+		assert.Falsef(t, IsServiceManagedENIInterfaceType(it), "interface_type %q should be importable", it)
+	}
+	// Service-managed (parent-owned) interface types — un-importable. Includes
+	// a fabricated future value to pin the forward-compatible default.
+	for _, it := range []string{"nat_gateway", "vpc_endpoint", "network_load_balancer", "lambda", "transit_gateway", "some_future_managed_type"} {
+		assert.Truef(t, IsServiceManagedENIInterfaceType(it), "interface_type %q should be service-managed", it)
+	}
+}
+
+func TestUnimportableReason_KMSAlias(t *testing.T) {
+	t.Parallel()
+	// AWS-managed alias, name carried via each of the three identity surfaces
+	// the discoverer may populate, to prove the fallback order.
+	t.Run("via NativeIDs name", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:      "aws_kms_alias",
+			NativeIDs: map[string]string{"name": "alias/aws/rds"},
+		}}
+		assert.Equal(t, ReasonAWSManagedKMSAlias, UnimportableReason(ir))
+	})
+	t.Run("via ImportID", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:     "aws_kms_alias",
+			ImportID: "alias/aws/ebs",
+		}}
+		assert.Equal(t, ReasonAWSManagedKMSAlias, UnimportableReason(ir))
+	})
+	t.Run("via NameHint", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:     "aws_kms_alias",
+			NameHint: "alias/aws/dynamodb",
+		}}
+		assert.Equal(t, ReasonAWSManagedKMSAlias, UnimportableReason(ir))
+	})
+	t.Run("customer alias is importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:      "aws_kms_alias",
+			NativeIDs: map[string]string{"name": "alias/my-app"},
+			ImportID:  "alias/my-app",
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
+}
+
+func TestUnimportableReason_ENI(t *testing.T) {
+	t.Parallel()
+	t.Run("service-managed interface_type", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:      "aws_network_interface",
+			NativeIDs: map[string]string{"id": "eni-abc", "interface_type": "nat_gateway"},
+		}}
+		assert.Equal(t, ReasonServiceManagedENI, UnimportableReason(ir))
+	})
+	t.Run("standard interface_type is importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:      "aws_network_interface",
+			NativeIDs: map[string]string{"id": "eni-abc", "interface_type": "interface"},
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
+	t.Run("absent interface_type is importable (genconfig backstop covers it)", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:      "aws_network_interface",
+			NativeIDs: map[string]string{"id": "eni-abc"},
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
+}
+
+func TestUnimportableReason_OtherTypesImportable(t *testing.T) {
+	t.Parallel()
+	for _, typ := range []string{"aws_vpc", "aws_s3_bucket", "aws_kms_key", "aws_lambda_function"} {
+		ir := ImportedResource{Identity: ResourceIdentity{Type: typ, ImportID: "alias/aws/rds"}}
+		assert.Equalf(t, "", UnimportableReason(ir), "type %q must never be classified un-importable by this predicate", typ)
+	}
+}
+
+func TestReasonDescription(t *testing.T) {
+	t.Parallel()
+	// Pin a distinctive phrase per code (not just non-empty) so a regression
+	// that swaps the two case bodies — or truncates a description — fails.
+	kms := ReasonDescription(ReasonAWSManagedKMSAlias)
+	assert.Truef(t, strings.Contains(kms, "alias/aws/"), "KMS description must mention the reserved prefix, got %q", kms)
+	eni := ReasonDescription(ReasonServiceManagedENI)
+	assert.Truef(t, strings.Contains(eni, "network interface"), "ENI description must mention network interface, got %q", eni)
+	assert.NotEqual(t, kms, eni, "the two descriptions must be distinct (guards against swapped case bodies)")
+	assert.Equal(t, "", ReasonDescription("unknown_code"))
+}


### PR DESCRIPTION
Closes #709. Cross-repo consumer half: [luthersystems/reliable#1967](https://github.com/luthersystems/reliable/issues/1967).

## Problem
Broad AWS reverse-import selections can include resources that are **supported types** but whose **specific instances** can never be adopted into customer Terraform state:
- AWS-managed default KMS aliases (`alias/aws/rds`, `alias/aws/ebs`, …) — the provider rejects any `aws_kms_alias` under the reserved `alias/aws/` prefix.
- Service/parent-managed ENIs (`nat_gateway`, `vpc_endpoint`, load balancer, Lambda, …) — owned by their parent resource, not standalone-importable.

Left in a selection they fail `terraform plan -generate-config-out` for the whole import — the Dario prod repro behind #708. #708 added a defense-in-depth genconfig prune; **this is the root-cause UX fix: don't offer them in the first place.**

## What changed
**Shared classifier** — `pkg/composer/imported/importability.go` (new). The single source of truth so discovery, the genconfig prune, and reliable's wizard all classify identically:
- reason codes `ReasonAWSManagedKMSAlias` / `ReasonServiceManagedENI` (wire-stable identifiers),
- predicates `IsAWSManagedKMSAliasName` / `IsServiceManagedENIInterfaceType`,
- `UnimportableReason(ir ImportedResource) string` and `ReasonDescription(code) string`.

`cmd/insideout-import/genconfig/unimportable.go` now **delegates** to it (the local reason consts are aliases) so #708's prune and this gate can never drift.

**Discovery**
- `aws_network_interface` surfaces `interface_type` into `NativeIDs["interface_type"]` (absent-safe) so the classifier can see it pre-genconfig.
- `partitionUnimportable` routes un-importable instances out of `imported.json` into the unsupported set with a reason — merged into `unsupported.json` under `--include-unsupported`, and reported on stderr regardless.

**Wire shape** — `UnsupportedResource` gains a `reason` field (`omitempty`) carrying the code; reliable maps it via `imported.ReasonDescription`.

## Coverage note (honest scope)
- **KMS aliases**: classifiable at discovery everywhere (the alias name is the import ID / native ID). Fully covered.
- **Service-managed ENIs**: classifiable at discovery **only when CloudControl surfaces `InterfaceType`** in the resource payload. The extractor is absent-safe — if it's missing, the ENI is treated as importable here and the **genconfig prune (#708) remains the backstop**. The exact CloudControl payload for managed ENIs wants a live-account confirmation (the golden fixture pins the TF-provider value `interface_type = "nat_gateway"`); flagging for review.

## Tests
- `pkg/composer/imported/importability_test.go` — predicates, three-surface KMS name fallback, forward-compatible ENI default, wire-stable reason-code literals, `ReasonDescription` distinct-phrase pins.
- `cmd/insideout-import/unsupported_partition_test.go` — keep/dropped order + reasons, wizard-field stamping, **JSON `reason` wire contract** (key name, value round-trip, `omitempty`).
- `cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go` — `TestNetworkInterfaceConfig` (surface / absent-safe / verbatim passthrough).
- Pre-existing `genconfig/unimportable_test.go` + the `golden_stack_test.go` #708 regression gate still pass (refactor is behavior-preserving).

All affected-package tests pass (2399) + the golden-stack gate.