### PR TITLE
feat(bindings): add chartable metrics binding for google_identity_platform_config (#712)

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 135 types · 81% Discoverable · 81% Enrichable · 100% DriftDetectable · 67% MetricsAvailable · 91% AgentEditable
-- **GCP:** 64 types · 84% Discoverable · 84% Enrichable · 100% DriftDetectable · 77% MetricsAvailable · 91% AgentEditable
+- **GCP:** 64 types · 84% Discoverable · 84% Enrichable · 100% DriftDetectable · 78% MetricsAvailable · 91% AgentEditable
 
 ## AWS
 
@@ -205,7 +205,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_firestore_database` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_iam_workload_identity_pool` | – | – | ✓ | – | ✓ |
 | `google_iam_workload_identity_pool_provider` | – | – | ✓ | – | ✓ |
-| `google_identity_platform_config` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_identity_platform_config` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | ✓ | ✓ | – | ✓ |

--- a/pkg/imported/bindings/coverage_test.go
+++ b/pkg/imported/bindings/coverage_test.go
@@ -54,11 +54,13 @@ import (
 //     compute_backend_service, compute_security_policy, vpc_access_connector,
 //     service_networking_connection): metrics surface on the consumer
 //     workload (Cloud Run, GKE), not the network primitive.
-//   - GCP singleton / metadata (identity_platform_*, firestore_database,
-//     api_gateway_*, kms_*, secret_manager_secret*, logging_project_sink,
-//     monitoring_*, vertex_ai_dataset, storage_bucket_object,
-//     sql_user): no per-resource metrics or metrics aggregate at the
-//     project level.
+//   - GCP singleton / metadata (identity_platform_default_supported_idp_config,
+//     firestore_database, api_gateway_*, kms_*, secret_manager_secret*,
+//     logging_project_sink, monitoring_*, vertex_ai_dataset,
+//     storage_bucket_object, sql_user): no per-resource metrics or metrics
+//     aggregate at the project level. (identity_platform_config is the
+//     exception — it now binds the project-scoped consumed-API series that
+//     the managed gcp_identity_platform metric charts.)
 //   - Lambda sub-resources (lambda_alias, lambda_event_source_mapping,
 //     lambda_function_url, lambda_permission): metrics aggregate on the
 //     parent aws_lambda_function.
@@ -269,7 +271,6 @@ var metricsBindingExempt = map[string]bool{
 
 	// --- GCP singletons / configuration (no per-resource metrics) ---
 	"google_firestore_database":                             true,
-	"google_identity_platform_config":                       true,
 	"google_identity_platform_default_supported_idp_config": true,
 	"google_kms_crypto_key":                                 true,
 	"google_kms_key_ring":                                   true,

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -92,6 +92,7 @@ var seededTypes = []string{
 	"google_compute_health_check",
 	"google_api_gateway_gateway",
 	"google_cloudbuild_trigger",
+	"google_identity_platform_config",
 	"aws_eip",
 	"aws_network_interface",
 	"aws_ssm_parameter",
@@ -769,6 +770,23 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "trigger_id",
 		DimensionFrom:  "id",
 		DefaultMetrics: []string{"cloudbuild.googleapis.com/build_count", "cloudbuild.googleapis.com/build/duration"},
+	},
+	// google_identity_platform_config is the project-scoped singleton for
+	// GCP Identity Platform — there is no per-instance dimension. The
+	// managed gcp_identity_platform metric (pkg/observability
+	// gcpServiceMetrics["identityplatform"]) charts the consumed-API
+	// request_count series under the `service` label, so the imported
+	// binding mirrors that: serviceruntime.googleapis.com/api/request_count
+	// filtered on the `service` dimension (= identitytoolkit.googleapis.com).
+	// DimensionFrom "name" carries the resource's project-scoped name —
+	// the same project-level dimension google_project_service uses — since
+	// no narrower key exists for a project singleton.
+	"google_identity_platform_config": {
+		Service:        "identityplatform",
+		Action:         "timeseries-list",
+		DimensionKey:   "service",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"serviceruntime.googleapis.com/api/request_count", "serviceruntime.googleapis.com/api/request_latencies"},
 	},
 	"aws_eip": {
 		Service:        "ec2",

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -50,6 +50,28 @@ var emptyDefaultMetricsAllowed = map[string]bool{
 	"google_secret_manager_secret_iam_member": true,
 }
 
+// TestIdentityPlatformConfigChartable pins the parity fix for
+// presets#712 / reliable#1981: the managed gcp_identity_platform metric
+// charts a consumed-API request series, but the imported
+// google_identity_platform_config had a policy entry and NO
+// MetricsBinding — so its Observable panel could not chart anything.
+// This asserts the type now resolves to a chartable binding (non-empty
+// DefaultMetrics) on the `service` dimension the managed path uses.
+func TestIdentityPlatformConfigChartable(t *testing.T) {
+	reseed(t)
+
+	b, ok := Binding("google_identity_platform_config")
+	require.True(t, ok, "google_identity_platform_config has no binding — imported observable panel cannot chart")
+	require.NotEmpty(t, b.DefaultMetrics,
+		"google_identity_platform_config binding has empty DefaultMetrics — nothing to chart")
+	assert.Contains(t, b.DefaultMetrics, "serviceruntime.googleapis.com/api/request_count",
+		"binding must mirror the managed gcp_identity_platform consumed-API request series")
+	// Mirror the managed metric's `service` dimension (gcpServiceMetrics
+	// ["identityplatform"] LabelKey: "service").
+	assert.Equal(t, "service", b.DimensionKey)
+	assert.NotEmpty(t, b.DimensionFrom)
+}
+
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 


### PR DESCRIPTION
## Summary

Parity fix for the imported observability audit (epic #712). The managed `gcp_identity_platform` metric charts a Cloud Monitoring consumed-API series, but the imported `google_identity_platform_config` had a policy entry and **no** `MetricsBinding`, so its imported Observable panel could not chart anything. This adds a chartable binding so imported reaches observable parity.

## What changed

- Registered a `MetricsBinding` for `google_identity_platform_config` in `pkg/imported/bindings/seed.go` (`seededBindings` + `seededTypes`).
- Removed it from `metricsBindingExempt` in `coverage_test.go` and refreshed the singletons rationale comment so the decision log stays accurate.
- Added `TestIdentityPlatformConfigChartable` asserting the type resolves to a binding with non-empty `DefaultMetrics` on the `service` dimension.
- Regenerated `SUPPORTED_RESOURCES.md` — `MetricsAvailable` flips to checked; GCP coverage 77% to 78%.

## Mirrored metric / dimension

Mirrors the managed `gcpServiceMetrics["identityplatform"]` spec (`pkg/observability/component_observability.go`):

- Metric: `serviceruntime.googleapis.com/api/request_count` (plus `.../api/request_latencies`)
- Dimension: `service` (Cloud Monitoring `consumed_api` `service` label = `identitytoolkit.googleapis.com`)
- `DimensionFrom: name` — project-scoped, same key `google_project_service` uses, since `google_identity_platform_config` is a project singleton with no narrower per-instance dimension.

## Verification

- `go build ./...`
- `go test ./pkg/imported/...` green (336 tests)
- `make verify-supported-resources` gate passes after regen
- `gofmt` clean

Companion: luthersystems/reliable#1981. Part of epic #712.
