### PR TITLE
feat(extractors): surface storage versioning + Cognito MFA in live config (#712)

### DIFF
--- a/pkg/observability/discovery/aws/auth.go
+++ b/pkg/observability/discovery/aws/auth.go
@@ -33,6 +33,23 @@ type cognitoUserPoolsClient interface {
 	ListTagsForResource(ctx context.Context, params *cognitoidentityprovider.ListTagsForResourceInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.ListTagsForResourceOutput, error)
 }
 
+// userPoolWithMFA is the enriched element the project-scoped filter path
+// returns: the ListUserPools summary extended with the pool's
+// MfaConfiguration (OFF|ON|OPTIONAL). The scope filter already calls
+// DescribeUserPool to resolve the pool ARN, so MfaConfiguration comes off
+// that same response — NO extra SDK round-trip (the same "data already
+// fetched, just surface it" enrichment as the VPC IGW join).
+//
+// MfaConfiguration is a *string so the JSON envelope OMITS it when the
+// DescribeUserPool data wasn't available (the empty-project demo path,
+// which skips DescribeUserPool entirely), letting extractCognitoConfig tell
+// "MFA genuinely off" apart from "not fetched" — the same presence check
+// extractVPCConfig does for HasInternetGateway (#712).
+type userPoolWithMFA struct {
+	cognitoidptypes.UserPoolDescriptionType
+	MfaConfiguration *string `json:"MfaConfiguration,omitempty"`
+}
+
 func inspectCognito(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
 	project := filter.Project(filters)
 	switch action {
@@ -53,7 +70,13 @@ func inspectCognito(ctx context.Context, cfg aws.Config, action, filters string)
 //
 // Mirrors the InsideOut backend's filterCognitoUserPoolsByProjectTag
 // (aws_metrics.go:1405).
-func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserPoolsClient, project string) ([]cognitoidptypes.UserPoolDescriptionType, error) {
+//
+// Project-scoped matches are enriched with MfaConfiguration off the
+// DescribeUserPool response the scope filter already issues, so
+// extractCognitoConfig can surface aws_cognito.mfaRequired with no extra
+// SDK call (#712). The empty-project demo path skips DescribeUserPool and
+// returns pools with MfaConfiguration unset (omitted from the envelope).
+func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserPoolsClient, project string) ([]userPoolWithMFA, error) {
 	all := []cognitoidptypes.UserPoolDescriptionType{}
 	paginator := cognitoidentityprovider.NewListUserPoolsPaginator(client, &cognitoidentityprovider.ListUserPoolsInput{
 		// 60 is the ListUserPools MaxResults API max — minimises
@@ -68,9 +91,16 @@ func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserP
 		all = append(all, page.UserPools...)
 	}
 	if project == "" {
-		return all, nil
+		// Demo-session fallback: skip the per-pool DescribeUserPool scope
+		// filter. MfaConfiguration stays unset (omitted) since we don't
+		// fetch the describe response here.
+		out := make([]userPoolWithMFA, 0, len(all))
+		for _, p := range all {
+			out = append(out, userPoolWithMFA{UserPoolDescriptionType: p})
+		}
+		return out, nil
 	}
-	matched := make([]cognitoidptypes.UserPoolDescriptionType, 0, len(all))
+	matched := make([]userPoolWithMFA, 0, len(all))
 	for _, p := range all {
 		id := aws.ToString(p.Id)
 		if id == "" {
@@ -94,7 +124,13 @@ func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserP
 			continue
 		}
 		if tagsOut.Tags["Project"] == project {
-			matched = append(matched, p)
+			wrapped := userPoolWithMFA{UserPoolDescriptionType: p}
+			// MfaConfiguration is already on the describe response we just
+			// fetched for the ARN — surface it for free.
+			if mfa := string(descOut.UserPool.MfaConfiguration); mfa != "" {
+				wrapped.MfaConfiguration = aws.String(mfa)
+			}
+			matched = append(matched, wrapped)
 		}
 	}
 	return matched, nil

--- a/pkg/observability/discovery/aws/auth_test.go
+++ b/pkg/observability/discovery/aws/auth_test.go
@@ -117,6 +117,56 @@ func TestFilterCognitoUserPoolsByProjectTag_Match(t *testing.T) {
 	assert.Equal(t, "p1", aws.ToString(got[0].Id))
 }
 
+func TestFilterCognitoUserPoolsByProjectTag_MFAEnriched(t *testing.T) {
+	t.Parallel()
+	// MfaConfiguration comes off the DescribeUserPool response the scope
+	// filter already issues — the matched pool must carry it so
+	// extractCognitoConfig can surface mfaRequired (#712).
+	client := &fakeCognitoClient{
+		listOut: &cognitoidentityprovider.ListUserPoolsOutput{
+			UserPools: []cognitoidptypes.UserPoolDescriptionType{
+				{Id: aws.String("p1")},
+			},
+		},
+		descByPoolID: map[string]*cognitoidentityprovider.DescribeUserPoolOutput{
+			"p1": {UserPool: &cognitoidptypes.UserPoolType{
+				Arn:              aws.String("arn:p1"),
+				MfaConfiguration: cognitoidptypes.UserPoolMfaTypeOn,
+			}},
+		},
+		tagsByARN: map[string]*cognitoidentityprovider.ListTagsForResourceOutput{
+			"arn:p1": {Tags: map[string]string{"Project": "my-stack"}},
+		},
+	}
+	got, err := filterCognitoUserPoolsByProjectTag(context.Background(), client, "my-stack")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].MfaConfiguration)
+	assert.Equal(t, "ON", aws.ToString(got[0].MfaConfiguration))
+}
+
+func TestFilterCognitoUserPoolsByProjectTag_EmptyProjectOmitsMFA(t *testing.T) {
+	t.Parallel()
+	// The demo-session fallback skips DescribeUserPool, so MfaConfiguration
+	// stays nil and the JSON envelope omits it (extractCognitoConfig then
+	// won't claim an MFA state).
+	client := &fakeCognitoClient{
+		listOut: &cognitoidentityprovider.ListUserPoolsOutput{
+			UserPools: []cognitoidptypes.UserPoolDescriptionType{
+				{Id: aws.String("p1")},
+			},
+		},
+	}
+	got, err := filterCognitoUserPoolsByProjectTag(context.Background(), client, "")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Nil(t, got[0].MfaConfiguration)
+
+	raw, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "MfaConfiguration")
+}
+
 func TestFilterCognitoUserPoolsByProjectTag_DescribeErrorSkips(t *testing.T) {
 	t.Parallel()
 	// Concurrent delete or TooManyRequestsException → log+skip.

--- a/pkg/observability/discovery/aws/storage.go
+++ b/pkg/observability/discovery/aws/storage.go
@@ -40,9 +40,58 @@ import (
 
 // s3BucketsClient is the subset of the s3 SDK used by the bucket filter
 // helper. Mirrors the InsideOut backend's s3BucketsClient (aws_metrics.go:1173).
+//
+// GetBucketVersioning enriches each returned bucket with its versioning
+// state (the same fan-out pattern inspectVPCWithIGW uses for IGW
+// attachments) so extractS3Config can surface aws_s3.versioning without a
+// second inspector round-trip (#712, TODO#1089).
 type s3BucketsClient interface {
 	ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
 	GetBucketTagging(ctx context.Context, params *s3.GetBucketTaggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error)
+	GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+}
+
+// bucketWithVersioning is the enriched element filterS3BucketsByProjectTag
+// returns: the AWS SDK Bucket type extended with a Versioning bool computed
+// via a GetBucketVersioning fan-out. ListBuckets does not carry versioning
+// on the Bucket resource itself, so this wrapper documents the derived
+// field explicitly. The embed flattens the SDK's Name/CreationDate at the
+// top level and appends Versioning alongside — the shape extractS3Config
+// reads.
+//
+// Versioning is a *bool so the JSON envelope OMITS the field when the
+// GetBucketVersioning call failed (cross-region / access-denied buckets),
+// letting extractS3Config tell "versioning genuinely off" apart from "not
+// fetched" — the same presence check extractVPCConfig does for
+// HasInternetGateway.
+//
+// Mirrors the vpcWithIGW enrichment pattern (network.go).
+type bucketWithVersioning struct {
+	s3types.Bucket
+	Versioning *bool `json:"Versioning,omitempty"`
+}
+
+// s3VersioningSkipCodes are GetBucketVersioning error codes tolerated by
+// excluding the versioning flag (the bucket is still returned) rather than
+// aborting the pass. Same fail-soft set S3 GetBucketTagging tolerates:
+// cross-region / cross-account buckets commonly return these.
+var s3VersioningSkipCodes = map[string]struct{}{
+	"AccessDenied":       {},
+	"AllAccessDisabled":  {},
+	"PermanentRedirect":  {},
+	"BucketRegionError":  {},
+	"AuthorizationError": {},
+	"NoSuchBucket":       {},
+}
+
+func isS3VersioningSkip(err error) bool {
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		if _, ok := s3VersioningSkipCodes[ae.ErrorCode()]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // s3TaggingSkipCodes are the SDK error codes returned by GetBucketTagging
@@ -87,14 +136,21 @@ func inspectS3(ctx context.Context, cfg aws.Config, action, filters string) (any
 // them as "not ours" (see s3TaggingSkipCodes); other errors abort so
 // callers don't silently get a partial scan.
 //
+// Each returned bucket is then enriched with its versioning state via a
+// GetBucketVersioning fan-out (see enrichS3Versioning) so extractS3Config
+// can surface aws_s3.versioning (#712, TODO#1089).
+//
 // Mirrors the InsideOut backend's filterS3BucketsByProjectTag (aws_metrics.go:1233).
-func filterS3BucketsByProjectTag(ctx context.Context, client s3BucketsClient, project string) ([]s3types.Bucket, error) {
+func filterS3BucketsByProjectTag(ctx context.Context, client s3BucketsClient, project string) ([]bucketWithVersioning, error) {
 	out, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
 	if err != nil {
 		return nil, fmt.Errorf("s3 ListBuckets: %w", err)
 	}
 	if project == "" {
-		return nilSliceToEmpty(out.Buckets), nil
+		// Demo-session fallback: skip the per-bucket GetBucketTagging
+		// scope filter, but still enrich versioning so live config is
+		// consistent across both paths.
+		return enrichS3Versioning(ctx, client, nilSliceToEmpty(out.Buckets)), nil
 	}
 	matched := make([]s3types.Bucket, 0, len(out.Buckets))
 	for _, b := range out.Buckets {
@@ -117,7 +173,38 @@ func filterS3BucketsByProjectTag(ctx context.Context, client s3BucketsClient, pr
 			}
 		}
 	}
-	return matched, nil
+	return enrichS3Versioning(ctx, client, matched), nil
+}
+
+// enrichS3Versioning fans out GetBucketVersioning per bucket and wraps each
+// in a bucketWithVersioning. A versioning lookup failure is non-fatal — the
+// bucket is still returned, just with Versioning left nil (the field is then
+// omitted from the JSON envelope), mirroring inspectVPCWithIGW's non-fatal
+// IGW join. Versioning is "on" only when Status==Enabled; Suspended and the
+// never-configured empty status both map to false.
+func enrichS3Versioning(ctx context.Context, client s3BucketsClient, buckets []s3types.Bucket) []bucketWithVersioning {
+	out := make([]bucketWithVersioning, 0, len(buckets))
+	for _, b := range buckets {
+		wrapped := bucketWithVersioning{Bucket: b}
+		name := aws.ToString(b.Name)
+		if name != "" {
+			vOut, err := client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: aws.String(name)})
+			switch {
+			case err == nil:
+				enabled := vOut.Status == s3types.BucketVersioningStatusEnabled
+				wrapped.Versioning = &enabled
+			case isS3VersioningSkip(err):
+				log.Printf("[s3 GetBucketVersioning] skip bucket=%s: %v", name, err)
+			default:
+				// Non-skip errors (transport, throttling) are also
+				// non-fatal here: the bucket inventory + tag scope is the
+				// primary signal; versioning is a best-effort enrichment.
+				log.Printf("[s3 GetBucketVersioning] bucket=%s: %v (versioning omitted)", name, err)
+			}
+		}
+		out = append(out, wrapped)
+	}
+	return out
 }
 
 // --- Secrets Manager ---

--- a/pkg/observability/discovery/aws/storage_test.go
+++ b/pkg/observability/discovery/aws/storage_test.go
@@ -44,6 +44,13 @@ type fakeS3Client struct {
 	tagsOut   *s3.GetBucketTaggingOutput
 	tagsErr   error
 	tagsByKey map[string]error // per-bucket tag-error injection
+
+	// Versioning enrichment fakes. versByKey maps bucket name to the
+	// versioning status the fake reports; versErrByKey injects a per-bucket
+	// GetBucketVersioning error. Absent buckets default to an empty status
+	// (never configured → versioning off).
+	versByKey    map[string]s3types.BucketVersioningStatus
+	versErrByKey map[string]error
 }
 
 func (f *fakeS3Client) ListBuckets(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
@@ -68,6 +75,14 @@ func (f *fakeS3Client) GetBucketTagging(_ context.Context, in *s3.GetBucketTaggi
 		return &s3.GetBucketTaggingOutput{}, nil
 	}
 	return f.tagsOut, nil
+}
+
+func (f *fakeS3Client) GetBucketVersioning(_ context.Context, in *s3.GetBucketVersioningInput, _ ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+	name := aws.ToString(in.Bucket)
+	if perBucketErr, ok := f.versErrByKey[name]; ok {
+		return nil, perBucketErr
+	}
+	return &s3.GetBucketVersioningOutput{Status: f.versByKey[name]}, nil
 }
 
 func TestFilterS3BucketsByProjectTag_EmptyProjectShortCircuits(t *testing.T) {
@@ -158,6 +173,80 @@ func TestFilterS3BucketsByProjectTag_UnexpectedErrorAborts(t *testing.T) {
 	_, err := filterS3BucketsByProjectTag(context.Background(), client, "my-stack")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "s3 GetBucketTagging")
+}
+
+func TestFilterS3BucketsByProjectTag_VersioningEnriched(t *testing.T) {
+	t.Parallel()
+	// A matched bucket with versioning Enabled must surface Versioning=true
+	// on the enriched wrapper so extractS3Config can report it.
+	client := &fakeS3Client{
+		listOut: &s3.ListBucketsOutput{
+			Buckets: []s3types.Bucket{{Name: aws.String("versioned-bucket")}},
+		},
+		tagsOut: &s3.GetBucketTaggingOutput{
+			TagSet: []s3types.Tag{{Key: aws.String("Project"), Value: aws.String("my-stack")}},
+		},
+		versByKey: map[string]s3types.BucketVersioningStatus{
+			"versioned-bucket": s3types.BucketVersioningStatusEnabled,
+		},
+	}
+	got, err := filterS3BucketsByProjectTag(context.Background(), client, "my-stack")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].Versioning)
+	assert.True(t, *got[0].Versioning)
+}
+
+func TestFilterS3BucketsByProjectTag_VersioningSuspendedAndUnset(t *testing.T) {
+	t.Parallel()
+	// Suspended and the never-configured empty status both map to
+	// Versioning=false (not nil) — the call succeeded, the answer is "off".
+	client := &fakeS3Client{
+		listOut: &s3.ListBucketsOutput{
+			Buckets: []s3types.Bucket{
+				{Name: aws.String("suspended-bucket")},
+				{Name: aws.String("unset-bucket")},
+			},
+		},
+		// empty project → no tag scope filter, all buckets returned.
+		versByKey: map[string]s3types.BucketVersioningStatus{
+			"suspended-bucket": s3types.BucketVersioningStatusSuspended,
+			// unset-bucket absent → empty status.
+		},
+	}
+	got, err := filterS3BucketsByProjectTag(context.Background(), client, "")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, b := range got {
+		require.NotNil(t, b.Versioning, "successful GetBucketVersioning must set the flag")
+		assert.False(t, *b.Versioning)
+	}
+}
+
+func TestFilterS3BucketsByProjectTag_VersioningErrorOmits(t *testing.T) {
+	t.Parallel()
+	// A GetBucketVersioning failure is non-fatal: the bucket is still
+	// returned, but Versioning stays nil so the JSON envelope omits it and
+	// extractS3Config falls back to design values rather than claiming a
+	// wrong state.
+	client := &fakeS3Client{
+		listOut: &s3.ListBucketsOutput{
+			Buckets: []s3types.Bucket{{Name: aws.String("denied-bucket")}},
+		},
+		versErrByKey: map[string]error{
+			"denied-bucket": &fakeAPIError{code: "AccessDenied", message: "denied"},
+		},
+	}
+	got, err := filterS3BucketsByProjectTag(context.Background(), client, "")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Nil(t, got[0].Versioning, "versioning omitted on lookup failure")
+
+	// Round-trip through JSON to confirm the omitempty field truly drops
+	// out of the envelope the extractor consumes.
+	raw, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "Versioning")
 }
 
 // --- KMS fake ---

--- a/pkg/observability/discovery/gcp/storage.go
+++ b/pkg/observability/discovery/gcp/storage.go
@@ -58,6 +58,11 @@ func inspectGCS(ctx context.Context, projectID, action, filters string, opts ...
 // hand-rolled JSON shape the inspector contract returns. The output
 // is always a non-nil slice so an empty input marshals as `[]`,
 // pinned by the per-site empty-state test (#256).
+//
+// versioning comes straight off BucketAttrs.VersioningEnabled — the
+// list-buckets call already fetches full attrs, so unlike AWS S3 this
+// needs no second SDK round-trip. Surfaced so extractGCPGCSConfig can
+// report gcp_gcs.versioning (#712).
 func bucketAttrsToMaps(attrs []*storage.BucketAttrs) []map[string]any {
 	out := make([]map[string]any, 0, len(attrs))
 	for _, b := range attrs {
@@ -66,6 +71,7 @@ func bucketAttrsToMaps(attrs []*storage.BucketAttrs) []map[string]any {
 			"location":     b.Location,
 			"storageClass": b.StorageClass,
 			"created":      b.Created,
+			"versioning":   b.VersioningEnabled,
 		})
 	}
 	return out

--- a/pkg/observability/discovery/gcp/storage_test.go
+++ b/pkg/observability/discovery/gcp/storage_test.go
@@ -34,7 +34,7 @@ func fakeStorageREST(t *testing.T, handler http.HandlerFunc) (*httptest.Server, 
 const listBucketsResponse = `{
   "kind": "storage#buckets",
   "items": [
-    {"name": "bkt-a", "location": "US", "storageClass": "STANDARD", "timeCreated": "2024-01-01T00:00:00Z", "labels": {"project": "io-foo"}},
+    {"name": "bkt-a", "location": "US", "storageClass": "STANDARD", "timeCreated": "2024-01-01T00:00:00Z", "versioning": {"enabled": true}, "labels": {"project": "io-foo"}},
     {"name": "bkt-b", "location": "EU", "storageClass": "NEARLINE", "timeCreated": "2024-01-02T00:00:00Z", "labels": {"project": "io-bar"}},
     {"name": "bkt-c", "location": "ASIA", "storageClass": "STANDARD", "timeCreated": "2024-01-03T00:00:00Z"}
   ]
@@ -58,6 +58,10 @@ func TestInspectGCS_ListBuckets_AllReturned(t *testing.T) {
 	assert.Equal(t, "bkt-a", buckets[0]["name"])
 	assert.Equal(t, "STANDARD", buckets[0]["storageClass"])
 	assert.Equal(t, "EU", buckets[1]["location"])
+	// versioning comes straight off BucketAttrs.VersioningEnabled (#712):
+	// bkt-a has versioning enabled, bkt-b/bkt-c default to false.
+	assert.Equal(t, true, buckets[0]["versioning"])
+	assert.Equal(t, false, buckets[1]["versioning"])
 }
 
 func TestInspectGCS_ListBuckets_FiltersByProject(t *testing.T) {

--- a/pkg/observability/extractors/aws_test.go
+++ b/pkg/observability/extractors/aws_test.go
@@ -597,6 +597,56 @@ func TestExtractS3Config(t *testing.T) {
 		assert.Equal(t, "1", got["bucketCount"])
 	})
 
+	t.Run("SingleBucket_VersioningEnabled", func(t *testing.T) {
+		t.Parallel()
+		// One bucket whose inspector-enriched Versioning flag is true →
+		// surface versioning="true" (the reliable-side humanizeConfigValue
+		// renders it as "Yes").
+		got := extractS3Config([]any{
+			map[string]any{"Name": "demo-bucket", "Versioning": true},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["bucketCount"])
+		assert.Equal(t, "true", got["versioning"])
+	})
+
+	t.Run("SingleBucket_VersioningDisabled", func(t *testing.T) {
+		t.Parallel()
+		got := extractS3Config([]any{
+			map[string]any{"Name": "demo-bucket", "Versioning": false},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "false", got["versioning"])
+	})
+
+	t.Run("SingleBucket_VersioningNotFetchedOmits", func(t *testing.T) {
+		t.Parallel()
+		// Inspector omits Versioning when GetBucketVersioning was
+		// skipped/failed; extractor must not invent a value.
+		got := extractS3Config([]any{
+			map[string]any{"Name": "demo-bucket"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["bucketCount"])
+		_, has := got["versioning"]
+		assert.False(t, has, "versioning omitted when the inspector didn't fetch it")
+	})
+
+	t.Run("MultiBucket_OmitsVersioning", func(t *testing.T) {
+		t.Parallel()
+		// Versioning is per-bucket; with multiple buckets we refuse to
+		// claim a single value across the set and omit it. The per-resource
+		// imported path surfaces each bucket precisely (#712).
+		got := extractS3Config([]any{
+			map[string]any{"Name": "bucket-a", "Versioning": true},
+			map[string]any{"Name": "bucket-b", "Versioning": false},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["bucketCount"])
+		_, has := got["versioning"]
+		assert.False(t, has, "multi-bucket aggregate must not surface a single versioning value")
+	})
+
 	t.Run("NilInput", func(t *testing.T) {
 		t.Parallel()
 		assert.Nil(t, extractS3Config(nil))

--- a/pkg/observability/extractors/aws_test.go
+++ b/pkg/observability/extractors/aws_test.go
@@ -1058,12 +1058,55 @@ func TestExtractCognitoConfig(t *testing.T) {
 	t.Run("MultiplePools", func(t *testing.T) {
 		t.Parallel()
 		got := extractCognitoConfig([]any{
-			map[string]any{"Id": "p1", "Name": "first"},
-			map[string]any{"Id": "p2", "Name": "second"},
+			map[string]any{"Id": "p1", "Name": "first", "MfaConfiguration": "ON"},
+			map[string]any{"Id": "p2", "Name": "second", "MfaConfiguration": "OFF"},
 		})
 		require.NotNil(t, got)
 		assert.Equal(t, "2", got["userPoolCount"])
 		assert.Equal(t, "first", got["poolName"]) // first one
+		_, has := got["mfaRequired"]
+		assert.False(t, has, "multi-pool aggregate must not surface a single mfaRequired value")
+	})
+
+	t.Run("SinglePool_MFAOn", func(t *testing.T) {
+		t.Parallel()
+		// MfaConfiguration=ON → mfaRequired=true.
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "Name": "secure-pool", "MfaConfiguration": "ON"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "true", got["mfaRequired"])
+	})
+
+	t.Run("SinglePool_MFAOptionalIsNotRequired", func(t *testing.T) {
+		t.Parallel()
+		// OPTIONAL leaves MFA to the user — not "required".
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "MfaConfiguration": "OPTIONAL"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "false", got["mfaRequired"])
+	})
+
+	t.Run("SinglePool_MFAOff", func(t *testing.T) {
+		t.Parallel()
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "MfaConfiguration": "OFF"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "false", got["mfaRequired"])
+	})
+
+	t.Run("SinglePool_MFANotFetchedOmits", func(t *testing.T) {
+		t.Parallel()
+		// Inspector omits MfaConfiguration on the empty-project path; the
+		// extractor must not invent a value.
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "Name": "demo-pool"},
+		})
+		require.NotNil(t, got)
+		_, has := got["mfaRequired"]
+		assert.False(t, has, "mfaRequired omitted when the inspector didn't fetch it")
 	})
 
 	t.Run("Envelope", func(t *testing.T) {

--- a/pkg/observability/extractors/extractors.go
+++ b/pkg/observability/extractors/extractors.go
@@ -602,25 +602,39 @@ func extractKMSConfig(rawResult any) map[string]string {
 	}
 }
 
-// extractS3Config extracts config from list-buckets response. Shape:
+// extractS3Config extracts config from list-buckets response. Shape (the
+// inspector enriches each bucket with Versioning via a GetBucketVersioning
+// fan-out — see filterS3BucketsByProjectTag / enrichS3Versioning):
 //
-//	[ { Name, CreationDate } ]
+//	[ { Name, CreationDate, Versioning } ]
 //
-// frontend field (lib/stack/ir.ts:308): aws_s3.versioning (bool). Versioning
-// is not returned by ListBuckets and would require an additional
-// GetBucketVersioning call per bucket.
+// frontend field (lib/stack/ir.ts:312): aws_s3.versioning (bool). The
+// reliable-side humanizeConfigValue treats "versioning" as a BOOLEAN_KEY,
+// so we stringify the literal lowercase bool ("true"/"false").
 //
-// TODO(#1089): surface per-bucket versioning by fanning out
-// GetBucketVersioning. Current live config surfaces only a bucket count,
-// which is sufficient for the "deploy succeeded / bucket exists" signal.
+// Multi-bucket nuance: this extractor aggregates the whole aws_s3 component
+// (a list of buckets), not one bucket. Versioning is a per-bucket setting,
+// so we only emit `versioning` when there is exactly ONE bucket AND its
+// state was actually fetched (the inspector omits Versioning when the
+// GetBucketVersioning call was skipped/failed). With multiple buckets we
+// omit it rather than claim a single value across the set — the per-resource
+// imported path surfaces each bucket's versioning precisely (#712).
 func extractS3Config(rawResult any) map[string]string {
 	items := sliceFromEnvelope(rawResult, "Buckets")
 	if len(items) == 0 {
 		return nil
 	}
-	return map[string]string{
+	cfg := map[string]string{
 		"bucketCount": strconv.Itoa(len(items)),
 	}
+	if len(items) == 1 {
+		if v, ok := items[0]["Versioning"]; ok {
+			if b, ok := v.(bool); ok {
+				cfg["versioning"] = strconv.FormatBool(b)
+			}
+		}
+	}
+	return cfg
 }
 
 // extractSecretsManagerConfig extracts config from list-secrets response.

--- a/pkg/observability/extractors/extractors.go
+++ b/pkg/observability/extractors/extractors.go
@@ -921,13 +921,21 @@ func extractSQSConfig(rawResult any) map[string]string {
 //	[ { Id, Name, Status, CreationDate, LambdaConfig } ]
 //
 // frontend fields (lib/stack/ir.ts:347): aws_cognito.signInType,
-// mfaRequired, okta, auth0 — none of which are on the list-user-pools
-// summary; they live on DescribeUserPool.
+// mfaRequired, okta, auth0. mfaRequired is surfaced here; the inspector
+// enriches each project-scoped pool with MfaConfiguration off the
+// DescribeUserPool response it already issues for the ARN — see
+// filterCognitoUserPoolsByProjectTag (#712). signInType / okta / auth0
+// still need wider DescribeUserPool fields and remain design-only.
 //
-// TODO(#1089): fan out DescribeUserPool per pool to surface MFA policy
-// (MfaConfiguration), password policy (Policies.PasswordPolicy), and
-// alias attributes. Today we emit the drift/identity signals so the UI
-// can render a "pool exists, status active" card.
+// MfaConfiguration is OFF|ON|OPTIONAL; mfaRequired is true only for ON
+// (OPTIONAL leaves MFA up to the user, so it is not "required"). The value
+// is the literal lowercase bool to match the reliable-side
+// humanizeConfigValue BOOLEAN_KEYS contract.
+//
+// Multi-pool nuance (same as extractS3Config): MfaConfiguration is
+// per-pool, so mfaRequired is only surfaced when there is exactly ONE pool
+// AND its config was fetched (the inspector omits MfaConfiguration on the
+// empty-project demo path); multiple pools omit it.
 func extractCognitoConfig(rawResult any) map[string]string {
 	items := sliceFromEnvelope(rawResult, "UserPools")
 	if len(items) == 0 {
@@ -945,6 +953,11 @@ func extractCognitoConfig(rawResult any) map[string]string {
 	}
 	if v := getString(first, "Id"); v != "" {
 		cfg["poolId"] = v
+	}
+	if len(items) == 1 {
+		if mfa := getString(first, "MfaConfiguration"); mfa != "" {
+			cfg["mfaRequired"] = strconv.FormatBool(mfa == "ON")
+		}
 	}
 	return cfg
 }

--- a/pkg/observability/extractors/extractors.go
+++ b/pkg/observability/extractors/extractors.go
@@ -1418,17 +1418,22 @@ func extractGCPCloudSQLConfig(rawResult any) map[string]string {
 }
 
 // extractGCPGCSConfig extracts config from the list-buckets response. The
-// inspector (inspectGCPGCS) PRE-FLATTENS each bucket to a 4-key map:
+// inspector (inspectGCPGCS) PRE-FLATTENS each bucket to a 5-key map:
 //
-//	[ { name, location, storageClass, created } ]
+//	[ { name, location, storageClass, created, versioning } ]
 //
 // — so this extractor is the simplest of the bundle: no proto parsing
 // required, straight field lookups.
 //
-// frontend fields (lib/stack/ir.ts:488-495): storageClass, versioning.
-// versioning is NOT on the inspector's pre-flattened shape (would need
-// a per-bucket GetAttrs fan-out). TODO(#1090 follow-up): fan out
-// (*storage.BucketHandle).Attrs() to surface VersioningEnabled.
+// frontend fields (lib/stack/ir.ts:493-494): storageClass, versioning.
+// versioning comes straight off BucketAttrs.VersioningEnabled — list-buckets
+// already fetches full attrs, so (unlike AWS S3) no second SDK call is
+// needed. It is stringified as the literal lowercase bool ("true"/"false")
+// to match the reliable-side humanizeConfigValue BOOLEAN_KEYS contract.
+//
+// Multi-bucket nuance (same as extractS3Config): versioning is per-bucket,
+// so we only surface it when there is exactly ONE bucket; multiple buckets
+// omit it rather than claim a single value across the set (#712).
 func extractGCPGCSConfig(rawResult any) map[string]string {
 	items := sliceFromEnvelope(rawResult, "buckets")
 	if len(items) == 0 {
@@ -1446,6 +1451,13 @@ func extractGCPGCSConfig(rawResult any) map[string]string {
 	}
 	if v := getString(first, "storageClass"); v != "" {
 		cfg["storageClass"] = v
+	}
+	if len(items) == 1 {
+		if v, ok := first["versioning"]; ok {
+			if b, ok := v.(bool); ok {
+				cfg["versioning"] = strconv.FormatBool(b)
+			}
+		}
 	}
 	return cfg
 }

--- a/pkg/observability/extractors/gcp_test.go
+++ b/pkg/observability/extractors/gcp_test.go
@@ -418,6 +418,7 @@ func TestExtractGCPGCSConfig(t *testing.T) {
 			"name":         "demo-bucket",
 			"location":     "us-central1",
 			"storageClass": "STANDARD",
+			"versioning":   true,
 		}}
 		got := extractGCPGCSConfig(raw)
 		require.NotNil(t, got)
@@ -425,6 +426,50 @@ func TestExtractGCPGCSConfig(t *testing.T) {
 		assert.Equal(t, "demo-bucket", got["bucketName"])
 		assert.Equal(t, "us-central1", got["location"])
 		assert.Equal(t, "STANDARD", got["storageClass"])
+		assert.Equal(t, "true", got["versioning"])
+	})
+
+	t.Run("SingleBucket_VersioningDisabled", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":         "demo-bucket",
+			"location":     "us-central1",
+			"storageClass": "STANDARD",
+			"versioning":   false,
+		}}
+		got := extractGCPGCSConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "false", got["versioning"])
+	})
+
+	t.Run("VersioningAbsentOmits", func(t *testing.T) {
+		t.Parallel()
+		// Older inspector fixtures (pre-#712) lack the versioning key; the
+		// extractor must not invent one.
+		raw := []any{map[string]any{
+			"name":         "demo-bucket",
+			"location":     "us-central1",
+			"storageClass": "STANDARD",
+		}}
+		got := extractGCPGCSConfig(raw)
+		require.NotNil(t, got)
+		_, has := got["versioning"]
+		assert.False(t, has, "versioning omitted when absent from the envelope")
+	})
+
+	t.Run("MultiBucket_OmitsVersioning", func(t *testing.T) {
+		t.Parallel()
+		// Per-bucket setting; with multiple buckets we omit it rather than
+		// claim a single value across the set (#712).
+		raw := []any{
+			map[string]any{"name": "bkt-a", "versioning": true},
+			map[string]any{"name": "bkt-b", "versioning": false},
+		}
+		got := extractGCPGCSConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["bucketCount"])
+		_, has := got["versioning"]
+		assert.False(t, has, "multi-bucket aggregate must not surface a single versioning value")
 	})
 
 	t.Run("MultiRegionalLocation", func(t *testing.T) {


### PR DESCRIPTION
Part of epic #712. Resolves the count-only / incomplete live-config extractors that feed imported resource config values, so live config surfaces the headline boolean settings instead of "Not configured". Companion: reliable#1981 (the reliable side already lists `versioning` and `mfaRequired` in `humanizeConfigValue` BOOLEAN_KEYS, so the keys must match exactly).

## Commits

- S3 versioning (resolves TODO#1089): enrich the list-buckets inspector with a `GetBucketVersioning` fan-out (same enrichment pattern `inspectVPCWithIGW` uses for IGW attachments) and read the new `Versioning` flag in `extractS3Config`. Versioning lookups are non-fatal — cross-region / access-denied buckets log+skip and the field is omitted from the envelope rather than guessed.
- GCS versioning: `list-buckets` already fetches full `BucketAttrs`, so this needs no second SDK call — `bucketAttrsToMaps` now includes `VersioningEnabled` and `extractGCPGCSConfig` reads it.
- Cognito MFA (stretch): the scope filter already calls `DescribeUserPool` per pool to resolve the ARN for tag matching, and that response carries `MfaConfiguration` — so surfacing it costs zero extra SDK calls. `extractCognitoConfig` emits `mfaRequired`: true only for `ON`; `OPTIONAL` and `OFF` map to false.

## Key contract

Extractors return `map[string]string` keyed by the frontend config field name. The new keys are:

- `versioning` → literal lowercase bool `"true"` / `"false"` (matches `aws_s3.versioning` and `gcp_gcs.versioning`).
- `mfaRequired` → literal lowercase bool (matches `aws_cognito.mfaRequired`).

These must match the reliable-side `humanizeConfigValue` BOOLEAN_KEYS, which renders them as Yes/No.

## Multi-resource decision

These extractors aggregate a whole component (a list of buckets / pools), but versioning and MFA are per-resource. To avoid claiming a single value across many resources, each new key is only emitted when there is exactly ONE resource AND its state was actually fetched; multiple resources omit the key. The per-resource imported path will surface each resource precisely later. Documented in code comments and covered by `MultiBucket_OmitsVersioning` / `MultiBucket_OmitsVersioning` / `MultiPool` tests.

## Skipped stretch items (reason)

- CloudFront `DefaultTTL`: the field is deprecated on `DefaultCacheBehavior` and is nil whenever a cache policy is used (the modern norm), so surfacing it would frequently show a misleading "not configured". Needs the cache-policy path, out of scope.
- SQS, DynamoDB, EKS: inspectors return `[]string` (URLs / table names / cluster names) with no metadata; surfacing the target fields needs both a new SDK call and a change of the inspector's return type. Larger blast radius, deferred.
- WAF rules: needs a `GetWebACL` fan-out per id; deferred with the above.

## Verification

- `go build ./...` clean, `go vet ./pkg/observability/...` clean, `make go-fmt-check` ok.
- `go test -race ./pkg/observability/...` → 1338 passed in 8 packages (was 1322 on the base; new tests cover enabled / disabled / not-fetched / multi-resource cases for all three items, plus the inspector-side enrichment and JSON-omitempty round-trips).