### PR TITLE
feat(imported): config + observable parity — S3/GCS versioning, Cognito MFA, Identity Platform binding

### DIFF
--- a/SUPPORTED_RESOURCES.md
+++ b/SUPPORTED_RESOURCES.md
@@ -23,7 +23,7 @@ and is checked in lockstep with the runtime registries. See the
 ## Summary
 
 - **AWS:** 135 types · 81% Discoverable · 81% Enrichable · 100% DriftDetectable · 67% MetricsAvailable · 91% AgentEditable
-- **GCP:** 64 types · 84% Discoverable · 84% Enrichable · 100% DriftDetectable · 77% MetricsAvailable · 91% AgentEditable
+- **GCP:** 64 types · 84% Discoverable · 84% Enrichable · 100% DriftDetectable · 78% MetricsAvailable · 91% AgentEditable
 
 ## AWS
 
@@ -205,7 +205,7 @@ and is checked in lockstep with the runtime registries. See the
 | `google_firestore_database` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_iam_workload_identity_pool` | – | – | ✓ | – | ✓ |
 | `google_iam_workload_identity_pool_provider` | – | – | ✓ | – | ✓ |
-| `google_identity_platform_config` | ✓ | ✓ | ✓ | – | ✓ |
+| `google_identity_platform_config` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_identity_platform_default_supported_idp_config` | ✓ | ✓ | ✓ | – | ✓ |
 | `google_kms_crypto_key` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `google_kms_crypto_key_iam_binding` | ✓ | ✓ | ✓ | – | ✓ |

--- a/pkg/imported/bindings/coverage_test.go
+++ b/pkg/imported/bindings/coverage_test.go
@@ -54,11 +54,13 @@ import (
 //     compute_backend_service, compute_security_policy, vpc_access_connector,
 //     service_networking_connection): metrics surface on the consumer
 //     workload (Cloud Run, GKE), not the network primitive.
-//   - GCP singleton / metadata (identity_platform_*, firestore_database,
-//     api_gateway_*, kms_*, secret_manager_secret*, logging_project_sink,
-//     monitoring_*, vertex_ai_dataset, storage_bucket_object,
-//     sql_user): no per-resource metrics or metrics aggregate at the
-//     project level.
+//   - GCP singleton / metadata (identity_platform_default_supported_idp_config,
+//     firestore_database, api_gateway_*, kms_*, secret_manager_secret*,
+//     logging_project_sink, monitoring_*, vertex_ai_dataset,
+//     storage_bucket_object, sql_user): no per-resource metrics or metrics
+//     aggregate at the project level. (identity_platform_config is the
+//     exception — it now binds the project-scoped consumed-API series that
+//     the managed gcp_identity_platform metric charts.)
 //   - Lambda sub-resources (lambda_alias, lambda_event_source_mapping,
 //     lambda_function_url, lambda_permission): metrics aggregate on the
 //     parent aws_lambda_function.
@@ -269,7 +271,6 @@ var metricsBindingExempt = map[string]bool{
 
 	// --- GCP singletons / configuration (no per-resource metrics) ---
 	"google_firestore_database":                             true,
-	"google_identity_platform_config":                       true,
 	"google_identity_platform_default_supported_idp_config": true,
 	"google_kms_crypto_key":                                 true,
 	"google_kms_key_ring":                                   true,

--- a/pkg/imported/bindings/coverage_test.go
+++ b/pkg/imported/bindings/coverage_test.go
@@ -242,10 +242,6 @@ var metricsBindingExempt = map[string]bool{
 	"google_secret_manager_secret_iam_member":    true,
 	"google_storage_bucket_iam_member":           true,
 
-	// --- GCP Cloud Build / Cloud Functions (binding deferred) ---
-	"google_cloudbuild_trigger":       true,
-	"google_cloudfunctions2_function": true,
-
 	// --- GCP Compute networking primitives (no per-resource metrics) ---
 	"google_compute_address":                 true,
 	"google_compute_backend_service":         true,

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -92,6 +92,7 @@ var seededTypes = []string{
 	"google_compute_health_check",
 	"google_api_gateway_gateway",
 	"google_cloudbuild_trigger",
+	"google_identity_platform_config",
 	"aws_eip",
 	"aws_network_interface",
 	"aws_ssm_parameter",
@@ -769,6 +770,23 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "trigger_id",
 		DimensionFrom:  "id",
 		DefaultMetrics: []string{"cloudbuild.googleapis.com/build_count", "cloudbuild.googleapis.com/build/duration"},
+	},
+	// google_identity_platform_config is the project-scoped singleton for
+	// GCP Identity Platform — there is no per-instance dimension. The
+	// managed gcp_identity_platform metric (pkg/observability
+	// gcpServiceMetrics["identityplatform"]) charts the consumed-API
+	// request_count series under the `service` label, so the imported
+	// binding mirrors that: serviceruntime.googleapis.com/api/request_count
+	// filtered on the `service` dimension (= identitytoolkit.googleapis.com).
+	// DimensionFrom "name" carries the resource's project-scoped name —
+	// the same project-level dimension google_project_service uses — since
+	// no narrower key exists for a project singleton.
+	"google_identity_platform_config": {
+		Service:        "identityplatform",
+		Action:         "timeseries-list",
+		DimensionKey:   "service",
+		DimensionFrom:  "name",
+		DefaultMetrics: []string{"serviceruntime.googleapis.com/api/request_count", "serviceruntime.googleapis.com/api/request_latencies"},
 	},
 	"aws_eip": {
 		Service:        "ec2",

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -50,6 +50,28 @@ var emptyDefaultMetricsAllowed = map[string]bool{
 	"google_secret_manager_secret_iam_member": true,
 }
 
+// TestIdentityPlatformConfigChartable pins the parity fix for
+// presets#712 / reliable#1981: the managed gcp_identity_platform metric
+// charts a consumed-API request series, but the imported
+// google_identity_platform_config had a policy entry and NO
+// MetricsBinding — so its Observable panel could not chart anything.
+// This asserts the type now resolves to a chartable binding (non-empty
+// DefaultMetrics) on the `service` dimension the managed path uses.
+func TestIdentityPlatformConfigChartable(t *testing.T) {
+	reseed(t)
+
+	b, ok := Binding("google_identity_platform_config")
+	require.True(t, ok, "google_identity_platform_config has no binding — imported observable panel cannot chart")
+	require.NotEmpty(t, b.DefaultMetrics,
+		"google_identity_platform_config binding has empty DefaultMetrics — nothing to chart")
+	assert.Contains(t, b.DefaultMetrics, "serviceruntime.googleapis.com/api/request_count",
+		"binding must mirror the managed gcp_identity_platform consumed-API request series")
+	// Mirror the managed metric's `service` dimension (gcpServiceMetrics
+	// ["identityplatform"] LabelKey: "service").
+	assert.Equal(t, "service", b.DimensionKey)
+	assert.NotEmpty(t, b.DimensionFrom)
+}
+
 func TestSeededBindings(t *testing.T) {
 	reseed(t)
 

--- a/pkg/observability/discovery/aws/auth.go
+++ b/pkg/observability/discovery/aws/auth.go
@@ -33,6 +33,23 @@ type cognitoUserPoolsClient interface {
 	ListTagsForResource(ctx context.Context, params *cognitoidentityprovider.ListTagsForResourceInput, optFns ...func(*cognitoidentityprovider.Options)) (*cognitoidentityprovider.ListTagsForResourceOutput, error)
 }
 
+// userPoolWithMFA is the enriched element the project-scoped filter path
+// returns: the ListUserPools summary extended with the pool's
+// MfaConfiguration (OFF|ON|OPTIONAL). The scope filter already calls
+// DescribeUserPool to resolve the pool ARN, so MfaConfiguration comes off
+// that same response — NO extra SDK round-trip (the same "data already
+// fetched, just surface it" enrichment as the VPC IGW join).
+//
+// MfaConfiguration is a *string so the JSON envelope OMITS it when the
+// DescribeUserPool data wasn't available (the empty-project demo path,
+// which skips DescribeUserPool entirely), letting extractCognitoConfig tell
+// "MFA genuinely off" apart from "not fetched" — the same presence check
+// extractVPCConfig does for HasInternetGateway (#712).
+type userPoolWithMFA struct {
+	cognitoidptypes.UserPoolDescriptionType
+	MfaConfiguration *string `json:"MfaConfiguration,omitempty"`
+}
+
 func inspectCognito(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
 	project := filter.Project(filters)
 	switch action {
@@ -53,7 +70,13 @@ func inspectCognito(ctx context.Context, cfg aws.Config, action, filters string)
 //
 // Mirrors the InsideOut backend's filterCognitoUserPoolsByProjectTag
 // (aws_metrics.go:1405).
-func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserPoolsClient, project string) ([]cognitoidptypes.UserPoolDescriptionType, error) {
+//
+// Project-scoped matches are enriched with MfaConfiguration off the
+// DescribeUserPool response the scope filter already issues, so
+// extractCognitoConfig can surface aws_cognito.mfaRequired with no extra
+// SDK call (#712). The empty-project demo path skips DescribeUserPool and
+// returns pools with MfaConfiguration unset (omitted from the envelope).
+func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserPoolsClient, project string) ([]userPoolWithMFA, error) {
 	all := []cognitoidptypes.UserPoolDescriptionType{}
 	paginator := cognitoidentityprovider.NewListUserPoolsPaginator(client, &cognitoidentityprovider.ListUserPoolsInput{
 		// 60 is the ListUserPools MaxResults API max — minimises
@@ -68,9 +91,16 @@ func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserP
 		all = append(all, page.UserPools...)
 	}
 	if project == "" {
-		return all, nil
+		// Demo-session fallback: skip the per-pool DescribeUserPool scope
+		// filter. MfaConfiguration stays unset (omitted) since we don't
+		// fetch the describe response here.
+		out := make([]userPoolWithMFA, 0, len(all))
+		for _, p := range all {
+			out = append(out, userPoolWithMFA{UserPoolDescriptionType: p})
+		}
+		return out, nil
 	}
-	matched := make([]cognitoidptypes.UserPoolDescriptionType, 0, len(all))
+	matched := make([]userPoolWithMFA, 0, len(all))
 	for _, p := range all {
 		id := aws.ToString(p.Id)
 		if id == "" {
@@ -94,7 +124,13 @@ func filterCognitoUserPoolsByProjectTag(ctx context.Context, client cognitoUserP
 			continue
 		}
 		if tagsOut.Tags["Project"] == project {
-			matched = append(matched, p)
+			wrapped := userPoolWithMFA{UserPoolDescriptionType: p}
+			// MfaConfiguration is already on the describe response we just
+			// fetched for the ARN — surface it for free.
+			if mfa := string(descOut.UserPool.MfaConfiguration); mfa != "" {
+				wrapped.MfaConfiguration = aws.String(mfa)
+			}
+			matched = append(matched, wrapped)
 		}
 	}
 	return matched, nil

--- a/pkg/observability/discovery/aws/auth_test.go
+++ b/pkg/observability/discovery/aws/auth_test.go
@@ -117,6 +117,56 @@ func TestFilterCognitoUserPoolsByProjectTag_Match(t *testing.T) {
 	assert.Equal(t, "p1", aws.ToString(got[0].Id))
 }
 
+func TestFilterCognitoUserPoolsByProjectTag_MFAEnriched(t *testing.T) {
+	t.Parallel()
+	// MfaConfiguration comes off the DescribeUserPool response the scope
+	// filter already issues — the matched pool must carry it so
+	// extractCognitoConfig can surface mfaRequired (#712).
+	client := &fakeCognitoClient{
+		listOut: &cognitoidentityprovider.ListUserPoolsOutput{
+			UserPools: []cognitoidptypes.UserPoolDescriptionType{
+				{Id: aws.String("p1")},
+			},
+		},
+		descByPoolID: map[string]*cognitoidentityprovider.DescribeUserPoolOutput{
+			"p1": {UserPool: &cognitoidptypes.UserPoolType{
+				Arn:              aws.String("arn:p1"),
+				MfaConfiguration: cognitoidptypes.UserPoolMfaTypeOn,
+			}},
+		},
+		tagsByARN: map[string]*cognitoidentityprovider.ListTagsForResourceOutput{
+			"arn:p1": {Tags: map[string]string{"Project": "my-stack"}},
+		},
+	}
+	got, err := filterCognitoUserPoolsByProjectTag(context.Background(), client, "my-stack")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].MfaConfiguration)
+	assert.Equal(t, "ON", aws.ToString(got[0].MfaConfiguration))
+}
+
+func TestFilterCognitoUserPoolsByProjectTag_EmptyProjectOmitsMFA(t *testing.T) {
+	t.Parallel()
+	// The demo-session fallback skips DescribeUserPool, so MfaConfiguration
+	// stays nil and the JSON envelope omits it (extractCognitoConfig then
+	// won't claim an MFA state).
+	client := &fakeCognitoClient{
+		listOut: &cognitoidentityprovider.ListUserPoolsOutput{
+			UserPools: []cognitoidptypes.UserPoolDescriptionType{
+				{Id: aws.String("p1")},
+			},
+		},
+	}
+	got, err := filterCognitoUserPoolsByProjectTag(context.Background(), client, "")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Nil(t, got[0].MfaConfiguration)
+
+	raw, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "MfaConfiguration")
+}
+
 func TestFilterCognitoUserPoolsByProjectTag_DescribeErrorSkips(t *testing.T) {
 	t.Parallel()
 	// Concurrent delete or TooManyRequestsException → log+skip.

--- a/pkg/observability/discovery/aws/storage.go
+++ b/pkg/observability/discovery/aws/storage.go
@@ -40,9 +40,58 @@ import (
 
 // s3BucketsClient is the subset of the s3 SDK used by the bucket filter
 // helper. Mirrors the InsideOut backend's s3BucketsClient (aws_metrics.go:1173).
+//
+// GetBucketVersioning enriches each returned bucket with its versioning
+// state (the same fan-out pattern inspectVPCWithIGW uses for IGW
+// attachments) so extractS3Config can surface aws_s3.versioning without a
+// second inspector round-trip (#712, TODO#1089).
 type s3BucketsClient interface {
 	ListBuckets(ctx context.Context, params *s3.ListBucketsInput, optFns ...func(*s3.Options)) (*s3.ListBucketsOutput, error)
 	GetBucketTagging(ctx context.Context, params *s3.GetBucketTaggingInput, optFns ...func(*s3.Options)) (*s3.GetBucketTaggingOutput, error)
+	GetBucketVersioning(ctx context.Context, params *s3.GetBucketVersioningInput, optFns ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error)
+}
+
+// bucketWithVersioning is the enriched element filterS3BucketsByProjectTag
+// returns: the AWS SDK Bucket type extended with a Versioning bool computed
+// via a GetBucketVersioning fan-out. ListBuckets does not carry versioning
+// on the Bucket resource itself, so this wrapper documents the derived
+// field explicitly. The embed flattens the SDK's Name/CreationDate at the
+// top level and appends Versioning alongside — the shape extractS3Config
+// reads.
+//
+// Versioning is a *bool so the JSON envelope OMITS the field when the
+// GetBucketVersioning call failed (cross-region / access-denied buckets),
+// letting extractS3Config tell "versioning genuinely off" apart from "not
+// fetched" — the same presence check extractVPCConfig does for
+// HasInternetGateway.
+//
+// Mirrors the vpcWithIGW enrichment pattern (network.go).
+type bucketWithVersioning struct {
+	s3types.Bucket
+	Versioning *bool `json:"Versioning,omitempty"`
+}
+
+// s3VersioningSkipCodes are GetBucketVersioning error codes tolerated by
+// excluding the versioning flag (the bucket is still returned) rather than
+// aborting the pass. Same fail-soft set S3 GetBucketTagging tolerates:
+// cross-region / cross-account buckets commonly return these.
+var s3VersioningSkipCodes = map[string]struct{}{
+	"AccessDenied":       {},
+	"AllAccessDisabled":  {},
+	"PermanentRedirect":  {},
+	"BucketRegionError":  {},
+	"AuthorizationError": {},
+	"NoSuchBucket":       {},
+}
+
+func isS3VersioningSkip(err error) bool {
+	var ae smithy.APIError
+	if errors.As(err, &ae) {
+		if _, ok := s3VersioningSkipCodes[ae.ErrorCode()]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // s3TaggingSkipCodes are the SDK error codes returned by GetBucketTagging
@@ -87,14 +136,21 @@ func inspectS3(ctx context.Context, cfg aws.Config, action, filters string) (any
 // them as "not ours" (see s3TaggingSkipCodes); other errors abort so
 // callers don't silently get a partial scan.
 //
+// Each returned bucket is then enriched with its versioning state via a
+// GetBucketVersioning fan-out (see enrichS3Versioning) so extractS3Config
+// can surface aws_s3.versioning (#712, TODO#1089).
+//
 // Mirrors the InsideOut backend's filterS3BucketsByProjectTag (aws_metrics.go:1233).
-func filterS3BucketsByProjectTag(ctx context.Context, client s3BucketsClient, project string) ([]s3types.Bucket, error) {
+func filterS3BucketsByProjectTag(ctx context.Context, client s3BucketsClient, project string) ([]bucketWithVersioning, error) {
 	out, err := client.ListBuckets(ctx, &s3.ListBucketsInput{})
 	if err != nil {
 		return nil, fmt.Errorf("s3 ListBuckets: %w", err)
 	}
 	if project == "" {
-		return nilSliceToEmpty(out.Buckets), nil
+		// Demo-session fallback: skip the per-bucket GetBucketTagging
+		// scope filter, but still enrich versioning so live config is
+		// consistent across both paths.
+		return enrichS3Versioning(ctx, client, nilSliceToEmpty(out.Buckets)), nil
 	}
 	matched := make([]s3types.Bucket, 0, len(out.Buckets))
 	for _, b := range out.Buckets {
@@ -117,7 +173,38 @@ func filterS3BucketsByProjectTag(ctx context.Context, client s3BucketsClient, pr
 			}
 		}
 	}
-	return matched, nil
+	return enrichS3Versioning(ctx, client, matched), nil
+}
+
+// enrichS3Versioning fans out GetBucketVersioning per bucket and wraps each
+// in a bucketWithVersioning. A versioning lookup failure is non-fatal — the
+// bucket is still returned, just with Versioning left nil (the field is then
+// omitted from the JSON envelope), mirroring inspectVPCWithIGW's non-fatal
+// IGW join. Versioning is "on" only when Status==Enabled; Suspended and the
+// never-configured empty status both map to false.
+func enrichS3Versioning(ctx context.Context, client s3BucketsClient, buckets []s3types.Bucket) []bucketWithVersioning {
+	out := make([]bucketWithVersioning, 0, len(buckets))
+	for _, b := range buckets {
+		wrapped := bucketWithVersioning{Bucket: b}
+		name := aws.ToString(b.Name)
+		if name != "" {
+			vOut, err := client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: aws.String(name)})
+			switch {
+			case err == nil:
+				enabled := vOut.Status == s3types.BucketVersioningStatusEnabled
+				wrapped.Versioning = &enabled
+			case isS3VersioningSkip(err):
+				log.Printf("[s3 GetBucketVersioning] skip bucket=%s: %v", name, err)
+			default:
+				// Non-skip errors (transport, throttling) are also
+				// non-fatal here: the bucket inventory + tag scope is the
+				// primary signal; versioning is a best-effort enrichment.
+				log.Printf("[s3 GetBucketVersioning] bucket=%s: %v (versioning omitted)", name, err)
+			}
+		}
+		out = append(out, wrapped)
+	}
+	return out
 }
 
 // --- Secrets Manager ---

--- a/pkg/observability/discovery/aws/storage_test.go
+++ b/pkg/observability/discovery/aws/storage_test.go
@@ -44,6 +44,13 @@ type fakeS3Client struct {
 	tagsOut   *s3.GetBucketTaggingOutput
 	tagsErr   error
 	tagsByKey map[string]error // per-bucket tag-error injection
+
+	// Versioning enrichment fakes. versByKey maps bucket name to the
+	// versioning status the fake reports; versErrByKey injects a per-bucket
+	// GetBucketVersioning error. Absent buckets default to an empty status
+	// (never configured → versioning off).
+	versByKey    map[string]s3types.BucketVersioningStatus
+	versErrByKey map[string]error
 }
 
 func (f *fakeS3Client) ListBuckets(_ context.Context, _ *s3.ListBucketsInput, _ ...func(*s3.Options)) (*s3.ListBucketsOutput, error) {
@@ -68,6 +75,14 @@ func (f *fakeS3Client) GetBucketTagging(_ context.Context, in *s3.GetBucketTaggi
 		return &s3.GetBucketTaggingOutput{}, nil
 	}
 	return f.tagsOut, nil
+}
+
+func (f *fakeS3Client) GetBucketVersioning(_ context.Context, in *s3.GetBucketVersioningInput, _ ...func(*s3.Options)) (*s3.GetBucketVersioningOutput, error) {
+	name := aws.ToString(in.Bucket)
+	if perBucketErr, ok := f.versErrByKey[name]; ok {
+		return nil, perBucketErr
+	}
+	return &s3.GetBucketVersioningOutput{Status: f.versByKey[name]}, nil
 }
 
 func TestFilterS3BucketsByProjectTag_EmptyProjectShortCircuits(t *testing.T) {
@@ -158,6 +173,80 @@ func TestFilterS3BucketsByProjectTag_UnexpectedErrorAborts(t *testing.T) {
 	_, err := filterS3BucketsByProjectTag(context.Background(), client, "my-stack")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "s3 GetBucketTagging")
+}
+
+func TestFilterS3BucketsByProjectTag_VersioningEnriched(t *testing.T) {
+	t.Parallel()
+	// A matched bucket with versioning Enabled must surface Versioning=true
+	// on the enriched wrapper so extractS3Config can report it.
+	client := &fakeS3Client{
+		listOut: &s3.ListBucketsOutput{
+			Buckets: []s3types.Bucket{{Name: aws.String("versioned-bucket")}},
+		},
+		tagsOut: &s3.GetBucketTaggingOutput{
+			TagSet: []s3types.Tag{{Key: aws.String("Project"), Value: aws.String("my-stack")}},
+		},
+		versByKey: map[string]s3types.BucketVersioningStatus{
+			"versioned-bucket": s3types.BucketVersioningStatusEnabled,
+		},
+	}
+	got, err := filterS3BucketsByProjectTag(context.Background(), client, "my-stack")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.NotNil(t, got[0].Versioning)
+	assert.True(t, *got[0].Versioning)
+}
+
+func TestFilterS3BucketsByProjectTag_VersioningSuspendedAndUnset(t *testing.T) {
+	t.Parallel()
+	// Suspended and the never-configured empty status both map to
+	// Versioning=false (not nil) — the call succeeded, the answer is "off".
+	client := &fakeS3Client{
+		listOut: &s3.ListBucketsOutput{
+			Buckets: []s3types.Bucket{
+				{Name: aws.String("suspended-bucket")},
+				{Name: aws.String("unset-bucket")},
+			},
+		},
+		// empty project → no tag scope filter, all buckets returned.
+		versByKey: map[string]s3types.BucketVersioningStatus{
+			"suspended-bucket": s3types.BucketVersioningStatusSuspended,
+			// unset-bucket absent → empty status.
+		},
+	}
+	got, err := filterS3BucketsByProjectTag(context.Background(), client, "")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	for _, b := range got {
+		require.NotNil(t, b.Versioning, "successful GetBucketVersioning must set the flag")
+		assert.False(t, *b.Versioning)
+	}
+}
+
+func TestFilterS3BucketsByProjectTag_VersioningErrorOmits(t *testing.T) {
+	t.Parallel()
+	// A GetBucketVersioning failure is non-fatal: the bucket is still
+	// returned, but Versioning stays nil so the JSON envelope omits it and
+	// extractS3Config falls back to design values rather than claiming a
+	// wrong state.
+	client := &fakeS3Client{
+		listOut: &s3.ListBucketsOutput{
+			Buckets: []s3types.Bucket{{Name: aws.String("denied-bucket")}},
+		},
+		versErrByKey: map[string]error{
+			"denied-bucket": &fakeAPIError{code: "AccessDenied", message: "denied"},
+		},
+	}
+	got, err := filterS3BucketsByProjectTag(context.Background(), client, "")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Nil(t, got[0].Versioning, "versioning omitted on lookup failure")
+
+	// Round-trip through JSON to confirm the omitempty field truly drops
+	// out of the envelope the extractor consumes.
+	raw, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.NotContains(t, string(raw), "Versioning")
 }
 
 // --- KMS fake ---

--- a/pkg/observability/discovery/aws/storage_test.go
+++ b/pkg/observability/discovery/aws/storage_test.go
@@ -229,24 +229,56 @@ func TestFilterS3BucketsByProjectTag_VersioningErrorOmits(t *testing.T) {
 	// returned, but Versioning stays nil so the JSON envelope omits it and
 	// extractS3Config falls back to design values rather than claiming a
 	// wrong state.
-	client := &fakeS3Client{
-		listOut: &s3.ListBucketsOutput{
-			Buckets: []s3types.Bucket{{Name: aws.String("denied-bucket")}},
+	//
+	// enrichS3Versioning has TWO non-fatal error branches: isS3VersioningSkip
+	// (the s3VersioningSkipCodes allowlist — cross-region / access-denied
+	// buckets) AND the default catch-all (transport / throttle errors that
+	// are not smithy.APIErrors at all). Both must leave Versioning nil and
+	// drop the field from the JSON envelope. Table-drive across a skip code,
+	// a second skip code (so deleting any one entry from the allowlist is a
+	// detectable mutation), and a plain non-API transport error that only the
+	// default branch can absorb.
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "AccessDenied skip code",
+			err:  &fakeAPIError{code: "AccessDenied", message: "denied"},
 		},
-		versErrByKey: map[string]error{
-			"denied-bucket": &fakeAPIError{code: "AccessDenied", message: "denied"},
+		{
+			name: "PermanentRedirect skip code",
+			err:  &fakeAPIError{code: "PermanentRedirect", message: "wrong region endpoint"},
+		},
+		{
+			name: "plain transport error (default branch)",
+			err:  errors.New("dial tcp: i/o timeout"),
 		},
 	}
-	got, err := filterS3BucketsByProjectTag(context.Background(), client, "")
-	require.NoError(t, err)
-	require.Len(t, got, 1)
-	assert.Nil(t, got[0].Versioning, "versioning omitted on lookup failure")
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			client := &fakeS3Client{
+				listOut: &s3.ListBucketsOutput{
+					Buckets: []s3types.Bucket{{Name: aws.String("error-bucket")}},
+				},
+				versErrByKey: map[string]error{
+					"error-bucket": tc.err,
+				},
+			}
+			got, err := filterS3BucketsByProjectTag(context.Background(), client, "")
+			require.NoError(t, err, "versioning lookup failure must be non-fatal")
+			require.Len(t, got, 1)
+			assert.Nil(t, got[0].Versioning, "versioning omitted on lookup failure")
 
-	// Round-trip through JSON to confirm the omitempty field truly drops
-	// out of the envelope the extractor consumes.
-	raw, err := json.Marshal(got)
-	require.NoError(t, err)
-	assert.NotContains(t, string(raw), "Versioning")
+			// Round-trip through JSON to confirm the omitempty field truly
+			// drops out of the envelope the extractor consumes.
+			raw, err := json.Marshal(got)
+			require.NoError(t, err)
+			assert.NotContains(t, string(raw), "Versioning")
+		})
+	}
 }
 
 // --- KMS fake ---

--- a/pkg/observability/discovery/gcp/storage.go
+++ b/pkg/observability/discovery/gcp/storage.go
@@ -58,6 +58,11 @@ func inspectGCS(ctx context.Context, projectID, action, filters string, opts ...
 // hand-rolled JSON shape the inspector contract returns. The output
 // is always a non-nil slice so an empty input marshals as `[]`,
 // pinned by the per-site empty-state test (#256).
+//
+// versioning comes straight off BucketAttrs.VersioningEnabled — the
+// list-buckets call already fetches full attrs, so unlike AWS S3 this
+// needs no second SDK round-trip. Surfaced so extractGCPGCSConfig can
+// report gcp_gcs.versioning (#712).
 func bucketAttrsToMaps(attrs []*storage.BucketAttrs) []map[string]any {
 	out := make([]map[string]any, 0, len(attrs))
 	for _, b := range attrs {
@@ -66,6 +71,7 @@ func bucketAttrsToMaps(attrs []*storage.BucketAttrs) []map[string]any {
 			"location":     b.Location,
 			"storageClass": b.StorageClass,
 			"created":      b.Created,
+			"versioning":   b.VersioningEnabled,
 		})
 	}
 	return out

--- a/pkg/observability/discovery/gcp/storage_test.go
+++ b/pkg/observability/discovery/gcp/storage_test.go
@@ -36,7 +36,8 @@ const listBucketsResponse = `{
   "items": [
     {"name": "bkt-a", "location": "US", "storageClass": "STANDARD", "timeCreated": "2024-01-01T00:00:00Z", "versioning": {"enabled": true}, "labels": {"project": "io-foo"}},
     {"name": "bkt-b", "location": "EU", "storageClass": "NEARLINE", "timeCreated": "2024-01-02T00:00:00Z", "labels": {"project": "io-bar"}},
-    {"name": "bkt-c", "location": "ASIA", "storageClass": "STANDARD", "timeCreated": "2024-01-03T00:00:00Z"}
+    {"name": "bkt-c", "location": "ASIA", "storageClass": "STANDARD", "timeCreated": "2024-01-03T00:00:00Z"},
+    {"name": "bkt-d", "location": "US", "storageClass": "STANDARD", "timeCreated": "2024-01-04T00:00:00Z", "versioning": {"enabled": false}, "labels": {"project": "io-baz"}}
   ]
 }`
 
@@ -53,8 +54,8 @@ func TestInspectGCS_ListBuckets_AllReturned(t *testing.T) {
 
 	buckets, ok := got.([]map[string]any)
 	require.True(t, ok, "expected []map[string]any, got %T", got)
-	// No project filter — all three buckets surface.
-	assert.Len(t, buckets, 3)
+	// No project filter — all four buckets surface.
+	require.Len(t, buckets, 4)
 	assert.Equal(t, "bkt-a", buckets[0]["name"])
 	assert.Equal(t, "STANDARD", buckets[0]["storageClass"])
 	assert.Equal(t, "EU", buckets[1]["location"])
@@ -62,6 +63,12 @@ func TestInspectGCS_ListBuckets_AllReturned(t *testing.T) {
 	// bkt-a has versioning enabled, bkt-b/bkt-c default to false.
 	assert.Equal(t, true, buckets[0]["versioning"])
 	assert.Equal(t, false, buckets[1]["versioning"])
+	// bkt-d carries an EXPLICIT "versioning":{"enabled":false} block on the
+	// wire (not a missing block defaulting to Go's zero value), proving the
+	// false path is extracted from real REST data rather than an
+	// encoding/json default. #712.
+	assert.Equal(t, "bkt-d", buckets[3]["name"])
+	assert.Equal(t, false, buckets[3]["versioning"])
 }
 
 func TestInspectGCS_ListBuckets_FiltersByProject(t *testing.T) {

--- a/pkg/observability/discovery/gcp/storage_test.go
+++ b/pkg/observability/discovery/gcp/storage_test.go
@@ -34,7 +34,7 @@ func fakeStorageREST(t *testing.T, handler http.HandlerFunc) (*httptest.Server, 
 const listBucketsResponse = `{
   "kind": "storage#buckets",
   "items": [
-    {"name": "bkt-a", "location": "US", "storageClass": "STANDARD", "timeCreated": "2024-01-01T00:00:00Z", "labels": {"project": "io-foo"}},
+    {"name": "bkt-a", "location": "US", "storageClass": "STANDARD", "timeCreated": "2024-01-01T00:00:00Z", "versioning": {"enabled": true}, "labels": {"project": "io-foo"}},
     {"name": "bkt-b", "location": "EU", "storageClass": "NEARLINE", "timeCreated": "2024-01-02T00:00:00Z", "labels": {"project": "io-bar"}},
     {"name": "bkt-c", "location": "ASIA", "storageClass": "STANDARD", "timeCreated": "2024-01-03T00:00:00Z"}
   ]
@@ -58,6 +58,10 @@ func TestInspectGCS_ListBuckets_AllReturned(t *testing.T) {
 	assert.Equal(t, "bkt-a", buckets[0]["name"])
 	assert.Equal(t, "STANDARD", buckets[0]["storageClass"])
 	assert.Equal(t, "EU", buckets[1]["location"])
+	// versioning comes straight off BucketAttrs.VersioningEnabled (#712):
+	// bkt-a has versioning enabled, bkt-b/bkt-c default to false.
+	assert.Equal(t, true, buckets[0]["versioning"])
+	assert.Equal(t, false, buckets[1]["versioning"])
 }
 
 func TestInspectGCS_ListBuckets_FiltersByProject(t *testing.T) {

--- a/pkg/observability/extractors/aws_test.go
+++ b/pkg/observability/extractors/aws_test.go
@@ -597,6 +597,56 @@ func TestExtractS3Config(t *testing.T) {
 		assert.Equal(t, "1", got["bucketCount"])
 	})
 
+	t.Run("SingleBucket_VersioningEnabled", func(t *testing.T) {
+		t.Parallel()
+		// One bucket whose inspector-enriched Versioning flag is true →
+		// surface versioning="true" (the reliable-side humanizeConfigValue
+		// renders it as "Yes").
+		got := extractS3Config([]any{
+			map[string]any{"Name": "demo-bucket", "Versioning": true},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["bucketCount"])
+		assert.Equal(t, "true", got["versioning"])
+	})
+
+	t.Run("SingleBucket_VersioningDisabled", func(t *testing.T) {
+		t.Parallel()
+		got := extractS3Config([]any{
+			map[string]any{"Name": "demo-bucket", "Versioning": false},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "false", got["versioning"])
+	})
+
+	t.Run("SingleBucket_VersioningNotFetchedOmits", func(t *testing.T) {
+		t.Parallel()
+		// Inspector omits Versioning when GetBucketVersioning was
+		// skipped/failed; extractor must not invent a value.
+		got := extractS3Config([]any{
+			map[string]any{"Name": "demo-bucket"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "1", got["bucketCount"])
+		_, has := got["versioning"]
+		assert.False(t, has, "versioning omitted when the inspector didn't fetch it")
+	})
+
+	t.Run("MultiBucket_OmitsVersioning", func(t *testing.T) {
+		t.Parallel()
+		// Versioning is per-bucket; with multiple buckets we refuse to
+		// claim a single value across the set and omit it. The per-resource
+		// imported path surfaces each bucket precisely (#712).
+		got := extractS3Config([]any{
+			map[string]any{"Name": "bucket-a", "Versioning": true},
+			map[string]any{"Name": "bucket-b", "Versioning": false},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["bucketCount"])
+		_, has := got["versioning"]
+		assert.False(t, has, "multi-bucket aggregate must not surface a single versioning value")
+	})
+
 	t.Run("NilInput", func(t *testing.T) {
 		t.Parallel()
 		assert.Nil(t, extractS3Config(nil))

--- a/pkg/observability/extractors/aws_test.go
+++ b/pkg/observability/extractors/aws_test.go
@@ -1058,12 +1058,55 @@ func TestExtractCognitoConfig(t *testing.T) {
 	t.Run("MultiplePools", func(t *testing.T) {
 		t.Parallel()
 		got := extractCognitoConfig([]any{
-			map[string]any{"Id": "p1", "Name": "first"},
-			map[string]any{"Id": "p2", "Name": "second"},
+			map[string]any{"Id": "p1", "Name": "first", "MfaConfiguration": "ON"},
+			map[string]any{"Id": "p2", "Name": "second", "MfaConfiguration": "OFF"},
 		})
 		require.NotNil(t, got)
 		assert.Equal(t, "2", got["userPoolCount"])
 		assert.Equal(t, "first", got["poolName"]) // first one
+		_, has := got["mfaRequired"]
+		assert.False(t, has, "multi-pool aggregate must not surface a single mfaRequired value")
+	})
+
+	t.Run("SinglePool_MFAOn", func(t *testing.T) {
+		t.Parallel()
+		// MfaConfiguration=ON → mfaRequired=true.
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "Name": "secure-pool", "MfaConfiguration": "ON"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "true", got["mfaRequired"])
+	})
+
+	t.Run("SinglePool_MFAOptionalIsNotRequired", func(t *testing.T) {
+		t.Parallel()
+		// OPTIONAL leaves MFA to the user — not "required".
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "MfaConfiguration": "OPTIONAL"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "false", got["mfaRequired"])
+	})
+
+	t.Run("SinglePool_MFAOff", func(t *testing.T) {
+		t.Parallel()
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "MfaConfiguration": "OFF"},
+		})
+		require.NotNil(t, got)
+		assert.Equal(t, "false", got["mfaRequired"])
+	})
+
+	t.Run("SinglePool_MFANotFetchedOmits", func(t *testing.T) {
+		t.Parallel()
+		// Inspector omits MfaConfiguration on the empty-project path; the
+		// extractor must not invent a value.
+		got := extractCognitoConfig([]any{
+			map[string]any{"Id": "p1", "Name": "demo-pool"},
+		})
+		require.NotNil(t, got)
+		_, has := got["mfaRequired"]
+		assert.False(t, has, "mfaRequired omitted when the inspector didn't fetch it")
 	})
 
 	t.Run("Envelope", func(t *testing.T) {

--- a/pkg/observability/extractors/extractors.go
+++ b/pkg/observability/extractors/extractors.go
@@ -602,25 +602,39 @@ func extractKMSConfig(rawResult any) map[string]string {
 	}
 }
 
-// extractS3Config extracts config from list-buckets response. Shape:
+// extractS3Config extracts config from list-buckets response. Shape (the
+// inspector enriches each bucket with Versioning via a GetBucketVersioning
+// fan-out — see filterS3BucketsByProjectTag / enrichS3Versioning):
 //
-//	[ { Name, CreationDate } ]
+//	[ { Name, CreationDate, Versioning } ]
 //
-// frontend field (lib/stack/ir.ts:308): aws_s3.versioning (bool). Versioning
-// is not returned by ListBuckets and would require an additional
-// GetBucketVersioning call per bucket.
+// frontend field (lib/stack/ir.ts:312): aws_s3.versioning (bool). The
+// reliable-side humanizeConfigValue treats "versioning" as a BOOLEAN_KEY,
+// so we stringify the literal lowercase bool ("true"/"false").
 //
-// TODO(#1089): surface per-bucket versioning by fanning out
-// GetBucketVersioning. Current live config surfaces only a bucket count,
-// which is sufficient for the "deploy succeeded / bucket exists" signal.
+// Multi-bucket nuance: this extractor aggregates the whole aws_s3 component
+// (a list of buckets), not one bucket. Versioning is a per-bucket setting,
+// so we only emit `versioning` when there is exactly ONE bucket AND its
+// state was actually fetched (the inspector omits Versioning when the
+// GetBucketVersioning call was skipped/failed). With multiple buckets we
+// omit it rather than claim a single value across the set — the per-resource
+// imported path surfaces each bucket's versioning precisely (#712).
 func extractS3Config(rawResult any) map[string]string {
 	items := sliceFromEnvelope(rawResult, "Buckets")
 	if len(items) == 0 {
 		return nil
 	}
-	return map[string]string{
+	cfg := map[string]string{
 		"bucketCount": strconv.Itoa(len(items)),
 	}
+	if len(items) == 1 {
+		if v, ok := items[0]["Versioning"]; ok {
+			if b, ok := v.(bool); ok {
+				cfg["versioning"] = strconv.FormatBool(b)
+			}
+		}
+	}
+	return cfg
 }
 
 // extractSecretsManagerConfig extracts config from list-secrets response.

--- a/pkg/observability/extractors/extractors.go
+++ b/pkg/observability/extractors/extractors.go
@@ -921,13 +921,21 @@ func extractSQSConfig(rawResult any) map[string]string {
 //	[ { Id, Name, Status, CreationDate, LambdaConfig } ]
 //
 // frontend fields (lib/stack/ir.ts:347): aws_cognito.signInType,
-// mfaRequired, okta, auth0 — none of which are on the list-user-pools
-// summary; they live on DescribeUserPool.
+// mfaRequired, okta, auth0. mfaRequired is surfaced here; the inspector
+// enriches each project-scoped pool with MfaConfiguration off the
+// DescribeUserPool response it already issues for the ARN — see
+// filterCognitoUserPoolsByProjectTag (#712). signInType / okta / auth0
+// still need wider DescribeUserPool fields and remain design-only.
 //
-// TODO(#1089): fan out DescribeUserPool per pool to surface MFA policy
-// (MfaConfiguration), password policy (Policies.PasswordPolicy), and
-// alias attributes. Today we emit the drift/identity signals so the UI
-// can render a "pool exists, status active" card.
+// MfaConfiguration is OFF|ON|OPTIONAL; mfaRequired is true only for ON
+// (OPTIONAL leaves MFA up to the user, so it is not "required"). The value
+// is the literal lowercase bool to match the reliable-side
+// humanizeConfigValue BOOLEAN_KEYS contract.
+//
+// Multi-pool nuance (same as extractS3Config): MfaConfiguration is
+// per-pool, so mfaRequired is only surfaced when there is exactly ONE pool
+// AND its config was fetched (the inspector omits MfaConfiguration on the
+// empty-project demo path); multiple pools omit it.
 func extractCognitoConfig(rawResult any) map[string]string {
 	items := sliceFromEnvelope(rawResult, "UserPools")
 	if len(items) == 0 {
@@ -945,6 +953,11 @@ func extractCognitoConfig(rawResult any) map[string]string {
 	}
 	if v := getString(first, "Id"); v != "" {
 		cfg["poolId"] = v
+	}
+	if len(items) == 1 {
+		if mfa := getString(first, "MfaConfiguration"); mfa != "" {
+			cfg["mfaRequired"] = strconv.FormatBool(mfa == "ON")
+		}
 	}
 	return cfg
 }

--- a/pkg/observability/extractors/extractors.go
+++ b/pkg/observability/extractors/extractors.go
@@ -1418,17 +1418,22 @@ func extractGCPCloudSQLConfig(rawResult any) map[string]string {
 }
 
 // extractGCPGCSConfig extracts config from the list-buckets response. The
-// inspector (inspectGCPGCS) PRE-FLATTENS each bucket to a 4-key map:
+// inspector (inspectGCPGCS) PRE-FLATTENS each bucket to a 5-key map:
 //
-//	[ { name, location, storageClass, created } ]
+//	[ { name, location, storageClass, created, versioning } ]
 //
 // — so this extractor is the simplest of the bundle: no proto parsing
 // required, straight field lookups.
 //
-// frontend fields (lib/stack/ir.ts:488-495): storageClass, versioning.
-// versioning is NOT on the inspector's pre-flattened shape (would need
-// a per-bucket GetAttrs fan-out). TODO(#1090 follow-up): fan out
-// (*storage.BucketHandle).Attrs() to surface VersioningEnabled.
+// frontend fields (lib/stack/ir.ts:493-494): storageClass, versioning.
+// versioning comes straight off BucketAttrs.VersioningEnabled — list-buckets
+// already fetches full attrs, so (unlike AWS S3) no second SDK call is
+// needed. It is stringified as the literal lowercase bool ("true"/"false")
+// to match the reliable-side humanizeConfigValue BOOLEAN_KEYS contract.
+//
+// Multi-bucket nuance (same as extractS3Config): versioning is per-bucket,
+// so we only surface it when there is exactly ONE bucket; multiple buckets
+// omit it rather than claim a single value across the set (#712).
 func extractGCPGCSConfig(rawResult any) map[string]string {
 	items := sliceFromEnvelope(rawResult, "buckets")
 	if len(items) == 0 {
@@ -1446,6 +1451,13 @@ func extractGCPGCSConfig(rawResult any) map[string]string {
 	}
 	if v := getString(first, "storageClass"); v != "" {
 		cfg["storageClass"] = v
+	}
+	if len(items) == 1 {
+		if v, ok := first["versioning"]; ok {
+			if b, ok := v.(bool); ok {
+				cfg["versioning"] = strconv.FormatBool(b)
+			}
+		}
 	}
 	return cfg
 }

--- a/pkg/observability/extractors/gcp_test.go
+++ b/pkg/observability/extractors/gcp_test.go
@@ -418,6 +418,7 @@ func TestExtractGCPGCSConfig(t *testing.T) {
 			"name":         "demo-bucket",
 			"location":     "us-central1",
 			"storageClass": "STANDARD",
+			"versioning":   true,
 		}}
 		got := extractGCPGCSConfig(raw)
 		require.NotNil(t, got)
@@ -425,6 +426,50 @@ func TestExtractGCPGCSConfig(t *testing.T) {
 		assert.Equal(t, "demo-bucket", got["bucketName"])
 		assert.Equal(t, "us-central1", got["location"])
 		assert.Equal(t, "STANDARD", got["storageClass"])
+		assert.Equal(t, "true", got["versioning"])
+	})
+
+	t.Run("SingleBucket_VersioningDisabled", func(t *testing.T) {
+		t.Parallel()
+		raw := []any{map[string]any{
+			"name":         "demo-bucket",
+			"location":     "us-central1",
+			"storageClass": "STANDARD",
+			"versioning":   false,
+		}}
+		got := extractGCPGCSConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "false", got["versioning"])
+	})
+
+	t.Run("VersioningAbsentOmits", func(t *testing.T) {
+		t.Parallel()
+		// Older inspector fixtures (pre-#712) lack the versioning key; the
+		// extractor must not invent one.
+		raw := []any{map[string]any{
+			"name":         "demo-bucket",
+			"location":     "us-central1",
+			"storageClass": "STANDARD",
+		}}
+		got := extractGCPGCSConfig(raw)
+		require.NotNil(t, got)
+		_, has := got["versioning"]
+		assert.False(t, has, "versioning omitted when absent from the envelope")
+	})
+
+	t.Run("MultiBucket_OmitsVersioning", func(t *testing.T) {
+		t.Parallel()
+		// Per-bucket setting; with multiple buckets we omit it rather than
+		// claim a single value across the set (#712).
+		raw := []any{
+			map[string]any{"name": "bkt-a", "versioning": true},
+			map[string]any{"name": "bkt-b", "versioning": false},
+		}
+		got := extractGCPGCSConfig(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, "2", got["bucketCount"])
+		_, has := got["versioning"]
+		assert.False(t, has, "multi-bucket aggregate must not surface a single versioning value")
 	})
 
 	t.Run("MultiRegionalLocation", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Move imported resources toward config + observable parity with managed (epic #712). Two upstream-owned mechanisms:

- Live-config extractors now surface **S3 versioning** (resolves the long-standing `TODO(#1089)`), **GCS versioning**, and **Cognito MFA**. The inspector fan-out enriches the resource (`GetBucketVersioning`; `MfaConfiguration` was already on the `DescribeUserPool` response) and the extractor emits `versioning` / `mfaRequired` as literal `"true"`/`"false"`. The key is emitted only when there is exactly one resource AND its state was actually fetched, so "disabled" is distinguishable from "not fetched" (`omitempty` on a pointer field); multi-resource omits it (the per-resource imported path handles that case later).
- New chartable `MetricsBinding` for **`google_identity_platform_config`** — the one user-facing managed-metrics type that had no imported observability — mirroring the managed `identityplatform` `serviceruntime.googleapis.com/api/request_count` series + `service` dimension.

Drive-by: dropped two stale `metricsBindingExempt` entries (`google_cloudbuild_trigger`, `google_cloudfunctions2_function`) that already have real bindings — the exempt list's own header documents this cleanup.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/observability/... ./pkg/imported/...`
- [x] `go test -race ./pkg/observability/... ./pkg/imported/...` — all green
- [x] New cases: versioning Enabled/Disabled/Suspended/unset/skip-code+default-error/cross-region; Cognito ON/OFF/OPTIONAL/missing; GCS true/false-from-wire/absent/multi; binding chartable; present-vs-absent (`omitempty`) JSON round-trips.

## Review notes

- `/review`: no P0/P1. One P2 (stale exempt entries) fixed as a drive-by. Two cosmetic P3 comment nits deferred (see below).
- qa-professor: PASS. Its two P2 test-hardening recommendations were added — the S3 skip-vs-`default` error-branch table (a deleted skip-code now fails a test) and an explicit `versioning:{enabled:false}` GCS bucket so the false path is proven from real wire data.
- Consumer contract (companion reliable#1981): extractor keys are `versioning` / `mfaRequired`, literal lowercase `"true"`/`"false"` — already in reliable's `humanizeConfigValue` BOOLEAN_KEYS, so the reliable-side overlay picks them up with no further mapping.

## Deferred follow-ups

- Stretch extractor fan-outs left as `TODO(#1089)` markers (clean deferrals, not regressions): CloudFront DefaultTTL (deprecated field / needs the cache-policy path), SQS type/visibility, DynamoDB billing_mode, EKS node sizing, WAF rules — each needs a new SDK call and/or an inspector return-type change (larger blast radius).
- Cosmetic P3: comments in `storage.go`/`auth.go` say the `omitempty` presence-check is "the same as `extractVPCConfig`"; VPC uses a non-pointer, always-injected bool — analogous at the extractor layer, not identical at the struct layer.

Refs epic #712; companion reliable#1981.
