### PR TITLE
fix(imported): advance config and observable parity

### DIFF
--- a/cmd/insideout-import/gcpdiscover/identity_platform_config.go
+++ b/cmd/insideout-import/gcpdiscover/identity_platform_config.go
@@ -26,6 +26,7 @@ import (
 const (
 	identityPlatformConfigTFType    = "google_identity_platform_config"
 	identityPlatformConfigAssetType = "identitytoolkit.googleapis.com/Config" // descriptive; not in CAI
+	identityPlatformConfigService   = "identitytoolkit.googleapis.com"
 )
 
 type identityPlatformConfigDiscoverer struct {
@@ -73,6 +74,7 @@ func (d *identityPlatformConfigDiscoverer) ListNonCAI(ctx context.Context, proje
 	return []imported.ImportedResource{
 		makeImportedResource(book, identityPlatformConfigTFType, "config", importID, projectID, "", map[string]string{
 			"asset_name": assetName,
+			"service":    identityPlatformConfigService,
 		}, nil),
 	}, nil
 }

--- a/cmd/insideout-import/gcpdiscover/identity_platform_config_test.go
+++ b/cmd/insideout-import/gcpdiscover/identity_platform_config_test.go
@@ -33,6 +33,9 @@ func TestIdentityPlatformConfigListNonCAI_ReturnsConfigWhenActivated(t *testing.
 	if got[0].Identity.ImportID != "real-proj" {
 		t.Errorf("ImportID=%q, want real-proj", got[0].Identity.ImportID)
 	}
+	if got[0].Identity.NativeIDs["service"] != identityPlatformConfigService {
+		t.Errorf("NativeIDs[service]=%q, want %q", got[0].Identity.NativeIDs["service"], identityPlatformConfigService)
+	}
 }
 
 func TestIdentityPlatformConfigListNonCAI_NotActivatedYieldsZero(t *testing.T) {

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -778,14 +778,15 @@ var seededBindings = map[string]ComponentMetricsBinding{
 	// request_count series under the `service` label, so the imported
 	// binding mirrors that: serviceruntime.googleapis.com/api/request_count
 	// filtered on the `service` dimension (= identitytoolkit.googleapis.com).
-	// DimensionFrom "name" carries the resource's project-scoped name —
-	// the same project-level dimension google_project_service uses — since
-	// no narrower key exists for a project singleton.
+	// DimensionFrom "service" resolves from NativeIDs["service"], which the
+	// non-CAI discoverer stamps to identitytoolkit.googleapis.com. Using
+	// "name" here would incorrectly filter the service label to the
+	// singleton resource name ("config" / projects/<p>/config).
 	"google_identity_platform_config": {
 		Service:        "identityplatform",
 		Action:         "timeseries-list",
 		DimensionKey:   "service",
-		DimensionFrom:  "name",
+		DimensionFrom:  "service",
 		DefaultMetrics: []string{"serviceruntime.googleapis.com/api/request_count", "serviceruntime.googleapis.com/api/request_latencies"},
 	},
 	"aws_eip": {

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -66,10 +66,9 @@ func TestIdentityPlatformConfigChartable(t *testing.T) {
 		"google_identity_platform_config binding has empty DefaultMetrics — nothing to chart")
 	assert.Contains(t, b.DefaultMetrics, "serviceruntime.googleapis.com/api/request_count",
 		"binding must mirror the managed gcp_identity_platform consumed-API request series")
-	// Mirror the managed metric's `service` dimension (gcpServiceMetrics
-	// ["identityplatform"] LabelKey: "service").
 	assert.Equal(t, "service", b.DimensionKey)
-	assert.NotEmpty(t, b.DimensionFrom)
+	assert.Equal(t, "service", b.DimensionFrom,
+		"DimensionFrom must resolve to NativeIDs[service]=identitytoolkit.googleapis.com; the resource name is just the project singleton")
 }
 
 func TestSeededBindings(t *testing.T) {


### PR DESCRIPTION
## Summary

- Supersedes #715 with the same S3/GCS versioning and Cognito MFA live-config extractor work.
- Adds the imported `google_identity_platform_config` metrics binding and fixes its dimension source so it filters `service=identitytoolkit.googleapis.com` instead of the singleton resource name.
- Documents the presets-side #712 status: S3 durable attrs capture is already covered by the existing `aws_s3_bucket` enricher and reverse-import final-plan backfill; this PR advances #712 but does not close the epic because Reliable-side imported config overlay work remains.

## Test plan

- [x] `go test ./cmd/insideout-import/gcpdiscover ./cmd/insideout-import/awsdiscover ./pkg/reverseimport ./pkg/observability/discovery/aws ./pkg/observability/discovery/gcp ./pkg/observability/extractors ./pkg/imported/bindings`

## Review notes

- Refs #712, supersedes #715.
- Security review: no auth, credential, secret, or user-input trust-boundary changes. Added constants are public cloud service identifiers and metrics metadata.
- QA professor review: PASS. Tests pin true/false/omitted config extractor behavior, reverse-import S3 attrs persistence already exists, and the Identity Platform binding now has mutation-resistant assertions for the service dimension source.
