### PR TITLE
fix: accept human duration word forms in parseTTLSeconds (symmetric with humanizeDuration)

### DIFF
--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1542,6 +1542,8 @@ func normalizeStorageSizeGBString(s, fieldName string) (string, error) {
 //   - "0" / "<N>" — bare integer (already in seconds)
 //   - "<N>s" / "<N>m" / "<N>h" — durations
 //   - "1day" / "<N>day" / "<N>days" — day shorthand the IR uses for CDN TTL
+//   - "<N> seconds" / "<N> minutes" / "<N> hours" — the human word forms
+//     humanizeDuration emits (see below)
 func parseTTLSeconds(s, fieldName string) (int, error) {
 	t := strings.TrimSpace(s)
 
@@ -1564,13 +1566,36 @@ func parseTTLSeconds(s, fieldName string) (int, error) {
 		}
 	}
 
+	// Human word forms emitted by humanizeDuration ("30 seconds" / "10 minutes"
+	// / "1 hour"). parseTTLSeconds must accept what the composer humanizes TO,
+	// so a humanizeDuration -> parseTTLSeconds round-trip is lossless and IR
+	// enums that surface the human label (e.g. SQS visibilityTimeout) compose
+	// instead of erroring. Mirrors the day/hour word handling in
+	// parseRetentionHours. See luthersystems/reliable#1994.
+	for _, u := range []struct {
+		sufs []string
+		mult int
+	}{
+		{[]string{"seconds", "second"}, 1},
+		{[]string{"minutes", "minute"}, 60},
+		{[]string{"hours", "hour"}, 3600},
+	} {
+		for _, suf := range u.sufs {
+			if rest, ok := strings.CutSuffix(low, suf); ok {
+				if n, err := strconv.Atoi(strings.TrimSpace(rest)); err == nil && n >= 0 {
+					return n * u.mult, nil
+				}
+			}
+		}
+	}
+
 	// "<N>s" / "<N>m" / "<N>h"
 	if secs, ok := matchDuration(t); ok {
 		return secs, nil
 	}
 
 	return 0, NewValidationError(fmt.Sprintf(
-		"%s=%q: expected seconds, \"<N>s\" / \"<N>m\" / \"<N>h\", or \"<N>day(s)\"",
+		"%s=%q: expected seconds, \"<N>s\" / \"<N>m\" / \"<N>h\", \"<N>day(s)\", or \"<N> seconds/minutes/hours\"",
 		fieldName, s,
 	))
 }

--- a/pkg/composer/parse_ttl_human_test.go
+++ b/pkg/composer/parse_ttl_human_test.go
@@ -1,0 +1,78 @@
+package composer
+
+import "testing"
+
+// TestParseTTLSeconds_HumanWordForms locks the fix for luthersystems/reliable#1994:
+// parseTTLSeconds must accept the human duration word forms humanizeDuration
+// emits (e.g. SQS visibilityTimeout "30 seconds"), not only "<N>s/m/h" and
+// "<N>day(s)". Existing accepted forms must keep working.
+func TestParseTTLSeconds_HumanWordForms(t *testing.T) {
+	ok := []struct {
+		in   string
+		want int
+	}{
+		// New: human word forms (what humanizeDuration produces).
+		{"30 seconds", 30},
+		{"1 second", 1},
+		{"10 minutes", 600},
+		{"1 minute", 60},
+		{"1 hour", 3600},
+		{"5 hours", 18000},
+		{"30 Seconds", 30},   // case-insensitive
+		{" 30 seconds ", 30}, // surrounding whitespace
+		// Existing forms still accepted.
+		{"0", 0},
+		{"600", 600},
+		{"30s", 30},
+		{"10m", 600},
+		{"1h", 3600},
+		{"1day", 86400},
+		{"7 days", 604800},
+	}
+	for _, tc := range ok {
+		got, err := parseTTLSeconds(tc.in, "visibilityTimeout")
+		if err != nil {
+			t.Errorf("parseTTLSeconds(%q) unexpected error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("parseTTLSeconds(%q) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+
+	bad := []string{"potato", "soon", "", "-5 minutes"}
+	for _, in := range bad {
+		if _, err := parseTTLSeconds(in, "visibilityTimeout"); err == nil {
+			t.Errorf("parseTTLSeconds(%q) = nil error, want validation error", in)
+		}
+	}
+}
+
+// TestParseTTLSeconds_RoundTripsHumanizeDuration is the symmetry guard: every
+// machine duration the composer humanizes for display must parse back to the
+// same number of seconds. This keeps parseTTLSeconds and humanizeDuration from
+// drifting apart again (#1994).
+func TestParseTTLSeconds_RoundTripsHumanizeDuration(t *testing.T) {
+	cases := []struct {
+		machine string
+		want    int
+	}{
+		{"30s", 30},
+		{"10m", 600},
+		{"1h", 3600},
+		{"1s", 1},
+		{"1m", 60},
+		{"2h", 7200},
+	}
+	for _, tc := range cases {
+		human := humanizeDuration(tc.machine)
+		got, err := parseTTLSeconds(human, "visibilityTimeout")
+		if err != nil {
+			t.Errorf("parseTTLSeconds(humanizeDuration(%q)=%q) error: %v", tc.machine, human, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("round-trip %q -> humanize %q -> parse %d, want %d", tc.machine, human, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

`parseTTLSeconds` now accepts the human duration word forms the composer's own `humanizeDuration` emits — `"<N> seconds"` / `"<N> minutes"` / `"<N> hours"` — in addition to the existing bare-int, `<N>s/m/h`, and `<N>day(s)` forms. This mirrors how `parseRetentionHours` already accepts `"<N> days"`.

## Why

`humanizeDuration("30s") -> "30 seconds"`, but `parseTTLSeconds("30 seconds")` errored — the humanize and parse directions were asymmetric. Any IR field that surfaces the human label and maps through `parseTTLSeconds` (SQS `visibilityTimeout`, CDN TTL) could fail to compose. Surfaces downstream as a "Terraform Error" in luthersystems/reliable#1994.

## Tests

- `TestParseTTLSeconds_HumanWordForms` — word forms (incl. case + whitespace) parse correctly; all existing forms still work; junk still errors.
- `TestParseTTLSeconds_RoundTripsHumanizeDuration` — `parseTTLSeconds(humanizeDuration(x)) == x` for representative durations, so the two functions can't drift apart again.

Full `pkg/composer` suite (1550 tests) passes; gofmt/vet clean.

Closes #717
Surfaces in luthersystems/reliable#1994