### PR TITLE
test(imported): classify inventory-only observable surfaces

### DIFF
--- a/pkg/imported/managed_components_test.go
+++ b/pkg/imported/managed_components_test.go
@@ -11,12 +11,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var observableParityKnownGaps = map[composer.ComponentKey]string{
-	composer.KeyAWSAppRunner:     "#712 - aws_apprunner_service has no imported metrics binding yet",
-	composer.KeyAWSGrafana:       "#712 - aws_grafana_workspace is not an imported supported type while the managed preset is still a placeholder",
-	composer.KeyAWSSageMaker:     "#712 - aws_sagemaker_domain has no imported metrics binding yet",
-	composer.KeyGCPCloudDeploy:   "#712 - google_clouddeploy_delivery_pipeline has no imported metrics binding yet",
-	composer.KeyGCPGitHubActions: "#712 - google_iam_workload_identity_pool is a security/IAM artifact, not a chartable time-series surface",
+type nonChartableObservableSurface struct {
+	Class  string
+	Reason string
+}
+
+// observableParityNonChartable records managed components with imported
+// inventory coverage but no chartable metrics surface. These are not parity
+// gaps: the component detail panel can discover the top-level resource, but
+// there is no reliable DefaultMetrics binding to synthesize. If a real metrics
+// binding lands for one of these tfTypes, TestObservableParity_NonChartableRowsAreStillNonChartable
+// fails until the row is removed.
+var observableParityNonChartable = map[composer.ComponentKey]nonChartableObservableSurface{
+	composer.KeyAWSAppRunner: {
+		Class:  "inventory-only",
+		Reason: "#712 - aws_apprunner_service uses apprunner.list-services inventory; no default imported chart metrics",
+	},
+	composer.KeyAWSGrafana: {
+		Class:  "placeholder",
+		Reason: "#712 - aws_grafana_workspace is not an imported supported type while the managed preset is still a placeholder",
+	},
+	composer.KeyAWSSageMaker: {
+		Class:  "inventory-only",
+		Reason: "#712 - aws_sagemaker_domain uses sagemaker.list-domains inventory; no default imported chart metrics",
+	},
+	composer.KeyGCPCloudDeploy: {
+		Class:  "inventory-only",
+		Reason: "#712 - google_clouddeploy_delivery_pipeline uses clouddeploy.list-delivery-pipelines inventory; no default imported chart metrics",
+	},
+	composer.KeyGCPGitHubActions: {
+		Class:  "security-inventory-only",
+		Reason: "#712 - google_iam_workload_identity_pool is a security/IAM artifact, not a chartable time-series surface",
+	},
 }
 
 func TestPrimaryTFTypeForComponent_KnownPairs(t *testing.T) {
@@ -47,7 +73,7 @@ func TestManagedComponentPrimaryTFTypes_ReturnsCopy(t *testing.T) {
 	assert.Equal(t, "aws_s3_bucket", tfType, "caller mutation must not affect package registry")
 }
 
-func TestObservableParity_ManagedMetricsHaveChartableImport(t *testing.T) {
+func TestObservableParity_ManagedMetricsHaveImportedCoverage(t *testing.T) {
 	t.Parallel()
 
 	require.GreaterOrEqualf(t, len(observability.ComponentMetricsMapping), 40,
@@ -59,14 +85,16 @@ func TestObservableParity_ManagedMetricsHaveChartableImport(t *testing.T) {
 		t.Run(string(key), func(t *testing.T) {
 			t.Parallel()
 
-			if reason, gap := observableParityKnownGaps[key]; gap {
-				t.Skipf("known gap: %s", reason)
-			}
-
 			tfType, ok := PrimaryTFTypeForComponent(key)
 			require.Truef(t, ok,
 				"managed metrics key %q has no primary imported tfType; add it to pkg/imported.ManagedComponentPrimaryTFTypes or allowlist with an issue ref",
 				key)
+
+			if surface, nonChartable := observableParityNonChartable[key]; nonChartable {
+				assert.NotEmptyf(t, surface.Class, "observableParityNonChartable[%q] must classify the non-chartable surface", key)
+				assert.NotEmptyf(t, surface.Reason, "observableParityNonChartable[%q] must explain the non-chartable surface", key)
+				return
+			}
 
 			binding, ok := bindings.Binding(tfType)
 			require.Truef(t, ok,
@@ -79,33 +107,52 @@ func TestObservableParity_ManagedMetricsHaveChartableImport(t *testing.T) {
 	}
 }
 
-func TestObservableParity_KnownGapsHaveIssue(t *testing.T) {
+func TestObservableParity_NonChartableRowsHaveIssue(t *testing.T) {
 	t.Parallel()
 
 	issueRef := regexp.MustCompile(`#\d{2,}`)
-	for key, reason := range observableParityKnownGaps {
-		assert.Regexp(t, issueRef, reason,
-			"observableParityKnownGaps[%q] must reference a tracking issue", key)
+	for key, surface := range observableParityNonChartable {
+		assert.Regexp(t, issueRef, surface.Reason,
+			"observableParityNonChartable[%q] must reference a tracking issue", key)
 	}
 }
 
-func TestObservableParity_KnownGapsAreManagedMetrics(t *testing.T) {
+func TestObservableParity_RequestedInventoryOnlyRows(t *testing.T) {
 	t.Parallel()
 
-	for key := range observableParityKnownGaps {
+	for _, key := range []composer.ComponentKey{
+		composer.KeyAWSAppRunner,
+		composer.KeyAWSSageMaker,
+		composer.KeyGCPCloudDeploy,
+	} {
+		surface, ok := observableParityNonChartable[key]
+		require.Truef(t, ok, "expected %q to be classified as non-chartable inventory-only", key)
+		assert.Equalf(t, "inventory-only", surface.Class, "expected %q to be inventory-only", key)
+	}
+}
+
+func TestObservableParity_NonChartableRowsHaveManagedDispatch(t *testing.T) {
+	t.Parallel()
+
+	for key, surface := range observableParityNonChartable {
 		_, ok := observability.ComponentMetricsMapping[key]
 		assert.Truef(t, ok,
-			"observableParityKnownGaps[%q] is not in ComponentMetricsMapping; remove the stale allowlist row", key)
+			"observableParityNonChartable[%q] is not in ComponentMetricsMapping; remove the stale classification", key)
 		_, ok = PrimaryTFTypeForComponent(key)
 		assert.Truef(t, ok,
-			"observableParityKnownGaps[%q] has no primary imported tfType; fix the map or remove the stale row", key)
+			"observableParityNonChartable[%q] has no primary imported tfType; fix the map or remove the stale classification", key)
+		switch surface.Class {
+		case "inventory-only", "security-inventory-only", "placeholder":
+		default:
+			t.Fatalf("observableParityNonChartable[%q] has unknown class %q", key, surface.Class)
+		}
 	}
 }
 
-func TestObservableParity_KnownGapsAreStillGaps(t *testing.T) {
+func TestObservableParity_NonChartableRowsAreStillNonChartable(t *testing.T) {
 	t.Parallel()
 
-	for key := range observableParityKnownGaps {
+	for key := range observableParityNonChartable {
 		key := key
 		t.Run(string(key), func(t *testing.T) {
 			t.Parallel()
@@ -116,7 +163,7 @@ func TestObservableParity_KnownGapsAreStillGaps(t *testing.T) {
 			}
 			binding, ok := bindings.Binding(tfType)
 			if ok && len(binding.DefaultMetrics) > 0 {
-				t.Fatalf("observableParityKnownGaps[%q] is stale: %q is now chartable; remove the allowlist row", key, tfType)
+				t.Fatalf("observableParityNonChartable[%q] is stale: %q is now chartable; remove the non-chartable classification", key, tfType)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Replace the observable parity "known gaps" allowlist with explicit non-chartable surface classifications.
- Mark `aws_apprunner`, `aws_sagemaker`, and `gcp_cloud_deploy` as `inventory-only`.
- Keep stale checks so a future real `DefaultMetrics` binding fails the test until the non-chartable classification is removed.

Refs #712.

## Test plan

- [x] `go test ./pkg/imported -run 'Test(PrimaryTFTypeForComponent|ManagedComponentPrimaryTFTypes|ObservableParity)'`
- [x] `go test ./pkg/imported`
- [x] `go test -race ./pkg/imported`
- [x] `git diff --check`

## Review notes

- Security review: test-contract-only change; no runtime, auth, credentials, network, or generated artifacts changed.
- QA review: PASS. The tests assert the requested inventory-only classes directly, still require issue references and managed dispatch coverage, and stale-check non-chartable rows against accidental real metrics bindings.
