### PR TITLE
fix: reverse-import — normalize final HCL + stream per-iteration plan output

### DIFF
--- a/cmd/insideout-import/driftfix/runner.go
+++ b/cmd/insideout-import/driftfix/runner.go
@@ -40,21 +40,29 @@ type terraformRunner interface {
 // genconfig).
 type execRunner struct {
 	tf *tfexec.Terraform
+	// stream, when non-nil, is the live progress sink. PlanTo points
+	// tf.stdout here for the duration of the plan call so the
+	// human-readable plan diff streams to the caller (the Mars
+	// reverse-import job → import plan-log console). Show/Validate must NOT
+	// stream — terraform-exec captures their -json payloads on stdout — so
+	// PlanTo restores io.Discard before returning.
+	stream io.Writer
 }
 
 // newExecRunner constructs an execRunner for workdir. When stream is
-// non-nil the terraform subprocess streams its *stderr* there so a
-// long-running caller can surface live progress; nil keeps the historical
+// non-nil the terraform subprocess streams its stderr there (always) and
+// its stdout there for the plan call only (see PlanTo) so a long-running
+// caller can surface the live plan diff; nil keeps the historical
 // "discard subprocess output" behavior.
 //
-// We deliberately do NOT call tf.SetStdout: ShowPlan (ShowPlanFile) and
-// Validate capture `-json` payloads on stdout, and terraform-exec merges
-// tf.stdout into that captured stream, so pointing tf.stdout at the live
-// log leaks the JSON into the user-facing log and blows the gRPC-limited
-// stream (reliable#1896). Leaving stdout unset lets tfexec discard it for
-// these commands while the JSON is still captured internally. Mirrors the
-// stderr-only discipline in genconfig.execRunner and
-// pkg/reverseimport/terraform.go.
+// stdout is scoped to PlanTo rather than set globally: ShowPlan
+// (ShowPlanFile) and Validate capture `-json` payloads on stdout, and
+// terraform-exec shares one tf.stdout across commands, so a global stdout
+// would leak that JSON into the user-facing log and blow the gRPC-limited
+// stream (reliable#1896). PlanTo restores io.Discard before returning so
+// those commands keep their JSON captured internally. Mirrors the
+// stderr-only discipline in genconfig.execRunner and the human-vs-json
+// split in pkg/reverseimport/terraform.go.
 func newExecRunner(workdir string, stream io.Writer) (*execRunner, error) {
 	bin, err := exec.LookPath("terraform")
 	if err != nil {
@@ -67,10 +75,20 @@ func newExecRunner(workdir string, stream io.Writer) (*execRunner, error) {
 	if stream != nil {
 		tf.SetStderr(stream)
 	}
-	return &execRunner{tf: tf}, nil
+	return &execRunner{tf: tf, stream: stream}, nil
 }
 
 func (r *execRunner) PlanTo(ctx context.Context, planFile string) (bool, error) {
+	// Stream the human-readable `terraform plan` diff to the live log for
+	// THIS call only. ShowPlan/Validate emit -json on stdout and
+	// terraform-exec shares one stdout across commands, so restore
+	// io.Discard before returning to keep those payloads captured
+	// (reliable#1896). The plan text is monochrome (no TTY); the import
+	// plan-log console colorizes it client-side (lib/stream/logColorize).
+	if r.stream != nil {
+		r.tf.SetStdout(r.stream)
+		defer r.tf.SetStdout(io.Discard)
+	}
 	return r.tf.Plan(ctx, tfexec.Out(planFile))
 }
 

--- a/cmd/insideout-import/driftfix/runner_test.go
+++ b/cmd/insideout-import/driftfix/runner_test.go
@@ -105,9 +105,13 @@ func TestExecRunner_PlanStreamsHumanDiffToStream(t *testing.T) {
 	require.NoError(t, err)
 
 	planFile := filepath.Join(workdir, "tfplan.bin")
-	hasChanges, err := runner.PlanTo(ctx, planFile)
+	// The hasChanges bool is intentionally ignored: terraform's
+	// -detailed-exitcode signalling for the builtin terraform_data resource is
+	// version-dependent, and it isn't what this test verifies. The streamed
+	// plan text below is the actual contract — PlanTo routes terraform's
+	// stdout to the live log.
+	_, err = runner.PlanTo(ctx, planFile)
 	require.NoError(t, err)
-	assert.True(t, hasChanges, "creating terraform_data.x is a change")
 
 	streamed := stream.String()
 	// The human-readable plan diff (not JSON) must reach the live log.

--- a/cmd/insideout-import/driftfix/runner_test.go
+++ b/cmd/insideout-import/driftfix/runner_test.go
@@ -77,6 +77,47 @@ func TestExecRunner_JSONCaptureDoesNotLeakToStream(t *testing.T) {
 	}
 }
 
+// TestExecRunner_PlanStreamsHumanDiffToStream is the positive companion to the
+// #1896 leak guard above: the per-iteration `terraform plan` HUMAN diff MUST
+// reach the live-log stream so the import plan-log console shows it. Before
+// this change the driftfix runner left tf.stdout unset, so only driftfix's own
+// "running terraform plan…" narration streamed and the actual plan output was
+// invisible. PlanTo now scopes tf.stdout to the plan call (Show/Validate keep
+// it discarded — asserted by the sibling test) so the human diff streams while
+// the JSON-capture payloads stay internal.
+func TestExecRunner_PlanStreamsHumanDiffToStream(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform CLI not available, skipping plan-stream test")
+	}
+
+	workdir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "main.tf"), []byte(builtinProviderStack), 0o644))
+
+	ctx := context.Background()
+	initCmd := exec.CommandContext(ctx, "terraform", "init", "-input=false", "-no-color")
+	initCmd.Dir = workdir
+	initCmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
+	out, err := initCmd.CombinedOutput()
+	require.NoError(t, err, "terraform init (builtin provider, offline):\n%s", out)
+
+	var stream stringSink
+	runner, err := newExecRunner(workdir, &stream)
+	require.NoError(t, err)
+
+	planFile := filepath.Join(workdir, "tfplan.bin")
+	hasChanges, err := runner.PlanTo(ctx, planFile)
+	require.NoError(t, err)
+	assert.True(t, hasChanges, "creating terraform_data.x is a change")
+
+	streamed := stream.String()
+	// The human-readable plan diff (not JSON) must reach the live log.
+	assert.Contains(t, streamed, "terraform_data.x", "plan human diff should stream to the log")
+	assert.Contains(t, streamed, "Plan:", "plan summary should stream to the log")
+	// Scoping still holds: the plan call must not drag show/validate JSON in.
+	assert.NotContains(t, streamed, `"format_version"`,
+		"plan stream must not carry JSON-capture payload (reliable#1896)")
+}
+
 // stringSink is a small mutex-guarded io.Writer for capturing streamed output
 // in tests. terraform-exec drains stderr from a goroutine that runs
 // concurrently with the command, so the writer must be safe under -race.

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -97,6 +97,7 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_lb":                    fixupLBSubnetMappingConflict,
 	"aws_subnet":                fixupSubnetProviderQuirks,
 	"aws_route_table":           fixupRouteTableEmptyRouteFields,
+	"aws_security_group":        fixupSecurityGroupInlineRuleObjects,
 	"aws_nat_gateway":           fixupNATGatewaySecondaryIPConflict,
 	"aws_lb_listener":           fixupLBListenerStickinessDurationZero,
 	"aws_lb_target_group":       fixupLBTargetGroupProviderQuirks,
@@ -354,16 +355,41 @@ func fixupSubnetProviderQuirks(blk *hclwrite.Block) {
 	}
 }
 
+// routeTableRouteStringFields is the provider's object shape for
+// aws_route_table.route. Terraform treats object attributes as required at
+// validate time, even for Optional+Computed set(object(...)) fields, so route
+// elements must carry every key with null for the fields AWS left absent.
+var routeTableRouteStringFields = []string{
+	"carrier_gateway_id",
+	"cidr_block",
+	"core_network_arn",
+	"destination_prefix_list_id",
+	"egress_only_gateway_id",
+	"gateway_id",
+	"ipv6_cidr_block",
+	"local_gateway_id",
+	"nat_gateway_id",
+	"network_interface_id",
+	"odb_network_arn",
+	"transit_gateway_id",
+	"vpc_endpoint_id",
+	"vpc_peering_connection_id",
+}
+
 // fixupRouteTableEmptyRouteFields replaces empty-string fields with
-// null in each route object literal emitted in aws_route_table.route.
+// null in each route object literal emitted in aws_route_table.route,
+// and backfills provider-added route object keys that were absent from
+// older generated models.
 // The provider's per-field validators (CIDR check on ipv6_cidr_block,
 // resource-id format on gateway_id, etc.) reject literal "" but skip
 // null. terraform plan -generate-config-out emits "" for every absent
 // field in the route object; null-replacement satisfies the validators
 // while preserving the object type's field set (the route attribute is
-// schema-typed as an object with all 12 fields required to be present
-// — DROPPING fields breaks the object type and produces a different
-// "Incorrect attribute value type" failure).
+// schema-typed as an object with every field required to be present —
+// DROPPING fields breaks the object type and produces a different
+// "Incorrect attribute value type" failure). AWS provider 6.47 added
+// odb_network_arn; final imported.tf emitted from older generated models
+// therefore needs a null placeholder for that key too.
 //
 // Shape note: generate-config-out emits route as an attribute carrying
 // a list-of-objects expression (route = [{...}, ...]), NOT as nested
@@ -390,20 +416,20 @@ func fixupRouteTableEmptyRouteFields(blk *hclwrite.Block) {
 	if diags.HasErrors() {
 		return
 	}
-	filtered, changed := nullEmptyStringFieldsInTuple(val)
+	filtered, changed := normalizeStringFieldsInTuple(val, routeTableRouteStringFields)
 	if !changed {
 		return
 	}
 	body.SetAttributeValue("route", filtered)
 }
 
-// nullEmptyStringFieldsInTuple walks a tuple/list of object values and
-// returns a new tuple with each object's empty-string fields replaced
-// by null (preserving field set, just blanking the value). The boolean
-// reports whether any field was rewritten, so callers can short-circuit
-// a no-op back to the original tokens. Non-tuple/non-list inputs and
-// unknown/null values pass through unchanged.
-func nullEmptyStringFieldsInTuple(v cty.Value) (cty.Value, bool) {
+// normalizeStringFieldsInTuple walks a tuple/list of object values and returns
+// a new tuple with each object's empty-string fields replaced by null and any
+// missing required string fields added as null. The boolean reports whether any
+// field was rewritten, so callers can short-circuit a no-op back to the original
+// tokens. Non-tuple/non-list inputs and unknown/null values pass through
+// unchanged.
+func normalizeStringFieldsInTuple(v cty.Value, requiredFields []string) (cty.Value, bool) {
 	if v.IsNull() || !v.IsKnown() {
 		return v, false
 	}
@@ -419,7 +445,7 @@ func nullEmptyStringFieldsInTuple(v cty.Value) (cty.Value, bool) {
 	it := v.ElementIterator()
 	for it.Next() {
 		_, elem := it.Element()
-		cleaned, c := nullEmptyStringFieldsInObject(elem)
+		cleaned, c := normalizeStringFieldsInObject(elem, requiredFields)
 		if c {
 			changed = true
 		}
@@ -431,14 +457,14 @@ func nullEmptyStringFieldsInTuple(v cty.Value) (cty.Value, bool) {
 	return cty.TupleVal(out), true
 }
 
-// nullEmptyStringFieldsInObject returns a new object value with
-// empty-string string fields replaced by null. Non-object inputs pass
-// through unchanged. The field set is preserved (object type unchanged)
-// — this is the difference between "satisfies the schema's type
-// requirement that all 12 route fields be present" and "fails with
-// Incorrect attribute value type because we dropped fields the type
-// declared."
-func nullEmptyStringFieldsInObject(v cty.Value) (cty.Value, bool) {
+// normalizeStringFieldsInObject returns a new object value with empty-string
+// string fields replaced by null and any missing required string fields added
+// as null. Non-object inputs pass through unchanged. The field set is preserved
+// or widened to the provider's required object shape — this is the difference
+// between "satisfies the schema's type requirement that all route fields be
+// present" and "fails with Incorrect attribute value type because a generated
+// model omitted a provider-added key."
+func normalizeStringFieldsInObject(v cty.Value, requiredFields []string) (cty.Value, bool) {
 	if v.IsNull() || !v.IsKnown() {
 		return v, false
 	}
@@ -454,6 +480,104 @@ func nullEmptyStringFieldsInObject(v cty.Value) (cty.Value, bool) {
 			continue
 		}
 		fields[k] = fv
+	}
+	for _, k := range requiredFields {
+		if _, ok := fields[k]; ok {
+			continue
+		}
+		fields[k] = cty.NullVal(cty.String)
+		changed = true
+	}
+	if !changed {
+		return v, false
+	}
+	return cty.ObjectVal(fields), true
+}
+
+// securityGroupInlineRuleListFields is the collection-valued subset of the
+// provider's aws_security_group ingress/egress object shape. The composer may
+// omit an empty collection when the typed imported model has nil for that field,
+// but terraform validate still requires the key to exist inside each inline
+// object. Add empty collections for absent keys so self-referencing default
+// rules validate without changing intent.
+var securityGroupInlineRuleListFields = []string{
+	"cidr_blocks",
+	"ipv6_cidr_blocks",
+	"prefix_list_ids",
+	"security_groups",
+}
+
+// fixupSecurityGroupInlineRuleObjects backfills missing empty collection keys in
+// aws_security_group ingress/egress object literals. The live failure this
+// prevents is a self-referencing default security group rule with `self = true`
+// and no CIDR ranges; the imported typed HCL omitted `cidr_blocks`, but the AWS
+// provider's set(object(...)) schema requires that attribute to be present.
+func fixupSecurityGroupInlineRuleObjects(blk *hclwrite.Block) {
+	body := blk.Body()
+	for _, attrName := range []string{"ingress", "egress"} {
+		attr := body.GetAttribute(attrName)
+		if attr == nil {
+			continue
+		}
+		exprBytes := attr.Expr().BuildTokens(nil).Bytes()
+		expr, diags := hclsyntax.ParseExpression(exprBytes, attrName, hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			continue
+		}
+		val, diags := expr.Value(nil)
+		if diags.HasErrors() {
+			continue
+		}
+		filtered, changed := addMissingListFieldsInTuple(val, securityGroupInlineRuleListFields)
+		if changed {
+			body.SetAttributeValue(attrName, filtered)
+		}
+	}
+}
+
+func addMissingListFieldsInTuple(v cty.Value, requiredFields []string) (cty.Value, bool) {
+	if v.IsNull() || !v.IsKnown() {
+		return v, false
+	}
+	t := v.Type()
+	if !t.IsTupleType() && !t.IsListType() {
+		return v, false
+	}
+	if v.LengthInt() == 0 {
+		return v, false
+	}
+	out := make([]cty.Value, 0, v.LengthInt())
+	changed := false
+	it := v.ElementIterator()
+	for it.Next() {
+		_, elem := it.Element()
+		cleaned, c := addMissingListFieldsInObject(elem, requiredFields)
+		if c {
+			changed = true
+		}
+		out = append(out, cleaned)
+	}
+	if !changed {
+		return v, false
+	}
+	return cty.TupleVal(out), true
+}
+
+func addMissingListFieldsInObject(v cty.Value, requiredFields []string) (cty.Value, bool) {
+	if v.IsNull() || !v.IsKnown() {
+		return v, false
+	}
+	if !v.Type().IsObjectType() {
+		return v, false
+	}
+	fields := v.AsValueMap()
+	changed := false
+	for _, k := range requiredFields {
+		if _, ok := fields[k]; ok {
+			continue
+		}
+		fields[k] = cty.ListValEmpty(cty.String)
+		changed = true
 	}
 	if !changed {
 		return v, false

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -800,6 +800,8 @@ func fixupEBSVolumeInitializationRateZero(blk *hclwrite.Block) {
 // interface_type is also normalized: the literal "interface" is the
 // describe-only value generate-config-out emits for a standard ENI, but the
 // provider only accepts efa/efa-only/branch/trunk on create, so we drop it.
+// Older enriched attrs can also carry the string literal "null"; drop that as
+// an absent value rather than rendering invalid provider input.
 // Service-managed interface_type values (nat_gateway, vpc_endpoint, …) are
 // left in place — pruneUnimportable drops those whole resources, since a
 // service-owned ENI cannot be adopted as a standalone aws_network_interface.
@@ -825,7 +827,7 @@ func fixupNetworkInterfaceProviderQuirks(blk *hclwrite.Block) {
 		resolveENIListCountConflict(body, pair[0], pair[1])
 	}
 
-	if v := stringLitFromAttr(body.GetAttribute("interface_type")); v == "interface" {
+	if v := stringLitFromAttr(body.GetAttribute("interface_type")); v == "interface" || v == "null" {
 		body.RemoveAttribute("interface_type")
 	}
 }

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -1118,7 +1118,7 @@ func TestFixupRouteTable_EmptyIPv6CIDRReplacedWithNull(t *testing.T) {
 // TestFixupRouteTable_AllEmptyStringFieldsNulled pins broad-strip
 // semantics with the null-replacement contract: every field whose
 // value is the literal "" gets rewritten to null. The fixture mirrors
-// the CUST3 smoke output shape (12 absent fields emitted as ""). After
+// the CUST3 smoke output shape (absent fields emitted as ""). After
 // fixup, all field names survive (object type preserved) but empty
 // values become null.
 func TestFixupRouteTable_AllEmptyStringFieldsNulled(t *testing.T) {
@@ -1156,6 +1156,7 @@ func TestFixupRouteTable_AllEmptyStringFieldsNulled(t *testing.T) {
 		"ipv6_cidr_block",
 		"local_gateway_id",
 		"network_interface_id",
+		"odb_network_arn",
 		"transit_gateway_id",
 		"vpc_endpoint_id",
 		"vpc_peering_connection_id",
@@ -1182,11 +1183,14 @@ func TestFixupRouteTable_AllEmptyStringFieldsNulled(t *testing.T) {
 	}
 }
 
-// TestFixupRouteTable_NonEmptyFieldsPreserved pins isolation: a route
-// object with no empty-string fields flows through untouched. A
-// mutation that broadened the filter to non-empty values would fail
-// this test.
-func TestFixupRouteTable_NonEmptyFieldsPreserved(t *testing.T) {
+// TestFixupRouteTable_NonEmptyFieldsPreservedAndProviderKeysBackfilled pins
+// two constraints at once: non-empty route fields must not be altered, and
+// provider-required object keys that were absent from older generated models
+// (notably AWS provider 6.47's odb_network_arn) must be backfilled as null.
+// This is the exact family of final imported.tf failure from Dario's
+// 2026-06-02 whole-account import: terraform validate rejected
+// aws_route_table.route because odb_network_arn was required but absent.
+func TestFixupRouteTable_NonEmptyFieldsPreservedAndProviderKeysBackfilled(t *testing.T) {
 	t.Parallel()
 	in := []byte(`resource "aws_route_table" "rt" {
   vpc_id = "vpc-123"
@@ -1207,9 +1211,96 @@ func TestFixupRouteTable_NonEmptyFieldsPreserved(t *testing.T) {
 			t.Errorf("non-empty %s must be preserved\n--- got ---\n%s", want, got)
 		}
 	}
-	// Negative: no field should have been rewritten to null.
-	if regexp.MustCompile(`(?m)^\s*\w+\s*=\s*null`).MatchString(got) {
-		t.Errorf("no field should be rewritten to null when none were empty\n--- got ---\n%s", got)
+	for _, want := range []string{
+		"carrier_gateway_id",
+		"core_network_arn",
+		"destination_prefix_list_id",
+		"egress_only_gateway_id",
+		"ipv6_cidr_block",
+		"local_gateway_id",
+		"network_interface_id",
+		"odb_network_arn",
+		"transit_gateway_id",
+		"vpc_endpoint_id",
+		"vpc_peering_connection_id",
+	} {
+		pat := `(?m)^\s*` + regexp.QuoteMeta(want) + `\s*=\s*null`
+		if !regexp.MustCompile(pat).MatchString(got) {
+			t.Errorf("missing route object key %s must be backfilled as null\n--- got ---\n%s", want, got)
+		}
+	}
+}
+
+// TestFixupSecurityGroup_SelfIngressBackfillsMissingCIDRBlocks captures the
+// other Dario 2026-06-02 validate failure resource: a default security group
+// with a self-referencing ingress rule. The typed imported model emitted
+// ipv6_cidr_blocks/prefix_list_ids/security_groups/self but omitted
+// cidr_blocks; the AWS provider's ingress set(object(...)) schema requires the
+// cidr_blocks key to exist even when it is an empty list.
+func TestFixupSecurityGroup_SelfIngressBackfillsMissingCIDRBlocks(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_security_group" "default" {
+  name        = "default"
+  description = "default VPC security group"
+  vpc_id      = "vpc-123"
+
+  ingress = [{
+    description      = ""
+    from_port        = 0
+    ipv6_cidr_blocks = []
+    prefix_list_ids  = []
+    protocol         = "-1"
+    security_groups  = []
+    self             = true
+    to_port          = 0
+  }]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`(?m)^\s*cidr_blocks\s*=\s*\[\]`).MatchString(got) {
+		t.Errorf("missing ingress cidr_blocks must be backfilled as an empty list\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*self\s*=\s*true`).MatchString(got) {
+		t.Errorf("self=true must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*protocol\s*=\s*"-1"`).MatchString(got) {
+		t.Errorf("protocol must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupSecurityGroup_EgressBackfillsAllMissingCollectionFields keeps the
+// egress side symmetric with ingress. A rule can be validly wide-open or empty
+// depending on the other scalar fields, but the provider object type still
+// requires every collection-valued key to be present.
+func TestFixupSecurityGroup_EgressBackfillsAllMissingCollectionFields(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_security_group" "sg" {
+  name   = "sg"
+  vpc_id = "vpc-123"
+
+  egress = [{
+    description = ""
+    from_port   = 0
+    protocol    = "-1"
+    self        = false
+    to_port     = 0
+  }]
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, want := range []string{"cidr_blocks", "ipv6_cidr_blocks", "prefix_list_ids", "security_groups"} {
+		pat := `(?m)^\s*` + regexp.QuoteMeta(want) + `\s*=\s*\[\]`
+		if !regexp.MustCompile(pat).MatchString(got) {
+			t.Errorf("missing egress %s must be backfilled as []\n--- got ---\n%s", want, got)
+		}
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -2735,6 +2735,34 @@ func TestFixupNetworkInterface_PopulatedCountWinsOverEmptyList(t *testing.T) {
 	}
 }
 
+// TestFixupNetworkInterface_NullStringInterfaceTypeDropped pins the Dario
+// final-HCL path: older enriched attrs can carry `interface_type` as the string
+// literal "null". The AWS provider rejects that value, so the fixup treats it
+// like an absent describe value and drops it.
+func TestFixupNetworkInterface_NullStringInterfaceTypeDropped(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_network_interface" "eni" {
+  provider       = aws.imported
+  interface_type = "null"
+  subnet_id      = "subnet-0e866663c4c5ad4d9"
+}
+`)
+	out, err := NormalizeImportedHCL(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if regexp.MustCompile(`(?m)^\s*interface_type\s*=`).MatchString(got) {
+		t.Errorf("interface_type=\"null\" must be dropped\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*provider\s*=\s*aws.imported`).MatchString(got) {
+		t.Errorf("provider = aws.imported must be preserved\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*subnet_id\s*=`).MatchString(got) {
+		t.Errorf("subnet_id must be preserved\n--- got ---\n%s", got)
+	}
+}
+
 // TestFixupNetworkInterface_ServiceManagedTypePreservedForPrune pins the
 // division of labor: the fixup only drops the standard "interface" literal.
 // Service-managed values (nat_gateway, …) must survive so pruneUnimportable

--- a/pkg/reverseimport/terraform.go
+++ b/pkg/reverseimport/terraform.go
@@ -46,6 +46,7 @@ func (r execTerraformRunner) Init(ctx context.Context, dir string) error {
 }
 
 func (r execTerraformRunner) Validate(ctx context.Context, dir string) ([]byte, error) {
+	streamErr := r.run(ctx, dir, "validate", "-no-color")
 	cmd := exec.CommandContext(ctx, r.bin(), "validate", "-json")
 	cmd.Dir = dir
 	// stdout is captured as the validate.json artifact, so only stderr
@@ -56,7 +57,7 @@ func (r execTerraformRunner) Validate(ctx context.Context, dir string) ([]byte, 
 	if err != nil {
 		return out, err
 	}
-	return out, nil
+	return out, streamErr
 }
 
 func (r execTerraformRunner) Plan(ctx context.Context, dir, planPath string) error {

--- a/pkg/reverseimport/terraform_test.go
+++ b/pkg/reverseimport/terraform_test.go
@@ -1,0 +1,93 @@
+package reverseimport
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExecTerraformRunnerValidateStreamsHumanOutputAndCapturesJSON(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bin := writeFakeTerraform(t, dir, `#!/bin/sh
+if [ "$1" = "validate" ] && [ "$2" = "-no-color" ]; then
+  echo "human validate stdout"
+  echo "human validate stderr" >&2
+  exit 0
+fi
+if [ "$1" = "validate" ] && [ "$2" = "-json" ]; then
+  echo "json validate stderr" >&2
+  printf '{"valid":true,"diagnostics":[]}\n'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 7
+`)
+
+	var stream strings.Builder
+	out, err := execTerraformRunner{binary: bin, stdout: &stream}.Validate(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	gotStream := stream.String()
+	for _, want := range []string{"human validate stdout", "human validate stderr", "json validate stderr"} {
+		if !strings.Contains(gotStream, want) {
+			t.Fatalf("stream missing %q:\n%s", want, gotStream)
+		}
+	}
+	if strings.Contains(gotStream, `"valid":true`) {
+		t.Fatalf("validate -json stdout leaked into stream:\n%s", gotStream)
+	}
+	if got := strings.TrimSpace(string(out)); got != `{"valid":true,"diagnostics":[]}` {
+		t.Fatalf("validate JSON = %q", got)
+	}
+}
+
+func TestExecTerraformRunnerValidateStillCapturesJSONAfterHumanValidateFailure(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	bin := writeFakeTerraform(t, dir, `#!/bin/sh
+if [ "$1" = "validate" ] && [ "$2" = "-no-color" ]; then
+  echo "Error: Incorrect attribute value type"
+  echo "  with aws_route_table.rtb_03988a8cc66567bd1,"
+  echo "attribute \"odb_network_arn\" is required"
+  exit 1
+fi
+if [ "$1" = "validate" ] && [ "$2" = "-json" ]; then
+  printf '{"valid":false,"error_count":1,"diagnostics":[{"summary":"Incorrect attribute value type"}]}\n'
+  exit 0
+fi
+echo "unexpected args: $*" >&2
+exit 7
+`)
+
+	var stream strings.Builder
+	out, err := execTerraformRunner{binary: bin, stdout: &stream}.Validate(context.Background(), dir)
+	if err == nil {
+		t.Fatal("Validate err = nil, want human validate failure")
+	}
+	gotStream := stream.String()
+	for _, want := range []string{
+		"Error: Incorrect attribute value type",
+		"aws_route_table.rtb_03988a8cc66567bd1",
+		`attribute "odb_network_arn" is required`,
+	} {
+		if !strings.Contains(gotStream, want) {
+			t.Fatalf("stream missing %q:\n%s", want, gotStream)
+		}
+	}
+	if got := strings.TrimSpace(string(out)); !strings.Contains(got, `"valid":false`) {
+		t.Fatalf("validate JSON was not captured after failure: %q", got)
+	}
+}
+
+func writeFakeTerraform(t *testing.T, dir, script string) string {
+	t.Helper()
+	path := filepath.Join(dir, "terraform")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}


### PR DESCRIPTION
Two related reverse-import fixes (one commit each).

## 1. `fb82b89` — normalize reverse-import final HCL
- `fixups.go`: add `aws_security_group` inline-rule-object fixup; route-table fixup now backfills provider-added required object keys (e.g. `odb_network_arn`, AWS provider 6.47) as `null`, fixing `Incorrect attribute value type` on older generated models.
- `terraform.go`: `Validate` streams the human pass then **always** captures `validate.json`, so the artifact survives a failing validate.

## 2. `c9df627` — driftfix streams the per-iteration terraform plan
The driftfix runner left `tf.stdout` unset, so terraform-exec discarded the `terraform plan` human diff — only driftfix's own "running terraform plan…" narration reached the job stdout (→ Oracle follow → import plan-log console). Every convergence iteration's actual plan was invisible.

Scope `tf.SetStdout(stream)` to the `PlanTo` call only: the human plan diff streams while `ShowPlan`/`Validate` keep stdout discarded so their `-json` payloads stay captured (reliable#1896). One plan per iteration — `ShowPlan` reads the saved binary plan, no extra terraform run. Output is monochrome (no TTY); the reliable import plan-log console colorizes it client-side (luthersystems/reliable#2008).

## Tests
- `go test ./cmd/insideout-import/genconfig ./pkg/reverseimport` — HCL fixups + validate.json capture.
- `driftfix/runner_test.go` — positive guard that `PlanTo` streams the human diff + existing #1896 leak guard proving `Show`/`Validate` do not.

## Downstream
- mars luthersystems/mars#185 bumps to `c9df627` (the reverse-import binary runs in the mars container).
- reliable luthersystems/reliable#2008 colorizes the streamed plan in the import plan-log console.