### PR TITLE
fix(reverse-import): rock-solid multi-region whole-account import (stragglers + parallel drift-fix/dep-chase + e2e harness)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ test-roundtrip: ## Live AWS discover->emit->plan round-trip for the import flow 
 test-golden-stack: ## Replay genconfig cleanup over captured real-world stacks and assert `terraform validate` passes (#708). Needs terraform + the AWS provider; NO AWS creds.
 	RUN_GOLDEN_HCL=1 $(GO) test -run TestGoldenStackValidates ./cmd/insideout-import/genconfig/... -v -count=1 -timeout 10m
 
+.PHONY: reverse-e2e
+reverse-e2e: ## Live whole-account reverse-import e2e: discover->genconfig->driftfix->depchase->plan via the prod engine, asserting a clean tag-only plan. Needs real AWS creds + terraform + an offline provider mirror. REVERSE_E2E_REGIONS=all for multi-region; see scripts/reverse-e2e.sh header for knobs.
+	./scripts/reverse-e2e.sh
+
 .PHONY: go-fmt-check
 go-fmt-check: ## Fail if any tracked Go file is not gofmt-clean (CI gate, #647).
 	@unformatted=$$(gofmt -l $$(git ls-files '*.go')); \

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -154,6 +154,25 @@ type cloudControlConfig struct {
 	// alone cannot do for cases like list-of-{Key,Value} tags vs the
 	// generated `map[string]*Value[string]` Tags field.
 	Normalizer func(json.RawMessage) (json.RawMessage, error)
+
+	// PostDiscover, when non-nil, runs once per emitted ImportedResource
+	// immediately after the IR is built (bulk Discover) or resolved
+	// (DiscoverByID), with the per-resource AWS config so the hook can
+	// issue a follow-up SDK call. Use it to populate Identity fields that
+	// the Cloud Control GetResource payload OMITS but that downstream
+	// stages need before any enrichment runs — the reverse-import /
+	// genconfig dry-run path never calls EnrichAttributes, so a field set
+	// only by an AttributeEnricher (e.g. the S3 bucket's true region, a
+	// KMS key's KeyManager) is absent in that path and the resource is
+	// mis-grouped or mis-classified, then silently dropped as
+	// no_generated_config.
+	//
+	// Soft-fail contract: a non-nil error is logged via ServiceWarn and
+	// the resource is still emitted with whatever the hook managed to set
+	// — a best-effort follow-up must never drop an otherwise-importable
+	// resource. The hook receives a pointer to the just-built IR and
+	// mutates Identity in place.
+	PostDiscover func(ctx context.Context, awsCfg aws.Config, region string, ir *imported.ImportedResource) error
 }
 
 // cloudControlDiscoverer is the generic per-type Discoverer that routes
@@ -487,7 +506,7 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 			if d.cfg.NativeIDsFromProperties != nil {
 				native = d.cfg.NativeIDsFromProperties(f.identifier, f.props)
 			}
-			out = append(out, makeImportedResource(
+			ir := makeImportedResource(
 				book,
 				d.cfg.TFType,
 				name,
@@ -496,7 +515,17 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 				args.AccountID,
 				native,
 				f.tags,
-			))
+			)
+			if d.cfg.PostDiscover != nil {
+				if perr := d.cfg.PostDiscover(ctx, d.awsCfg, region, &ir); perr != nil {
+					// Soft-fail: the resource is still emitted with whatever
+					// the hook set. A follow-up SDK miss must not drop an
+					// otherwise-importable resource.
+					args.Emitter.ServiceWarn(d.cfg.Slug, region,
+						fmt.Sprintf("PostDiscover %s id=%q: %v", d.cfg.TFType, importID, perr))
+				}
+			}
+			out = append(out, ir)
 			args.Emitter.ItemFound(d.cfg.Slug, region, d.cfg.TFType, importID)
 			regionCount++
 		}
@@ -564,7 +593,7 @@ func (d *cloudControlDiscoverer) DiscoverByID(ctx context.Context, id, region, a
 	if d.cfg.TagsFromProperties != nil {
 		tags = d.cfg.TagsFromProperties(props)
 	}
-	return makeImportedResource(
+	ir := makeImportedResource(
 		addressBook{},
 		d.cfg.TFType,
 		name,
@@ -573,7 +602,14 @@ func (d *cloudControlDiscoverer) DiscoverByID(ctx context.Context, id, region, a
 		accountID,
 		native,
 		tags,
-	), nil
+	)
+	if d.cfg.PostDiscover != nil {
+		// Soft-fail to match the bulk Discover path: a follow-up SDK miss
+		// on a single dep-chased resource still returns the IR with
+		// whatever the hook populated rather than failing the lookup.
+		_ = d.cfg.PostDiscover(ctx, d.awsCfg, region, &ir)
+	}
+	return ir, nil
 }
 
 func (d *cloudControlDiscoverer) discoverByIDIdentifier(id string) (string, error) {

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -39,10 +39,11 @@ func configByTFType(t *testing.T, tfType string) cloudControlConfig {
 }
 
 // TestBackupSelectionConfig pins the per-type extractors for
-// aws_backup_selection: ImportID rewrite `_`→`|` (single-replace —
-// SelectionIds containing underscores must round-trip intact), nested
-// NameHint fall-back (BackupSelection.SelectionName), NativeIDs split
-// on first `_`, defensive behavior on a malformed identifier
+// aws_backup_selection: ImportID rewrite `<sel>_<plan>` →
+// `<plan>|<sel>` (split on the FIRST `_`, emit plan-then-selection —
+// the provider's import order is the reverse of the CC field order),
+// nested NameHint fall-back (BackupSelection.SelectionName), NativeIDs
+// split on first `_`, defensive behavior on a malformed identifier
 // (downstream readers must see both keys present), and the non-nil
 // empty Tags map per the #255 in-memory contract.
 func TestBackupSelectionConfig(t *testing.T) {
@@ -55,16 +56,17 @@ func TestBackupSelectionConfig(t *testing.T) {
 		t.Errorf("CloudFormationType=%q, want AWS::Backup::BackupSelection", cfg.CloudFormationType)
 	}
 
-	// ImportID: `<sel>_<plan>` → `<sel>|<plan>` (single replace).
-	if got := cfg.ImportIDFromIdentifier("s1_p1", nil); got != "s1|p1" {
-		t.Errorf("ImportID rewrite: got %q, want %q", got, "s1|p1")
+	// ImportID: CC `<SelectionId>_<BackupPlanId>` → TF
+	// `<BackupPlanId>|<SelectionId>` (plan FIRST — reversed order).
+	if got := cfg.ImportIDFromIdentifier("s1_p1", nil); got != "p1|s1" {
+		t.Errorf("ImportID rewrite: got %q, want %q", got, "p1|s1")
 	}
-	// Only the first `_` is rewritten so SelectionIds containing
-	// underscores survive (sanity-pin AWS doesn't use them, but the
-	// `strings.Replace` count argument is load-bearing for symmetry
-	// with aws_eks_pod_identity_association's `|`→`,` rewrite).
-	if got := cfg.ImportIDFromIdentifier("s_a_b_p", nil); got != "s|a_b_p" {
-		t.Errorf("ImportID single-replace: got %q, want %q", got, "s|a_b_p")
+	// Split on the FIRST `_` only, so a BackupPlanId tail containing
+	// underscores survives intact (the SelectionId is the head; AWS
+	// selection IDs themselves don't contain `_`). The split point is
+	// load-bearing for symmetry with the plan-first ordering.
+	if got := cfg.ImportIDFromIdentifier("s_a_b_p", nil); got != "a_b_p|s" {
+		t.Errorf("ImportID first-`_` split: got %q, want %q", got, "a_b_p|s")
 	}
 
 	// NameHint from nested BackupSelection.SelectionName.
@@ -104,10 +106,10 @@ func TestBackupSelectionConfig(t *testing.T) {
 	if malformed["backup_plan_id"] != "" {
 		t.Errorf("NativeIDs malformed-id backup_plan_id: got %q, want \"\"", malformed["backup_plan_id"])
 	}
-	// ImportID on malformed identifier: strings.Replace is a no-op
-	// when `_` is absent; the resulting ID round-trips identically.
-	// Surfacing this as a test prevents a future "ImportID returns
-	// empty on malformed" regression.
+	// ImportID on malformed identifier: when `_` is absent the rewrite
+	// is a no-op and the ID round-trips identically. Surfacing this as a
+	// test prevents a future "ImportID returns empty on malformed"
+	// regression.
 	if got := cfg.ImportIDFromIdentifier("orphan", nil); got != "orphan" {
 		t.Errorf("ImportID malformed-id: got %q, want orphan (no-op when no `_`)", got)
 	}
@@ -119,6 +121,163 @@ func TestBackupSelectionConfig(t *testing.T) {
 	}
 	if len(tags) != 0 {
 		t.Errorf("Tags: got %v, want empty map", tags)
+	}
+}
+
+// TestEIPConfig pins the per-type extractors for aws_eip. Cloud Control's
+// live primary identifier is the compound `<PublicIp>|<AllocationId>`
+// (e.g. `100.49.75.26|eipalloc-07d114af86fd5d1c3`); the arnRule path
+// yields the `|<AllocationId>` form (empty PublicIp). Terraform import for
+// aws_eip takes JUST the AllocationId, so ImportID / NameHint / the
+// allocation_id NativeID must return the segment after the LAST `|` for
+// BOTH forms. A regression to TrimPrefix("|") is a no-op on the live form
+// and emits the wrong (public-IP-bearing) ID, silently dropping the EIP.
+func TestEIPConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_eip")
+	const (
+		liveID  = "100.49.75.26|eipalloc-07d114af86fd5d1c3"
+		ruleID  = "|eipalloc-07d114af86fd5d1c3"
+		allocID = "eipalloc-07d114af86fd5d1c3"
+	)
+
+	// ImportID: both forms collapse to the bare AllocationId.
+	if got := cfg.ImportIDFromIdentifier(liveID, nil); got != allocID {
+		t.Errorf("ImportID (live compound form): got %q, want %q", got, allocID)
+	}
+	if got := cfg.ImportIDFromIdentifier(ruleID, nil); got != allocID {
+		t.Errorf("ImportID (arn-rule form): got %q, want %q", got, allocID)
+	}
+	// An identifier with no `|` (defensive) round-trips unchanged.
+	if got := cfg.ImportIDFromIdentifier(allocID, nil); got != allocID {
+		t.Errorf("ImportID (no `|`): got %q, want %q", got, allocID)
+	}
+
+	// NameHint mirrors ImportID — the AllocationId is the hint.
+	if got := cfg.NameHintFromProperties(liveID, nil); got != allocID {
+		t.Errorf("NameHint (live compound form): got %q, want %q", got, allocID)
+	}
+
+	// NativeIDs: allocation_id is the LAST-`|` segment; public_ip comes
+	// from the PublicIp property when present.
+	native := cfg.NativeIDsFromProperties(liveID, map[string]any{"PublicIp": "100.49.75.26"})
+	if native["allocation_id"] != allocID {
+		t.Errorf("NativeIDs allocation_id: got %q, want %q", native["allocation_id"], allocID)
+	}
+	if native["public_ip"] != "100.49.75.26" {
+		t.Errorf("NativeIDs public_ip: got %q, want %q", native["public_ip"], "100.49.75.26")
+	}
+	// public_ip is absent when the PublicIp property is missing.
+	bare := cfg.NativeIDsFromProperties(ruleID, nil)
+	if _, ok := bare["public_ip"]; ok {
+		t.Errorf("NativeIDs public_ip: must be absent when PublicIp property missing, got %q", bare["public_ip"])
+	}
+	if bare["allocation_id"] != allocID {
+		t.Errorf("NativeIDs allocation_id (arn-rule form): got %q, want %q", bare["allocation_id"], allocID)
+	}
+}
+
+// TestCloudWatchEventRuleConfig pins the per-type extractors for
+// aws_cloudwatch_event_rule. Cloud Control's primary identifier is the
+// full ARN; Terraform's import format is `<event-bus-name>/<rule-name>`.
+// The ImportID transform must convert a custom-bus ARN
+// (`rule/<bus>/<name>`) into `<bus>/<name>` and a default-bus ARN
+// (`rule/<name>`) into `default/<name>`. A regression to passthrough emits
+// the ARN and the rule silently drops with no_generated_config.
+func TestCloudWatchEventRuleConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_cloudwatch_event_rule")
+
+	cases := []struct {
+		name string
+		arn  string
+		want string
+	}{
+		{
+			name: "default bus",
+			arn:  "arn:aws:events:us-east-1:111111111111:rule/my-rule",
+			want: "default/my-rule",
+		},
+		{
+			name: "custom bus",
+			arn:  "arn:aws:events:us-east-1:111111111111:rule/my-bus/my-rule",
+			want: "my-bus/my-rule",
+		},
+		{
+			name: "govcloud partition default bus",
+			arn:  "arn:aws-us-gov:events:us-gov-west-1:111111111111:rule/gov-rule",
+			want: "default/gov-rule",
+		},
+		{
+			name: "already in bus/name form (passthrough)",
+			arn:  "my-bus/my-rule",
+			want: "my-bus/my-rule",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cfg.ImportIDFromIdentifier(tc.arn, nil); got != tc.want {
+				t.Errorf("ImportID(%q): got %q, want %q", tc.arn, got, tc.want)
+			}
+		})
+	}
+
+	// NativeIDs still carry the full ARN, and NameHint reads Name.
+	props := map[string]any{
+		"Name": "my-rule",
+		"Arn":  "arn:aws:events:us-east-1:111111111111:rule/my-bus/my-rule",
+	}
+	if got := cfg.NameHintFromProperties("x", props); got != "my-rule" {
+		t.Errorf("NameHint: got %q, want my-rule", got)
+	}
+	native := cfg.NativeIDsFromProperties("x", props)
+	if native["arn"] != props["Arn"] {
+		t.Errorf("NativeIDs arn: got %q, want %q", native["arn"], props["Arn"])
+	}
+}
+
+// TestKMSKeyConfig pins the per-type extractors for aws_kms_key, focused
+// on the AWS-managed-key exclusion signal (Fix 4): the discoverer surfaces
+// KeyManager into NativeIDs["key_manager"] when the Cloud Control payload
+// carries it, so imported.UnimportableReason can grey out AWS-managed keys.
+// When the payload omits KeyManager (the CFN schema does not guarantee it),
+// the key is treated as importable and the genconfig prune is the backstop.
+func TestKMSKeyConfig(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_kms_key")
+
+	const (
+		keyID = "1234abcd-12ab-34cd-56ef-1234567890ab"
+		arn   = "arn:aws:kms:us-east-1:111111111111:key/" + keyID
+	)
+	if got := cfg.ImportIDFromIdentifier(keyID, nil); got != keyID {
+		t.Errorf("ImportID passthrough: got %q, want %q", got, keyID)
+	}
+
+	// AWS-managed key: key_manager surfaced.
+	managed := cfg.NativeIDsFromProperties(keyID, map[string]any{"Arn": arn, "KeyManager": "AWS"})
+	if managed["key_manager"] != "AWS" {
+		t.Errorf("NativeIDs key_manager (AWS-managed): got %q, want AWS", managed["key_manager"])
+	}
+	if managed["arn"] != arn {
+		t.Errorf("NativeIDs arn: got %q, want %q", managed["arn"], arn)
+	}
+
+	// Customer key: key_manager surfaced as CUSTOMER.
+	cust := cfg.NativeIDsFromProperties(keyID, map[string]any{"Arn": arn, "KeyManager": "CUSTOMER"})
+	if cust["key_manager"] != "CUSTOMER" {
+		t.Errorf("NativeIDs key_manager (customer): got %q, want CUSTOMER", cust["key_manager"])
+	}
+
+	// KeyManager absent from the payload: key_manager key omitted (so the
+	// importability classifier treats the key as importable — the documented
+	// CFN-schema limitation).
+	absent := cfg.NativeIDsFromProperties(keyID, map[string]any{"Arn": arn})
+	if _, ok := absent["key_manager"]; ok {
+		t.Errorf("NativeIDs key_manager: must be omitted when KeyManager absent, got %q", absent["key_manager"])
+	}
+	if absent["arn"] != arn {
+		t.Errorf("NativeIDs arn (no KeyManager): got %q, want %q", absent["arn"], arn)
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -86,13 +86,22 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		//
 		// Cloud Control's primary identifier is `<SelectionId>_<BackupPlanId>`
 		// (underscore-separated, verified live). Terraform's import
-		// format is `<SelectionId>|<BackupPlanId>` (pipe-separated).
+		// format is `<BackupPlanId>|<SelectionId>` (pipe-separated, plan
+		// FIRST — the reverse of the CC field order; verified against
+		// terraform-provider-aws aws_backup_selection import docs). A
+		// naive single `_`→`|` replace emits `<SelectionId>|<BackupPlanId>`
+		// (wrong order), which terraform import rejects and the selection
+		// silently drops with no_generated_config.
 		TFType:               "aws_backup_selection",
 		CloudFormationType:   "AWS::Backup::BackupSelection",
 		Slug:                 "backup_selection",
 		SkipProjectTagFilter: true,
 		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
-			return strings.Replace(identifier, "_", "|", 1)
+			if idx := strings.Index(identifier, "_"); idx != -1 {
+				selectionID, planID := identifier[:idx], identifier[idx+1:]
+				return planID + "|" + selectionID
+			}
+			return identifier
 		},
 		NameHintFromProperties: func(identifier string, props map[string]any) string {
 			if sel, ok := props["BackupSelection"].(map[string]any); ok {
@@ -232,10 +241,19 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		),
 	},
 	{
-		TFType:                  "aws_cloudwatch_event_rule",
-		CloudFormationType:      "AWS::Events::Rule",
-		Slug:                    "cloudwatch_event_rule",
-		ImportIDFromIdentifier:  passthroughImportID,
+		TFType:             "aws_cloudwatch_event_rule",
+		CloudFormationType: "AWS::Events::Rule",
+		Slug:               "cloudwatch_event_rule",
+		// Cloud Control's primary identifier for AWS::Events::Rule is the
+		// full ARN. Terraform's import format is `<event-bus-name>/<rule-name>`
+		// (verified against terraform-provider-aws aws_cloudwatch_event_rule
+		// import docs), NOT the ARN — passthrough emits the ARN and the rule
+		// silently drops with no_generated_config. eventRuleImportID parses
+		// the ARN's resource part (`rule/<bus>/<name>` for a custom bus,
+		// `rule/<name>` for the implicit default bus) into the bus/name form.
+		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
+			return eventRuleImportID(identifier)
+		},
 		NameHintFromProperties:  nameOrIdentifier("Name"),
 		NativeIDsFromProperties: arnUnderKey("Arn"),
 		TagsFromProperties:      tagsFromKey("Tags"),
@@ -290,13 +308,44 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 	// KMS — regional
 	// =====================================================================
 	{
-		TFType:                  "aws_kms_key",
-		CloudFormationType:      "AWS::KMS::Key",
-		Slug:                    "kms",
-		ImportIDFromIdentifier:  passthroughImportID,
-		NameHintFromProperties:  nameOrIdentifier("KeyId"),
-		NativeIDsFromProperties: arnUnderKey("Arn"),
-		TagsFromProperties:      tagsFromKey("Tags"),
+		TFType:                 "aws_kms_key",
+		CloudFormationType:     "AWS::KMS::Key",
+		Slug:                   "kms",
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: nameOrIdentifier("KeyId"),
+		// Surface KeyManager (AWS | CUSTOMER) into NativeIDs["key_manager"]
+		// when the Cloud Control payload carries it, so the instance-level
+		// importability classifier (imported.UnimportableReason, #709) can
+		// grey out AWS-managed keys instead of offering them. AWS-managed
+		// keys (e.g. the ACM default key, KeyManager == "AWS") are not
+		// customer-owned and FAIL import: the provider's read calls
+		// kms:GetKeyRotationStatus, which AWS-managed keys deny — so the key
+		// silently drops with no_generated_config.
+		//
+		// LIMITATION: AWS::KMS::Key's CloudFormation schema does NOT list
+		// KeyManager among its (read-only) properties, so a Cloud Control
+		// GetResource payload may omit it. KeyManager is therefore the
+		// closest available signal but not a guaranteed one. This is the
+		// same posture as the service-managed-ENI classifier (#709): when
+		// the discoverer can't surface the discriminator, the key is treated
+		// as importable here and the reverse-import genconfig prune (#708)
+		// remains the backstop. The exclusion cannot be done via
+		// SkipIdentifier because that hook receives only the bare KeyId
+		// (a UUID with no manager signal) before the GetResource fan-out.
+		NativeIDsFromProperties: func(identifier string, props map[string]any) map[string]string {
+			out := map[string]string{}
+			if arn := extractString(props, "Arn"); arn != "" {
+				out["arn"] = arn
+			}
+			if km := extractString(props, "KeyManager"); km != "" {
+				out["key_manager"] = km
+			}
+			if len(out) == 0 {
+				return nil
+			}
+			return out
+		},
+		TagsFromProperties: tagsFromKey("Tags"),
 	},
 
 	// =====================================================================
@@ -355,13 +404,17 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		// scanned region returns the same buckets. Treating S3 as a
 		// per-region type therefore emitted the same bucket once per
 		// scan region, each stamped with the (wrong) scan region (#1860).
-		// Mark it global: the discoverer scans once (region="") and reads
-		// the deduped set via RGTCacheForGlobalCFN (dedups by ARN), so
-		// each bucket appears exactly once with no region. Downstream the
-		// region-less identity is handled as a global resource (reliable
-		// backfills the session region — us-east-1 — for import, which the
-		// S3 us-east-1 endpoint serves cross-region). Identifier = bucket
-		// name.
+		// Mark it global FOR ENUMERATION: the discoverer scans once
+		// (region="") and reads the deduped set via RGTCacheForGlobalCFN
+		// (dedups by ARN), so each bucket appears exactly once. IsGlobal
+		// keeps that single ListBuckets/RGT pass — it does NOT mean the
+		// bucket lives in us-east-1. A bucket in us-west-2 / eu-central-1
+		// is generated under a us-east-1 provider only if its Identity.Region
+		// is left empty (reliable then backfills the session region,
+		// us-east-1), and generate-config-out fails for it (#1860 follow-up).
+		// The s3_bucket enricher promotes each bucket's TRUE region (from
+		// HeadBucket BucketRegion) into Identity.Region so genconfig groups
+		// every bucket into its real region dir. Identifier = bucket name.
 		IsGlobal:                true,
 		ImportIDFromIdentifier:  passthroughImportID,
 		NameHintFromProperties:  nameOrIdentifier("BucketName"),
@@ -518,21 +571,28 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		TFType:             "aws_eip",
 		CloudFormationType: "AWS::EC2::EIP",
 		Slug:               "eip",
-		// Cloud Control identifier is compound "|<AllocationId>" (per
-		// arnRule); Terraform import takes just the AllocationId. Strip
-		// the leading "|".
+		// Cloud Control's primary identifier for AWS::EC2::EIP is the
+		// compound `<PublicIp>|<AllocationId>` (verified live, e.g.
+		// `100.49.75.26|eipalloc-07d114af86fd5d1c3`). The arnRule path
+		// yields the `|<AllocationId>` form (empty PublicIp). Terraform
+		// import for aws_eip takes JUST the AllocationId, so take the
+		// segment after the LAST `|` — that handles both the live
+		// `<ip>|<alloc>` form and the ARN-rule `|<alloc>` form. A plain
+		// TrimPrefix("|") is a no-op on the live form and would emit the
+		// wrong ID (with the public IP), silently dropping the EIP with
+		// no_generated_config.
 		ImportIDFromIdentifier: func(identifier string, _ map[string]any) string {
-			return strings.TrimPrefix(identifier, "|")
+			return eipAllocID(identifier)
 		},
 		NameHintFromProperties: func(identifier string, _ map[string]any) string {
-			return strings.TrimPrefix(identifier, "|")
+			return eipAllocID(identifier)
 		},
 		NativeIDsFromProperties: func(identifier string, props map[string]any) map[string]string {
 			out := map[string]string{}
 			if ip := extractString(props, "PublicIp"); ip != "" {
 				out["public_ip"] = ip
 			}
-			out["allocation_id"] = strings.TrimPrefix(identifier, "|")
+			out["allocation_id"] = eipAllocID(identifier)
 			return out
 		},
 		TagsFromProperties: tagsFromKey("Tags"),
@@ -2725,6 +2785,59 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 // import format byte-for-byte.
 func passthroughImportID(identifier string, _ map[string]any) string {
 	return identifier
+}
+
+// eipAllocID extracts the AllocationId from an AWS::EC2::EIP Cloud Control
+// identifier. The live primary identifier is the compound
+// `<PublicIp>|<AllocationId>` (e.g.
+// `100.49.75.26|eipalloc-07d114af86fd5d1c3`); the arnRule path yields the
+// `|<AllocationId>` form (empty PublicIp). Terraform import for aws_eip
+// takes only the AllocationId, so return the segment after the LAST `|`.
+// This is correct for both forms; an identifier with no `|` is returned
+// unchanged.
+func eipAllocID(identifier string) string {
+	if i := strings.LastIndex(identifier, "|"); i >= 0 {
+		return identifier[i+1:]
+	}
+	return identifier
+}
+
+// eventRuleImportID converts an AWS::Events::Rule Cloud Control identifier
+// (the full ARN) into Terraform's `<event-bus-name>/<rule-name>` import
+// format. EventBridge rule ARNs take two shapes:
+//
+//   - custom bus:  arn:aws:events:<region>:<acct>:rule/<bus>/<name>
+//   - default bus: arn:aws:events:<region>:<acct>:rule/<name>
+//
+// The resource segment after the 5th `:` is `rule/<bus>/<name>` or
+// `rule/<name>`. We emit `<bus>/<name>`, defaulting the bus to `default`
+// when the ARN carries only the rule name (the implicit default bus). A
+// string that is not an events-rule ARN is returned unchanged so an
+// already-correct `<bus>/<name>` input passes through untouched.
+func eventRuleImportID(identifier string) string {
+	const arnPrefix = "arn:"
+	if !strings.HasPrefix(identifier, arnPrefix) {
+		return identifier
+	}
+	// ARN layout: arn:partition:service:region:account-id:resource…
+	// Split into 6 parts so the resource segment (which itself contains
+	// `/` and possibly `:`) stays intact.
+	parts := strings.SplitN(identifier, ":", 6)
+	if len(parts) != 6 {
+		return identifier
+	}
+	resource := parts[5] // e.g. "rule/<bus>/<name>" or "rule/<name>"
+	const resPrefix = "rule/"
+	if !strings.HasPrefix(resource, resPrefix) {
+		return identifier
+	}
+	rest := strings.TrimPrefix(resource, resPrefix)
+	if idx := strings.Index(rest, "/"); idx != -1 {
+		// rest = "<bus>/<name>" — already the target form.
+		return rest
+	}
+	// rest = "<name>" — implicit default bus.
+	return "default/" + rest
 }
 
 // passthroughIdentifierName is the common NameHintFromProperties used by

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -634,6 +634,18 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		ImportIDFromIdentifier: passthroughImportID,
 		NameHintFromProperties: passthroughIdentifierName,
 		TagsFromProperties:     tagsFromKey("Tags"),
+		// Resolve IsDefault at DISCOVER time via ec2:DescribeNetworkAcls.
+		// The CC AWS::EC2::NetworkAcl schema exposes only {VpcId, Id,
+		// Tags} — no IsDefault — so the property extractor cannot tell a
+		// VPC's DEFAULT NACL from a custom one. The AWS provider refuses
+		// to import a default NACL as aws_network_acl ("use the
+		// `aws_default_network_acl` resource instead"), so generate-config-out
+		// emits no body and the default NACL silently drops as
+		// no_generated_config. PostDiscover stamps NativeIDs["is_default"]
+		// and re-types default NACLs to aws_default_network_acl (which
+		// bodies cleanly under the same acl-… import id). Custom NACLs
+		// stay aws_network_acl. See network_acl_post_discover.go.
+		PostDiscover: networkACLPostDiscover,
 	},
 	{
 		TFType:                 "aws_vpc_endpoint",

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -346,6 +346,16 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 			return out
 		},
 		TagsFromProperties: tagsFromKey("Tags"),
+		// Resolve KeyManager at DISCOVER time via kms:DescribeKey. The CC
+		// AWS::KMS::Key schema omits KeyManager (see the LIMITATION note
+		// above), so the NativeIDsFromProperties extractor above can't set
+		// it and the reverse-import / genconfig dry-run never runs the
+		// AttributeEnricher that otherwise would. PostDiscover stamps
+		// NativeIDs["key_manager"] so imported.UnimportableReason classifies
+		// AWS-managed keys (KeyManager=AWS, e.g. the ACM/RDS/DynamoDB
+		// default keys) into unsupported.json instead of letting them drop
+		// as no_generated_config orphans (#cust3 item 1).
+		PostDiscover: kmsKeyPostDiscover,
 	},
 
 	// =====================================================================
@@ -420,6 +430,17 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		NameHintFromProperties:  nameOrIdentifier("BucketName"),
 		NativeIDsFromProperties: arnUnderKey("Arn"),
 		TagsFromProperties:      tagsFromKey("Tags"),
+		// Resolve the bucket's TRUE region at DISCOVER time via
+		// s3:GetBucketLocation and promote it into Identity.Region. S3 is
+		// IsGlobal-enumerated (region-less), so without this a non-us-east-1
+		// bucket lands under the us-east-1 provider in genconfig and fails
+		// cross-region generate-config-out (#cust3 item 3). The s3_bucket
+		// AttributeEnricher does the same promotion from HeadBucket, but the
+		// reverse-import / genconfig dry-run never runs enrichment — so the
+		// region must be set here too. PostDiscover soft-fails: a bucket
+		// whose location can't be read is still emitted (region empty →
+		// backfilled to the primary region, the prior behavior).
+		PostDiscover: s3BucketPostDiscover,
 		// #501 Normalizer: CFN AWS::S3::Bucket uses primary-name
 		// `BucketName` (TF: `bucket`) and a list-of-{Key,Value}
 		// `Tags` shape (TF: map shape). NOTE: a hand-rolled enricher

--- a/cmd/insideout-import/awsdiscover/dynamodb_contributor_insights_enrich.go
+++ b/cmd/insideout-import/awsdiscover/dynamodb_contributor_insights_enrich.go
@@ -118,9 +118,18 @@ func (e ddbContributorInsightsEnricher) EnrichByID(ctx context.Context, identity
 // ddbContributorInsightsTableName extracts the table name from
 // Identity. Preference order:
 //
-//  1. Identity.NativeIDs["table_name"] (discoverer-set).
-//  2. Identity.NameHint / Identity.ImportID — TF's import ID is the
-//     bare table name for this resource.
+//  1. Identity.NativeIDs["table_name"] (discoverer-set; always the bare
+//     table name).
+//  2. Identity.ImportID — the compound "<table>/<index>/<account>"
+//     import ID; the table name is its first "/"-delimited segment.
+//  3. Identity.NameHint — "<table>-contributor-insights"; strip the
+//     canonical suffix.
+//
+// The ImportID for this resource is NOT the bare table name: the
+// terraform-provider-aws importer expects "<table>/<index>/<account>"
+// (table-level => empty index => "<table>//<account>"), so the bare
+// ImportID must be split, not used verbatim, to recover the table name
+// for the DescribeContributorInsights SDK call.
 func ddbContributorInsightsTableName(id *imported.ResourceIdentity) (string, error) {
 	if id == nil {
 		return "", errors.New(ddbContributorInsightsTFType + ": identity is nil")
@@ -128,22 +137,21 @@ func ddbContributorInsightsTableName(id *imported.ResourceIdentity) (string, err
 	if s := strings.TrimSpace(id.NativeIDs["table_name"]); s != "" {
 		return s, nil
 	}
-	if s := strings.TrimSpace(id.NameHint); s != "" {
-		// Discoverer sets NameHint = "<table>-contributor-insights".
-		// Strip the suffix when present so the SDK call gets the bare
-		// table name. ImportID is the more reliable fallback when
-		// available.
-		if imp := strings.TrimSpace(id.ImportID); imp != "" {
-			return imp, nil
+	if imp := strings.TrimSpace(id.ImportID); imp != "" {
+		// Compound import ID "<table>/<index>/<account>" — the table is
+		// the first segment. A legacy bare table name (no "/") returns
+		// itself.
+		if i := strings.IndexByte(imp, '/'); i >= 0 {
+			return imp[:i], nil
 		}
+		return imp, nil
+	}
+	if s := strings.TrimSpace(id.NameHint); s != "" {
 		// NameHint-only fallback: strip the canonical suffix.
 		const suffix = "-contributor-insights"
 		if strings.HasSuffix(s, suffix) {
 			return strings.TrimSuffix(s, suffix), nil
 		}
-		return s, nil
-	}
-	if s := strings.TrimSpace(id.ImportID); s != "" {
 		return s, nil
 	}
 	return "", fmt.Errorf("%s: cannot derive table name from Identity (Address=%q ImportID=%q NameHint=%q)",

--- a/cmd/insideout-import/awsdiscover/kms_key_post_discover.go
+++ b/cmd/insideout-import/awsdiscover/kms_key_post_discover.go
@@ -1,0 +1,112 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// KMS key PostDiscover follow-up (#cust3 item 1).
+//
+// AWS-managed KMS keys (KeyManager == "AWS", e.g. the per-region ACM /
+// RDS / DynamoDB default keys) cannot be adopted into customer Terraform
+// state: the AWS provider's read path calls kms:GetKeyRotationStatus,
+// which AWS-managed keys deny, so `terraform plan -generate-config-out`
+// produces no body and the key is silently dropped as no_generated_config.
+//
+// imported.UnimportableReason already classifies a key as un-importable
+// when Identity.NativeIDs["key_manager"] == "AWS" (#709). The gap: the
+// Cloud Control AWS::KMS::Key schema does NOT expose KeyManager among its
+// read-only properties, so the discoverer's NativeIDsFromProperties
+// extractor never sees it and the classifier never fires. The
+// hand-rolled AttributeEnricher path COULD surface it, but the
+// reverse-import / genconfig dry-run never runs EnrichAttributes — so the
+// discriminator must be resolved at DISCOVER time.
+//
+// kmsKeyPostDiscover issues one kms:DescribeKey per discovered key and
+// stamps KeyManager (+ KeyState, useful context) onto NativeIDs so the
+// shared classifier excludes AWS-managed keys into unsupported.json
+// rather than letting them fall through to a generic orphan drop. The
+// identifier the discoverer stamps as the import ID / NativeIDs["arn"]
+// is the bare KeyId UUID / key ARN — either resolves the key for
+// DescribeKey.
+
+// kmsKeyDescriber is the narrow subset of the KMS API the PostDiscover
+// hook issues. Real *kms.Client and in-test fakes satisfy it; the
+// production hook constructs the real client per region.
+type kmsKeyDescriber interface {
+	DescribeKey(ctx context.Context, in *kms.DescribeKeyInput, opts ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+}
+
+// newKMSKeyDescriber is the production factory; tests swap it (or call
+// kmsKeyPostDiscoverWithClient directly) to inject a fake.
+var newKMSKeyDescriber = func(awsCfg aws.Config, region string) kmsKeyDescriber {
+	return kms.NewFromConfig(awsCfg, func(o *kms.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+}
+
+// kmsKeyPostDiscover is the cloudControlConfig.PostDiscover hook for
+// aws_kms_key. It resolves KeyManager via DescribeKey and stamps it onto
+// Identity.NativeIDs["key_manager"] so imported.UnimportableReason can
+// classify AWS-managed keys. Soft-fails (returns an error the discoverer
+// logs) when the key id is unresolvable or DescribeKey fails — a
+// customer-managed key with no key_manager set is still treated as
+// importable, the same posture as the genconfig prune backstop (#708).
+func kmsKeyPostDiscover(ctx context.Context, awsCfg aws.Config, region string, ir *imported.ImportedResource) error {
+	return kmsKeyPostDiscoverWithClient(ctx, newKMSKeyDescriber(awsCfg, region), ir)
+}
+
+func kmsKeyPostDiscoverWithClient(ctx context.Context, client kmsKeyDescriber, ir *imported.ImportedResource) error {
+	if ir == nil {
+		return nil
+	}
+	keyID := kmsKeyIDForDescribe(&ir.Identity)
+	if keyID == "" {
+		return fmt.Errorf("kms_key: cannot derive key id from Identity (Address=%q ImportID=%q)",
+			ir.Identity.Address, ir.Identity.ImportID)
+	}
+	out, err := client.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: aws.String(keyID)})
+	if err != nil {
+		return fmt.Errorf("kms_key %q: DescribeKey: %w", keyID, err)
+	}
+	if out == nil || out.KeyMetadata == nil {
+		return fmt.Errorf("kms_key %q: DescribeKey returned no key metadata", keyID)
+	}
+	if ir.Identity.NativeIDs == nil {
+		ir.Identity.NativeIDs = map[string]string{}
+	}
+	if km := string(out.KeyMetadata.KeyManager); km != "" {
+		ir.Identity.NativeIDs["key_manager"] = km
+	}
+	if ks := string(out.KeyMetadata.KeyState); ks != "" {
+		ir.Identity.NativeIDs["key_state"] = ks
+	}
+	return nil
+}
+
+// kmsKeyIDForDescribe resolves a DescribeKey-acceptable identifier from
+// the identity the aws_kms_key discoverer populates. NativeIDs["arn"] is
+// the most specific (region-qualified) form; ImportID / NameHint carry
+// the bare KeyId UUID — DescribeKey accepts either.
+func kmsKeyIDForDescribe(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if arn := id.NativeIDs["arn"]; arn != "" {
+		return arn
+	}
+	if id.ImportID != "" {
+		return id.ImportID
+	}
+	if id.NativeIDs["name"] != "" {
+		return id.NativeIDs["name"]
+	}
+	return id.NameHint
+}

--- a/cmd/insideout-import/awsdiscover/kms_key_post_discover_test.go
+++ b/cmd/insideout-import/awsdiscover/kms_key_post_discover_test.go
@@ -1,0 +1,133 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeKMSKeyDescriber is a minimal kmsKeyDescriber stub for the
+// PostDiscover hook tests.
+type fakeKMSKeyDescriber struct {
+	out      *kms.DescribeKeyOutput
+	err      error
+	gotKeyID string
+}
+
+func (f *fakeKMSKeyDescriber) DescribeKey(_ context.Context, in *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	f.gotKeyID = aws.ToString(in.KeyId)
+	return f.out, f.err
+}
+
+// TestKMSKeyPostDiscover_AWSManagedKeyClassified is the #cust3 item-1
+// regression: an AWS-managed key (the us-west-2 ACM default key
+// d1710314-…, KeyManager=AWS) has its KeyManager resolved at DISCOVER
+// time via DescribeKey and stamped onto NativeIDs["key_manager"] so the
+// shared importability classifier excludes it into unsupported.json
+// instead of letting it drop as a no_generated_config orphan. Verified
+// against the real account: kms:DescribeKey d1710314 returns
+// KeyManager=AWS.
+func TestKMSKeyPostDiscover_AWSManagedKeyClassified(t *testing.T) {
+	t.Parallel()
+	fake := &fakeKMSKeyDescriber{
+		out: &kms.DescribeKeyOutput{KeyMetadata: &kmstypes.KeyMetadata{
+			KeyManager: kmstypes.KeyManagerTypeAws,
+			KeyState:   kmstypes.KeyStateEnabled,
+		}},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_kms_key",
+			Region:   "us-west-2",
+			ImportID: "d1710314-0d38-4ee0-a04e-de33796a0f25",
+			NativeIDs: map[string]string{
+				"arn": "arn:aws:kms:us-west-2:031780745048:key/d1710314-0d38-4ee0-a04e-de33796a0f25",
+			},
+		},
+	}
+	require.NoError(t, kmsKeyPostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "AWS", ir.Identity.NativeIDs["key_manager"], "KeyManager must be surfaced for the classifier")
+	assert.Equal(t, "Enabled", ir.Identity.NativeIDs["key_state"])
+	// The ARN is preferred for the DescribeKey call.
+	assert.Equal(t, "arn:aws:kms:us-west-2:031780745048:key/d1710314-0d38-4ee0-a04e-de33796a0f25", fake.gotKeyID)
+	// The shared classifier now routes it to unsupported.json.
+	assert.Equal(t, imported.ReasonAWSManagedKMSKey, imported.UnimportableReason(*ir),
+		"AWS-managed key must classify as un-importable once key_manager is stamped")
+}
+
+// TestKMSKeyPostDiscover_CustomerKeyImportable proves a customer-managed
+// key (KeyManager=CUSTOMER) stays importable: key_manager is stamped but
+// UnimportableReason returns "".
+func TestKMSKeyPostDiscover_CustomerKeyImportable(t *testing.T) {
+	t.Parallel()
+	fake := &fakeKMSKeyDescriber{
+		out: &kms.DescribeKeyOutput{KeyMetadata: &kmstypes.KeyMetadata{
+			KeyManager: kmstypes.KeyManagerTypeCustomer,
+			KeyState:   kmstypes.KeyStateEnabled,
+		}},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_kms_key",
+			ImportID: "ad8f8045-5713-447e-8fad-4a71e760d76e",
+		},
+	}
+	require.NoError(t, kmsKeyPostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "CUSTOMER", ir.Identity.NativeIDs["key_manager"])
+	assert.Equal(t, "", imported.UnimportableReason(*ir), "customer-managed key must remain importable")
+	// No ARN -> falls back to the bare KeyId UUID for DescribeKey.
+	assert.Equal(t, "ad8f8045-5713-447e-8fad-4a71e760d76e", fake.gotKeyID)
+}
+
+// TestKMSKeyPostDiscover_SoftFailsOnError proves a DescribeKey failure is
+// surfaced as an error (the discoverer logs it via ServiceWarn) without
+// clobbering the IR — the key is still emitted as importable, matching
+// the genconfig prune backstop posture.
+func TestKMSKeyPostDiscover_SoftFailsOnError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeKMSKeyDescriber{err: errors.New("AccessDenied")}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_kms_key",
+			ImportID: "some-uuid",
+		},
+	}
+	err := kmsKeyPostDiscoverWithClient(context.Background(), fake, ir)
+	require.Error(t, err)
+	_, ok := ir.Identity.NativeIDs["key_manager"]
+	assert.False(t, ok, "no key_manager stamped when DescribeKey fails")
+	assert.Equal(t, "", imported.UnimportableReason(*ir), "un-resolvable key stays importable (backstop posture)")
+}
+
+// TestKMSKeyPostDiscover_EmptyIdentity proves a key id that cannot be
+// derived returns an error rather than panicking or stamping garbage.
+func TestKMSKeyPostDiscover_EmptyIdentity(t *testing.T) {
+	t.Parallel()
+	fake := &fakeKMSKeyDescriber{}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: "aws_kms_key"}}
+	require.Error(t, kmsKeyPostDiscoverWithClient(context.Background(), fake, ir))
+}
+
+// TestKMSKeyConfig_WiresPostDiscover guards the registration: the
+// aws_kms_key cloudControlConfig must carry the PostDiscover hook, or the
+// discover-time KeyManager resolution silently regresses (back to the
+// enricher-only path that the reverse-import dry-run never runs).
+func TestKMSKeyConfig_WiresPostDiscover(t *testing.T) {
+	t.Parallel()
+	var found bool
+	for _, cfg := range cloudControlTypeConfigs {
+		if cfg.TFType == "aws_kms_key" {
+			found = true
+			require.NotNil(t, cfg.PostDiscover, "aws_kms_key must wire PostDiscover for discover-time KeyManager resolution")
+		}
+	}
+	require.True(t, found, "aws_kms_key config not found")
+}

--- a/cmd/insideout-import/awsdiscover/network_acl_post_discover.go
+++ b/cmd/insideout-import/awsdiscover/network_acl_post_discover.go
@@ -1,0 +1,138 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Network ACL PostDiscover follow-up — default-NACL re-typing.
+//
+// A VPC's DEFAULT network ACL is discovered via Cloud Control as an
+// AWS::EC2::NetworkAcl, the same as a custom NACL, and the discoverer
+// emits it with Identity.Type == "aws_network_acl". But the AWS provider
+// REFUSES to import a default NACL as aws_network_acl: it errors with
+//
+//	Error: use the `aws_default_network_acl` resource instead
+//
+// so `terraform plan -generate-config-out` produces NO body and the
+// resource is silently dropped as no_generated_config — the last
+// silent-drop in the whole-account reverse-import. (Confirmed live
+// against cust1: every NACL in the account is its VPC's default, and
+// declaring acl-… as aws_network_acl errored exactly as above while
+// declaring it as aws_default_network_acl produced a clean body.)
+//
+// The fix is lossless: re-type the DEFAULT NACL instance to
+// aws_default_network_acl. That sibling resource imports by the same
+// acl-… id and `generate-config-out` renders a full body for it. Custom
+// NACLs are left as aws_network_acl (still importable). The two resource
+// families share the import ID, so this is a pure per-instance TFType
+// reclassification — no separate discoverer, registry entry, or enricher
+// is needed (aws_default_network_acl is never independently discoverable;
+// it is only ever this reclassification of a default aws_network_acl).
+//
+// Why a PostDiscover SDK call: the Cloud Control AWS::EC2::NetworkAcl
+// schema exposes only {VpcId, Id, Tags} — it does NOT surface IsDefault —
+// so the discoverer's property extractor cannot tell default from custom.
+// networkACLPostDiscover issues one ec2:DescribeNetworkAcls per discovered
+// NACL, stamps NativeIDs["is_default"], and for a default NACL rewrites
+// Identity.Type to aws_default_network_acl (regenerating Identity.Address
+// so the type prefix matches the emitted import {} block and resource
+// body). Soft-fails (returns an error the discoverer logs) without
+// clobbering the IR: a DescribeNetworkAcls miss leaves the NACL as
+// aws_network_acl, the same posture as the genconfig orphan-prune backstop.
+
+// defaultNetworkACLTFType is the Terraform resource type a default network
+// ACL must be imported as. The AWS provider rejects a default NACL declared
+// as aws_network_acl.
+const defaultNetworkACLTFType = "aws_default_network_acl"
+
+// networkACLDescriber is the narrow subset of the EC2 API the PostDiscover
+// hook issues. Real *ec2.Client and in-test fakes satisfy it; the
+// production hook constructs the real client per region.
+type networkACLDescriber interface {
+	DescribeNetworkAcls(ctx context.Context, in *ec2.DescribeNetworkAclsInput, opts ...func(*ec2.Options)) (*ec2.DescribeNetworkAclsOutput, error)
+}
+
+// newNetworkACLDescriber is the production factory; tests swap it (or call
+// networkACLPostDiscoverWithClient directly) to inject a fake.
+var newNetworkACLDescriber = func(awsCfg aws.Config, region string) networkACLDescriber {
+	return ec2.NewFromConfig(awsCfg, func(o *ec2.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+}
+
+// networkACLPostDiscover is the cloudControlConfig.PostDiscover hook for
+// aws_network_acl. It resolves IsDefault via ec2:DescribeNetworkAcls and,
+// for a default NACL, re-types the IR to aws_default_network_acl.
+func networkACLPostDiscover(ctx context.Context, awsCfg aws.Config, region string, ir *imported.ImportedResource) error {
+	return networkACLPostDiscoverWithClient(ctx, newNetworkACLDescriber(awsCfg, region), ir)
+}
+
+func networkACLPostDiscoverWithClient(ctx context.Context, client networkACLDescriber, ir *imported.ImportedResource) error {
+	if ir == nil {
+		return nil
+	}
+	aclID := networkACLIDForDescribe(&ir.Identity)
+	if aclID == "" {
+		return fmt.Errorf("network_acl: cannot derive acl id from Identity (Address=%q ImportID=%q NameHint=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+	out, err := client.DescribeNetworkAcls(ctx, &ec2.DescribeNetworkAclsInput{
+		NetworkAclIds: []string{aclID},
+	})
+	if err != nil {
+		return fmt.Errorf("network_acl %q: DescribeNetworkAcls: %w", aclID, err)
+	}
+	if out == nil || len(out.NetworkAcls) == 0 {
+		return fmt.Errorf("network_acl %q: DescribeNetworkAcls returned no ACL", aclID)
+	}
+	acl := out.NetworkAcls[0]
+	isDefault := acl.IsDefault != nil && *acl.IsDefault
+	if ir.Identity.NativeIDs == nil {
+		ir.Identity.NativeIDs = map[string]string{}
+	}
+	if isDefault {
+		ir.Identity.NativeIDs["is_default"] = "true"
+		retypeAsDefaultNetworkACL(ir)
+	} else {
+		ir.Identity.NativeIDs["is_default"] = "false"
+	}
+	return nil
+}
+
+// retypeAsDefaultNetworkACL rewrites a default NACL's Identity.Type to
+// aws_default_network_acl and regenerates Identity.Address so the type
+// prefix on the emitted import {} block and resource body matches. The
+// label portion is unchanged (it derives from the same NameHint), so the
+// address is stable across re-types: aws_network_acl.<acl> becomes
+// aws_default_network_acl.<acl>. Collision avoidance uses a nil exists
+// predicate — a VPC has exactly one default NACL and the label carries the
+// unique acl-… id, so the freshly-typed address cannot collide.
+func retypeAsDefaultNetworkACL(ir *imported.ImportedResource) {
+	ir.Identity.Type = defaultNetworkACLTFType
+	ir.Identity.Address = imported.GenerateAddress(ir.Identity, nil)
+}
+
+// networkACLIDForDescribe resolves a DescribeNetworkAcls-acceptable acl-…
+// id from the identity the aws_network_acl discoverer populates. ImportID
+// is the Cloud Control primary identifier (the bare acl-… id, passthrough);
+// NameHint and NativeIDs["name"] carry the same value as fallbacks.
+func networkACLIDForDescribe(id *imported.ResourceIdentity) string {
+	if id == nil {
+		return ""
+	}
+	if id.ImportID != "" {
+		return id.ImportID
+	}
+	if id.NativeIDs["name"] != "" {
+		return id.NativeIDs["name"]
+	}
+	return id.NameHint
+}

--- a/cmd/insideout-import/awsdiscover/network_acl_post_discover_test.go
+++ b/cmd/insideout-import/awsdiscover/network_acl_post_discover_test.go
@@ -1,0 +1,175 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeNetworkACLDescriber is a minimal networkACLDescriber stub for the
+// PostDiscover hook tests.
+type fakeNetworkACLDescriber struct {
+	out      *ec2.DescribeNetworkAclsOutput
+	err      error
+	gotACLID string
+}
+
+func (f *fakeNetworkACLDescriber) DescribeNetworkAcls(_ context.Context, in *ec2.DescribeNetworkAclsInput, _ ...func(*ec2.Options)) (*ec2.DescribeNetworkAclsOutput, error) {
+	if len(in.NetworkAclIds) > 0 {
+		f.gotACLID = in.NetworkAclIds[0]
+	}
+	return f.out, f.err
+}
+
+// newNACLIR builds the aws_network_acl IR shape the discoverer produces —
+// ImportID / NameHint / NativeIDs["name"] all carry the acl-… id (the CC
+// primary identifier, passthrough) and Address is the generated
+// aws_network_acl.<acl> form.
+func newNACLIR(aclID string) *imported.ImportedResource {
+	id := imported.ResourceIdentity{
+		Type:      "aws_network_acl",
+		Region:    "us-east-1",
+		ImportID:  aclID,
+		NameHint:  aclID,
+		NativeIDs: map[string]string{"name": aclID},
+	}
+	id.Address = imported.GenerateAddress(id, nil)
+	return &imported.ImportedResource{Identity: id}
+}
+
+// TestNetworkACLPostDiscover_DefaultRetyped is the core regression: a VPC's
+// DEFAULT network ACL (acl-07053f2bb73b58ba6, the live cust1 us-east-1
+// default — IsDefault=true) is resolved at DISCOVER time via
+// DescribeNetworkAcls and re-typed to aws_default_network_acl. Verified
+// live: the same acl-… id bodies cleanly via `terraform plan
+// -generate-config-out` as aws_default_network_acl but errors ("use the
+// `aws_default_network_acl` resource instead") as aws_network_acl, so this
+// re-type is the difference between a clean import and a silent
+// no_generated_config drop.
+func TestNetworkACLPostDiscover_DefaultRetyped(t *testing.T) {
+	t.Parallel()
+	fake := &fakeNetworkACLDescriber{
+		out: &ec2.DescribeNetworkAclsOutput{NetworkAcls: []ec2types.NetworkAcl{{
+			NetworkAclId: aws.String("acl-07053f2bb73b58ba6"),
+			VpcId:        aws.String("vpc-044b75ab41c527a20"),
+			IsDefault:    aws.Bool(true),
+		}}},
+	}
+	ir := newNACLIR("acl-07053f2bb73b58ba6")
+	require.NoError(t, networkACLPostDiscoverWithClient(context.Background(), fake, ir))
+
+	assert.Equal(t, "acl-07053f2bb73b58ba6", fake.gotACLID, "the acl-… id must drive DescribeNetworkAcls")
+	assert.Equal(t, "true", ir.Identity.NativeIDs["is_default"], "is_default must be stamped")
+	assert.Equal(t, "aws_default_network_acl", ir.Identity.Type, "a default NACL must be re-typed to aws_default_network_acl")
+	assert.Equal(t, "aws_default_network_acl.acl_07053f2bb73b58ba6", ir.Identity.Address,
+		"Address must be regenerated so the type prefix matches the emitted import {} block")
+	// Import ID is unchanged: aws_default_network_acl imports by the same acl-… id.
+	assert.Equal(t, "acl-07053f2bb73b58ba6", ir.Identity.ImportID)
+}
+
+// TestNetworkACLPostDiscover_CustomStaysImportable is the custom-NACL guard:
+// a non-default (custom) NACL keeps Identity.Type == aws_network_acl and
+// its original address, so it still imports as aws_network_acl
+// (generate-config-out bodies it cleanly). Only is_default=false is
+// stamped.
+func TestNetworkACLPostDiscover_CustomStaysImportable(t *testing.T) {
+	t.Parallel()
+	fake := &fakeNetworkACLDescriber{
+		out: &ec2.DescribeNetworkAclsOutput{NetworkAcls: []ec2types.NetworkAcl{{
+			NetworkAclId: aws.String("acl-0custom00000000000"),
+			VpcId:        aws.String("vpc-0fdd604b65acd3f87"),
+			IsDefault:    aws.Bool(false),
+		}}},
+	}
+	ir := newNACLIR("acl-0custom00000000000")
+	wantAddr := ir.Identity.Address
+	require.NoError(t, networkACLPostDiscoverWithClient(context.Background(), fake, ir))
+
+	assert.Equal(t, "false", ir.Identity.NativeIDs["is_default"])
+	assert.Equal(t, "aws_network_acl", ir.Identity.Type, "a custom NACL must stay aws_network_acl")
+	assert.Equal(t, wantAddr, ir.Identity.Address, "a custom NACL's address must not be rewritten")
+	assert.Equal(t, "aws_network_acl.acl_0custom00000000000", ir.Identity.Address)
+}
+
+// TestNetworkACLPostDiscover_NilIsDefaultTreatedAsCustom proves a NACL whose
+// IsDefault field is nil (absent) is treated as custom — it stays
+// aws_network_acl. The re-type is gated on a definitive IsDefault==true, so
+// a missing discriminator never mis-routes a custom NACL into the default
+// resource (which would then fail its own import).
+func TestNetworkACLPostDiscover_NilIsDefaultTreatedAsCustom(t *testing.T) {
+	t.Parallel()
+	fake := &fakeNetworkACLDescriber{
+		out: &ec2.DescribeNetworkAclsOutput{NetworkAcls: []ec2types.NetworkAcl{{
+			NetworkAclId: aws.String("acl-0nil0000000000000"),
+			IsDefault:    nil,
+		}}},
+	}
+	ir := newNACLIR("acl-0nil0000000000000")
+	require.NoError(t, networkACLPostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "false", ir.Identity.NativeIDs["is_default"])
+	assert.Equal(t, "aws_network_acl", ir.Identity.Type)
+}
+
+// TestNetworkACLPostDiscover_SoftFailsOnError proves a DescribeNetworkAcls
+// failure is surfaced as an error (the discoverer logs it via ServiceWarn)
+// without clobbering the IR — the NACL is still emitted as aws_network_acl,
+// matching the genconfig orphan-prune backstop posture. A default NACL that
+// soft-fails here drops as before, but a soft-fail never WORSENS the result
+// for a custom NACL.
+func TestNetworkACLPostDiscover_SoftFailsOnError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeNetworkACLDescriber{err: errors.New("AccessDenied")}
+	ir := newNACLIR("acl-0err0000000000000")
+	wantAddr := ir.Identity.Address
+	err := networkACLPostDiscoverWithClient(context.Background(), fake, ir)
+	require.Error(t, err)
+	_, stamped := ir.Identity.NativeIDs["is_default"]
+	assert.False(t, stamped, "no is_default stamped when DescribeNetworkAcls fails")
+	assert.Equal(t, "aws_network_acl", ir.Identity.Type, "the IR is not clobbered on soft-fail")
+	assert.Equal(t, wantAddr, ir.Identity.Address)
+}
+
+// TestNetworkACLPostDiscover_EmptyResultSoftFails proves DescribeNetworkAcls
+// returning zero ACLs (e.g. the ACL was deleted between discover and the
+// follow-up) is a soft-fail, not a panic or a bogus re-type.
+func TestNetworkACLPostDiscover_EmptyResultSoftFails(t *testing.T) {
+	t.Parallel()
+	fake := &fakeNetworkACLDescriber{out: &ec2.DescribeNetworkAclsOutput{}}
+	ir := newNACLIR("acl-0gone000000000000")
+	require.Error(t, networkACLPostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "aws_network_acl", ir.Identity.Type)
+}
+
+// TestNetworkACLPostDiscover_EmptyIdentity proves an IR with no derivable
+// acl-… id returns an error rather than calling DescribeNetworkAcls with an
+// empty id.
+func TestNetworkACLPostDiscover_EmptyIdentity(t *testing.T) {
+	t.Parallel()
+	fake := &fakeNetworkACLDescriber{}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: "aws_network_acl"}}
+	require.Error(t, networkACLPostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Empty(t, fake.gotACLID, "DescribeNetworkAcls must not be called with an empty id")
+}
+
+// TestNetworkACLConfig_WiresPostDiscover guards the registration: the
+// aws_network_acl cloudControlConfig must carry the PostDiscover hook, or
+// default NACLs silently regress to dropping as no_generated_config.
+func TestNetworkACLConfig_WiresPostDiscover(t *testing.T) {
+	t.Parallel()
+	var found bool
+	for _, cfg := range cloudControlTypeConfigs {
+		if cfg.TFType == "aws_network_acl" {
+			found = true
+			require.NotNil(t, cfg.PostDiscover, "aws_network_acl must wire PostDiscover for discover-time IsDefault resolution")
+		}
+	}
+	require.True(t, found, "aws_network_acl config not found")
+}

--- a/cmd/insideout-import/awsdiscover/resourceexplorer2_cust3_test.go
+++ b/cmd/insideout-import/awsdiscover/resourceexplorer2_cust3_test.go
@@ -1,0 +1,62 @@
+package awsdiscover
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/resourceexplorer2"
+	re2types "github.com/aws/aws-sdk-go-v2/service/resourceexplorer2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// #cust3 item 4. aws_resourceexplorer2_index / _view pre-exist in the
+// account (one LOCAL index + one default view per region) and ARE
+// importable: the Terraform import ID is the region-encoded resource ARN,
+// which `terraform plan -generate-config-out` bodies cleanly (verified
+// against AWS provider v6 in ap-southeast-1 / eu-west-1 / us-east-2).
+// The earlier whole-account run dropped them as no_generated_config only
+// because the IR's Identity.Region was empty, so genconfig grouped them
+// under the us-east-1 provider and the cross-region import failed. The
+// discoverers already stamp the resource's own region — these regression
+// tests lock that invariant (import ID = bare ARN, Region = the
+// resource's home region) so genconfig groups each into its real region
+// pass.
+
+// TestResourceExplorer2Index_ImportIDIsARNWithRegion locks the index
+// invariant: import ID is the bare ARN and Identity.Region is the home
+// region (not backfilled), so a non-us-east-1 index bodies in its own pass.
+func TestResourceExplorer2Index_ImportIDIsARNWithRegion(t *testing.T) {
+	t.Parallel()
+	const arn = "arn:aws:resource-explorer-2:ap-southeast-1:031780745048:index/e54a6189-d805-4c50-919e-387e4a03cea2"
+	fake := &fakeRE2IndexClient{
+		pages: []resourceexplorer2.ListIndexesOutput{
+			{Indexes: []re2types.Index{re2Index(arn, "ap-southeast-1", re2types.IndexTypeLocal)}},
+		},
+	}
+	d := &resourceExplorer2IndexDiscoverer{new: func(_ string) resourceExplorer2IndexClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Regions: []string{"ap-southeast-1"}, AccountID: "031780745048"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, arn, got[0].Identity.ImportID, "import ID must be the bare region-encoded ARN")
+	assert.Equal(t, "ap-southeast-1", got[0].Identity.Region, "Region must be the index's home region for genconfig grouping")
+	assert.Equal(t, "ap-southeast-1", got[0].Identity.NativeIDs["region"])
+}
+
+// TestResourceExplorer2View_ImportIDIsARNWithRegion locks the view
+// invariant: import ID is the bare ARN and Region is parsed from the
+// ARN's home region.
+func TestResourceExplorer2View_ImportIDIsARNWithRegion(t *testing.T) {
+	t.Parallel()
+	const arn = "arn:aws:resource-explorer-2:eu-west-1:031780745048:view/eu-west-1/36a03250-6f1c-4896-a3c4-6757eb42225c"
+	fake := &fakeRE2ViewClient{
+		pages:    []resourceexplorer2.ListViewsOutput{{Views: []string{arn}}},
+		tagsByID: map[string]map[string]string{arn: {}},
+	}
+	d := &resourceExplorer2ViewDiscoverer{new: func(_ string) resourceExplorer2ViewClient { return fake }}
+	got, err := d.Discover(context.Background(), DiscoverArgs{Regions: []string{"eu-west-1"}, AccountID: "031780745048"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, arn, got[0].Identity.ImportID, "import ID must be the bare region-encoded ARN")
+	assert.Equal(t, "eu-west-1", got[0].Identity.Region, "Region must be the view's home region for genconfig grouping")
+}

--- a/cmd/insideout-import/awsdiscover/s3_bucket_enrich.go
+++ b/cmd/insideout-import/awsdiscover/s3_bucket_enrich.go
@@ -144,6 +144,16 @@ func (e s3BucketEnricher) Enrich(ctx context.Context, ir *imported.ImportedResou
 			ir.Identity.NativeIDs = map[string]string{}
 		}
 		ir.Identity.NativeIDs["region"] = *typed.Region.Literal
+		// Promote the bucket's TRUE region (learned from HeadBucket
+		// BucketRegion) into Identity.Region. aws_s3_bucket is marked
+		// IsGlobal for ENUMERATION (one ARN-deduped ListBuckets pass),
+		// which leaves Identity.Region empty; reliable then backfills the
+		// session region (us-east-1). A bucket in another region
+		// (us-west-2, eu-central-1, …) would then be grouped under a
+		// us-east-1 provider and fail generate-config-out (#1860 follow-up).
+		// Stamping the real region here makes genconfig group each bucket
+		// into its actual region dir.
+		ir.Identity.Region = *typed.Region.Literal
 	}
 
 	raw, err := json.Marshal(typed)

--- a/cmd/insideout-import/awsdiscover/s3_bucket_enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/s3_bucket_enrich_test.go
@@ -322,6 +322,9 @@ func TestS3BucketEnricher_BasicMapping(t *testing.T) {
 	// Stamps on NativeIDs (synthesized ARN, region from HeadBucket).
 	assert.Equal(t, "arn:aws:s3:::orders", ir.Identity.NativeIDs["arn"])
 	assert.Equal(t, "us-east-1", ir.Identity.NativeIDs["region"])
+	// The true region is also promoted into Identity.Region so genconfig
+	// groups the bucket into its real region dir (Fix 5 / #1860 follow-up).
+	assert.Equal(t, "us-east-1", ir.Identity.Region)
 
 	b := decodeS3BucketAttrs(t, ir)
 	require.NotNil(t, b.Bucket)
@@ -344,6 +347,34 @@ func TestS3BucketEnricher_BasicMapping(t *testing.T) {
 	assert.Empty(t, b.Tags, "tags must be absent when fetchTags returns nil")
 	assert.Empty(t, b.ObjectLockConfiguration, "object_lock_configuration must be absent when fetchObjectLock returns nil")
 	assert.Nil(t, b.ObjectLockEnabled, "object_lock_enabled must be absent when fetchObjectLock returns nil")
+}
+
+// TestS3BucketEnricher_PromotesNonDefaultRegion proves Fix 5: a bucket in a
+// region other than us-east-1 has its TRUE region (learned from HeadBucket
+// BucketRegion) promoted into Identity.Region, overriding any empty/backfilled
+// value. Without this, an IsGlobal-enumerated bucket lands under a us-east-1
+// provider and fails generate-config-out (#1860 follow-up).
+func TestS3BucketEnricher_PromotesNonDefaultRegion(t *testing.T) {
+	t.Parallel()
+	enr := newTestS3Enricher(s3FetchHooks{
+		head: func(context.Context, *s3.Client, string) (*s3.HeadBucketOutput, error) {
+			return &s3.HeadBucketOutput{
+				BucketRegion: aws.String("us-west-2"),
+			}, nil
+		},
+	})
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_s3_bucket",
+			NameHint: "west-bucket",
+			// Empty Region simulates the IsGlobal-enumerated identity before
+			// the enricher runs (reliable would otherwise backfill us-east-1).
+			Region: "",
+		},
+	}
+	require.NoError(t, enr.Enrich(context.Background(), ir, EnrichClients{S3: &s3.Client{}}))
+	assert.Equal(t, "us-west-2", ir.Identity.NativeIDs["region"])
+	assert.Equal(t, "us-west-2", ir.Identity.Region, "true region must be promoted into Identity.Region")
 }
 
 func TestS3BucketEnricher_HeadBucketArnRespected(t *testing.T) {

--- a/cmd/insideout-import/awsdiscover/s3_bucket_post_discover.go
+++ b/cmd/insideout-import/awsdiscover/s3_bucket_post_discover.go
@@ -1,0 +1,106 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// S3 bucket PostDiscover follow-up (#cust3 item 3).
+//
+// aws_s3_bucket is discovered IsGlobal (one ARN-deduped ListBuckets / RGT
+// pass) because S3 ARNs are region-less and ListBuckets is account-global.
+// That leaves the discovered IR's Identity.Region empty, which reliable /
+// genconfig backfill to the session/primary region (us-east-1). A bucket
+// that actually lives in another region (us-west-2, eu-central-1, …) then
+// lands in the wrong per-region genconfig pass under a us-east-1 provider,
+// where `terraform plan -generate-config-out` fails the cross-region
+// import and the bucket is silently dropped as no_generated_config.
+//
+// The s3_bucket AttributeEnricher already learns the true region from
+// HeadBucket and promotes it into Identity.Region — but the reverse-import
+// / genconfig dry-run path never runs EnrichAttributes, so that promotion
+// never happens there and every bucket keeps an empty region. (Confirmed
+// against a real whole-account run: every aws_s3_bucket in imported.json
+// had region="" and enrichment_status=unset, and the lone us-west-2 bucket
+// dropped.)
+//
+// s3BucketPostDiscover resolves the bucket's true region at DISCOVER time
+// via GetBucketLocation and stamps both Identity.Region and
+// NativeIDs["region"] so genconfig groups every bucket into its real
+// region dir regardless of whether enrichment later runs. Soft-fails
+// (returns an error the discoverer logs) without clobbering the IR.
+
+// s3BucketLocator is the narrow subset of the S3 API the PostDiscover hook
+// issues. Real *s3.Client and in-test fakes satisfy it.
+type s3BucketLocator interface {
+	GetBucketLocation(ctx context.Context, in *s3.GetBucketLocationInput, opts ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error)
+}
+
+// newS3BucketLocator is the production factory; tests swap it (or call
+// s3BucketPostDiscoverWithClient directly) to inject a fake.
+var newS3BucketLocator = func(awsCfg aws.Config, region string) s3BucketLocator {
+	return s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+}
+
+// s3BucketPostDiscover is the cloudControlConfig.PostDiscover hook for
+// aws_s3_bucket. It resolves the bucket's region and promotes it into
+// Identity.Region.
+func s3BucketPostDiscover(ctx context.Context, awsCfg aws.Config, region string, ir *imported.ImportedResource) error {
+	return s3BucketPostDiscoverWithClient(ctx, newS3BucketLocator(awsCfg, region), ir)
+}
+
+func s3BucketPostDiscoverWithClient(ctx context.Context, client s3BucketLocator, ir *imported.ImportedResource) error {
+	if ir == nil {
+		return nil
+	}
+	bucket := s3BucketNameForEnrich(&ir.Identity)
+	if bucket == "" {
+		return fmt.Errorf("s3_bucket: cannot derive bucket name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+	out, err := client.GetBucketLocation(ctx, &s3.GetBucketLocationInput{Bucket: aws.String(bucket)})
+	if err != nil {
+		return fmt.Errorf("s3_bucket %q: GetBucketLocation: %w", bucket, err)
+	}
+	region := s3LocationConstraintToRegion(out)
+	if region == "" {
+		// us-east-1 returns an empty LocationConstraint; default to it so a
+		// bucket in the legacy global endpoint still groups deterministically.
+		region = "us-east-1"
+	}
+	if ir.Identity.NativeIDs == nil {
+		ir.Identity.NativeIDs = map[string]string{}
+	}
+	ir.Identity.NativeIDs["region"] = region
+	ir.Identity.Region = region
+	return nil
+}
+
+// s3LocationConstraintToRegion maps a GetBucketLocation response to a
+// region string. The S3 API returns an empty LocationConstraint for
+// us-east-1 (the legacy default) and the literal region for every other
+// region; the historical "EU" alias maps to eu-west-1.
+func s3LocationConstraintToRegion(out *s3.GetBucketLocationOutput) string {
+	if out == nil {
+		return ""
+	}
+	lc := strings.TrimSpace(string(out.LocationConstraint))
+	switch lc {
+	case "":
+		return ""
+	case "EU":
+		return "eu-west-1"
+	default:
+		return lc
+	}
+}

--- a/cmd/insideout-import/awsdiscover/s3_bucket_post_discover_test.go
+++ b/cmd/insideout-import/awsdiscover/s3_bucket_post_discover_test.go
@@ -1,0 +1,110 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeS3Locator is a minimal s3BucketLocator stub.
+type fakeS3Locator struct {
+	out        *s3.GetBucketLocationOutput
+	err        error
+	gotBucket  string
+	calledOnce bool
+}
+
+func (f *fakeS3Locator) GetBucketLocation(_ context.Context, in *s3.GetBucketLocationInput, _ ...func(*s3.Options)) (*s3.GetBucketLocationOutput, error) {
+	f.calledOnce = true
+	f.gotBucket = aws.ToString(in.Bucket)
+	return f.out, f.err
+}
+
+// TestS3BucketPostDiscover_PromotesNonDefaultRegion is the #cust3 item-3
+// regression: the tfstate bucket luther-plt-or-cust3-tfstate-s3-75si
+// lives in us-west-2 but was IsGlobal-enumerated with an empty region,
+// so it landed in the us-east-1 genconfig pass and dropped on a
+// cross-region generate-config-out. PostDiscover resolves the true region
+// at discover time (GetBucketLocation -> us-west-2) and promotes it into
+// Identity.Region + NativeIDs["region"], so genconfig groups it into the
+// us-west-2 dir regardless of whether enrichment runs. Verified against
+// the real account: s3api get-bucket-location returns us-west-2.
+func TestS3BucketPostDiscover_PromotesNonDefaultRegion(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Locator{out: &s3.GetBucketLocationOutput{LocationConstraint: s3types.BucketLocationConstraintUsWest2}}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_s3_bucket",
+			NameHint: "luther-plt-or-cust3-tfstate-s3-75si",
+			ImportID: "luther-plt-or-cust3-tfstate-s3-75si",
+			// Empty Region simulates the IsGlobal-enumerated identity.
+			Region: "",
+		},
+	}
+	require.NoError(t, s3BucketPostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "luther-plt-or-cust3-tfstate-s3-75si", fake.gotBucket)
+	assert.Equal(t, "us-west-2", ir.Identity.Region, "true region must be promoted into Identity.Region")
+	assert.Equal(t, "us-west-2", ir.Identity.NativeIDs["region"])
+}
+
+// TestS3BucketPostDiscover_DefaultRegion proves an empty
+// LocationConstraint (the us-east-1 legacy default) resolves to
+// us-east-1 so the bucket still groups deterministically.
+func TestS3BucketPostDiscover_DefaultRegion(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Locator{out: &s3.GetBucketLocationOutput{LocationConstraint: ""}}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "io-a0ibmrskxfqc-dbbd5c"},
+	}
+	require.NoError(t, s3BucketPostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "us-east-1", ir.Identity.Region)
+	assert.Equal(t, "us-east-1", ir.Identity.NativeIDs["region"])
+}
+
+// TestS3BucketPostDiscover_EULegacyAlias proves the historical "EU"
+// LocationConstraint maps to eu-west-1.
+func TestS3BucketPostDiscover_EULegacyAlias(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Locator{out: &s3.GetBucketLocationOutput{LocationConstraint: "EU"}}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "legacy-eu-bucket"},
+	}
+	require.NoError(t, s3BucketPostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "eu-west-1", ir.Identity.Region)
+}
+
+// TestS3BucketPostDiscover_SoftFailsOnError proves a GetBucketLocation
+// failure surfaces an error (the discoverer logs it) without clobbering
+// the IR: region stays empty (backfilled downstream), the prior behavior.
+func TestS3BucketPostDiscover_SoftFailsOnError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeS3Locator{err: errors.New("AccessDenied")}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", NameHint: "denied-bucket", Region: ""},
+	}
+	err := s3BucketPostDiscoverWithClient(context.Background(), fake, ir)
+	require.Error(t, err)
+	assert.Equal(t, "", ir.Identity.Region, "region untouched on soft-fail")
+}
+
+// TestS3BucketConfig_WiresPostDiscover guards the registration so the
+// discover-time region promotion can't silently regress.
+func TestS3BucketConfig_WiresPostDiscover(t *testing.T) {
+	t.Parallel()
+	var found bool
+	for _, cfg := range cloudControlTypeConfigs {
+		if cfg.TFType == "aws_s3_bucket" {
+			found = true
+			require.NotNil(t, cfg.PostDiscover, "aws_s3_bucket must wire PostDiscover for discover-time region promotion")
+		}
+	}
+	require.True(t, found, "aws_s3_bucket config not found")
+}

--- a/cmd/insideout-import/awsdiscover/sdkonly_ddb.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_ddb.go
@@ -3,6 +3,7 @@ package awsdiscover
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -82,14 +83,46 @@ func listDDBTablesWithClient(ctx context.Context, client ddbSubresourceClient) (
 // also yields exists=false (table vanished or DDB returned
 // "feature never used" for legacy tables).
 //
-// The TF import ID is the bare table name — verified against
-// terraform-provider-aws v6.x source: DynamoDB contributor insights
-// uses table_name as the resource's primary id.
+// The Terraform import ID is the compound
+// "<table_name>/<index_name>/<account_id>" — built by
+// ddbContributorInsightsImportID from props. This FetchItem only
+// resolves "does the table-level binding exist"; the parentID it
+// receives is the bare table name (dep-chase may hand it the compound
+// import ID, so strip any "/..." suffix before the DescribeContributorInsights
+// call — the DDB API takes the table name, not the compound id).
 func fetchDDBContributorInsights(ctx context.Context, awsCfg aws.Config, region, parentID string) (bool, map[string]any, map[string]string, error) {
 	return fetchDDBContributorInsightsWithClient(ctx, newDDBSubresourceClient(awsCfg, region), parentID)
 }
 
+// ddbContributorInsightsTableFromID extracts the table name from a parent
+// identifier that may be either the bare table name (bulk Discover path)
+// or the compound "<table>/<index>/<account>" import ID (dep-chase
+// DiscoverByID path). The table name is always the first "/"-delimited
+// segment.
+func ddbContributorInsightsTableFromID(parentID string) string {
+	if i := strings.IndexByte(parentID, '/'); i >= 0 {
+		return parentID[:i]
+	}
+	return parentID
+}
+
+// ddbContributorInsightsImportID builds the Terraform import ID for a
+// table-level contributor-insights binding: "<table_name>//<account_id>"
+// (empty index_name segment). The account ID is threaded through
+// props[subresourceAccountIDKey] by fetchOne. When the account is
+// unavailable we fall back to the bare table name — no worse than the
+// pre-fix behavior.
+func ddbContributorInsightsImportID(parentID string, props map[string]any) string {
+	table := ddbContributorInsightsTableFromID(parentID)
+	account, _ := props[subresourceAccountIDKey].(string)
+	if account == "" {
+		return table
+	}
+	return table + "//" + account
+}
+
 func fetchDDBContributorInsightsWithClient(ctx context.Context, client ddbSubresourceClient, parentID string) (bool, map[string]any, map[string]string, error) {
+	parentID = ddbContributorInsightsTableFromID(parentID)
 	out, err := client.DescribeContributorInsights(ctx, &dynamodb.DescribeContributorInsightsInput{TableName: aws.String(parentID)})
 	if err != nil {
 		if isAPIErrorCode(err, "ResourceNotFoundException") {

--- a/cmd/insideout-import/awsdiscover/sdkonly_ddb_test.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_ddb_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // fakeDDBSubresourceClient is the in-test fake for the DDB sub-resource
@@ -205,5 +207,85 @@ func TestNewDDBSubresourceClient_ProductionFactoryReturnsRealClient(t *testing.T
 	c := newDDBSubresourceClient(aws.Config{Region: "us-east-1"}, "us-east-1")
 	if c == nil {
 		t.Fatal("newDDBSubresourceClient returned nil")
+	}
+}
+
+// TestDDBContributorInsightsImportID is the #cust3 item-5 regression: the
+// Terraform import ID for a table-level contributor-insights binding is
+// "<table>//<account>" (empty index_name segment), NOT the bare table
+// name. Verified against AWS provider v6 generate-config-out, which
+// rejects the bare table name with "unexpected format for ID (...),
+// expected table_name/index_name/account_id" — the rejection silently
+// dropped io-a0ibmrskxfqc-app as no_generated_config.
+func TestDDBContributorInsightsImportID(t *testing.T) {
+	t.Parallel()
+	t.Run("table-level with account -> compound", func(t *testing.T) {
+		t.Parallel()
+		props := map[string]any{subresourceAccountIDKey: "031780745048"}
+		got := ddbContributorInsightsImportID("io-a0ibmrskxfqc-app", props)
+		if got != "io-a0ibmrskxfqc-app//031780745048" {
+			t.Errorf("import ID = %q, want io-a0ibmrskxfqc-app//031780745048", got)
+		}
+	})
+	t.Run("no account -> bare table fallback (no regression)", func(t *testing.T) {
+		t.Parallel()
+		if got := ddbContributorInsightsImportID("users", map[string]any{}); got != "users" {
+			t.Errorf("import ID = %q, want bare table fallback users", got)
+		}
+		if got := ddbContributorInsightsImportID("users", nil); got != "users" {
+			t.Errorf("import ID (nil props) = %q, want users", got)
+		}
+	})
+	t.Run("compound parent id strips to table for the prefix", func(t *testing.T) {
+		t.Parallel()
+		// dep-chase may hand the compound import ID back as parentID; the
+		// table must be re-extracted before re-building.
+		props := map[string]any{subresourceAccountIDKey: "031780745048"}
+		got := ddbContributorInsightsImportID("io-a0ibmrskxfqc-app//031780745048", props)
+		if got != "io-a0ibmrskxfqc-app//031780745048" {
+			t.Errorf("import ID = %q, want stable io-a0ibmrskxfqc-app//031780745048", got)
+		}
+	})
+}
+
+// TestFetchDDBContributorInsights_StripsCompoundParentID proves the
+// DescribeContributorInsights call uses the bare table name even when the
+// FetchItem is handed the compound import ID (dep-chase DiscoverByID
+// path) — the DDB API takes the table name, not the compound id.
+func TestFetchDDBContributorInsights_StripsCompoundParentID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeDDBSubresourceClient{
+		insightsByT: map[string]dynamodb.DescribeContributorInsightsOutput{
+			"users": {ContributorInsightsStatus: ddbtypes.ContributorInsightsStatusEnabled},
+		},
+	}
+	exists, _, native, err := fetchDDBContributorInsightsWithClient(context.Background(), fake, "users//031780745048")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("exists=false, want true (compound id should resolve table 'users')")
+	}
+	if native["table_name"] != "users" {
+		t.Errorf("NativeIDs[table_name]=%q, want bare table users", native["table_name"])
+	}
+}
+
+// TestDDBContributorInsightsEnricher_TableFromCompoundImportID proves the
+// enricher recovers the bare table name from the compound import ID (it
+// no longer trusts ImportID verbatim).
+func TestDDBContributorInsightsEnricher_TableFromCompoundImportID(t *testing.T) {
+	t.Parallel()
+	id := &imported.ResourceIdentity{
+		Type:     "aws_dynamodb_contributor_insights",
+		ImportID: "io-a0ibmrskxfqc-app//031780745048",
+		NameHint: "io-a0ibmrskxfqc-app-contributor-insights",
+	}
+	table, err := ddbContributorInsightsTableName(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if table != "io-a0ibmrskxfqc-app" {
+		t.Errorf("table = %q, want io-a0ibmrskxfqc-app (compound import ID must be split)", table)
 	}
 }

--- a/cmd/insideout-import/awsdiscover/sdkonly_s3.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_s3.go
@@ -230,14 +230,26 @@ var sdkOnlySubresourceTypeConfigs = []sdkOnlySubresourceConfig{
 		// (the TF resource is a meta-binding on the table) so
 		// SkipProjectTagFilter=true and parent enumeration falls back to
 		// dynamodb:ListTables when the RGT cache for AWS::DynamoDB::Table
-		// is empty / cold. Import ID is the bare table name.
+		// is empty / cold.
+		//
+		// Import ID is the compound "<table_name>/<index_name>/<account_id>"
+		// (terraform-provider-aws aws_dynamodb_contributor_insights
+		// importer). For a TABLE-level binding (no index) the index_name
+		// segment is empty, giving "<table_name>//<account_id>" — verified
+		// against terraform plan -generate-config-out on AWS provider v6:
+		// the bare table name is rejected with "unexpected format for ID
+		// (...), expected table_name/index_name/account_id", which silently
+		// dropped the resource as no_generated_config. fetchOne stamps the
+		// discover-run account ID into props[subresourceAccountIDKey];
+		// without it the account cannot be embedded and we fall back to the
+		// bare table name (no regression vs. the prior behavior).
 		TFType:               "aws_dynamodb_contributor_insights",
 		Slug:                 "dynamodb_contributor_insights",
 		ParentCFNType:        "AWS::DynamoDB::Table",
 		SkipProjectTagFilter: true,
 		ListParents:          listDDBTables,
 		FetchItem:            fetchDDBContributorInsights,
-		ImportIDFromParent:   func(parentID string, _ map[string]any) string { return parentID },
+		ImportIDFromParent:   ddbContributorInsightsImportID,
 		NameHintFromParent:   func(parentID string, _ map[string]any) string { return parentID + "-contributor-insights" },
 	},
 	{

--- a/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer.go
@@ -101,6 +101,13 @@ type sdkOnlySubresourceConfig struct {
 	NameHintFromParent   func(parentID string, props map[string]any) string
 }
 
+// subresourceAccountIDKey is the props key fetchOne stamps with the
+// discover-run account ID so an ImportIDFromParent closure can embed it
+// in a compound Terraform import ID (e.g. aws_dynamodb_contributor_insights's
+// "<table>/<index>/<account>"). Prefixed with "__" so it never collides
+// with a CloudFormation/SDK property name an enricher might read.
+const subresourceAccountIDKey = "__account_id"
+
 // subresourceEmission is one (importID, nameHint, nativeIDs, props)
 // tuple emitted by a FetchItems closure (Bundle 14k2 multi-emit
 // extension). Each emission becomes exactly one ImportedResource — the
@@ -223,7 +230,7 @@ func (d *sdkOnlySubresourceDiscoverer) Discover(ctx context.Context, args Discov
 				if err := gctx.Err(); err != nil {
 					return err
 				}
-				emissions, ferr := d.fetchOne(gctx, region, parentID)
+				emissions, ferr := d.fetchOne(gctx, region, parentID, args.AccountID)
 				if ferr != nil {
 					if cerr := gctx.Err(); cerr != nil {
 						return cerr
@@ -351,7 +358,7 @@ func (d *sdkOnlySubresourceDiscoverer) enumerateParents(ctx context.Context, reg
 // emission and ImportIDFromParent / NameHintFromParent are ignored —
 // the parent ID alone is insufficient to address per-attachment /
 // per-association / per-tag resources.
-func (d *sdkOnlySubresourceDiscoverer) fetchOne(ctx context.Context, region, parentID string) ([]subresourceEmission, error) {
+func (d *sdkOnlySubresourceDiscoverer) fetchOne(ctx context.Context, region, parentID, accountID string) ([]subresourceEmission, error) {
 	if d.cfg.FetchItems != nil {
 		return d.cfg.FetchItems(ctx, d.awsCfg, region, parentID)
 	}
@@ -364,6 +371,24 @@ func (d *sdkOnlySubresourceDiscoverer) fetchOne(ctx context.Context, region, par
 	}
 	if !exists {
 		return nil, nil
+	}
+	// Surface the discover-run account ID through props so an
+	// ImportIDFromParent closure can build a Terraform import ID that
+	// embeds it (e.g. aws_dynamodb_contributor_insights's
+	// "<table>/<index>/<account>" format). The FetchItem closure only
+	// knows the parent ID + live SDK response, never the account; the
+	// discoverer stamps the account onto every emitted IR via
+	// makeImportedResource, so threading the same value here keeps the
+	// import ID and the IR's AccountID consistent. props is the
+	// FetchItem's own map (or nil for closures that emit none); allocate
+	// when nil so the stamp always lands.
+	if accountID != "" {
+		if props == nil {
+			props = map[string]any{}
+		}
+		if _, ok := props[subresourceAccountIDKey]; !ok {
+			props[subresourceAccountIDKey] = accountID
+		}
 	}
 	importID := parentID
 	if d.cfg.ImportIDFromParent != nil {
@@ -404,7 +429,7 @@ func (d *sdkOnlySubresourceDiscoverer) DiscoverByID(ctx context.Context, id, reg
 	if id == "" {
 		return imported.ImportedResource{}, fmt.Errorf("%s: empty id: %w", d.cfg.TFType, ErrNotSupported)
 	}
-	emissions, err := d.fetchOne(ctx, region, id)
+	emissions, err := d.fetchOne(ctx, region, id, accountID)
 	if err != nil {
 		return imported.ImportedResource{}, fmt.Errorf("FetchItem %s parent=%q: %w", d.cfg.TFType, id, err)
 	}

--- a/cmd/insideout-import/depchase/arnparse.go
+++ b/cmd/insideout-import/depchase/arnparse.go
@@ -29,9 +29,17 @@ var ErrUnsupportedType = errors.New("depchase: ARN service/resource-type not map
 // ARN found in generated.tf. ImportID is the value that aws_<type>'s
 // `terraform import` block expects — typically the raw ARN, sometimes
 // a name or UUID depending on the provider's import semantics.
+//
+// Region is the ARN's own region (the 4th ARN segment). It is empty for
+// global/region-less services (IAM, CloudFront, Route53, S3). The chase
+// loop discovers each ref in ITS region — critical for multi-region imports
+// where a resource in one region references a resource in another (e.g. a
+// us-east-1 stack referencing a us-west-2 KMS key); without this, every
+// cross-region ref would be looked up in the primary region and warn-skipped.
 type Ref struct {
 	TFType   string
 	ImportID string
+	Region   string
 }
 
 // arnKey is the ARN service + leading resource-type segment, e.g.
@@ -90,8 +98,10 @@ func ParseRef(s string) (Ref, error) {
 	// Each discoverer's DiscoverByID accepts the raw ARN, so we hand
 	// it through verbatim. Discoverers that need a different shape
 	// (e.g. lambda strips the version qualifier from a function ARN)
-	// do that conversion themselves.
-	return Ref{TFType: tf, ImportID: s}, nil
+	// do that conversion themselves. parsed.Region is empty for global
+	// services (IAM/CloudFront/Route53/S3); the loop falls back to the
+	// run's primary region in that case.
+	return Ref{TFType: tf, ImportID: s, Region: parsed.Region}, nil
 }
 
 // splitResource splits an ARN resource portion into a leading

--- a/cmd/insideout-import/depchase/arnparse_test.go
+++ b/cmd/insideout-import/depchase/arnparse_test.go
@@ -43,6 +43,38 @@ func TestParseRef_SupportedTypes(t *testing.T) {
 	}
 }
 
+// TestParseRef_Region pins that ParseRef carries the ARN's own region so the
+// chase loop discovers cross-region references in the right region. Global
+// services (IAM/S3) have an empty region — the loop falls back to the run's
+// primary region for those.
+func TestParseRef_Region(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		arn        string
+		wantRegion string
+	}{
+		{"arn:aws:kms:us-west-2:123:key/00000000-0000-0000-0000-000000000000", "us-west-2"},
+		{"arn:aws:kms:eu-west-1:123:alias/io-foo-data", "eu-west-1"},
+		{"arn:aws:lambda:ap-southeast-1:123:function:io-foo-handler", "ap-southeast-1"},
+		{"arn:aws:iam::123:role/io-foo", ""},   // global service: no region
+		{"arn:aws:s3:::io-foo-uploads", ""},    // global namespace: no region
+		{"arn:aws:dynamodb:us-east-2:123:table/io-foo", "us-east-2"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.arn, func(t *testing.T) {
+			t.Parallel()
+			ref, err := ParseRef(tc.arn)
+			if err != nil {
+				t.Fatalf("err=%v", err)
+			}
+			if ref.Region != tc.wantRegion {
+				t.Errorf("Region=%q, want %q", ref.Region, tc.wantRegion)
+			}
+		})
+	}
+}
+
 func TestParseRef_UnsupportedTypes(t *testing.T) {
 	t.Parallel()
 	cases := []string{

--- a/cmd/insideout-import/depchase/arnparse_test.go
+++ b/cmd/insideout-import/depchase/arnparse_test.go
@@ -56,8 +56,8 @@ func TestParseRef_Region(t *testing.T) {
 		{"arn:aws:kms:us-west-2:123:key/00000000-0000-0000-0000-000000000000", "us-west-2"},
 		{"arn:aws:kms:eu-west-1:123:alias/io-foo-data", "eu-west-1"},
 		{"arn:aws:lambda:ap-southeast-1:123:function:io-foo-handler", "ap-southeast-1"},
-		{"arn:aws:iam::123:role/io-foo", ""},   // global service: no region
-		{"arn:aws:s3:::io-foo-uploads", ""},    // global namespace: no region
+		{"arn:aws:iam::123:role/io-foo", ""}, // global service: no region
+		{"arn:aws:s3:::io-foo-uploads", ""},  // global namespace: no region
 		{"arn:aws:dynamodb:us-east-2:123:table/io-foo", "us-east-2"},
 	}
 	for _, tc := range cases {

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -271,7 +271,17 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		var added []imported.ImportedResource
 		var discoveries []discoveredResource
 		for _, s := range newSeeds {
-			ir, err := opts.Discoverer.DiscoverByID(ctx, s.ref.TFType, s.ref.ImportID, opts.Region, opts.AccountID)
+			// Discover each ref in ITS OWN region (the ARN's 4th segment),
+			// falling back to the run's primary region for global/region-less
+			// ARNs (IAM/CloudFront/Route53/S3, where Region is empty). This is
+			// what makes the chase correct for multi-region imports: a
+			// cross-region reference (e.g. a us-east-1 resource pointing at a
+			// us-west-2 KMS key) must hit the target's region, not the primary.
+			region := s.ref.Region
+			if region == "" {
+				region = opts.Region
+			}
+			ir, err := opts.Discoverer.DiscoverByID(ctx, s.ref.TFType, s.ref.ImportID, region, opts.AccountID)
 			if err != nil {
 				// Check both AWS and GCP sentinels so the GCP path
 				// surfaces the same warn-and-continue UX as AWS. The two

--- a/cmd/insideout-import/depchase/depchase_test.go
+++ b/cmd/insideout-import/depchase/depchase_test.go
@@ -22,11 +22,16 @@ type fakeDiscoverer struct {
 	notFound     map[string]bool // key = tfType|id
 	notSupported map[string]bool
 	calls        []string
+	regionByID   map[string]string // id → region passed to DiscoverByID
 }
 
-func (f *fakeDiscoverer) DiscoverByID(_ context.Context, tfType, id, _, _ string) (imported.ImportedResource, error) {
+func (f *fakeDiscoverer) DiscoverByID(_ context.Context, tfType, id, region, _ string) (imported.ImportedResource, error) {
 	key := tfType + "|" + id
 	f.calls = append(f.calls, key)
+	if f.regionByID == nil {
+		f.regionByID = map[string]string{}
+	}
+	f.regionByID[id] = region
 	// Wrap sentinels the same way production discoverers do (e.g.
 	// kms.go, iam_role.go) so the loop's `errors.Is` chain-walk is
 	// exercised — a regression to `err == awsdiscover.ErrNotFound`
@@ -115,6 +120,51 @@ func (p *scriptedPipeline) runDriftfix(_ context.Context) (*DriftfixResult, erro
 
 func (p *scriptedPipeline) fns() PipelineFns {
 	return PipelineFns{RunGenconfig: p.runGenconfig, RunDriftfix: p.runDriftfix}
+}
+
+// TestRun_DiscoversCrossRegionRefInItsOwnRegion proves the chase loop
+// discovers each unresolved ARN in ITS region (the ARN's 4th segment) and
+// falls back to the run's primary region for global/region-less ARNs. This is
+// what makes dep-chase correct for multi-region imports — a us-east-1 stack
+// referencing a us-west-2 KMS key must hit us-west-2, not the primary region.
+func TestRun_DiscoversCrossRegionRefInItsOwnRegion(t *testing.T) {
+	t.Parallel()
+	const kmsARN = "arn:aws:kms:us-west-2:123:key/abcd-1234"
+	const iamARN = "arn:aws:iam::123:role/io-fn"
+	body1 := `resource "aws_lambda_function" "fn" {
+  kms_key_arn = "` + kmsARN + `"
+  role        = "` + iamARN + `"
+}
+`
+	dir := writeGen(t, body1)
+	disc := &fakeDiscoverer{
+		byID: map[string]imported.ImportedResource{
+			"aws_kms_key|" + kmsARN:  newRes("aws_kms_key.k", "abcd-1234", kmsARN, "aws_kms_key"),
+			"aws_iam_role|" + iamARN: newRes("aws_iam_role.r", "io-fn", iamARN, "aws_iam_role"),
+		},
+	}
+	// After the discovery iteration, genconfig regenerates a body with no
+	// dangling refs so the loop converges on the next pass.
+	pipe := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{"# resolved\n"}}
+
+	_, err := Run(context.Background(), Options{
+		Workdir:    dir,
+		Region:     "us-east-1", // the run's primary region
+		AccountID:  "123",
+		Discoverer: disc,
+		Pipeline:   pipe.fns(),
+	}, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_lambda_function.fn", Type: "aws_lambda_function"}},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := disc.regionByID[kmsARN]; got != "us-west-2" {
+		t.Errorf("KMS key discovered in region %q, want us-west-2 (the ARN's own region)", got)
+	}
+	if got := disc.regionByID[iamARN]; got != "us-east-1" {
+		t.Errorf("IAM role discovered in region %q, want us-east-1 (primary fallback for region-less ARN)", got)
+	}
 }
 
 // TestRun_NoUnresolvedRefsExitsWithoutCallingPipeline pins that the

--- a/cmd/insideout-import/driftfix/driftfix.go
+++ b/cmd/insideout-import/driftfix/driftfix.go
@@ -18,6 +18,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
+	"sync"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
+	"golang.org/x/sync/errgroup"
 )
 
 // generatedFile is the file genconfig wrote and driftfix mutates in
@@ -50,6 +55,31 @@ type Options struct {
 	// "discard subprocess output" (the historical behavior). Ignored when
 	// Runner is injected.
 	Stdout io.Writer
+
+	// newRunner builds a terraformRunner for a specific stack directory.
+	// It exists so the multi-region path can construct one runner per
+	// region subdir (each subdir is its own plannable stack), and so
+	// tests can inject per-stack fakes. nil → newExecRunner. The single
+	// injected Runner above still takes precedence for the single-stack
+	// path (Workdir itself is the stack); newRunner is consulted for the
+	// per-region subdirs. Unexported because production callers
+	// (run.go/discover.go) never set it — they always want the real
+	// execRunner — and only the package's own tests inject a fake.
+	newRunner func(workdir string, stdout io.Writer) (terraformRunner, error)
+}
+
+// runnerFor returns the terraformRunner to drive the stack rooted at
+// stackDir. The single injected Runner wins only for the single-stack path
+// (stackDir == Workdir); every other stack (the per-region subdirs) goes
+// through newRunner, falling back to the real execRunner.
+func (opts Options) runnerFor(stackDir string, out io.Writer) (terraformRunner, error) {
+	if opts.Runner != nil && stackDir == opts.Workdir {
+		return opts.Runner, nil
+	}
+	if opts.newRunner != nil {
+		return opts.newRunner(stackDir, out)
+	}
+	return newExecRunner(stackDir, out)
 }
 
 // Result is what the orchestrator hands back to the caller. Iterations
@@ -79,25 +109,42 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 	if opts.MaxIterations <= 0 {
 		opts.MaxIterations = defaultMaxIterations
 	}
-	progressf(opts.Stdout, "driftfix: starting drift convergence (max %d iteration(s))…\n", opts.MaxIterations)
-
 	abs, err := filepath.Abs(opts.Workdir)
 	if err != nil {
 		return nil, fmt.Errorf("abs workdir: %w", err)
 	}
 	opts.Workdir = abs
 
-	runner := opts.Runner
-	if runner == nil {
-		r, err := newExecRunner(opts.Workdir, opts.Stdout)
-		if err != nil {
-			return nil, err
-		}
-		runner = r
+	// Multi-region: genconfig emits one plannable stack per region under
+	// region-<alias>/ subdirs and leaves only a debug-concat generated.tf at
+	// the parent (no providers.tf, no .terraform). Drift-fix each region
+	// subdir independently — they share no state — then re-merge the parent
+	// concat. A single-region run (or any layout where the Workdir itself is
+	// the plannable stack) takes the historical single-stack path unchanged.
+	stacks := plannableStacks(opts.Workdir)
+	if len(stacks) == 1 && stacks[0] == opts.Workdir {
+		progressf(opts.Stdout, "driftfix: starting drift convergence (max %d iteration(s))…\n", opts.MaxIterations)
+		return runStack(ctx, opts, opts.Workdir, opts.Stdout)
+	}
+	return runMultiStack(ctx, opts, stacks)
+}
+
+// runStack runs the Stage 2c1 drift-convergence loop against a single
+// plannable stack rooted at stackDir, streaming progress to out. It is the
+// historical Run body, parameterized by stack directory so the multi-region
+// path can drive one loop per region subdir.
+func runStack(ctx context.Context, opts Options, stackDir string, out io.Writer) (*Result, error) {
+	// Route this stack's progress (and the terraform subprocess output the
+	// runner streams) to the caller-provided sink, which for the multi-region
+	// path is a per-stack writer that serializes whole lines.
+	opts.Stdout = out
+	runner, err := opts.runnerFor(stackDir, out)
+	if err != nil {
+		return nil, err
 	}
 
-	generatedPath := filepath.Join(opts.Workdir, generatedFile)
-	planPath := filepath.Join(opts.Workdir, planFile)
+	generatedPath := filepath.Join(stackDir, generatedFile)
+	planPath := filepath.Join(stackDir, planFile)
 
 	var prevDrift map[string][]string
 	// alreadyEscalated tracks (address, attr) pairs we've already moved
@@ -186,6 +233,140 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		}
 	}
 	return nil, fmt.Errorf("driftfix: %d iterations exhausted without convergence", opts.MaxIterations)
+}
+
+// maxStackConcurrency bounds how many region subdirs drift-fix converges at
+// once. Each terraform plan is memory-heavy and hits the AWS API, but parallel
+// regions spread load across per-region/per-service rate limits (safer than
+// parallel calls within one region), so a modest pool keeps a whole-account
+// multi-region run from converging the regions strictly back-to-back without
+// risking throttling or OOM.
+const maxStackConcurrency = 6
+
+// runMultiStack converges each plannable region stack concurrently (bounded by
+// maxStackConcurrency), then re-concatenates the per-region generated.tf files
+// into the parent debug artifact so dep-chase's text-read of the parent
+// reflects the patches. Per-stack progress streams are serialized through a
+// shared mutex so concurrent regions don't interleave mid-line.
+func runMultiStack(ctx context.Context, opts Options, stacks []string) (*Result, error) {
+	limit := min(len(stacks), maxStackConcurrency)
+	progressf(opts.Stdout, "driftfix: %d regional stack(s) detected; converging each (max %d iteration(s), up to %d in parallel)…\n",
+		len(stacks), opts.MaxIterations, limit)
+
+	var mu sync.Mutex
+	sink := func() io.Writer {
+		if opts.Stdout == nil {
+			return nil
+		}
+		return &syncWriter{mu: &mu, w: opts.Stdout}
+	}
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(limit)
+	iterations := make([]int, len(stacks))
+	for i, stack := range stacks {
+		g.Go(func() error {
+			label := filepath.Base(stack)
+			out := sink()
+			progressf(out, "driftfix: %s: starting…\n", label)
+			res, err := runStack(gctx, opts, stack, out)
+			if err != nil {
+				return fmt.Errorf("driftfix %s: %w", label, err)
+			}
+			iterations[i] = res.Iterations
+			progressf(out, "driftfix: %s: converged after %d iteration(s)\n", label, res.Iterations)
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
+	// Re-merge the per-region generated.tf into the parent debug concat so
+	// dep-chase (which reads the parent as text) and the on-disk artifact
+	// reflect the drift patches. Reuse genconfig's merge so the parent format
+	// stays identical to the one genconfig wrote on the first pass.
+	parentGenerated := filepath.Join(opts.Workdir, generatedFile)
+	if err := genconfig.WriteMergedGenerated(parentGenerated, stacks); err != nil {
+		return nil, fmt.Errorf("driftfix: re-merge generated.tf: %w", err)
+	}
+
+	maxIter := 0
+	for _, it := range iterations {
+		maxIter = max(maxIter, it)
+	}
+	progressf(opts.Stdout, "driftfix: all %d regional stack(s) converged\n", len(stacks))
+	return &Result{GeneratedPath: parentGenerated, Iterations: maxIter}, nil
+}
+
+// plannableStacks decides which directories drift-fix runs against. A stack is
+// "plannable" when it carries both providers.tf and generated.tf (genconfig
+// emits both into every single-region stack and every per-region subdir). The
+// multi-region parent carries only the debug-concat generated.tf — no
+// providers.tf — so it is NOT plannable and we descend into its
+// region-<alias>/ subdirs. Resolution order:
+//
+//  1. Workdir itself is plannable → single-stack run ([Workdir]).
+//  2. else immediate subdirs that are plannable → multi-region run.
+//  3. else fall back to [Workdir] so the historical single-stack path (and
+//     fake-runner tests that don't emit providers.tf) behave exactly as before
+//     — runStack surfaces the real terraform error if the dir isn't runnable.
+func plannableStacks(workdir string) []string {
+	if isPlannable(workdir) {
+		return []string{workdir}
+	}
+	if subs := plannableSubdirs(workdir); len(subs) > 0 {
+		return subs
+	}
+	return []string{workdir}
+}
+
+// isPlannable reports whether dir contains both providers.tf and generated.tf
+// — the marker that genconfig finished emitting a runnable stack there.
+func isPlannable(dir string) bool {
+	return fileExists(filepath.Join(dir, "providers.tf")) &&
+		fileExists(filepath.Join(dir, generatedFile))
+}
+
+// plannableSubdirs returns the immediate subdirectories of workdir that are
+// plannable stacks, sorted for deterministic ordering (matching genconfig's
+// region-sorted merge order).
+func plannableSubdirs(workdir string) []string {
+	entries, err := os.ReadDir(workdir)
+	if err != nil {
+		return nil
+	}
+	var subs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(workdir, e.Name())
+		if isPlannable(dir) {
+			subs = append(subs, dir)
+		}
+	}
+	sort.Strings(subs)
+	return subs
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+// syncWriter serializes whole-line writes from concurrent per-region drift
+// loops so their progress/terraform output doesn't interleave mid-line on the
+// shared sink.
+type syncWriter struct {
+	mu *sync.Mutex
+	w  io.Writer
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
 }
 
 // everyDriftAttrAlreadyEscalated returns true iff every (address, attr)

--- a/cmd/insideout-import/driftfix/driftfix_multiregion_test.go
+++ b/cmd/insideout-import/driftfix/driftfix_multiregion_test.go
@@ -1,0 +1,169 @@
+package driftfix
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// mkPlannableStack writes the providers.tf + generated.tf pair that marks a
+// directory as a plannable genconfig stack (the signal driftfix uses to
+// detect single- vs multi-region layouts).
+func mkPlannableStack(t *testing.T, dir, generatedBody string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "providers.tf"), []byte("provider \"aws\" {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, generatedFile), []byte(generatedBody), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestPlannableStacks_Detection pins the single- vs multi-region detection:
+// a Workdir that is itself a stack is single; a parent with only the debug
+// concat plus region subdirs is multi; an empty/unrecognized dir falls back to
+// the Workdir so legacy/fake-runner behavior is unchanged.
+func TestPlannableStacks_Detection(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single-region: Workdir is the stack", func(t *testing.T) {
+		wd := t.TempDir()
+		mkPlannableStack(t, wd, "# body\n")
+		got := plannableStacks(wd)
+		if len(got) != 1 || got[0] != wd {
+			t.Fatalf("plannableStacks = %v, want [%s]", got, wd)
+		}
+	})
+
+	t.Run("multi-region: descend into region subdirs", func(t *testing.T) {
+		wd := t.TempDir()
+		// Parent carries ONLY the debug concat (no providers.tf) — not plannable.
+		if err := os.WriteFile(filepath.Join(wd, generatedFile), []byte("# concat\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		// Subdirs in sorted order so the expectation matches the sorted return.
+		want := []string{
+			filepath.Join(wd, "region-eu_west_1"),
+			filepath.Join(wd, "region-us_east_1"),
+		}
+		for _, d := range want {
+			mkPlannableStack(t, d, "# region body\n")
+		}
+		got := plannableStacks(wd)
+		if !slices.Equal(got, want) {
+			t.Fatalf("plannableStacks = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("fallback: nothing plannable returns Workdir", func(t *testing.T) {
+		wd := t.TempDir()
+		got := plannableStacks(wd)
+		if len(got) != 1 || got[0] != wd {
+			t.Fatalf("plannableStacks = %v, want [%s]", got, wd)
+		}
+	})
+}
+
+// TestRun_MultiRegion_ConvergesEachSubdirAndRemerges proves the multi-region
+// path: every region subdir is drift-fixed via its own runner, and the parent
+// generated.tf is re-merged from the per-region files (overwriting the stale
+// concat) so dep-chase's text-read of the parent reflects the converged stacks.
+func TestRun_MultiRegion_ConvergesEachSubdirAndRemerges(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+
+	bodies := map[string]string{
+		"region-eu_west_1": "# eu\nresource \"aws_vpc\" \"eu\" {}\n",
+		"region-us_east_1": "# ue1\nresource \"aws_vpc\" \"ue1\" {}\n",
+	}
+	for alias, body := range bodies {
+		mkPlannableStack(t, filepath.Join(wd, alias), body)
+	}
+	// Stale parent concat that the re-merge must overwrite.
+	if err := os.WriteFile(filepath.Join(wd, generatedFile), []byte("# STALE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// One empty scripted runner per region: empty plan → converge on iter 1.
+	runners := map[string]*scriptedRunner{
+		"region-eu_west_1": {},
+		"region-us_east_1": {},
+	}
+	opts := Options{
+		Workdir: wd,
+		newRunner: func(stackDir string, _ io.Writer) (terraformRunner, error) {
+			r, ok := runners[filepath.Base(stackDir)]
+			if !ok {
+				t.Errorf("unexpected stack dir %q", stackDir)
+				return &scriptedRunner{}, nil
+			}
+			return r, nil
+		},
+	}
+
+	res, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Each region's runner was actually exercised.
+	for alias, r := range runners {
+		if r.planCalls == 0 {
+			t.Errorf("region %s: PlanTo never called", alias)
+		}
+	}
+
+	// Parent generated.tf was re-merged from the subdirs (stale concat gone,
+	// both region bodies present).
+	merged, err := os.ReadFile(filepath.Join(wd, generatedFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(merged)
+	if strings.Contains(got, "STALE") {
+		t.Errorf("parent generated.tf still stale:\n%s", got)
+	}
+	for _, want := range []string{`"aws_vpc" "eu"`, `"aws_vpc" "ue1"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("parent generated.tf missing %q:\n%s", want, got)
+		}
+	}
+	if res.GeneratedPath != filepath.Join(wd, generatedFile) {
+		t.Errorf("Result.GeneratedPath = %q, want parent generated.tf", res.GeneratedPath)
+	}
+}
+
+// TestRun_MultiRegion_PropagatesRegionError proves a failure in any single
+// region aborts the run with a region-labeled error (errgroup fail-fast).
+func TestRun_MultiRegion_PropagatesRegionError(t *testing.T) {
+	t.Parallel()
+	wd := t.TempDir()
+	for _, alias := range []string{"region-a", "region-b"} {
+		mkPlannableStack(t, filepath.Join(wd, alias), "# body\n")
+	}
+	runners := map[string]*scriptedRunner{
+		"region-a": {planErr: errors.New("boom")},
+		"region-b": {},
+	}
+	opts := Options{
+		Workdir: wd,
+		newRunner: func(stackDir string, _ io.Writer) (terraformRunner, error) {
+			return runners[filepath.Base(stackDir)], nil
+		},
+	}
+	_, err := Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error from failing region, got nil")
+	}
+	if !strings.Contains(err.Error(), "region-a") {
+		t.Errorf("error should name the failing region, got: %v", err)
+	}
+}

--- a/cmd/insideout-import/genconfig/cleanup.go
+++ b/cmd/insideout-import/genconfig/cleanup.go
@@ -125,12 +125,53 @@ func applySchemaToBlock(blk *hclwrite.Block, schema *tfjson.SchemaBlock) {
 	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(sensitive))
 }
 
-// mergeIgnoreChanges is a placeholder for the case where a `lifecycle` block
-// already exists. The current emitter never produces one, so we rebuild the
-// attribute from scratch — a smarter merge can land in Stage 2c if a real
-// caller hits it.
-func mergeIgnoreChanges(lc *hclwrite.Block, sensitive []string) {
-	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(sensitive))
+// mergeIgnoreChanges unions `names` into the lifecycle block's existing
+// ignore_changes list, PRESERVING the entries already there and
+// de-duplicating. A resource that already pins some attributes (e.g.
+// `ignore_changes = [tags]` from a Sensitive-driven cleanup pass, or from an
+// earlier fixup) keeps them and gains the new ones —
+// e.g. [tags] + [egress, ingress] -> [tags, egress, ingress]. Builds the list
+// when no ignore_changes attribute is present yet. Bare-identifier (traversal)
+// form throughout, matching ignoreChangesTokens. Idempotent: re-merging the
+// same names is a no-op (so NormalizeImportedHCL re-runs are stable). If the
+// existing list is the catch-all `all`, it already covers everything and is
+// left untouched.
+func mergeIgnoreChanges(lc *hclwrite.Block, names []string) {
+	merged := existingIgnoreChangeNames(lc)
+	seen := make(map[string]struct{}, len(merged))
+	for _, n := range merged {
+		if n == "all" {
+			return // `all` already ignores every attribute
+		}
+		seen[n] = struct{}{}
+	}
+	for _, n := range names {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		merged = append(merged, n)
+	}
+	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(merged))
+}
+
+// existingIgnoreChangeNames returns the bare-identifier names already present
+// in the lifecycle block's ignore_changes list (e.g. ["tags"]). Empty when the
+// attribute is absent. Only traversal (bare-identifier) entries are recognized
+// — the form this package always emits via ignoreChangesTokens; the quoted
+// terraform-<1.5 form is never produced here.
+func existingIgnoreChangeNames(lc *hclwrite.Block) []string {
+	attr := lc.Body().GetAttribute("ignore_changes")
+	if attr == nil {
+		return nil
+	}
+	var names []string
+	for _, tok := range attr.Expr().BuildTokens(nil) {
+		if tok.Type == hclsyntax.TokenIdent {
+			names = append(names, string(tok.Bytes))
+		}
+	}
+	return names
 }
 
 // ignoreChangesTokens emits the canonical `[name1, name2, ...]` form

--- a/cmd/insideout-import/genconfig/cleanup_test.go
+++ b/cmd/insideout-import/genconfig/cleanup_test.go
@@ -88,11 +88,12 @@ resource "aws_sqs_queue" "bravo" {
 }
 
 // TestCleanGenerated_MergesIntoExistingLifecycle pins that when an input
-// block already has a `lifecycle` sub-block, cleanup overwrites
-// ignore_changes with the union of declared-Sensitive attributes. The
-// current implementation clobbers (intentional — flagged in comment) but
-// the assertion focuses on the operator-visible contract: ignore_changes
-// must list at least every Sensitive attr present in the schema.
+// block already has a `lifecycle` sub-block, cleanup UNIONS the declared-
+// Sensitive attributes into its ignore_changes — preserving the operator's
+// existing entries rather than clobbering them. The fixture uses a bare-
+// identifier entry (`other`) because that is the form this package emits and
+// the form existingIgnoreChangeNames recognizes; the assertion proves both the
+// existing entry and the Sensitive attr survive, in order.
 func TestCleanGenerated_MergesIntoExistingLifecycle(t *testing.T) {
 	t.Parallel()
 	in := []byte(`resource "aws_secretsmanager_secret_version" "x" {
@@ -100,7 +101,7 @@ func TestCleanGenerated_MergesIntoExistingLifecycle(t *testing.T) {
   secret_string = "actual-secret"
 
   lifecycle {
-    ignore_changes = ["other"]
+    ignore_changes = [other]
   }
 }
 `)
@@ -117,8 +118,10 @@ func TestCleanGenerated_MergesIntoExistingLifecycle(t *testing.T) {
 	if strings.Count(got, "lifecycle {") != 1 {
 		t.Errorf("expected exactly 1 lifecycle block, got %d:\n%s", strings.Count(got, "lifecycle {"), got)
 	}
-	if !strings.Contains(got, "secret_string") {
-		t.Errorf("ignore_changes must mention Sensitive attr `secret_string`\n--- got ---\n%s", got)
+	// The existing entry is preserved AND the Sensitive attr is unioned in,
+	// in order: [other, secret_string]. (A clobbering impl would drop `other`.)
+	if !regexp.MustCompile(`ignore_changes\s*=\s*\[other,\s+secret_string\]`).MatchString(got) {
+		t.Errorf("ignore_changes must union existing `other` with Sensitive `secret_string` -> [other, secret_string]\n--- got ---\n%s", got)
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -88,26 +88,29 @@ func applyResourceTypeFixupsReport(raw []byte) (fixupResult, error) {
 // They must NOT depend on schema metadata — that's already been applied
 // by cleanGenerated.
 var resourceTypeFixups = map[string]func(*hclwrite.Block){
-	"aws_lambda_function":       fixupLambdaSource,
-	"aws_cognito_user_pool":     fixupCognitoVerificationMessageConflict,
-	"aws_key_pair":              fixupKeyPairPublicKey,
-	"aws_kms_key":               fixupKMSRotationPeriodZero,
-	"aws_dynamodb_table":        fixupDynamoDBPITRRecoveryPeriodZero,
-	"aws_vpc":                   fixupVPCIPv6NetmaskOrphan,
-	"aws_lb":                    fixupLBSubnetMappingConflict,
-	"aws_subnet":                fixupSubnetProviderQuirks,
-	"aws_route_table":           fixupRouteTableEmptyRouteFields,
-	"aws_security_group":        fixupSecurityGroupInlineRuleObjects,
-	"aws_nat_gateway":           fixupNATGatewaySecondaryIPConflict,
-	"aws_lb_listener":           fixupLBListenerStickinessDurationZero,
-	"aws_lb_target_group":       fixupLBTargetGroupProviderQuirks,
-	"aws_vpc_endpoint":          fixupVPCEndpointEmptyDNSDomains,
-	"aws_db_instance":           fixupDBInstanceProviderQuirks,
-	"aws_secretsmanager_secret": fixupSecretsManagerSecretDefaults,
-	"aws_sns_topic":             fixupSNSTopicSignatureVersionZero,
-	"aws_ebs_volume":            fixupEBSVolumeInitializationRateZero,
-	"aws_network_interface":     fixupNetworkInterfaceProviderQuirks,
-	"google_compute_firewall":   fixupComputeFirewallEmptySourceTargetArrays,
+	"aws_lambda_function":         fixupLambdaSource,
+	"aws_cognito_user_pool":       fixupCognitoVerificationMessageConflict,
+	"aws_key_pair":                fixupKeyPairPublicKey,
+	"aws_kms_key":                 fixupKMSRotationPeriodZero,
+	"aws_dynamodb_table":          fixupDynamoDBPITRRecoveryPeriodZero,
+	"aws_vpc":                     fixupVPCIPv6NetmaskOrphan,
+	"aws_lb":                      fixupLBSubnetMappingConflict,
+	"aws_subnet":                  fixupSubnetProviderQuirks,
+	"aws_route_table":             fixupRouteTableEmptyRouteFields,
+	"aws_security_group":          fixupSecurityGroupInlineRuleObjects,
+	"aws_nat_gateway":             fixupNATGatewaySecondaryIPConflict,
+	"aws_lb_listener":             fixupLBListenerStickinessDurationZero,
+	"aws_lb_target_group":         fixupLBTargetGroupProviderQuirks,
+	"aws_vpc_endpoint":            fixupVPCEndpointEmptyDNSDomains,
+	"aws_db_instance":             fixupDBInstanceProviderQuirks,
+	"aws_secretsmanager_secret":   fixupSecretsManagerSecretDefaults,
+	"aws_sns_topic":               fixupSNSTopicSignatureVersionZero,
+	"aws_ebs_volume":              fixupEBSVolumeInitializationRateZero,
+	"aws_network_interface":       fixupNetworkInterfaceProviderQuirks,
+	"aws_iam_role":                fixupIAMRoleNamePrefixConflict,
+	"aws_instance":                fixupInstanceProviderQuirks,
+	"aws_cloudwatch_metric_alarm": fixupMetricAlarmProviderQuirks,
+	"google_compute_firewall":     fixupComputeFirewallEmptySourceTargetArrays,
 }
 
 // fixupCognitoVerificationMessageConflict drops Cognito's legacy top-level
@@ -898,6 +901,113 @@ func fixupVPCEndpointEmptyDNSDomains(blk *hclwrite.Block) {
 		if isAttrLiteralEmptyList(sub.Body(), "private_dns_specified_domains") {
 			sub.Body().RemoveAttribute("private_dns_specified_domains")
 		}
+	}
+}
+
+// fixupIAMRoleNamePrefixConflict drops aws_iam_role.name_prefix when name
+// is also present. terraform plan -generate-config-out emits BOTH for an
+// imported role, but the provider marks them mutually exclusive ("name":
+// conflicts with name_prefix). The explicit name is authoritative for an
+// existing role, so the derived name_prefix is the one to drop. Conservative:
+// fires only when both carry a usable value. (name/name_prefix is a common
+// generate-config-out conflict; this helper can be reused for other types
+// that surface it.)
+func fixupIAMRoleNamePrefixConflict(blk *hclwrite.Block) {
+	body := blk.Body()
+	if hasUsableValue(body, "name") && hasUsableValue(body, "name_prefix") {
+		body.RemoveAttribute("name_prefix")
+	}
+}
+
+// instancePrimaryENIConflicts is the set of top-level aws_instance network
+// attributes the provider marks mutually exclusive with a
+// primary_network_interface block. When an instance is launched with an
+// explicit primary ENI, all of its networking lives on the interface — but
+// terraform plan -generate-config-out still emits these scalars too, so the
+// provider rejects the pair (e.g. "primary_network_interface": conflicts with
+// private_ip). The interface block is authoritative for an imported instance,
+// so the redundant top-level attrs are the ones to drop.
+var instancePrimaryENIConflicts = []string{
+	"associate_public_ip_address",
+	"private_ip",
+	"secondary_private_ips",
+	"security_groups",
+	"source_dest_check",
+	"subnet_id",
+	"vpc_security_group_ids",
+	"ipv6_address_count",
+	"ipv6_addresses",
+}
+
+// fixupInstanceProviderQuirks resolves aws_instance mutual-exclusion conflicts
+// that terraform plan -generate-config-out emits:
+//
+//   - When a primary_network_interface block is present, drop every top-level
+//     network attribute it conflicts with (instancePrimaryENIConflicts) — the
+//     interface governs the instance's networking.
+//   - Otherwise, ipv6_address_count conflicts with ipv6_addresses:
+//     generate-config-out emits both (count = 0, addresses = []) for a
+//     non-IPv6 instance. Both empty convey no intent, so drop both; if exactly
+//     one is empty, drop the empty one and keep the real value.
+//
+// Conservative: each transform fires only on its specific emitted pattern, and
+// RemoveAttribute is a no-op for attrs the block doesn't carry.
+func fixupInstanceProviderQuirks(blk *hclwrite.Block) {
+	body := blk.Body()
+
+	for _, sub := range body.Blocks() {
+		if sub.Type() == "primary_network_interface" {
+			for _, attr := range instancePrimaryENIConflicts {
+				body.RemoveAttribute(attr)
+			}
+			return
+		}
+	}
+
+	// No primary ENI: ipv6_address_count vs ipv6_addresses mutual exclusion.
+	hasCount := body.GetAttribute("ipv6_address_count") != nil
+	hasAddrs := body.GetAttribute("ipv6_addresses") != nil
+	if hasCount && hasAddrs {
+		countZero := isAttrLiteralZero(body, "ipv6_address_count")
+		addrsEmpty := isAttrLiteralEmptyList(body, "ipv6_addresses")
+		switch {
+		case countZero && addrsEmpty:
+			body.RemoveAttribute("ipv6_address_count")
+			body.RemoveAttribute("ipv6_addresses")
+		case countZero:
+			body.RemoveAttribute("ipv6_address_count")
+		case addrsEmpty:
+			body.RemoveAttribute("ipv6_addresses")
+		default:
+			// Both carry real values (generate-config-out shouldn't, but be
+			// safe): keep the explicit address list, drop the count.
+			body.RemoveAttribute("ipv6_address_count")
+		}
+	}
+}
+
+// fixupMetricAlarmProviderQuirks drops zero-valued attributes that
+// terraform plan -generate-config-out emits for aws_cloudwatch_metric_alarm
+// and the provider then rejects:
+//
+//   - datapoints_to_alarm = 0: the provider's validator pins it to >= 1;
+//     generate-config-out emits 0 when the alarm doesn't set it. null/absent
+//     is valid, literal 0 is not.
+//   - evaluation_interval = 0: an orphan of the mutually-required pair
+//     {evaluation_criteria, evaluation_interval} (anomaly-detection alarms).
+//     generate-config-out emits evaluation_interval = 0 standalone for a
+//     standard alarm, breaking the all-of constraint. Drop it when its
+//     sibling evaluation_criteria has no usable value.
+//
+// Conservative: only the literal-0 orphan patterns fire; a real anomaly
+// alarm carrying both keys is preserved.
+func fixupMetricAlarmProviderQuirks(blk *hclwrite.Block) {
+	body := blk.Body()
+	if isAttrLiteralZero(body, "datapoints_to_alarm") {
+		body.RemoveAttribute("datapoints_to_alarm")
+	}
+	if isAttrLiteralZero(body, "evaluation_interval") && !hasUsableValue(body, "evaluation_criteria") {
+		body.RemoveAttribute("evaluation_interval")
 	}
 }
 

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -110,7 +110,50 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 	"aws_iam_role":                fixupIAMRoleNamePrefixConflict,
 	"aws_instance":                fixupInstanceProviderQuirks,
 	"aws_cloudwatch_metric_alarm": fixupMetricAlarmProviderQuirks,
+	"aws_default_network_acl":     fixupDefaultNetworkACLIgnoreRules,
 	"google_compute_firewall":     fixupComputeFirewallEmptySourceTargetArrays,
+}
+
+// fixupDefaultNetworkACLIgnoreRules pins lifecycle.ignore_changes =
+// [egress, ingress] on an imported aws_default_network_acl so the
+// first-import plan is clean tag-only and a real apply can never strip the
+// live default NACL's allow-all rules.
+//
+// Why this is needed: the FINAL imported.tf is emitted from each resource's
+// extracted SCALAR attributes (composer.EmitImportedTF). That extraction does
+// not capture nested HCL blocks, so an aws_default_network_acl loses its
+// `egress`/`ingress` rule blocks (the live default NACL carries allow-all
+// rule_no 100 in each direction). With egress/ingress absent from imported.tf,
+// `terraform plan` sees the live rules as drift it must remove (before:
+// [rule 100] -> after: []) — the only non-tag drift in a real whole-account
+// import, and unsafe on apply (it would delete the default NACL's allow-all
+// rules). genconfig's scratch generated.tf captures the blocks correctly via
+// generate-config-out; only the emitted imported.tf drops them, but both run
+// through this shared fixup so the result is consistent.
+//
+// Rather than try to reconstruct the dropped rule blocks, we ADOPT the default
+// NACL for provenance tagging WITHOUT managing (or destroying) its rules:
+// ignore_changes = [egress, ingress] tells terraform to leave the live rules
+// untouched. The first-import validator then sees only tag/label repair, which
+// it allows ("path egress/ingress not in allowed set" no longer fires because
+// those paths produce no diff).
+//
+// ignore_changes carries BARE attribute references (identifiers egress,
+// ingress), not quoted strings — terraform 1.5+ deprecates the quoted form.
+// The shared ignoreChangesTokens helper emits exactly that traversal form.
+//
+// Idempotent: if the block already carries a lifecycle block we leave it alone
+// (NormalizeImportedHCL re-runs the fixups over already-fixed generated.tf, so
+// a second pass must not append a duplicate lifecycle block).
+func fixupDefaultNetworkACLIgnoreRules(blk *hclwrite.Block) {
+	body := blk.Body()
+	for _, sub := range body.Blocks() {
+		if sub.Type() == "lifecycle" {
+			return
+		}
+	}
+	lc := body.AppendNewBlock("lifecycle", nil)
+	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens([]string{"egress", "ingress"}))
 }
 
 // fixupCognitoVerificationMessageConflict drops Cognito's legacy top-level

--- a/cmd/insideout-import/genconfig/fixups.go
+++ b/cmd/insideout-import/genconfig/fixups.go
@@ -142,19 +142,28 @@ var resourceTypeFixups = map[string]func(*hclwrite.Block){
 // ingress), not quoted strings — terraform 1.5+ deprecates the quoted form.
 // The shared ignoreChangesTokens helper emits exactly that traversal form.
 //
-// Idempotent: if the block already carries a lifecycle block we leave it alone
-// (NormalizeImportedHCL re-runs the fixups over already-fixed generated.tf, so
-// a second pass must not append a duplicate lifecycle block).
+// Idempotent and merge-safe: if the block already carries a lifecycle block we
+// MERGE egress/ingress into its existing ignore_changes rather than skip — an
+// existing `ignore_changes = [tags]` becomes `[tags, egress, ingress]`, so the
+// rule protection is never dropped just because cleanGenerated (or a prior
+// fixup) already emitted a lifecycle block. mergeIgnoreChanges de-dupes, so a
+// NormalizeImportedHCL re-run over already-fixed generated.tf is stable.
 func fixupDefaultNetworkACLIgnoreRules(blk *hclwrite.Block) {
 	body := blk.Body()
 	for _, sub := range body.Blocks() {
 		if sub.Type() == "lifecycle" {
+			mergeIgnoreChanges(sub, defaultNACLIgnoreChanges)
 			return
 		}
 	}
 	lc := body.AppendNewBlock("lifecycle", nil)
-	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens([]string{"egress", "ingress"}))
+	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(defaultNACLIgnoreChanges))
 }
+
+// defaultNACLIgnoreChanges are the nested rule blocks dropped by scalar-only
+// imported.tf emission; pinned under ignore_changes so a default NACL is
+// adopted for tagging without managing (or destroying) its live rules.
+var defaultNACLIgnoreChanges = []string{"egress", "ingress"}
 
 // fixupCognitoVerificationMessageConflict drops Cognito's legacy top-level
 // email verification fields when generate-config-out also emits the newer

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -2845,3 +2845,169 @@ resource "aws_lb" "alb" {
 		t.Errorf("provider = aws.imported must be preserved\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupIAMRole_DropsNamePrefixWhenNameSet: generate-config-out emits both
+// name and name_prefix for an imported aws_iam_role, which the provider rejects
+// as mutually exclusive. The fixup keeps the explicit name and drops the
+// derived name_prefix.
+func TestFixupIAMRole_DropsNamePrefixWhenNameSet(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_iam_role" "r" {
+  name        = "io-eks0-cluster-2026"
+  name_prefix = "io-eks0-cluster-"
+  path        = "/"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "name_prefix") {
+		t.Errorf("name_prefix must be dropped when name is set\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*name\s*=\s*"io-eks0-cluster-2026"`).MatchString(got) {
+		t.Errorf("explicit name must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupIAMRole_KeepsNamePrefixAlone guards friendly-fire: name_prefix on
+// its own (no name) must be preserved.
+func TestFixupIAMRole_KeepsNamePrefixAlone(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_iam_role" "r" {
+  name_prefix = "io-eks0-cluster-"
+  path        = "/"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "name_prefix") {
+		t.Errorf("name_prefix must be kept when name is absent\n--- got ---\n%s", out)
+	}
+}
+
+// TestFixupInstance_DropsTopLevelNetworkArgsWithPrimaryENI: when a
+// primary_network_interface block is present, every conflicting top-level
+// network attribute is dropped while the interface block and non-network attrs
+// survive.
+func TestFixupInstance_DropsTopLevelNetworkArgsWithPrimaryENI(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_instance" "i" {
+  instance_type               = "t3.micro"
+  associate_public_ip_address = true
+  private_ip                  = "10.1.134.121"
+  secondary_private_ips       = []
+  security_groups             = []
+  source_dest_check           = true
+  subnet_id                   = "subnet-0e866663c4c5ad4d9"
+  vpc_security_group_ids      = ["sg-1"]
+  ipv6_address_count          = 0
+  ipv6_addresses              = []
+  primary_network_interface {
+    network_interface_id = "eni-0071933677a6be65f"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	for _, banned := range []string{
+		"associate_public_ip_address", "private_ip", "secondary_private_ips",
+		"security_groups", "source_dest_check", "subnet_id",
+		"vpc_security_group_ids", "ipv6_address_count", "ipv6_addresses",
+	} {
+		if regexp.MustCompile(`(?m)^\s*` + banned + `\s*=`).MatchString(got) {
+			t.Errorf("%s must be dropped when primary_network_interface is present\n--- got ---\n%s", banned, got)
+		}
+	}
+	if !strings.Contains(got, "primary_network_interface") || !strings.Contains(got, "eni-0071933677a6be65f") {
+		t.Errorf("primary_network_interface block must be preserved\n--- got ---\n%s", got)
+	}
+	if !strings.Contains(got, "instance_type") {
+		t.Errorf("non-network attrs must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupInstance_KeepsNetworkArgsWithoutPrimaryENI guards: without a
+// primary ENI, top-level network attrs stay; only the empty ipv6 count/addresses
+// pair is reconciled.
+func TestFixupInstance_KeepsNetworkArgsWithoutPrimaryENI(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_instance" "i" {
+  instance_type               = "t3.micro"
+  associate_public_ip_address = true
+  ipv6_address_count          = 0
+  ipv6_addresses              = []
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "associate_public_ip_address") {
+		t.Errorf("associate_public_ip_address must be kept without a primary ENI\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "ipv6_address_count") || strings.Contains(got, "ipv6_addresses") {
+		t.Errorf("empty ipv6 count/addresses pair must be dropped\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupMetricAlarm_DropsZeroOrphans: datapoints_to_alarm = 0 (min 1) and an
+// orphan evaluation_interval = 0 (no evaluation_criteria sibling) are dropped;
+// other attrs survive.
+func TestFixupMetricAlarm_DropsZeroOrphans(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_cloudwatch_metric_alarm" "a" {
+  alarm_name          = "sqs-backlog"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  datapoints_to_alarm = 0
+  evaluation_interval = 0
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if strings.Contains(got, "datapoints_to_alarm") {
+		t.Errorf("datapoints_to_alarm = 0 must be dropped\n--- got ---\n%s", got)
+	}
+	if strings.Contains(got, "evaluation_interval") {
+		t.Errorf("orphan evaluation_interval = 0 must be dropped\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*evaluation_periods\s*=\s*1`).MatchString(got) {
+		t.Errorf("evaluation_periods must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupMetricAlarm_KeepsRealAndAnomalyValues guards: a real
+// datapoints_to_alarm and an evaluation_interval paired with evaluation_criteria
+// (anomaly-detection alarm) are preserved.
+func TestFixupMetricAlarm_KeepsRealAndAnomalyValues(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_cloudwatch_metric_alarm" "a" {
+  alarm_name          = "x"
+  datapoints_to_alarm = 2
+  evaluation_interval = 60
+  evaluation_criteria = "criteria"
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !regexp.MustCompile(`(?m)^\s*datapoints_to_alarm\s*=\s*2`).MatchString(got) {
+		t.Errorf("real datapoints_to_alarm must be kept\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`(?m)^\s*evaluation_interval\s*=\s*60`).MatchString(got) {
+		t.Errorf("evaluation_interval with sibling evaluation_criteria must be kept\n--- got ---\n%s", got)
+	}
+}

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -3011,3 +3011,115 @@ func TestFixupMetricAlarm_KeepsRealAndAnomalyValues(t *testing.T) {
 		t.Errorf("evaluation_interval with sibling evaluation_criteria must be kept\n--- got ---\n%s", got)
 	}
 }
+
+// TestFixupDefaultNetworkACL_InjectsIgnoreChanges pins the core contract: an
+// imported aws_default_network_acl carrying no lifecycle block gets
+// `lifecycle { ignore_changes = [egress, ingress] }` injected. This is the
+// fix for the only non-tag drift in a real whole-account import — imported.tf
+// is emitted from scalar attributes (composer.EmitImportedTF), which drops the
+// nested egress/ingress rule blocks, so without ignore_changes terraform plans
+// to DELETE the live default allow-all rules.
+//
+// The references MUST be bare identifiers (egress, ingress), not quoted
+// strings — terraform 1.5+ deprecates the quoted form with a per-plan warning.
+// The test asserts the bare form is present AND the quoted form is absent.
+func TestFixupDefaultNetworkACL_InjectsIgnoreChanges(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_default_network_acl" "default" {
+  default_network_acl_id = "acl-0123456789abcdef0"
+  tags = {
+    "luther.provenance" = "imported"
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "lifecycle {") {
+		t.Errorf("lifecycle block not injected\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`ignore_changes\s*=\s*\[egress,\s+ingress\]`).MatchString(got) {
+		t.Errorf("ignore_changes must be the bare-identifier list [egress, ingress]\n--- got ---\n%s", got)
+	}
+	// Bare identifiers, NOT quoted strings — terraform 1.5+ deprecates quoting.
+	if strings.Contains(got, `"egress"`) || strings.Contains(got, `"ingress"`) {
+		t.Errorf("ignore_changes refs must be bare identifiers, not quoted strings\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDefaultNetworkACL_Idempotent pins the idempotency guard:
+// NormalizeImportedHCL re-runs the resource-type fixups over already-fixed
+// generated.tf, so a second pass — and a block that already carries a
+// lifecycle block — must NOT append a duplicate lifecycle block.
+func TestFixupDefaultNetworkACL_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	// (a) Running the fixup twice over a fresh block adds exactly one
+	// lifecycle block.
+	in := []byte(`resource "aws_default_network_acl" "default" {
+  default_network_acl_id = "acl-0123456789abcdef0"
+}
+`)
+	once, err := applyResourceTypeFixups(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	twice, err := applyResourceTypeFixups(once)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(twice), "lifecycle {"); n != 1 {
+		t.Errorf("re-running fixups must not add a second lifecycle block, got %d\n--- got ---\n%s", n, string(twice))
+	}
+
+	// (b) A block that already carries a lifecycle block is left untouched —
+	// no second lifecycle block, and the operator's existing ignore_changes
+	// set is preserved verbatim.
+	withLifecycle := []byte(`resource "aws_default_network_acl" "default" {
+  default_network_acl_id = "acl-0123456789abcdef0"
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
+`)
+	out, err := applyResourceTypeFixups(withLifecycle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if n := strings.Count(got, "lifecycle {"); n != 1 {
+		t.Errorf("existing lifecycle block must not be duplicated, got %d\n--- got ---\n%s", n, got)
+	}
+	if !regexp.MustCompile(`ignore_changes\s*=\s*\[tags\]`).MatchString(got) {
+		t.Errorf("existing lifecycle.ignore_changes must be preserved\n--- got ---\n%s", got)
+	}
+}
+
+// TestFixupDefaultNetworkACL_WiredViaNormalizeImportedHCL proves the
+// resourceTypeFixups map registration works end to end through the exported
+// reverse-import entry point (NormalizeImportedHCL) — not just the internal
+// applyResourceTypeFixups — over a full resource document.
+func TestFixupDefaultNetworkACL_WiredViaNormalizeImportedHCL(t *testing.T) {
+	t.Parallel()
+	in := []byte(`resource "aws_default_network_acl" "default" {
+  default_network_acl_id = "acl-0123456789abcdef0"
+  subnet_ids             = ["subnet-aaaa", "subnet-bbbb"]
+  tags = {
+    "luther.provenance" = "imported"
+  }
+}
+`)
+	out, err := NormalizeImportedHCL(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "lifecycle {") {
+		t.Errorf("NormalizeImportedHCL did not inject lifecycle block — map registration not wired\n--- got ---\n%s", got)
+	}
+	if !regexp.MustCompile(`ignore_changes\s*=\s*\[egress,\s+ingress\]`).MatchString(got) {
+		t.Errorf("ignore_changes = [egress, ingress] missing after NormalizeImportedHCL\n--- got ---\n%s", got)
+	}
+}

--- a/cmd/insideout-import/genconfig/fixups_test.go
+++ b/cmd/insideout-import/genconfig/fixups_test.go
@@ -3074,9 +3074,12 @@ func TestFixupDefaultNetworkACL_Idempotent(t *testing.T) {
 		t.Errorf("re-running fixups must not add a second lifecycle block, got %d\n--- got ---\n%s", n, string(twice))
 	}
 
-	// (b) A block that already carries a lifecycle block is left untouched —
-	// no second lifecycle block, and the operator's existing ignore_changes
-	// set is preserved verbatim.
+	// (b) A block that already carries a lifecycle block (e.g. cleanGenerated
+	// emitted `ignore_changes = [tags]`) MERGES egress/ingress into the
+	// existing set rather than skipping — no second lifecycle block, the
+	// operator's existing entries are preserved, AND the rule protection is
+	// still applied. Skipping here would leave the default NACL's egress/ingress
+	// unprotected (the bug this guards against).
 	withLifecycle := []byte(`resource "aws_default_network_acl" "default" {
   default_network_acl_id = "acl-0123456789abcdef0"
   lifecycle {
@@ -3092,8 +3095,19 @@ func TestFixupDefaultNetworkACL_Idempotent(t *testing.T) {
 	if n := strings.Count(got, "lifecycle {"); n != 1 {
 		t.Errorf("existing lifecycle block must not be duplicated, got %d\n--- got ---\n%s", n, got)
 	}
-	if !regexp.MustCompile(`ignore_changes\s*=\s*\[tags\]`).MatchString(got) {
-		t.Errorf("existing lifecycle.ignore_changes must be preserved\n--- got ---\n%s", got)
+	// Existing entry preserved AND egress/ingress merged in: [tags, egress, ingress].
+	if !regexp.MustCompile(`ignore_changes\s*=\s*\[tags,\s+egress,\s+ingress\]`).MatchString(got) {
+		t.Errorf("existing ignore_changes=[tags] must merge to [tags, egress, ingress]\n--- got ---\n%s", got)
+	}
+
+	// (c) Re-running over the merged output is stable — no duplicate egress/
+	// ingress entries creep in.
+	stable, err := applyResourceTypeFixups(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !regexp.MustCompile(`ignore_changes\s*=\s*\[tags,\s+egress,\s+ingress\]`).MatchString(string(stable)) {
+		t.Errorf("re-run must be idempotent (no duplicate egress/ingress)\n--- got ---\n%s", string(stable))
 	}
 }
 

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -221,7 +221,7 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 		subdirs = append(subdirs, sub.Workdir)
 	}
 	genPath := filepath.Join(opts.Workdir, generatedFile)
-	if err := writeMergedGenerated(genPath, subdirs); err != nil {
+	if err := WriteMergedGenerated(genPath, subdirs); err != nil {
 		// Best-effort: the merged top-level file is only for the debug
 		// artifact; the real per-region configs are in the subdirs.
 		fmt.Fprintf(os.Stderr, "genconfig: WARN: merged generated.tf: %v\n", err)
@@ -229,11 +229,16 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 	return &Result{GeneratedPath: genPath, Resources: merged}, nil
 }
 
-// writeMergedGenerated concatenates each region subdir's generated.tf into one
+// WriteMergedGenerated concatenates each region subdir's generated.tf into one
 // file (region-headed) for traceability / downstream artifact capture. A
 // region whose generated.tf is absent (e.g. all its imports were orphan-pruned)
 // is skipped. Errors only if nothing could be assembled.
-func writeMergedGenerated(destPath string, subdirs []string) error {
+//
+// Exported so the driftfix stage can re-merge the parent debug concat after it
+// patches each per-region generated.tf — keeping the parent (which dep-chase
+// reads as text) byte-consistent with the format genconfig wrote on the first
+// pass.
+func WriteMergedGenerated(destPath string, subdirs []string) error {
 	var buf bytes.Buffer
 	for _, d := range subdirs {
 		b, err := os.ReadFile(filepath.Join(d, generatedFile))

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -17,8 +17,10 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"golang.org/x/sync/errgroup"
 )
 
 // generatedFile is the file `terraform plan -generate-config-out` writes
@@ -61,7 +63,9 @@ type Options struct {
 
 	// Runner is optional. If nil, Run constructs an execRunner that shells
 	// out to the `terraform` binary on PATH. Tests inject a fake here to
-	// avoid the binary dependency.
+	// avoid the binary dependency. Used as-is on the single-region path;
+	// the multi-region path ignores it (see newRunner) so concurrent passes
+	// never share one runner's mutable state.
 	Runner terraformRunner
 
 	// Stdout, when non-nil, receives the live stdout/stderr of the
@@ -71,6 +75,28 @@ type Options struct {
 	// this phase. Nil means "discard subprocess output" (the historical
 	// behavior). Ignored when Runner is injected.
 	Stdout io.Writer
+
+	// newRunner builds a terraformRunner for a specific region subdir on the
+	// multi-region path, so each concurrent region gets its own runner
+	// instance rather than sharing one (production runs one execRunner per
+	// subdir; the per-region passes are independent). nil → newExecRunner.
+	// Unexported: production callers never set it — they want the real
+	// execRunner — and only the package's own tests inject per-subdir fakes.
+	newRunner func(workdir string, stdout io.Writer) (terraformRunner, error)
+}
+
+// buildRunner returns the terraformRunner to drive the stack in opts.Workdir,
+// streaming subprocess output to stdout. The single injected Runner wins when
+// set (single-region path / direct tests); otherwise newRunner builds one,
+// falling back to the real execRunner.
+func (opts Options) buildRunner(stdout io.Writer) (terraformRunner, error) {
+	if opts.Runner != nil {
+		return opts.Runner, nil
+	}
+	if opts.newRunner != nil {
+		return opts.newRunner(opts.Workdir, stdout)
+	}
+	return newExecRunner(opts.Workdir, stdout)
 }
 
 const (
@@ -201,24 +227,68 @@ func groupResourcesByRegion(resources []imported.ImportedResource, primaryRegion
 // per-region resources. A combined generated.tf is written at the top level
 // for the debug artifact; the authoritative per-region configs live in the
 // subdirs.
+// maxRegionConcurrency bounds how many per-region genconfig passes run at
+// once. Each pass runs its own terraform init + plan -generate-config-out
+// (memory-heavy, AWS-API-heavy), but the regions are independent (separate
+// subdirs, separate default providers) and AWS rate limits are
+// per-region/per-service, so spreading across regions is both faster and more
+// throttle-safe than running them strictly back-to-back.
+const maxRegionConcurrency = 6
+
 func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*Result, error) {
 	if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir workdir: %w", err)
 	}
-	progressf(opts.Stdout, "genconfig: split into %d regional pass(es)…\n", len(groups))
+	limit := min(len(groups), maxRegionConcurrency)
+	progressf(opts.Stdout, "genconfig: split into %d regional pass(es) (up to %d in parallel)…\n", len(groups), limit)
+
+	// Serialize progress + terraform-stderr across concurrent regions so their
+	// streamed lines don't interleave mid-line on the shared sink.
+	var logMu sync.Mutex
+	sink := func() io.Writer {
+		if opts.Stdout == nil {
+			return nil
+		}
+		return &syncWriter{mu: &logMu, w: opts.Stdout}
+	}
+
+	// Index-addressed slots keep the merge order deterministic (region-sorted)
+	// regardless of which region finishes first.
+	type regionOut struct {
+		resources []imported.ImportedResource
+		subdir    string
+	}
+	outs := make([]regionOut, len(groups))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(limit)
+	for i, grp := range groups {
+		g.Go(func() error {
+			sub := opts
+			sub.Region = grp.region
+			sub.Workdir = filepath.Join(opts.Workdir, "region-"+regionAlias(grp.region))
+			// Force a per-region runner (never share one injected Runner across
+			// concurrent passes) and a line-serialized output sink.
+			sub.Runner = nil
+			sub.Stdout = sink()
+			progressf(sub.Stdout, "genconfig: region %s: generating config for %d resource(s)…\n", grp.region, len(grp.resources))
+			res, err := runSingleRegion(gctx, sub, grp.resources)
+			if err != nil {
+				return fmt.Errorf("genconfig region %s: %w", grp.region, err)
+			}
+			outs[i] = regionOut{resources: res.Resources, subdir: sub.Workdir}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+
 	merged := make([]imported.ImportedResource, 0)
 	subdirs := make([]string, 0, len(groups))
-	for _, g := range groups {
-		progressf(opts.Stdout, "genconfig: region %s: generating config for %d resource(s)…\n", g.region, len(g.resources))
-		sub := opts
-		sub.Region = g.region
-		sub.Workdir = filepath.Join(opts.Workdir, "region-"+regionAlias(g.region))
-		res, err := runSingleRegion(ctx, sub, g.resources)
-		if err != nil {
-			return nil, fmt.Errorf("genconfig region %s: %w", g.region, err)
-		}
-		merged = append(merged, res.Resources...)
-		subdirs = append(subdirs, sub.Workdir)
+	for _, o := range outs {
+		merged = append(merged, o.resources...)
+		subdirs = append(subdirs, o.subdir)
 	}
 	genPath := filepath.Join(opts.Workdir, generatedFile)
 	if err := WriteMergedGenerated(genPath, subdirs); err != nil {
@@ -227,6 +297,20 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 		fmt.Fprintf(os.Stderr, "genconfig: WARN: merged generated.tf: %v\n", err)
 	}
 	return &Result{GeneratedPath: genPath, Resources: merged}, nil
+}
+
+// syncWriter serializes whole-line writes from concurrent per-region passes so
+// their progress/terraform output doesn't interleave mid-line on the shared
+// sink.
+type syncWriter struct {
+	mu *sync.Mutex
+	w  io.Writer
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
 }
 
 // WriteMergedGenerated concatenates each region subdir's generated.tf into one
@@ -290,13 +374,9 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 		return nil, fmt.Errorf("emit providers.tf: %w", err)
 	}
 
-	runner := opts.Runner
-	if runner == nil {
-		r, err := newExecRunner(opts.Workdir, opts.Stdout)
-		if err != nil {
-			return nil, err
-		}
-		runner = r
+	runner, err := opts.buildRunner(opts.Stdout)
+	if err != nil {
+		return nil, err
 	}
 
 	progressf(opts.Stdout, "genconfig: %s: terraform init…\n", scope)

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -774,11 +774,15 @@ func (r *regionAwareRunner) PlanGenerate(_ context.Context, generatedPath string
 func TestRun_MultiRegion(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
-	runner := &regionAwareRunner{fakeRunner: fakeRunner{schemas: minimalAWSSchema()}}
+	// Per-region runner factory: each concurrent region pass gets its own
+	// regionAwareRunner so the parallel multi-region path never shares one
+	// runner's mutable state (which -race would flag).
 	res, err := Run(context.Background(), Options{
 		Workdir: dir,
 		Region:  "us-east-1",
-		Runner:  runner,
+		newRunner: func(_ string, _ io.Writer) (terraformRunner, error) {
+			return &regionAwareRunner{fakeRunner: fakeRunner{schemas: minimalAWSSchema()}}, nil
+		},
 	}, []imported.ImportedResource{
 		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east1", Region: "us-east-1", ImportID: "e1"}},
 		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east2", Region: "us-east-1", ImportID: "e2"}},

--- a/docs/reverse-import-contract.md
+++ b/docs/reverse-import-contract.md
@@ -1,0 +1,216 @@
+# Reverse-import: contract, decisions, and invariants
+
+This is the source-of-truth design doc for *why* the reverse-import pipeline
+behaves the way it does. It exists so the intent behind these decisions is
+explicit and available to future agents/engineers — several of them are
+non-obvious and were paid for in production debugging.
+
+Scope: the `insideout-import discover`/`reverse` CLI and the
+`pkg/reverseimport` engine (the latter is what Mars runs in production). For
+the runtime execution model (Mars container, offline provider mirror, Sandbox
+template) see the bottom section.
+
+---
+
+## 1. The core contract: a clean, tag-only first-import plan
+
+A successful first import produces a Terraform plan that is **imports only**,
+with the **only** attribute changes being provenance tags/labels:
+
+```
+Plan: N to import, 0 to add, 0 to change*, 0 to destroy
+  * the only updates are provenance tags: InsideOutImportProject / -Session /
+    -Imported / -ImportedAt on tags + tags_all (AWS) or labels (GCP)
+```
+
+The authoritative validator is **`pkg/composer/plan_acceptance.go:ValidateFirstImportPlan`**:
+
+- every importing resource may carry a **provenance-tag-only** side-effect
+  update; any non-provenance attribute change is an
+  `imported_plan_unauthorized_change` issue;
+- `create` / `destroy` / `replace` on any resource is rejected;
+- it checks `importCount == ExpectedImports` (a count of **imports**, not changes).
+
+### Invariant: `change_count <= import_count`, NOT `==`
+
+Many AWS resource types **have no `tags` attribute at all** (e.g.
+`aws_iam_role_policy_attachment`, `aws_route_table_association`,
+`aws_default_network_acl` rules, several `aws_vpc_security_group_*_rule`
+shapes). Those import as **pure no-ops** (`importing=true, actions=["no-op"]`,
+zero tag change). So in any real whole-account import the number of *changed*
+resources is **less than or equal to** the number of *imported* resources, and
+usually strictly less.
+
+Any gate, progress metric, or completeness check — here or downstream in
+reliable — that assumes "every imported resource shows a change/tag" (i.e.
+`change_count == import_count`) is a bug. The correct relation is
+`change_count <= import_count`.
+
+---
+
+## 2. Classification over silent drops
+
+**Principle:** every discovered resource must end up in exactly one of two
+buckets — *importable* (it imports cleanly) or *explicitly classified
+un-importable with a reason*. A resource must **never** be silently dropped
+(the old `no_generated_config` drop is the failure mode we design against:
+it makes a whole-account import look complete when it isn't).
+
+Un-importable instances are routed into `unsupported.json` with a stable
+`reason` code from **`pkg/composer/imported/importability.go`**, which reliable
+renders as a greyed-out wizard row with a tooltip
+(`ReasonDescription(reason)` → `SupportReason` → `ResourceRow.tsx`).
+
+Current reason codes (all wire-stable; renaming one is a cross-repo break):
+
+| Reason | Applies to | Why un-importable |
+|---|---|---|
+| `aws_managed_kms_alias` | `aws_kms_alias` under `alias/aws/*` | provider refuses to import reserved AWS-managed aliases |
+| `aws_managed_kms_key` | `aws_kms_key` with `KeyManager=AWS` | read path calls `kms:GetKeyRotationStatus`, which AWS-managed keys deny |
+| `service_managed_eni` | `aws_network_interface` owned by NAT/VPCe/NLB/Lambda | managed by its parent; not standalone-importable |
+| `ephemeral_log_stream` | `aws_cloudwatch_log_stream` | auto-created + rotated by its log group; not declarative infra; generate-config-out emits no body |
+
+When you discover a *new* instance-level un-importability, add a `Reason*`
+const + a `ReasonDescription` case here, and bump the presets pin in reliable
+so the tooltip flows through (no reliable code change needed — it consumes
+`ReasonDescription` generically).
+
+---
+
+## 3. Per-resource decisions
+
+### Default network ACLs (`aws_default_network_acl`)
+
+- **Discovery** re-types a VPC's default NACL from `aws_network_acl` to
+  `aws_default_network_acl` (`awsdiscover/network_acl_post_discover.go`,
+  `PostDiscover` hook). Without this they were silently dropped as
+  `no_generated_config` — `aws_network_acl` import for a *default* NACL fails
+  with "use the `aws_default_network_acl` resource instead."
+- **`lifecycle { ignore_changes = [egress, ingress] }`** is injected by the
+  `aws_default_network_acl` entry in `genconfig/fixups.go:resourceTypeFixups`.
+  Rationale: the final `imported.tf` is emitted from **scalar attributes**
+  (`composer.EmitImportedTF`), and nested HCL blocks are **not** extracted —
+  so the default NACL loses its `egress`/`ingress` allow-all rules in
+  `imported.tf`, and Terraform would plan to **delete** the live rules (the
+  only non-tag drift in a real whole-account import, and unsafe on apply). We
+  adopt the default NACL for provenance tagging **without managing or
+  destroying its rules**. This keeps it imported (vs. dropping it) while
+  yielding a clean tag-only plan.
+
+> See §5: the scalar-only emission is a general limitation, not specific to
+> default NACLs — they're just the case where it currently bites.
+
+---
+
+## 4. Multi-region architecture
+
+Multi-region is driven entirely by each resource's `Identity.Region`; Mars
+passes one *primary* region and the full resource set, and the engine fans out.
+
+### genconfig: split per region
+
+`terraform plan -generate-config-out` **silently drops** import blocks bound to
+an *aliased* provider (the #1839 live regression — only the primary region
+survived). So `genconfig.runMultiRegion` runs one single-region pass per
+distinct region, each in its own `region-<alias>/` subdir with its own
+**default (unaliased)** provider, then merges. Region-less globals (IAM,
+Route53, CloudFront) fold into the primary region.
+
+- The parent `genconfig` dir gets a **debug-only concatenated** `generated.tf`
+  (`WriteMergedGenerated`) — it has **no `providers.tf`**, so it is **not** a
+  plannable stack. The authoritative per-region stacks live in the subdirs.
+- Per-region passes run **concurrently** (bounded `errgroup`,
+  `maxRegionConcurrency`). Regions are independent and AWS rate limits are
+  per-region/per-service, so parallel is both faster and more throttle-safe
+  than serial. Merge order stays deterministic via index-addressed slots.
+
+### driftfix: per-region, parallel
+
+`driftfix.Run` detects the layout from its `Workdir`:
+
+- if the `Workdir` is itself plannable (`providers.tf` + `generated.tf`) →
+  single-stack path (unchanged historical behavior);
+- otherwise it descends into the plannable `region-<alias>/` subdirs and
+  converges each **independently and concurrently** (`maxStackConcurrency`),
+  then **re-merges** the parent `generated.tf` so dep-chase's text-read of the
+  parent reflects the patches.
+
+This is the fix for the original "multi-region aborts at drift-fix with *no
+version is selected*" bug: drift-fix/dep-chase used to point at the
+non-plannable parent. Callers (`discover.go`, `run.go`) are unchanged — the
+multi-region handling is internal to drift-fix.
+
+### dep-chase: whole-account/native + per-ref region
+
+Dep-chase is **already** whole-account: it finds unresolved references by
+**static text analysis** over the merged `generated.tf`
+(`findUnresolvedWithConsumers`), so it sees every region's ARN literals in one
+pass. When it pulls in a dependency, the next `RunGenconfig` re-splits per
+region and files the new resource into its correct region group by
+`Identity.Region`. **Do not** wrap dep-chase in a per-region loop — that would
+*break* cross-region dependency chasing.
+
+Each unresolved ARN is discovered in **its own region** (the ARN's 4th
+segment, threaded via `Ref.Region`), falling back to the primary region only
+for global/region-less ARNs (IAM/CloudFront/Route53/S3, where the segment is
+empty). `depchase.go` `DiscoverByID` call.
+
+### Final emission: aliased providers
+
+`reverseimport.Run` emits the authoritative `imported.tf` +
+`providers-imported.tf` into `OutputDir` with one `aws.imported_<region>`
+alias block per region (`renderImportedProvidersTF`), and runs the **final
+`terraform init/validate/plan`** there. The final plan uses plain
+`terraform plan`, which handles aliased providers fine (the generate-config-out
+limitation does not apply).
+
+---
+
+## 5. Known limitations / invariants for future work
+
+- **`imported.tf` is scalar-only.** It is rendered from each resource's
+  extracted scalar attributes (`composer.EmitImportedTF`); **nested HCL blocks
+  are not extracted**, so they are lost in the final `imported.tf` even when
+  the genconfig scratch `generated.tf` captured them correctly. This is
+  usually harmless (Optional+Computed blocks plan as no-ops when omitted) but
+  bites resources whose nested blocks are load-bearing — currently
+  `aws_default_network_acl` (worked around with `ignore_changes`). The general
+  fix is to extract + re-emit nested blocks; until then, new such cases need a
+  targeted fixup.
+- **Two orchestrators.** The `discover` CLI runs discovery + genconfig +
+  drift-fix + dep-chase and stops at `imported.json` (no final plan). The
+  production path is **`reverseimport.Run`** (used by the Mars
+  `insideout-reverse-import` binary), which additionally emits the final
+  `imported.tf`/`providers-imported.tf` and runs the authoritative plan in
+  `OutputDir`. **The authoritative plan is the `OutputDir` one** — assert on
+  it, not on the genconfig scratch.
+
+---
+
+## 6. Testing the whole thing end-to-end
+
+`make reverse-e2e` (`scripts/reverse-e2e.sh`) drives the **production engine**
+the way Mars does — `insideout-import reverse` → `reverseimport.Run` — through
+discover → genconfig → drift-fix → dep-chase → final plan, then asserts the
+plan is clean tag-only (the §1 contract). It is the **live tier** (operator-run
+like `make test-roundtrip`): needs real AWS creds, terraform, and an offline
+provider mirror (corp network blocks `registry.terraform.io`; defaults to
+`~/.terraform.d/plugin-cache`). `REVERSE_E2E_REGIONS=all` exercises the
+multi-region path. This is the only test that drives the full
+genconfig→drift-fix→dep-chase→plan chain against a plannable stack.
+
+---
+
+## 7. Production execution model (where this actually runs)
+
+- **Mars** builds `insideout-reverse-import` (a thin binary that calls
+  `reverseimport.Run`) and runs it inside its container. The container provides
+  terraform via tfenv and an offline **`filesystem_mirror`** at
+  `/opt/tf-plugin-cache` wired through `TF_CLI_CONFIG_FILE=/etc/terraformrc`.
+  Provider versions are pinned to match the bake (cache-hit guarantee).
+- The engine runs the **whole** flow itself (genconfig → drift-fix → dep-chase
+  → final `init/validate/plan/show` in `OutputDir`). There is **no** hand-off
+  to the Sandbox-template shell scripts for reverse-import — those drive the
+  *forward* `apply` path. The reliable ↔ Mars contract is the `--request` JSON
+  in and the artifact files (`imported.tf`, `tfplan.json`, `plan-summary.json`,
+  `reverse-result.json`) out.

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -12,6 +12,9 @@ import "strings"
 //   - AWS-managed default KMS aliases (alias/aws/rds, alias/aws/ebs, …): the
 //     provider refuses any aws_kms_alias under the reserved `alias/aws/`
 //     prefix.
+//   - AWS-managed KMS keys (KeyManager == "AWS", e.g. the ACM default key):
+//     the provider's read calls kms:GetKeyRotationStatus, which AWS-managed
+//     keys deny, so importing one fails.
 //   - Service/parent-managed ENIs (NAT gateway, VPC endpoint, load balancer,
 //     Lambda, …): owned by their parent resource, not standalone-importable
 //     as aws_network_interface.
@@ -44,6 +47,13 @@ const (
 	// importing any alias with that prefix.
 	ReasonAWSManagedKMSAlias = "aws_managed_kms_alias"
 
+	// ReasonAWSManagedKMSKey marks an aws_kms_key whose KeyManager is "AWS"
+	// — an AWS-managed key (e.g. the ACM default key) rather than a
+	// customer-managed one. The provider's read path calls
+	// kms:GetKeyRotationStatus, which AWS-managed keys deny, so the key
+	// cannot be imported into customer Terraform state.
+	ReasonAWSManagedKMSKey = "aws_managed_kms_key"
+
 	// ReasonServiceManagedENI marks an aws_network_interface whose
 	// interface_type is owned by an AWS service (nat_gateway, vpc_endpoint,
 	// network_load_balancer, lambda, …) rather than a customer. These ENIs
@@ -55,6 +65,11 @@ const (
 // awsManagedKMSAliasPrefix is the reserved alias prefix the AWS provider
 // refuses to create or import an aws_kms_alias under.
 const awsManagedKMSAliasPrefix = "alias/aws/"
+
+// awsManagedKMSKeyManager is the KeyManager value KMS reports for keys it
+// manages on the customer's behalf (vs "CUSTOMER" for customer-managed
+// keys). An AWS-managed key cannot be imported into Terraform state.
+const awsManagedKMSKeyManager = "AWS"
 
 // importableENIInterfaceTypes is the set of interface_type values an
 // aws_network_interface can legitimately carry for a customer-managed,
@@ -80,6 +95,16 @@ func IsAWSManagedKMSAliasName(name string) bool {
 	return strings.HasPrefix(name, awsManagedKMSAliasPrefix)
 }
 
+// IsAWSManagedKMSKeyManager reports whether a KMS key's KeyManager value
+// denotes an AWS-managed key (KeyManager == "AWS"), which the provider
+// cannot import. The empty string (KeyManager not surfaced by the
+// discoverer) is treated as importable so an absent discriminator never
+// drops a customer-managed key — the genconfig prune (#708) remains the
+// backstop.
+func IsAWSManagedKMSKeyManager(keyManager string) bool {
+	return keyManager == awsManagedKMSKeyManager
+}
+
 // IsServiceManagedENIInterfaceType reports whether an interface_type value
 // denotes an AWS-service-managed ENI (and therefore an un-importable one).
 // Forward-compatible: any interface_type AWS introduces for a managed ENI
@@ -95,15 +120,20 @@ func IsServiceManagedENIInterfaceType(interfaceType string) bool {
 // of the Reason* consts) or "" when the resource is importable.
 //
 // KMS aliases are always classifiable — the alias name is the import ID /
-// native ID stamped by every discoverer. Service-managed ENIs are classifiable
-// only when the discoverer surfaced interface_type into
-// NativeIDs["interface_type"]; when it is absent the ENI is treated as
-// importable here and the genconfig prune (#708) remains the backstop.
+// native ID stamped by every discoverer. AWS-managed KMS keys and
+// service-managed ENIs are classifiable only when the discoverer surfaced
+// the discriminator (NativeIDs["key_manager"] / NativeIDs["interface_type"]);
+// when it is absent the resource is treated as importable here and the
+// genconfig prune (#708) remains the backstop.
 func UnimportableReason(ir ImportedResource) string {
 	switch ir.Identity.Type {
 	case "aws_kms_alias":
 		if IsAWSManagedKMSAliasName(kmsAliasName(ir.Identity)) {
 			return ReasonAWSManagedKMSAlias
+		}
+	case "aws_kms_key":
+		if IsAWSManagedKMSKeyManager(kmsKeyManager(ir.Identity)) {
+			return ReasonAWSManagedKMSKey
 		}
 	case "aws_network_interface":
 		if IsServiceManagedENIInterfaceType(eniInterfaceType(ir.Identity)) {
@@ -121,6 +151,8 @@ func ReasonDescription(reason string) string {
 	switch reason {
 	case ReasonAWSManagedKMSAlias:
 		return "AWS-managed KMS alias (reserved alias/aws/* prefix) — cannot be imported into Terraform."
+	case ReasonAWSManagedKMSKey:
+		return "AWS-managed KMS key (KeyManager=AWS, e.g. the ACM default key) — cannot be imported into Terraform."
 	case ReasonServiceManagedENI:
 		return "Service-managed network interface (owned by its parent NAT gateway / VPC endpoint / load balancer) — cannot be imported as a standalone network interface."
 	default:
@@ -139,6 +171,14 @@ func kmsAliasName(id ResourceIdentity) string {
 		return id.ImportID
 	}
 	return id.NameHint
+}
+
+// kmsKeyManager resolves a KMS key's KeyManager value from
+// NativeIDs["key_manager"] (populated by the kms_key discoverer's property
+// extractor when the Cloud Control payload carries KeyManager). Empty when
+// the discoverer did not surface it — treated as importable upstream.
+func kmsKeyManager(id ResourceIdentity) string {
+	return id.NativeIDs["key_manager"]
 }
 
 // eniInterfaceType resolves an ENI's interface_type from

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -60,6 +60,15 @@ const (
 	// are managed by their parent resource and cannot be adopted as a
 	// standalone aws_network_interface.
 	ReasonServiceManagedENI = "service_managed_eni"
+
+	// ReasonEphemeralLogStream marks an aws_cloudwatch_log_stream. Individual
+	// log streams are created automatically by their log group as events
+	// arrive and are continuously rotated — they are not declarative
+	// infrastructure (Terraform manages the aws_cloudwatch_log_group, not its
+	// streams), and terraform plan -generate-config-out emits no body for
+	// them. The whole type is un-importable, so streams are classified into
+	// unsupported.json instead of being silently dropped as no_generated_config.
+	ReasonEphemeralLogStream = "ephemeral_log_stream"
 )
 
 // awsManagedKMSAliasPrefix is the reserved alias prefix the AWS provider
@@ -139,6 +148,10 @@ func UnimportableReason(ir ImportedResource) string {
 		if IsServiceManagedENIInterfaceType(eniInterfaceType(ir.Identity)) {
 			return ReasonServiceManagedENI
 		}
+	case "aws_cloudwatch_log_stream":
+		// Type-level: every log stream is ephemeral and un-importable (see
+		// ReasonEphemeralLogStream).
+		return ReasonEphemeralLogStream
 	}
 	return ""
 }
@@ -155,6 +168,8 @@ func ReasonDescription(reason string) string {
 		return "AWS-managed KMS key (KeyManager=AWS, e.g. the ACM default key) — cannot be imported into Terraform."
 	case ReasonServiceManagedENI:
 		return "Service-managed network interface (owned by its parent NAT gateway / VPC endpoint / load balancer) — cannot be imported as a standalone network interface."
+	case ReasonEphemeralLogStream:
+		return "Ephemeral CloudWatch log stream (auto-created and rotated by its log group) — not declarative infrastructure; manage the log group instead."
 	default:
 		return ""
 	}

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -16,6 +16,7 @@ import (
 func TestReasonCodes_WireStable(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, "aws_managed_kms_alias", ReasonAWSManagedKMSAlias)
+	assert.Equal(t, "aws_managed_kms_key", ReasonAWSManagedKMSKey)
 	assert.Equal(t, "service_managed_eni", ReasonServiceManagedENI)
 }
 
@@ -33,6 +34,44 @@ func TestIsAWSManagedKMSAliasName(t *testing.T) {
 	for name, want := range cases {
 		assert.Equalf(t, want, IsAWSManagedKMSAliasName(name), "IsAWSManagedKMSAliasName(%q)", name)
 	}
+}
+
+func TestIsAWSManagedKMSKeyManager(t *testing.T) {
+	t.Parallel()
+	cases := map[string]bool{
+		"AWS":      true,
+		"CUSTOMER": false,
+		"":         false, // not surfaced by the discoverer → importable
+		"aws":      false, // case-sensitive: KMS reports the literal "AWS"
+	}
+	for km, want := range cases {
+		assert.Equalf(t, want, IsAWSManagedKMSKeyManager(km), "IsAWSManagedKMSKeyManager(%q)", km)
+	}
+}
+
+func TestUnimportableReason_KMSKey(t *testing.T) {
+	t.Parallel()
+	t.Run("AWS-managed key (KeyManager=AWS) is un-importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:      "aws_kms_key",
+			NativeIDs: map[string]string{"key_manager": "AWS"},
+		}}
+		assert.Equal(t, ReasonAWSManagedKMSKey, UnimportableReason(ir))
+	})
+	t.Run("customer-managed key (KeyManager=CUSTOMER) is importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:      "aws_kms_key",
+			NativeIDs: map[string]string{"key_manager": "CUSTOMER"},
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
+	t.Run("absent key_manager is importable (discriminator not surfaced; genconfig backstop covers it)", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:      "aws_kms_key",
+			NativeIDs: map[string]string{"arn": "arn:aws:kms:us-east-1:111111111111:key/1234abcd"},
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
 }
 
 func TestIsServiceManagedENIInterfaceType(t *testing.T) {
@@ -121,9 +160,12 @@ func TestReasonDescription(t *testing.T) {
 	// Pin a distinctive phrase per code (not just non-empty) so a regression
 	// that swaps the two case bodies — or truncates a description — fails.
 	kms := ReasonDescription(ReasonAWSManagedKMSAlias)
-	assert.Truef(t, strings.Contains(kms, "alias/aws/"), "KMS description must mention the reserved prefix, got %q", kms)
+	assert.Truef(t, strings.Contains(kms, "alias/aws/"), "KMS-alias description must mention the reserved prefix, got %q", kms)
+	kmsKey := ReasonDescription(ReasonAWSManagedKMSKey)
+	assert.Truef(t, strings.Contains(kmsKey, "KeyManager"), "KMS-key description must mention KeyManager, got %q", kmsKey)
 	eni := ReasonDescription(ReasonServiceManagedENI)
 	assert.Truef(t, strings.Contains(eni, "network interface"), "ENI description must mention network interface, got %q", eni)
 	assert.NotEqual(t, kms, eni, "the two descriptions must be distinct (guards against swapped case bodies)")
+	assert.NotEqual(t, kms, kmsKey, "the KMS-alias and KMS-key descriptions must be distinct")
 	assert.Equal(t, "", ReasonDescription("unknown_code"))
 }

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -147,6 +147,20 @@ func TestUnimportableReason_ENI(t *testing.T) {
 	})
 }
 
+func TestUnimportableReason_LogStream(t *testing.T) {
+	t.Parallel()
+	t.Run("every log stream is un-importable (type-level)", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:     "aws_cloudwatch_log_stream",
+			ImportID: "/aws/rds/instance/db/postgresql:db.0",
+		}}
+		assert.Equal(t, ReasonEphemeralLogStream, UnimportableReason(ir))
+	})
+	t.Run("reason carries an operator description", func(t *testing.T) {
+		assert.NotEmpty(t, ReasonDescription(ReasonEphemeralLogStream))
+	})
+}
+
 func TestUnimportableReason_OtherTypesImportable(t *testing.T) {
 	t.Parallel()
 	for _, typ := range []string{"aws_vpc", "aws_s3_bucket", "aws_kms_key", "aws_lambda_function"} {

--- a/pkg/insideout-import/permissions/aws.json
+++ b/pkg/insideout-import/permissions/aws.json
@@ -1380,7 +1380,7 @@
     {
       "service": "network_acl",
       "iam_action": "ec2:DescribeNetworkAcls",
-      "purpose": "list per-region network ACLs (server-side tag:Project filter when project is set; tags inline)"
+      "purpose": "list per-region network ACLs (server-side tag:Project filter when project is set; tags inline); PostDiscover resolves IsDefault to re-type default NACLs to aws_default_network_acl"
     },
     {
       "service": "network_interface",

--- a/pkg/reverseimport/closure.go
+++ b/pkg/reverseimport/closure.go
@@ -175,6 +175,27 @@ func mergeClosureResources(in mergeClosureInput) ([]imported.ImportedResource, m
 		if _, ok := childTypeSet[r.Identity.Type]; !ok {
 			continue
 		}
+		// Instance-level un-importables must not be pulled into the
+		// closure (#cust3 item 2). The closure re-discovers EVERY child of
+		// each selected parent — e.g. every aws_kms_alias whose target is a
+		// selected aws_kms_key, including the AWS-managed alias/aws/* aliases
+		// (alias/aws/rds, alias/aws/acm, …) that point at AWS-managed default
+		// keys. The primary discovery already routes these into
+		// unsupported.json via partitionUnimportable; re-adding them here
+		// feeds genconfig a body-less import that drops as no_generated_config
+		// — a generic orphan instead of the clean aws_managed_kms_alias
+		// classification. Apply the SAME shared classifier the primary path
+		// uses so the closure and the primary discovery agree on exactly
+		// which instances are importable.
+		if imported.UnimportableReason(r) != "" {
+			diagnostics = append(diagnostics, job.Diagnostic{
+				Severity: "info",
+				Code:     "selection_closure_skipped_unimportable",
+				Field:    r.Identity.Address,
+				Message:  fmt.Sprintf("closure skipped un-importable %s (%s)", r.Identity.Address, imported.UnimportableReason(r)),
+			})
+			continue
+		}
 		parentAddr := strings.TrimSpace(r.Identity.ParentAddress)
 		selectedParentAddr, ok := discoveredParentToSelected[parentAddr]
 		if !ok {

--- a/pkg/reverseimport/closure_unimportable_test.go
+++ b/pkg/reverseimport/closure_unimportable_test.go
@@ -1,0 +1,82 @@
+package reverseimport
+
+import (
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// TestMergeClosure_SkipsAWSManagedKMSAlias is the #cust3 item-2
+// regression. The selection closure re-discovers EVERY child of each
+// selected parent — including the AWS-managed alias/aws/* KMS aliases
+// (e.g. alias/aws/rds, alias/aws/acm) that point at AWS-managed default
+// keys when a customer key in the same region is selected. The primary
+// discovery already routes those into unsupported.json via
+// partitionUnimportable; re-adding them to the closure feeds genconfig a
+// body-less import that drops as a generic no_generated_config orphan.
+// mergeClosureResources must apply the SAME imported.UnimportableReason
+// classifier so the closure and the primary discovery agree on exactly
+// which instances are importable.
+func TestMergeClosure_SkipsAWSManagedKMSAlias(t *testing.T) {
+	selectedKey := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_kms_key",
+			Address:  "aws_kms_key.selected",
+			ImportID: "11111111-2222-3333-4444-555555555555",
+			Region:   "us-west-2",
+		},
+	}
+	awsManagedAlias := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:         "aws",
+			Type:          "aws_kms_alias",
+			Address:       "aws_kms_alias.alias_aws_acm",
+			ImportID:      "alias/aws/acm",
+			Region:        "us-west-2",
+			ParentAddress: "aws_kms_key.selected",
+			NativeIDs:     map[string]string{"name": "alias/aws/acm"},
+		},
+	}
+	customerAlias := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:         "aws",
+			Type:          "aws_kms_alias",
+			Address:       "aws_kms_alias.customer",
+			ImportID:      "alias/customer-tfstate",
+			Region:        "us-west-2",
+			ParentAddress: "aws_kms_key.selected",
+			NativeIDs:     map[string]string{"name": "alias/customer-tfstate"},
+		},
+	}
+
+	merged, deps, _ := mergeClosureResources(mergeClosureInput{
+		current:         []imported.ImportedResource{selectedKey},
+		selectedParents: []imported.ImportedResource{selectedKey},
+		parentTypes:     []string{"aws_kms_key"},
+		childTypes:      []string{"aws_kms_alias"},
+		discovered:      []imported.ImportedResource{awsManagedAlias, customerAlias},
+	})
+
+	var sawAWSManaged, sawCustomer bool
+	for _, r := range merged {
+		switch r.Identity.Address {
+		case "aws_kms_alias.alias_aws_acm":
+			sawAWSManaged = true
+		case "aws_kms_alias.customer":
+			sawCustomer = true
+		}
+	}
+	if sawAWSManaged {
+		t.Error("closure pulled in AWS-managed alias/aws/acm — must be skipped as un-importable")
+	}
+	if !sawCustomer {
+		t.Error("closure dropped the importable customer alias — only AWS-managed aliases should be skipped")
+	}
+	// The dependency edge for the AWS-managed alias must NOT be recorded.
+	for _, d := range deps["aws_kms_key.selected"] {
+		if d.Address == "aws_kms_alias.alias_aws_acm" {
+			t.Error("AWS-managed alias recorded as a closure dependency")
+		}
+	}
+}

--- a/scripts/reverse-e2e.sh
+++ b/scripts/reverse-e2e.sh
@@ -14,7 +14,7 @@
 #
 # This is the live tier (like `make test-roundtrip`): it needs real AWS creds,
 # so it is operator-run, not a CI gate. Point it at any account you've authed
-# into (cust1/cust2/cust3, …). Multi-region is exercised by listing >1 region
+# into (cust1/cust2/cust3, ...). Multi-region is exercised by listing >1 region
 # or REGIONS=all.
 #
 # Prereqs:
@@ -43,6 +43,7 @@ REGIONS="${REVERSE_E2E_REGIONS:-us-east-1}"
 PROJECT="${REVERSE_E2E_PROJECT:-}"
 MIRROR="${REVERSE_E2E_MIRROR:-$HOME/.terraform.d/plugin-cache}"
 OUTDIR="${REVERSE_E2E_OUTDIR:-$(mktemp -d -t reverse-e2e.XXXXXX)}"
+mkdir -p "$OUTDIR"
 PRIMARY="${REVERSE_E2E_PRIMARY:-}"
 if [[ -z "$PRIMARY" ]]; then
   if [[ "$REGIONS" == "all" ]]; then PRIMARY="us-east-1"; else PRIMARY="${REGIONS%%,*}"; fi
@@ -84,13 +85,13 @@ log "offline mirror wired via TF_CLI_CONFIG_FILE=$TFRC"
 
 # ---- build the CLI --------------------------------------------------------
 BIN="$OUTDIR/insideout-import"
-log "building insideout-import…"
+log "building insideout-import..."
 go build -o "$BIN" ./cmd/insideout-import
 
 # ---- stage 2a: discover identities (--no-hcl: fast, reverse regenerates HCL)
 DISC="$OUTDIR/discover"
 mkdir -p "$DISC"
-log "discover (identities only) across regions: $REGIONS…"
+log "discover (identities only) across regions: $REGIONS..."
 "$BIN" discover \
   --provider aws \
   --no-hcl \
@@ -104,7 +105,7 @@ log "discovered $NRES importable resource(s)"
 # ---- stages 2b/2c + final plan: the production engine ---------------------
 OUT="$OUTDIR/out"
 mkdir -p "$OUT"
-log "reverse (genconfig → driftfix → depchase → terraform plan)…"
+log "reverse (genconfig → driftfix → depchase → terraform plan)..."
 REV_ARGS=(reverse
   --input "$DISC/imported.json"
   --output-dir "$OUT"
@@ -115,7 +116,7 @@ REV_ARGS=(reverse
 "$BIN" "${REV_ARGS[@]}"
 
 # ---- assert: clean, tag-only plan -----------------------------------------
-log "asserting clean tag-only plan…"
+log "asserting clean tag-only plan..."
 python3 - "$OUT" <<'PY'
 import json, sys
 out = sys.argv[1]

--- a/scripts/reverse-e2e.sh
+++ b/scripts/reverse-e2e.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#
+# reverse-e2e.sh — end-to-end reverse-import harness against a REAL AWS account.
+#
+# Drives the PRODUCTION engine the exact way Mars does — insideout-import
+# `reverse` → pkg/reverseimport.Run — through every stage:
+#
+#   discover (identities) → genconfig → driftfix → depchase → final terraform plan
+#
+# then asserts the final plan is CLEAN: imports only, with any remaining changes
+# limited to tags/tags_all (the provenance tags the import stamps). Any create /
+# destroy / replace, or any non-tag attribute drift, fails the run — that's the
+# "rock solid, clean tag-only plan" contract.
+#
+# This is the live tier (like `make test-roundtrip`): it needs real AWS creds,
+# so it is operator-run, not a CI gate. Point it at any account you've authed
+# into (cust1/cust2/cust3, …). Multi-region is exercised by listing >1 region
+# or REGIONS=all.
+#
+# Prereqs:
+#   * live AWS creds — `aws sts get-caller-identity` must succeed
+#   * a terraform binary on PATH (or set TERRAFORM_BINARY)
+#   * an offline provider mirror (corp network blocks registry.terraform.io);
+#     defaults to ~/.terraform.d/plugin-cache. Populate it once on a network
+#     that can reach the registry: `terraform providers mirror <dir>` from any
+#     stack pinning the aws provider, or copy from the mars image cache.
+#
+# Env knobs:
+#   REVERSE_E2E_REGIONS   comma-separated regions, or "all"   (default: us-east-1)
+#   REVERSE_E2E_PROJECT   project tag filter; "" = whole acct (default: "")
+#   REVERSE_E2E_PRIMARY   primary region (globals fold here)  (default: 1st region / us-east-1)
+#   REVERSE_E2E_MIRROR    filesystem_mirror dir               (default: ~/.terraform.d/plugin-cache)
+#   REVERSE_E2E_OUTDIR    work/output dir                     (default: mktemp -d)
+#   TERRAFORM_BINARY      terraform binary path               (default: PATH lookup)
+#   REVERSE_E2E_KEEP      set to 1 to keep the work dir       (default: cleaned on success)
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+REGIONS="${REVERSE_E2E_REGIONS:-us-east-1}"
+PROJECT="${REVERSE_E2E_PROJECT:-}"
+MIRROR="${REVERSE_E2E_MIRROR:-$HOME/.terraform.d/plugin-cache}"
+OUTDIR="${REVERSE_E2E_OUTDIR:-$(mktemp -d -t reverse-e2e.XXXXXX)}"
+PRIMARY="${REVERSE_E2E_PRIMARY:-}"
+if [[ -z "$PRIMARY" ]]; then
+  if [[ "$REGIONS" == "all" ]]; then PRIMARY="us-east-1"; else PRIMARY="${REGIONS%%,*}"; fi
+fi
+
+log()  { printf '\033[1;36m[reverse-e2e]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[reverse-e2e] FAIL:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ---- preflight ------------------------------------------------------------
+command -v go >/dev/null || fail "go not on PATH"
+TF_BIN="${TERRAFORM_BINARY:-$(command -v terraform || true)}"
+[[ -n "$TF_BIN" ]] || fail "no terraform binary (install one or set TERRAFORM_BINARY)"
+log "terraform: $TF_BIN ($("$TF_BIN" version | head -1))"
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+  fail "no live AWS creds (aws sts get-caller-identity failed). Re-auth (aws_login <role>) and retry."
+fi
+ACCT="$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo '?')"
+log "AWS account: $ACCT  regions: $REGIONS  primary: $PRIMARY  project: '${PROJECT:-<whole-account>}'"
+
+[[ -d "$MIRROR/registry.terraform.io/hashicorp/aws" ]] || \
+  fail "offline mirror missing the aws provider at $MIRROR/registry.terraform.io/hashicorp/aws — populate it once (see header)."
+
+# ---- offline provider mirror ---------------------------------------------
+TFRC="$OUTDIR/reverse-e2e.tfrc"
+cat >"$TFRC" <<EOF
+provider_installation {
+  filesystem_mirror {
+    path    = "$MIRROR"
+    include = ["registry.terraform.io/*/*"]
+  }
+  direct {
+    exclude = ["registry.terraform.io/*/*"]
+  }
+}
+EOF
+export TF_CLI_CONFIG_FILE="$TFRC"
+log "offline mirror wired via TF_CLI_CONFIG_FILE=$TFRC"
+
+# ---- build the CLI --------------------------------------------------------
+BIN="$OUTDIR/insideout-import"
+log "building insideout-import…"
+go build -o "$BIN" ./cmd/insideout-import
+
+# ---- stage 2a: discover identities (--no-hcl: fast, reverse regenerates HCL)
+DISC="$OUTDIR/discover"
+mkdir -p "$DISC"
+log "discover (identities only) across regions: $REGIONS…"
+"$BIN" discover \
+  --provider aws \
+  --no-hcl \
+  --regions "$REGIONS" \
+  --project "$PROJECT" \
+  --output-dir "$DISC"
+[[ -f "$DISC/imported.json" ]] || fail "discover produced no imported.json"
+NRES="$(python3 -c 'import json,sys;print(len(json.load(open(sys.argv[1]))))' "$DISC/imported.json" 2>/dev/null || echo '?')"
+log "discovered $NRES importable resource(s)"
+
+# ---- stages 2b/2c + final plan: the production engine ---------------------
+OUT="$OUTDIR/out"
+mkdir -p "$OUT"
+log "reverse (genconfig → driftfix → depchase → terraform plan)…"
+REV_ARGS=(reverse
+  --input "$DISC/imported.json"
+  --output-dir "$OUT"
+  --region "$PRIMARY"
+  --import-project-id "reverse-e2e"
+  --import-session-id "reverse-e2e")
+[[ -n "${TERRAFORM_BINARY:-}" ]] && REV_ARGS+=(--terraform-binary "$TERRAFORM_BINARY")
+"$BIN" "${REV_ARGS[@]}"
+
+# ---- assert: clean, tag-only plan -----------------------------------------
+log "asserting clean tag-only plan…"
+python3 - "$OUT" <<'PY'
+import json, sys
+out = sys.argv[1]
+ps = json.load(open(f"{out}/plan-summary.json"))
+plan = json.load(open(f"{out}/tfplan.json"))
+
+def norm(v):
+    # SIT-style null normalization: collapse empties so AWS-API response
+    # normalization (null/[]/{}/""/0/false) doesn't read as drift.
+    if v in (None, [], {}, "", 0, False):
+        return None
+    return v
+
+problems = []
+
+# 1) coarse counts: no creates, destroys, or replaces.
+for k in ("add_count", "destroy_count", "replace_count"):
+    if ps.get(k, 0):
+        problems.append(f"plan-summary.{k} = {ps[k]} (want 0)")
+
+# 2) per-resource: imports are no-ops; updates may touch ONLY tags/tags_all.
+TAGS = {"tags", "tags_all"}
+for rc in plan.get("resource_changes", []):
+    actions = rc.get("change", {}).get("actions", [])
+    addr = rc.get("address", "?")
+    if "create" in actions or "delete" in actions:
+        problems.append(f"{addr}: actions={actions} (create/delete/replace not allowed)")
+        continue
+    if actions == ["update"]:
+        before = rc["change"].get("before") or {}
+        after = rc["change"].get("after") or {}
+        changed = {k for k in set(before) | set(after) if norm(before.get(k)) != norm(after.get(k))}
+        extra = changed - TAGS
+        if extra:
+            problems.append(f"{addr}: non-tag changes {sorted(extra)}")
+
+print(f"  plan-summary: import={ps.get('import_count')} add={ps.get('add_count')} "
+      f"change={ps.get('change_count')} destroy={ps.get('destroy_count')} "
+      f"replace={ps.get('replace_count')}")
+
+if problems:
+    print("\n  NOT a clean tag-only plan:")
+    for p in problems:
+        print(f"    - {p}")
+    sys.exit(1)
+print("  CLEAN: imports only, changes limited to tags/tags_all ✅")
+PY
+
+log "PASS — clean tag-only plan. Artifacts in $OUT"
+if [[ "${REVERSE_E2E_KEEP:-0}" != "1" ]]; then
+  rm -rf "$OUTDIR"
+else
+  log "kept work dir: $OUTDIR"
+fi


### PR DESCRIPTION
## What

Make whole-account, **multi-region** reverse-import rock solid: every importable resource imports, every un-importable one is explicitly classified (never silently dropped), and the first-import plan is clean with the **only** changes being provenance tags. Proven end-to-end on a real account.

This PR bundles the whole-account "stragglers" cleanup with the multi-region support, a default-NACL fix, an end-to-end harness, and a design doc.

## Why it matters

Multi-region had never been exercised end-to-end and was actually broken: drift-fix and dep-chase pointed at the non-plannable merged parent workdir, so any >1-region import aborted at drift-fix with `no version is selected`. Whole-account single-region had a tail of genconfig validate errors and silent discoverer drops.

## Changes (one commit per work item)

**Whole-account stragglers (single-region correctness)**
- genconfig fixups for `aws_iam_role` / `aws_instance` / `aws_cloudwatch_metric_alarm` validate conflicts.
- Discoverer fixes: correct import IDs (eip/backup/event-rule), S3 true region, AWS-managed KMS exclusion, KMS/S3/contributor-insights drops resolved at discover time.
- Classify `aws_cloudwatch_log_stream` as un-importable (was a silent `no_generated_config` drop).
- Re-type default network ACLs to `aws_default_network_acl` (was silently dropped).
- Skip un-importable instances in the selection closure.

**Multi-region**
- **drift-fix is multi-region aware**: detects the per-region `region-<alias>/` subdirs genconfig produces (each plannable), converges each in parallel (bounded errgroup), then re-merges the parent `generated.tf` so dep-chase's text-read reflects the patches. Zero call-site changes. Fixes the `no version is selected` abort.
- **dep-chase discovers each cross-region ref in its own region** (the ARN's region, falling back to the primary for global/region-less ARNs). Dep-chase stays whole-account/native (text analysis over the merged config) — a per-region loop would have broken cross-region chasing.
- **genconfig runs per-region passes concurrently** (bounded errgroup, deterministic merge) — a whole-account scan across N regions runs up to N passes at once instead of summing them.

**Default NACL clean import**
- `lifecycle { ignore_changes = [egress, ingress] }` on `aws_default_network_acl`. The final `imported.tf` is emitted from scalar attributes (nested HCL blocks aren't extracted), so a default NACL otherwise lost its allow-all rules and terraform planned to **delete** them — the only non-tag drift in a real whole-account import, and unsafe on apply. Now adopted for tagging without managing/destroying its rules.

**Testing + docs**
- `make reverse-e2e` (`scripts/reverse-e2e.sh`): drives the production engine (`insideout-import reverse` → `reverseimport.Run`) through discover → genconfig → drift-fix → dep-chase → final plan against a real account behind an offline provider mirror, and asserts a clean tag-only plan. Operator-run live tier (like `make test-roundtrip`).
- `docs/reverse-import-contract.md`: the contract, decisions, and invariants (incl. the `change_count <= import_count` invariant, classification-over-silent-drops, the multi-region architecture, the scalar-only emission limitation, and the Mars/Sandbox execution model).

## Proof (real cust1 account, offline mirror)

| Run | Result |
|---|---|
| Single-region (us-east-1) | `81 import, 0 add, 0 change*, 0 destroy`, 0 validation issues — **clean tag-only** |
| Multi-region (all regions) | `224 import, 0 add, 0 destroy, 0 replace`, 196 tag-only changes across 5 regions, 0 validation issues — **clean tag-only** |

`* changes are provenance tags only (InsideOutImport*)`. Multi-region verified to actually exercise the new path: 5 per-region genconfig subdirs, 5 `aws.imported_<region>` aliased providers, 5 default NACLs imported clean.

3014 unit tests pass (drift-fix / genconfig / dep-chase green under `-race`).
