### PR TITLE
fix(genconfig): serialize tfenv install before multi-region init fan-out (#724)

### DIFF
--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -252,6 +252,36 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 		return &syncWriter{mu: &logMu, w: opts.Stdout}
 	}
 
+	// Warm tfenv ONCE before fanning out (#724). The first `terraform`
+	// invocation in an environment whose pinned version isn't pre-baked in the
+	// image makes tfenv auto-install it (download → unzip → chmod +x → exec),
+	// which is NOT concurrency-safe: N regions racing that first install hit
+	// `Permission denied` / `exit status 126` on the freshly written,
+	// not-yet-executable binary, failing the whole reverse-import job. Running
+	// `terraform version` once, serially, installs the pinned version up front
+	// so the parallel Init() calls below all find a present, executable binary.
+	// The version tfenv resolves here matches each region subdir's: the subdirs
+	// are children of Workdir and the emitted providers.tf pins no
+	// `required_version`, so resolution walks up to the same
+	// .terraform-version / env source either way.
+	//
+	// Build the warm-up runner the same way the per-region passes do — via the
+	// newRunner factory / execRunner, never a shared injected Runner. The
+	// fan-out forces sub.Runner = nil for exactly this reason (concurrent passes
+	// must not share one runner's mutable state); the warm-up clears it too so
+	// it exercises the same runner the children will, honoring the
+	// "multi-region ignores the injected Runner" contract (see Options.Runner).
+	progressf(opts.Stdout, "genconfig: warming terraform (installing pinned version once before parallel init)…\n")
+	warmOpts := opts
+	warmOpts.Runner = nil
+	warmup, err := warmOpts.buildRunner(sink())
+	if err != nil {
+		return nil, fmt.Errorf("genconfig: terraform warm-up runner: %w", err)
+	}
+	if err := warmup.Version(ctx); err != nil {
+		return nil, fmt.Errorf("genconfig: terraform warm-up (install pinned version): %w", err)
+	}
+
 	// Index-addressed slots keep the merge order deterministic (region-sorted)
 	// regardless of which region finishes first.
 	type regionOut struct {

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	tfjson "github.com/hashicorp/terraform-json"
@@ -29,6 +30,7 @@ type fakeRunner struct {
 	schemaErr   error
 	schemas     *tfjson.ProviderSchemas
 	validateErr error
+	versionErr  error
 
 	calls           []string
 	generatedPath   string
@@ -37,6 +39,15 @@ type fakeRunner struct {
 	initCalled      int
 	validateCalled  int
 	schemaCalled    int
+	versionCalled   int
+}
+
+// Version models the tfenv warm-up call (#724). The single-region path never
+// calls it; the multi-region path warms terraform once before fan-out.
+func (f *fakeRunner) Version(_ context.Context) error {
+	f.calls = append(f.calls, "version")
+	f.versionCalled++
+	return f.versionErr
 }
 
 func (f *fakeRunner) Init(_ context.Context) error {
@@ -145,6 +156,11 @@ func TestRun_HappyPath(t *testing.T) {
 	wantOrder := []string{"init", "plan", "schema", "validate"}
 	if !equalStrings(runner.calls, wantOrder) {
 		t.Errorf("pipeline order = %v, want %v", runner.calls, wantOrder)
+	}
+	// The tfenv warm-up (#724) is a multi-region-only concern — the
+	// single-region path inits serially, so it must never pay for a warm-up.
+	if runner.versionCalled != 0 {
+		t.Errorf("single-region path must not warm up tfenv; Version called %d time(s)", runner.versionCalled)
 	}
 	if res.GeneratedPath != filepath.Join(dir, generatedFile) {
 		t.Errorf("GeneratedPath=%q", res.GeneratedPath)
@@ -823,5 +839,184 @@ func TestRun_MultiRegion(t *testing.T) {
 	// A combined generated.tf is assembled at the top level for the artifact.
 	if _, err := os.Stat(res.GeneratedPath); err != nil {
 		t.Errorf("merged top-level generated.tf missing: %v", err)
+	}
+}
+
+// warmupOrder records, across every runner the multi-region fan-out builds,
+// the ordering of the #724 tfenv warm-up (Version) relative to the per-region
+// Init calls. All runners built by the factory share one instance, mutated
+// under its mutex so the assertions hold under -race.
+type warmupOrder struct {
+	mu sync.Mutex
+	// versionStarted/versionCompleted are tracked separately so the Init check
+	// below means "the warm-up RETURNED", not merely "the warm-up was entered".
+	// A warm-up still in flight during fan-out shows started > completed.
+	versionStarted   int
+	versionCompleted int
+	initCalls        int
+	initBeforeWarm   bool // an Init began before the warm-up Version had returned
+}
+
+// orderTrackingRunner wraps regionAwareRunner (region-correct generated.tf) and
+// records warm-up/init ordering into a shared warmupOrder.
+type orderTrackingRunner struct {
+	regionAwareRunner
+	order *warmupOrder
+}
+
+func (r *orderTrackingRunner) Version(_ context.Context) error {
+	r.order.mu.Lock()
+	r.order.versionStarted++
+	r.order.mu.Unlock()
+
+	err := r.versionErr // nil on the happy path; set to exercise warm-up failure
+
+	// Mark completion only after the call's work is done (here: once the result
+	// is determined), so Init observing versionCompleted means the warm-up has
+	// actually returned — not just begun.
+	r.order.mu.Lock()
+	r.order.versionCompleted++
+	r.order.mu.Unlock()
+	return err
+}
+
+func (r *orderTrackingRunner) Init(ctx context.Context) error {
+	r.order.mu.Lock()
+	// Contract: no per-region init may begin until the single warm-up has fully
+	// returned — exactly one Version started AND completed, none still in
+	// flight. A dropped warm-up (completed == 0) or a warm-up running
+	// concurrently with the fan-out (started > completed) both trip this.
+	if r.order.versionCompleted == 0 || r.order.versionStarted != r.order.versionCompleted {
+		r.order.initBeforeWarm = true
+	}
+	r.order.initCalls++
+	r.order.mu.Unlock()
+	return r.regionAwareRunner.Init(ctx)
+}
+
+// TestRun_MultiRegion_WarmsTerraformBeforeParallelInit is the #724 regression
+// guard: the multi-region path must run `terraform version` exactly once,
+// serially, BEFORE fanning out the per-region Init() calls. Without that
+// warm-up, the concurrent first-time tfenv installs race on the freshly
+// written binary and intermittently fail with exit 126 (Permission denied).
+//
+// We can't deterministically reproduce the OS-level race, so we pin the
+// contract that prevents it: every per-region Init observes a warm-up Version
+// that has already RETURNED, and the warm-up ran exactly once. A revert that
+// drops the warm-up leaves versionCompleted at 0, flipping initBeforeWarm true.
+func TestRun_MultiRegion_WarmsTerraformBeforeParallelInit(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	order := &warmupOrder{}
+	res, err := Run(context.Background(), Options{
+		Workdir: dir,
+		Region:  "us-east-1",
+		newRunner: func(_ string, _ io.Writer) (terraformRunner, error) {
+			return &orderTrackingRunner{
+				regionAwareRunner: regionAwareRunner{fakeRunner: fakeRunner{schemas: minimalAWSSchema()}},
+				order:             order,
+			}, nil
+		},
+	}, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east1", Region: "us-east-1", ImportID: "e1"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.west1", Region: "us-west-2", ImportID: "w1"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.euw1", Region: "eu-west-1", ImportID: "ew1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Resources) != 3 {
+		t.Fatalf("want 3 merged resources, got %d", len(res.Resources))
+	}
+
+	order.mu.Lock()
+	defer order.mu.Unlock()
+	if order.versionCompleted != 1 || order.versionStarted != 1 {
+		t.Errorf("terraform warm-up (version) started %d / completed %d time(s), want exactly 1 each before fan-out", order.versionStarted, order.versionCompleted)
+	}
+	if order.initCalls != 3 {
+		t.Errorf("per-region init ran %d time(s), want 3 (one per region)", order.initCalls)
+	}
+	if order.initBeforeWarm {
+		t.Error("a per-region terraform init began before the warm-up returned — the #724 tfenv install race is reintroduced")
+	}
+}
+
+// TestRun_MultiRegion_WarmUpFailureAbortsBeforeFanOut pins the other half of
+// the #724 contract: if the serial warm-up fails (e.g. tfenv can't install the
+// pinned version), Run must abort with a wrapped, warm-up-identified error and
+// must NOT fan out — starting the parallel inits after a failed install would
+// re-expose exactly the race the warm-up exists to prevent.
+func TestRun_MultiRegion_WarmUpFailureAbortsBeforeFanOut(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	order := &warmupOrder{}
+	wantErr := errors.New("tfenv: could not install terraform 1.7.5")
+	_, err := Run(context.Background(), Options{
+		Workdir: dir,
+		Region:  "us-east-1",
+		newRunner: func(_ string, _ io.Writer) (terraformRunner, error) {
+			return &orderTrackingRunner{
+				regionAwareRunner: regionAwareRunner{fakeRunner: fakeRunner{schemas: minimalAWSSchema(), versionErr: wantErr}},
+				order:             order,
+			}, nil
+		},
+	}, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east1", Region: "us-east-1", ImportID: "e1"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.west1", Region: "us-west-2", ImportID: "w1"}},
+	})
+	if err == nil {
+		t.Fatal("want an error when the tfenv warm-up fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "terraform warm-up (install pinned version)") {
+		t.Errorf("error %q must identify the warm-up step", err)
+	}
+	if !errors.Is(err, wantErr) {
+		t.Errorf("error must wrap the underlying tfenv failure, got %v", err)
+	}
+
+	order.mu.Lock()
+	defer order.mu.Unlock()
+	if order.versionCompleted != 1 {
+		t.Errorf("warm-up completed %d time(s), want exactly 1", order.versionCompleted)
+	}
+	if order.initCalls != 0 {
+		t.Errorf("the per-region fan-out must NOT start after a failed warm-up; %d init(s) ran", order.initCalls)
+	}
+}
+
+// TestRun_MultiRegion_IgnoresInjectedRunner pins the Options.Runner contract on
+// the multi-region path: an injected single Runner is ignored — by the warm-up
+// AND the per-region passes alike — so concurrent passes never share one
+// runner's mutable state. Each region forces sub.Runner = nil and the warm-up
+// clears it too; both build via the per-region factory instead. (The #724
+// warm-up originally honored the injected Runner, an inconsistency this guards
+// against.) If the injected Runner were ever touched, its call counters would
+// be non-zero.
+func TestRun_MultiRegion_IgnoresInjectedRunner(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	injected := &fakeRunner{schemas: minimalAWSSchema()}
+	res, err := Run(context.Background(), Options{
+		Workdir: dir,
+		Region:  "us-east-1",
+		Runner:  injected,
+		newRunner: func(_ string, _ io.Writer) (terraformRunner, error) {
+			return &regionAwareRunner{fakeRunner: fakeRunner{schemas: minimalAWSSchema()}}, nil
+		},
+	}, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east1", Region: "us-east-1", ImportID: "e1"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.west1", Region: "us-west-2", ImportID: "w1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Resources) != 2 {
+		t.Fatalf("want 2 merged resources, got %d", len(res.Resources))
+	}
+	touched := injected.versionCalled + injected.initCalled + injected.planCalled + injected.schemaCalled + injected.validateCalled
+	if touched != 0 {
+		t.Errorf("multi-region path used the injected Runner (version=%d init=%d plan=%d schema=%d validate=%d); warm-up + regions must use the per-region factory only",
+			injected.versionCalled, injected.initCalled, injected.planCalled, injected.schemaCalled, injected.validateCalled)
 	}
 }

--- a/cmd/insideout-import/genconfig/runner.go
+++ b/cmd/insideout-import/genconfig/runner.go
@@ -14,6 +14,14 @@ import (
 // Tests inject a fakeRunner; production uses execRunner backed by a real
 // terraform binary on PATH.
 type terraformRunner interface {
+	// Version runs `terraform version`. genconfig calls it as a one-time,
+	// serial warm-up before the multi-region fan-out: the first `terraform`
+	// invocation in an environment whose pinned version isn't pre-baked makes
+	// tfenv auto-install it (download → unzip → chmod +x → exec), which is NOT
+	// concurrency-safe — N regions racing that first install hit
+	// `Permission denied` / exit 126 on the freshly written, not-yet-executable
+	// binary (#724). Running version once forces that install serially.
+	Version(ctx context.Context) error
 	Init(ctx context.Context) error
 	// PlanGenerate runs `terraform plan -generate-config-out=<path>` and
 	// returns whether the plan has changes (which it always does for a fresh
@@ -61,6 +69,16 @@ func newExecRunner(workdir string, stream io.Writer) (*execRunner, error) {
 		tf.SetStderr(stream)
 	}
 	return &execRunner{tf: tf}, nil
+}
+
+// Version runs `terraform version`, discarding the parsed result — genconfig
+// only needs the side effect: forcing the binary to actually execute so tfenv
+// resolves and installs the pinned version. skipCache=true guarantees the
+// binary runs (rather than returning a cached value) so a cold tfenv version
+// is installed here, serially, before the parallel Init() fan-out.
+func (r *execRunner) Version(ctx context.Context) error {
+	_, _, err := r.tf.Version(ctx, true)
+	return err
 }
 
 func (r *execRunner) Init(ctx context.Context) error {


### PR DESCRIPTION
## What

Serialize the tfenv terraform-version install **before** the per-region `terraform init` fan-out in `genconfig.runMultiRegion`, eliminating the intermittent `exit status 126` (`Permission denied`) that fails multi-region reverse-imports.

Fixes #724

## Why it happened

mars prebakes one terraform version (`1.9.8` via `TFENV_PREINSTALL_VERSIONS`), but customer stacks pin their own (here `1.7.5`). When the pinned version isn't baked, tfenv auto-installs it on first `terraform` use (`download → unzip → chmod +x → exec`) — that's by design. The defect: tfenv's auto-install is **not concurrency-safe**, and #723 (`2fdd8ce`) made genconfig run per-region `init` concurrently. N regions racing that first install hit the freshly-written, not-yet-executable binary → `exit 126`. The interleaved `Permission denied` + `Success` lines in the staging log (`ri-2d3ebb39-4wqls`) are the smoking gun. Single-region is unaffected (serial init → single install).

## The fix

- Add `Version(ctx) error` to the `terraformRunner` interface, backed by tfexec's `tf.Version` (`skipCache=true` so the binary actually executes and tfenv installs).
- In `runMultiRegion`, call it once **serially** before the `errgroup` fan-out. tfenv resolves+installs the pinned version up front; the parallel `Init()` calls then all find a present, executable binary.

The warm-up resolves the **same** version each region subdir's init would: the region subdirs are children of `Workdir`, and the emitted `providers.tf` pins no `required_version`, so tfenv resolution walks up to the same `.terraform-version` / env source either way.

## Tests

- `TestRun_MultiRegion_WarmsTerraformBeforeParallelInit` — pins the contract that prevents the race: the warm-up `Version` runs **exactly once**, and **every** per-region `Init` observes a completed warm-up first. Verified it **fails** when the warm-up is removed (`versionCalls=0`, `initBeforeWarm=true`) and passes with it.
- Existing single-region `TestRun_HappyPath` already pins the single-region call order (`init,plan,schema,validate`) — i.e. no warm-up on the common path, so this adds zero overhead there.
- Full `genconfig` package green under `-race` (218 tests); `go build ./...`, `go vet`, `gofmt` clean.

## Follow-up (out of scope)

The mars-side **root-cause** fix — `flock` the tfenv auto-install and/or pre-bake common pinned versions — is the complementary fix noted in #724. It also covers the driftfix per-region parallelism (#723 `604d0c9`). This PR is the self-contained presets-side fix that ships now.