### PR TITLE
Classify InsideOut-imported resources during discovery

### DIFF
--- a/cmd/insideout-import/unsupported_partition.go
+++ b/cmd/insideout-import/unsupported_partition.go
@@ -11,8 +11,10 @@ import (
 // partitionUnimportable splits a freshly-discovered resource slice into the
 // importable rows (which stay in imported.json) and the instance-level
 // un-importable rows — a *supported type* whose specific instance can never be
-// adopted into customer Terraform state (AWS-managed alias/aws/* KMS aliases,
-// service/parent-managed ENIs). The dropped rows are returned as
+// adopted into customer Terraform state or should not be selected again
+// (AWS-managed alias/aws/* KMS aliases, service/parent-managed ENIs,
+// InsideOut-managed rows already carrying the imported marker). The dropped
+// rows are returned as
 // UnsupportedResource carriers (with a reason code) so the caller can route
 // them into unsupported.json alongside the type-level enumerator output (#709).
 //

--- a/cmd/insideout-import/unsupported_partition_test.go
+++ b/cmd/insideout-import/unsupported_partition_test.go
@@ -127,6 +127,59 @@ func TestPartitionUnimportable_StampsWizardFields(t *testing.T) {
 	}
 }
 
+func TestPartitionUnimportable_DropsInsideOutImportedMarker(t *testing.T) {
+	in := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{
+			Type:     "aws_vpc",
+			Address:  "aws_vpc.already_managed",
+			NameHint: "already-managed",
+			ImportID: "vpc-123",
+			Tags: map[string]string{
+				"InsideOutImportProject": "123456789012",
+				"InsideOutImported":      "true",
+			},
+		}},
+		{Identity: imported.ResourceIdentity{
+			Type:     "aws_vpc",
+			Address:  "aws_vpc.bare_project_tag",
+			NameHint: "bare-project-tag",
+			ImportID: "vpc-456",
+			Tags: map[string]string{
+				"InsideOutImportProject": "123456789012",
+			},
+		}},
+		{Identity: imported.ResourceIdentity{
+			Type:     "google_storage_bucket",
+			Address:  "google_storage_bucket.already_managed",
+			NameHint: "already-managed-gcp",
+			ImportID: "gcs-bucket",
+			Tags: map[string]string{
+				"insideout-imported": "true",
+			},
+		}},
+	}
+
+	keep, dropped := partitionUnimportable(in)
+	if len(keep) != 1 {
+		t.Fatalf("keep: got %d, want 1 (bare project tag only)", len(keep))
+	}
+	if keep[0].Identity.Address != "aws_vpc.bare_project_tag" {
+		t.Errorf("kept address = %q, want aws_vpc.bare_project_tag", keep[0].Identity.Address)
+	}
+
+	if len(dropped) != 2 {
+		t.Fatalf("dropped: got %d, want 2 (AWS + GCP imported markers)", len(dropped))
+	}
+	for i, row := range dropped {
+		if row.Reason != imported.ReasonInsideOutImported {
+			t.Errorf("dropped[%d].Reason = %q, want %q", i, row.Reason, imported.ReasonInsideOutImported)
+		}
+	}
+	if dropped[0].ID != "vpc-123" || dropped[1].ID != "gcs-bucket" {
+		t.Errorf("dropped IDs = [%q, %q], want [vpc-123, gcs-bucket]", dropped[0].ID, dropped[1].ID)
+	}
+}
+
 func TestPartitionUnimportable_Empty(t *testing.T) {
 	keep, dropped := partitionUnimportable(nil)
 	if keep == nil || dropped == nil {

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -4,10 +4,9 @@ import "strings"
 
 // Instance-level un-importability classification (#709).
 //
-// Some AWS resources are *supported types* (they appear in
+// Some resources are *supported types* (they appear in
 // registry.SupportedDiscoverTypes and have discoverers) but whose *specific
-// instances* can never be adopted into customer Terraform state — the AWS
-// provider rejects the import. The two known families:
+// instances* must not be offered for a new import. The known families:
 //
 //   - AWS-managed default KMS aliases (alias/aws/rds, alias/aws/ebs, …): the
 //     provider refuses any aws_kms_alias under the reserved `alias/aws/`
@@ -18,6 +17,9 @@ import "strings"
 //   - Service/parent-managed ENIs (NAT gateway, VPC endpoint, load balancer,
 //     Lambda, …): owned by their parent resource, not standalone-importable
 //     as aws_network_interface.
+//   - Resources already stamped with InsideOut's imported marker tag/label:
+//     already managed by InsideOut, so they are not selectable for another
+//     import run.
 //
 // This predicate is the single source of truth shared across the pipeline so
 // the reason codes never drift:
@@ -31,9 +33,9 @@ import "strings"
 //   - reliable's importer wizard + reverse-run persist gate (reliable#1967):
 //     stamp support=unsupported on the DTO and reject the run path.
 //
-// It inspects only the ResourceIdentity surface populated at discovery time —
-// never live provider schema or rendered HCL — so it produces the same verdict
-// everywhere it runs.
+// It inspects only the ResourceIdentity surface populated at discovery time
+// (including Tags/labels) — never live provider schema or rendered HCL — so it
+// produces the same verdict everywhere it runs.
 
 // Reason codes for instance-level un-importability. Stable wire identifiers
 // carried in the unsupported.json `reason` field (#709), the reverse-import
@@ -69,11 +71,25 @@ const (
 	// them. The whole type is un-importable, so streams are classified into
 	// unsupported.json instead of being silently dropped as no_generated_config.
 	ReasonEphemeralLogStream = "ephemeral_log_stream"
+
+	// ReasonInsideOutImported marks a resource already carrying InsideOut's
+	// adopted-resource marker tag/label. Discovery routes these rows to
+	// unsupported.json so another import run cannot select a resource already
+	// managed by InsideOut. The marker key is the signal; a project/account tag
+	// alone is not enough.
+	ReasonInsideOutImported = "insideout_imported"
 )
 
 // awsManagedKMSAliasPrefix is the reserved alias prefix the AWS provider
 // refuses to create or import an aws_kms_alias under.
 const awsManagedKMSAliasPrefix = "alias/aws/"
+
+const (
+	awsTagKeyImported        = "InsideOutImported"
+	gcpLabelKeyImported      = "insideout-imported"
+	awsTagKeyImportProject   = "InsideOutImportProject"
+	gcpLabelKeyImportProject = "insideout-import-project"
+)
 
 // awsManagedKMSKeyManager is the KeyManager value KMS reports for keys it
 // manages on the customer's behalf (vs "CUSTOMER" for customer-managed
@@ -124,17 +140,41 @@ func IsServiceManagedENIInterfaceType(interfaceType string) bool {
 	return !importable
 }
 
+// HasInsideOutImportedMarker reports whether discovery observed the
+// adopted-resource marker tag/label stamped by InsideOut. The marker key's
+// presence is enough; callers must not infer ownership from the project tag
+// because some historical resources carry a bare account/project marker
+// without having been imported.
+func HasInsideOutImportedMarker(tags map[string]string) bool {
+	if tags == nil {
+		return false
+	}
+	if _, ok := tags[awsTagKeyImported]; ok {
+		return true
+	}
+	if _, ok := tags[gcpLabelKeyImported]; ok {
+		return true
+	}
+	return false
+}
+
 // UnimportableReason classifies a discovered resource as inherently
 // un-importable into customer Terraform state, returning the reason code (one
 // of the Reason* consts) or "" when the resource is importable.
 //
-// KMS aliases are always classifiable — the alias name is the import ID /
-// native ID stamped by every discoverer. AWS-managed KMS keys and
-// service-managed ENIs are classifiable only when the discoverer surfaced
-// the discriminator (NativeIDs["key_manager"] / NativeIDs["interface_type"]);
-// when it is absent the resource is treated as importable here and the
-// genconfig prune (#708) remains the backstop.
+// InsideOut-managed resources are classified by the imported marker key in
+// Identity.Tags; the project/account marker alone is deliberately ignored. KMS
+// aliases are always classifiable — the alias name is the import ID / native ID
+// stamped by every discoverer. AWS-managed KMS keys and service-managed ENIs
+// are classifiable only when the discoverer surfaced the discriminator
+// (NativeIDs["key_manager"] / NativeIDs["interface_type"]); when it is absent
+// the resource is treated as importable here and the genconfig prune (#708)
+// remains the backstop.
 func UnimportableReason(ir ImportedResource) string {
+	if HasInsideOutImportedMarker(ir.Identity.Tags) {
+		return ReasonInsideOutImported
+	}
+
 	switch ir.Identity.Type {
 	case "aws_kms_alias":
 		if IsAWSManagedKMSAliasName(kmsAliasName(ir.Identity)) {
@@ -170,6 +210,8 @@ func ReasonDescription(reason string) string {
 		return "Service-managed network interface (owned by its parent NAT gateway / VPC endpoint / load balancer) — cannot be imported as a standalone network interface."
 	case ReasonEphemeralLogStream:
 		return "Ephemeral CloudWatch log stream (auto-created and rotated by its log group) — not declarative infrastructure; manage the log group instead."
+	case ReasonInsideOutImported:
+		return "Already managed by InsideOut — cannot be selected for a new import."
 	default:
 		return ""
 	}

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -18,6 +18,8 @@ func TestReasonCodes_WireStable(t *testing.T) {
 	assert.Equal(t, "aws_managed_kms_alias", ReasonAWSManagedKMSAlias)
 	assert.Equal(t, "aws_managed_kms_key", ReasonAWSManagedKMSKey)
 	assert.Equal(t, "service_managed_eni", ReasonServiceManagedENI)
+	assert.Equal(t, "ephemeral_log_stream", ReasonEphemeralLogStream)
+	assert.Equal(t, "insideout_imported", ReasonInsideOutImported)
 }
 
 func TestIsAWSManagedKMSAliasName(t *testing.T) {
@@ -85,6 +87,76 @@ func TestIsServiceManagedENIInterfaceType(t *testing.T) {
 	for _, it := range []string{"nat_gateway", "vpc_endpoint", "network_load_balancer", "lambda", "transit_gateway", "some_future_managed_type"} {
 		assert.Truef(t, IsServiceManagedENIInterfaceType(it), "interface_type %q should be service-managed", it)
 	}
+}
+
+func TestHasInsideOutImportedMarker(t *testing.T) {
+	t.Parallel()
+	cases := map[string]struct {
+		tags map[string]string
+		want bool
+	}{
+		"aws imported marker present": {
+			tags: map[string]string{awsTagKeyImported: "true"},
+			want: true,
+		},
+		"aws imported marker presence is enough": {
+			tags: map[string]string{awsTagKeyImported: ""},
+			want: true,
+		},
+		"gcp imported marker present": {
+			tags: map[string]string{gcpLabelKeyImported: "true"},
+			want: true,
+		},
+		"bare aws import project account id is not ownership": {
+			tags: map[string]string{awsTagKeyImportProject: "123456789012"},
+			want: false,
+		},
+		"bare gcp import project label is not ownership": {
+			tags: map[string]string{gcpLabelKeyImportProject: "customer-project"},
+			want: false,
+		},
+		"no tags": {
+			tags: map[string]string{},
+			want: false,
+		},
+		"not fetched": {
+			tags: nil,
+			want: false,
+		},
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, HasInsideOutImportedMarker(tc.tags))
+		})
+	}
+}
+
+func TestUnimportableReason_InsideOutImportedMarker(t *testing.T) {
+	t.Parallel()
+	t.Run("aws marker makes otherwise importable resource un-importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type: "aws_vpc",
+			Tags: map[string]string{awsTagKeyImported: "true"},
+		}}
+		assert.Equal(t, ReasonInsideOutImported, UnimportableReason(ir))
+	})
+	t.Run("gcp marker makes otherwise importable resource un-importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type: "google_storage_bucket",
+			Tags: map[string]string{gcpLabelKeyImported: "true"},
+		}}
+		assert.Equal(t, ReasonInsideOutImported, UnimportableReason(ir))
+	})
+	t.Run("bare import project account id stays importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type: "aws_vpc",
+			Tags: map[string]string{awsTagKeyImportProject: "123456789012"},
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
 }
 
 func TestUnimportableReason_KMSAlias(t *testing.T) {
@@ -179,7 +251,10 @@ func TestReasonDescription(t *testing.T) {
 	assert.Truef(t, strings.Contains(kmsKey, "KeyManager"), "KMS-key description must mention KeyManager, got %q", kmsKey)
 	eni := ReasonDescription(ReasonServiceManagedENI)
 	assert.Truef(t, strings.Contains(eni, "network interface"), "ENI description must mention network interface, got %q", eni)
+	insideOut := ReasonDescription(ReasonInsideOutImported)
+	assert.Truef(t, strings.Contains(insideOut, "InsideOut"), "InsideOut-imported description must mention InsideOut, got %q", insideOut)
 	assert.NotEqual(t, kms, eni, "the two descriptions must be distinct (guards against swapped case bodies)")
 	assert.NotEqual(t, kms, kmsKey, "the KMS-alias and KMS-key descriptions must be distinct")
+	assert.NotEqual(t, insideOut, kms, "the InsideOut-imported and KMS-alias descriptions must be distinct")
 	assert.Equal(t, "", ReasonDescription("unknown_code"))
 }


### PR DESCRIPTION
## Summary
- Classifies resources carrying `InsideOutImported` or `insideout-imported` as non-importable during discovery.
- Routes those rows through the existing unsupported/non-selectable path before Reliable receives them.
- Preserves the historical trap: a bare `InsideOutImportProject` account-id tag without the imported marker remains importable.

Closes #726

## Test plan
- [x] `go test ./pkg/composer/imported -run 'Test(ReasonCodes_WireStable|HasInsideOutImportedMarker|UnimportableReason|ReasonDescription)'`
- [x] `go test ./cmd/insideout-import -run 'TestPartitionUnimportable|TestUnsupportedResource_ReasonWireFormat|TestUnimportableReasonsSummary'`
- [x] `go test ./pkg/composer/imported ./cmd/insideout-import`
- [x] `git diff --check`

## Reviews
- Security review: no auth, network, secrets, or command-execution surface changed.
- Test quality review: focused classifier and discovery-boundary assertions cover AWS/GCP marker keys, marker-presence semantics, and the bare-project-tag regression trap.