### PR TITLE
Guard reverse import against already claimed resources

### DIFF
--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -149,11 +149,11 @@ func HasInsideOutImportedMarker(tags map[string]string) bool {
 	if tags == nil {
 		return false
 	}
-	if _, ok := tags[awsTagKeyImported]; ok {
-		return true
-	}
-	if _, ok := tags[gcpLabelKeyImported]; ok {
-		return true
+	for key := range tags {
+		switch strings.ToLower(strings.TrimSpace(key)) {
+		case strings.ToLower(awsTagKeyImported), gcpLabelKeyImported:
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -103,6 +103,10 @@ func TestHasInsideOutImportedMarker(t *testing.T) {
 			tags: map[string]string{awsTagKeyImported: ""},
 			want: true,
 		},
+		"aws imported marker match is case-insensitive": {
+			tags: map[string]string{"insideoutimported": "true"},
+			want: true,
+		},
 		"gcp imported marker present": {
 			tags: map[string]string{gcpLabelKeyImported: "true"},
 			want: true,

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -32,6 +32,13 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	if len(resources) == 0 {
 		return result, fmt.Errorf("reverseimport: no resources selected")
 	}
+	if issues := selectedUnimportableIssues(resources); len(issues) > 0 {
+		result.ValidationIssues = issuesFromComposer(issues)
+		if err := writeResult(opts.OutputDir, &result); err != nil {
+			return result, err
+		}
+		return result, fmt.Errorf("reverseimport: selected resource cannot be imported")
+	}
 	cloud := firstNonEmpty(opts.Cloud, resources[0].Identity.Cloud)
 	if cloud == "" {
 		return result, fmt.Errorf("reverseimport: cloud required")
@@ -254,6 +261,23 @@ func writeResult(outputDir string, result *job.Result) error {
 		return err
 	}
 	return nil
+}
+
+func selectedUnimportableIssues(resources []imported.ImportedResource) []composer.ValidationIssue {
+	var issues []composer.ValidationIssue
+	for i, resource := range resources {
+		reason := imported.UnimportableReason(resource)
+		if reason == "" {
+			continue
+		}
+		issues = append(issues, composer.ValidationIssue{
+			Field:      fmt.Sprintf("resources[%d]", i),
+			Code:       reason,
+			Reason:     fmt.Sprintf("selected resource %q cannot be imported: %s", resource.Identity.Address, imported.ReasonDescription(reason)),
+			Suggestion: "re-run discovery and select only importable resources",
+		})
+	}
+	return issues
 }
 
 func writeImportedTerraformArtifacts(outputDir, cloud, region, gcpProjectID, awsEndpointURL string, awsAuth awsProviderAuth, resources []imported.ImportedResource, emitOpts composer.EmitImportedOpts) error {

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -166,6 +166,119 @@ func TestRunWithoutStdoutStaysSilent(t *testing.T) {
 	}
 }
 
+func TestRunRejectsUnimportableSelectionBeforePlan(t *testing.T) {
+	cases := map[string]struct {
+		identity imported.ResourceIdentity
+		wantCode string
+	}{
+		"insideout imported marker": {
+			identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+				Region:   "us-east-1",
+				Tags: map[string]string{
+					"InsideOutImported":      "true",
+					"InsideOutImportProject": "4b982735-ff89-4295-a3fa-8a75a554ffc9",
+				},
+			},
+			wantCode: imported.ReasonInsideOutImported,
+		},
+		"aws managed kms key": {
+			identity: imported.ResourceIdentity{
+				Cloud:     "aws",
+				Type:      "aws_kms_key",
+				Address:   "aws_kms_key.aws_managed",
+				ImportID:  "1234abcd-12ab-34cd-56ef-1234567890ab",
+				Region:    "us-east-1",
+				NativeIDs: map[string]string{"key_manager": "AWS"},
+			},
+			wantCode: imported.ReasonAWSManagedKMSKey,
+		},
+		"aws managed kms alias": {
+			identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_kms_alias",
+				Address:  "aws_kms_alias.aws_rds",
+				ImportID: "alias/aws/rds",
+				Region:   "us-east-1",
+			},
+			wantCode: imported.ReasonAWSManagedKMSAlias,
+		},
+		"service managed eni": {
+			identity: imported.ResourceIdentity{
+				Cloud:     "aws",
+				Type:      "aws_network_interface",
+				Address:   "aws_network_interface.nat",
+				ImportID:  "eni-0123456789abcdef0",
+				Region:    "us-east-1",
+				NativeIDs: map[string]string{"interface_type": "nat_gateway"},
+			},
+			wantCode: imported.ReasonServiceManagedENI,
+		},
+		"ephemeral log stream": {
+			identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_cloudwatch_log_stream",
+				Address:  "aws_cloudwatch_log_stream.ephemeral",
+				ImportID: "app-log-group:2026/06/03/example",
+				Region:   "us-east-1",
+			},
+			wantCode: imported.ReasonEphemeralLogStream,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			req := job.Request{
+				Version: job.Version,
+				Resources: []job.ResourceSpec{{
+					Identity: tc.identity,
+					Tier:     imported.TierImportedFlat,
+					Source:   imported.SourceImporter,
+				}},
+			}
+
+			genconfigCalled := false
+			result, err := Run(context.Background(), req, Options{
+				OutputDir: dir,
+				deps: deps{
+					runGenconfig: func(context.Context, genconfig.Options, []imported.ImportedResource) (*genconfig.Result, error) {
+						genconfigCalled = true
+						return nil, fmt.Errorf("genconfig should not run")
+					},
+					runDriftfix: fakeDriftfix,
+					runDepChase: fakeDepChase,
+					tf:          fakeTerraformRunner{},
+				},
+			})
+			if err == nil {
+				t.Fatal("Run returned nil error for unimportable resource")
+			}
+			if genconfigCalled {
+				t.Fatal("Run reached genconfig for unimportable resource")
+			}
+			if result.Status != job.StatusFailed {
+				t.Fatalf("Status = %q, want %q", result.Status, job.StatusFailed)
+			}
+			if len(result.ValidationIssues) != 1 {
+				t.Fatalf("ValidationIssues len = %d, want 1: %#v", len(result.ValidationIssues), result.ValidationIssues)
+			}
+			if result.ValidationIssues[0].Code != tc.wantCode {
+				t.Fatalf("ValidationIssues[0].Code = %q, want %q", result.ValidationIssues[0].Code, tc.wantCode)
+			}
+			if _, statErr := os.Stat(filepath.Join(dir, "reverse-result.json")); statErr != nil {
+				t.Fatalf("reverse-result.json not written: %v", statErr)
+			}
+			if _, statErr := os.Stat(filepath.Join(dir, "imported.tf")); !os.IsNotExist(statErr) {
+				t.Fatalf("imported.tf should not be written before rejection, stat err=%v", statErr)
+			}
+		})
+	}
+}
+
 func TestRunEmitsAWSAssumeRoleFromProjectBundle(t *testing.T) {
 	root := t.TempDir()
 	mustWrite(t, filepath.Join(root, "outputs", "cloud-provision.json"), []byte(`{


### PR DESCRIPTION
## Summary
- add InsideOut imported marker as a shared `imported.UnimportableReason` reason code
- make reverse-import runtime validate every selected resource through `imported.UnimportableReason` before genconfig / Terraform plan
- return failed `reverse-result.json` validation issues for stale or direct job selections that include any unimportable resource

## Tests
- `go test ./pkg/composer/imported ./pkg/reverseimport -run 'Test(HasInsideOutImportedMarker|UnimportableReason_InsideOutImportedMarker|RunRejectsUnimportableSelectionBeforePlan)'`\n\nCloses #728