### PR TITLE
Discovery: retry + soft-skip AWS throttles instead of aborting the scan

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -233,7 +233,25 @@ func (d *cloudControlDiscoverer) ResourceType() string { return d.cfg.TFType }
 // Per-item GetResource errors are soft-fails: a ServiceWarn is emitted
 // and the item is skipped. Parent-context cancellation propagates via
 // gctx, so a shutdown signal still tears down in-flight goroutines
-// cleanly. ListResources errors abort the region.
+// cleanly. A ListResources error normally aborts the region, EXCEPT a
+// throttle ("Rate exceeded") that survives retryThrottled's backoff: that
+// degrades to a partial result for this type (ServiceWarn + skip) so one
+// rate-limited resource type can't abort the whole account scan.
+
+// listRetry* bound the throttle backoff retryThrottled applies around each
+// CloudControl ListResources page. Discovery fans up to
+// defaultDiscoverTypesConcurrency resource types across a shared per-region
+// CloudControl rate budget, so a downstream service throttle — surfaced as a
+// 400 handler-FAILED "Rate exceeded" the SDK adaptive retryer does not
+// classify as retryable — is retried here before we give up and skip the
+// type. Vars (not consts) so tests can shrink the delays; production never
+// reassigns them.
+var (
+	listRetryMaxAttempts = 4
+	listRetryBaseDelay   = 250 * time.Millisecond
+	listRetryMaxDelay    = 4 * time.Second
+)
+
 func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs) ([]imported.ImportedResource, error) {
 	args.Emitter = emitterOrNop(args.Emitter)
 	book := addressBook{}
@@ -347,6 +365,7 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 					}
 				}
 
+			listLoop:
 				for _, parentModel := range parentModels {
 					input := &cloudcontrol.ListResourcesInput{
 						TypeName: aws.String(d.cfg.CloudFormationType),
@@ -356,7 +375,17 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 					}
 					paginator := cloudcontrol.NewListResourcesPaginator(client, input)
 					for paginator.HasMorePages() {
-						page, err := paginator.NextPage(ctx)
+						// Retry each page on a throttle (backoff + jitter)
+						// before treating it as fatal. Layered on top of the
+						// SDK adaptive retryer to also cover CloudControl's
+						// 400 handler-FAILED "Rate exceeded", which the SDK
+						// does not classify as retryable.
+						var page *cloudcontrol.ListResourcesOutput
+						err := retryThrottled(ctx, listRetryMaxAttempts, listRetryBaseDelay, listRetryMaxDelay, func() error {
+							var perr error
+							page, perr = paginator.NextPage(ctx)
+							return perr
+						})
 						if err != nil {
 							// Per-parent ListResources fan-out: some
 							// CFN handlers (e.g. AWS::Lambda::Permission
@@ -378,6 +407,22 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 									fmt.Sprintf("ListResources %s%s: NotFound treated as empty (#426 — CFN handler returned NotFound for a parent with zero children of this type): %v",
 										d.cfg.CloudFormationType, parentLabelFromModel(parentModel), err))
 								break
+							}
+							// A throttle that survived both the SDK adaptive
+							// retryer and retryThrottled's backoff means this
+							// type/region is genuinely rate-limited right now.
+							// Degrade to a PARTIAL result for this type — warn
+							// and stop listing it in this region — rather than
+							// aborting the entire account scan: one throttled
+							// resource type must not nuke discovery of every
+							// other resource. The refs gathered so far still
+							// flow through the GetResource fan-out below, and
+							// other regions/types continue independently.
+							if isThrottleError(err) {
+								args.Emitter.ServiceWarn(d.cfg.Slug, region,
+									fmt.Sprintf("ListResources %s (region=%s): still throttled after %d retries — skipping the rest of this type's listing in this region (partial results): %v",
+										d.cfg.CloudFormationType, region, listRetryMaxAttempts, err))
+								break listLoop
 							}
 							args.Emitter.ServiceFinish(d.cfg.Slug, region, regionCount, time.Since(regionStart))
 							return nil, fmt.Errorf("ListResources %s (region=%s): %w", d.cfg.CloudFormationType, region, err)

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -420,7 +420,7 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 							// other regions/types continue independently.
 							if isThrottleError(err) {
 								args.Emitter.ServiceWarn(d.cfg.Slug, region,
-									fmt.Sprintf("ListResources %s (region=%s): still throttled after %d retries — skipping the rest of this type's listing in this region (partial results): %v",
+									fmt.Sprintf("ListResources %s (region=%s): still throttled after %d attempts — skipping the rest of this type's listing in this region (partial results): %v",
 										d.cfg.CloudFormationType, region, listRetryMaxAttempts, err))
 								break listLoop
 							}

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
@@ -132,6 +132,53 @@ func testConfig() cloudControlConfig {
 	}
 }
 
+// throttleListClient always fails ListResources with a CloudControl
+// handler-FAILED "Rate exceeded" (the exact shape a reverse-import scan hit
+// on ElastiCache), counting calls so the test can assert retryThrottled
+// retried before the discoverer soft-skipped the type. GetResource must
+// never be reached.
+type throttleListClient struct{ calls int }
+
+func (c *throttleListClient) ListResources(_ context.Context, _ *cloudcontrol.ListResourcesInput, _ ...func(*cloudcontrol.Options)) (*cloudcontrol.ListResourcesOutput, error) {
+	c.calls++
+	return nil, &smithy.GenericAPIError{
+		Code:    "GeneralServiceException",
+		Message: "AWS::ElastiCache::ReplicationGroup Handler returned status FAILED: Rate exceeded (Service: ElastiCache, Status Code: 400)",
+	}
+}
+
+func (c *throttleListClient) GetResource(_ context.Context, _ *cloudcontrol.GetResourceInput, _ ...func(*cloudcontrol.Options)) (*cloudcontrol.GetResourceOutput, error) {
+	return nil, errors.New("GetResource must not be called when ListResources is throttled")
+}
+
+// TestCloudControlDiscover_ThrottleSoftSkips pins the rate-limit fix: a
+// ListResources throttle that survives retryThrottled's backoff must degrade
+// to a PARTIAL result for that type (no resources, nil error) rather than
+// aborting the whole account scan. Before the fix, one throttled type
+// returned a hard error that failed the entire discover.
+func TestCloudControlDiscover_ThrottleSoftSkips(t *testing.T) {
+	t.Parallel()
+	client := &throttleListClient{}
+	d := &cloudControlDiscoverer{
+		cfg:            testConfig(),
+		new:            func(_ string) cloudControlClient { return client },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatalf("a surviving throttle must degrade to a partial result, not abort the scan; got err: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("a throttled type yields no resources; got %d", len(got))
+	}
+	if client.calls != listRetryMaxAttempts {
+		t.Errorf("ListResources call count=%d, want %d (retryThrottled must retry before soft-skipping)", client.calls, listRetryMaxAttempts)
+	}
+}
+
 // TestCloudControlDiscover_HappyPath exercises the full read path:
 // ListResources → per-id GetResource fan-out → tag extraction →
 // MatchesAll filter (none here) → ImportedResource emission. Pins

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
@@ -315,6 +316,20 @@ func isThrottleError(err error) bool {
 			return true
 		}
 	}
+	// CloudControl wraps a downstream service throttle as a handler failure
+	// rather than a ThrottlingException: HTTP 400 with an error code like
+	// GeneralServiceException/HandlerFailureException and a message of the
+	// form "...Handler returned status FAILED: Rate exceeded (Service:
+	// ElastiCache ...)". That is neither a throttle error-code nor a 429/503,
+	// so it slips past the checks above. Match it (and any other throttle
+	// surfaced only in the message) by substring so both the enrich backstop
+	// and the discovery ListResources retry treat it as throttling.
+	switch msg := strings.ToLower(err.Error()); {
+	case strings.Contains(msg, "rate exceeded"),
+		strings.Contains(msg, "throttl"),
+		strings.Contains(msg, "too many requests"):
+		return true
+	}
 	return false
 }
 
@@ -340,11 +355,28 @@ func isThrottleError(err error) bool {
 // ir.Attrs atomically, so a retried call simply overwrites the prior
 // (failed) attempt's partial state.
 func enrichWithRetry(ctx context.Context, fn func() error) error {
+	return retryThrottled(ctx, enrichRetryMaxAttempts, enrichRetryBaseDelay, enrichRetryMaxDelay, fn)
+}
+
+// retryThrottled calls fn and, if it returns a throttle error (per
+// isThrottleError), retries it under an exponential backoff with jitter — up
+// to maxAttempts total attempts. A nil result, a non-throttle error, or
+// exhausting the attempt budget returns immediately. The backoff sleep is
+// select-cancellable on ctx.Done(); on cancel the last error is returned.
+//
+// Shared by the enrich backstop (enrichWithRetry) and the discovery
+// ListResources retry (cloudControlDiscoverer.Discover) so both throttle-
+// sensitive paths use one backoff implementation. Layered ON TOP of the AWS
+// SDK adaptive retryer (awsdiscover.RetryMode): classic ThrottlingException /
+// 429 / 503 throttles are usually absorbed below this loop, so it primarily
+// catches throttles the SDK retryer does NOT classify as retryable — notably
+// CloudControl's HTTP 400 handler-FAILED "Rate exceeded" (see isThrottleError).
+func retryThrottled(ctx context.Context, maxAttempts int, baseDelay, maxDelay time.Duration, fn func() error) error {
 	var err error
-	backoff := enrichRetryBaseDelay
+	backoff := baseDelay
 	for attempt := 1; ; attempt++ {
 		err = fn()
-		if err == nil || !isThrottleError(err) || attempt >= enrichRetryMaxAttempts {
+		if err == nil || !isThrottleError(err) || attempt >= maxAttempts {
 			return err
 		}
 		// Half-fixed + half-random of the current backoff window so
@@ -357,10 +389,10 @@ func enrichWithRetry(ctx context.Context, fn func() error) error {
 			return err
 		case <-t.C:
 		}
-		if backoff < enrichRetryMaxDelay {
+		if backoff < maxDelay {
 			backoff *= 2
-			if backoff > enrichRetryMaxDelay {
-				backoff = enrichRetryMaxDelay
+			if backoff > maxDelay {
+				backoff = maxDelay
 			}
 		}
 	}

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -287,7 +287,8 @@ var ErrEnrichClientUnavailable = errors.New("enrich: required SDK client unavail
 // 429 (Too Many Requests) or 503 (Slow Down / Service Unavailable) as a
 // throttle via *smithyhttp.ResponseError.
 //
-// nil err returns false; a non-AWS error returns false.
+// nil err returns false; a non-AWS error returns false unless it carries a
+// throttle-shaped message.
 func isThrottleError(err error) bool {
 	if err == nil {
 		return false
@@ -362,7 +363,7 @@ func enrichWithRetry(ctx context.Context, fn func() error) error {
 // isThrottleError), retries it under an exponential backoff with jitter — up
 // to maxAttempts total attempts. A nil result, a non-throttle error, or
 // exhausting the attempt budget returns immediately. The backoff sleep is
-// select-cancellable on ctx.Done(); on cancel the last error is returned.
+// select-cancellable on ctx.Done(); on cancel ctx.Err() is returned.
 //
 // Shared by the enrich backstop (enrichWithRetry) and the discovery
 // ListResources retry (cloudControlDiscoverer.Discover) so both throttle-
@@ -386,7 +387,7 @@ func retryThrottled(ctx context.Context, maxAttempts int, baseDelay, maxDelay ti
 		select {
 		case <-ctx.Done():
 			t.Stop()
-			return err
+			return ctx.Err()
 		case <-t.C:
 		}
 		if backoff < maxDelay {

--- a/cmd/insideout-import/awsdiscover/enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/enrich_test.go
@@ -609,6 +609,18 @@ func TestIsThrottleError(t *testing.T) {
 		"a non-throttle handler failure must not be misclassified as a throttle")
 }
 
+func TestRetryThrottled_ContextCancelPropagates(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := retryThrottled(ctx, 2, time.Hour, time.Hour, func() error {
+		return &smithy.GenericAPIError{Code: "ThrottlingException"}
+	})
+	assert.ErrorIs(t, err, context.Canceled,
+		"parent cancellation must not be returned as the prior throttle error; callers use isThrottleError(err) to soft-skip")
+}
+
 // filterEvents returns the subset of recorded events whose Kind matches
 // kind. Mirrors gcpdiscover.filterEvents — kept per-package so each
 // cloud's test suite is self-contained.

--- a/cmd/insideout-import/awsdiscover/enrich_test.go
+++ b/cmd/insideout-import/awsdiscover/enrich_test.go
@@ -594,6 +594,19 @@ func TestIsThrottleError(t *testing.T) {
 	assert.True(t, isThrottleError(&smithy.GenericAPIError{Code: "RequestLimitExceeded"}))
 	assert.False(t, isThrottleError(&smithy.GenericAPIError{Code: "AccessDenied"}),
 		"a non-throttle API error code must not classify as a throttle")
+	// CloudControl wraps a downstream service throttle as a 400 handler
+	// failure whose error CODE is generic (GeneralServiceException) — the
+	// throttle signal lives only in the message. Classify it by message so
+	// the discovery retry/backoff engages on this shape (the exact error a
+	// reverse-import "scan my account" hit on ElastiCache).
+	assert.True(t, isThrottleError(&smithy.GenericAPIError{
+		Code:    "GeneralServiceException",
+		Message: "AWS::ElastiCache::ReplicationGroup Handler returned status FAILED: Rate exceeded (Service: ElastiCache, Status Code: 400)",
+	}), "CloudControl 400 handler-FAILED 'Rate exceeded' must classify as a throttle")
+	assert.True(t, isThrottleError(errors.New("operation error: Throttling: slow down")),
+		"a plain error whose message says Throttling must classify as a throttle")
+	assert.False(t, isThrottleError(&smithy.GenericAPIError{Code: "GeneralServiceException", Message: "validation failed"}),
+		"a non-throttle handler failure must not be misclassified as a throttle")
 }
 
 // filterEvents returns the subset of recorded events whose Kind matches

--- a/cmd/insideout-import/awsdiscover/retry_config.go
+++ b/cmd/insideout-import/awsdiscover/retry_config.go
@@ -1,0 +1,65 @@
+// internal/awsdiscover/retry_config.go
+//
+// Shared AWS SDK v2 retry tuning for every discovery code path.
+//
+// Discovery makes a large fan-out of CloudControl ListResources / GetResource
+// (and native SDK list/describe) calls across many resource types and regions
+// that share a per-region API rate budget, so throttling is the dominant
+// transient failure mode. The retryer settings that handle it used to live in
+// package main (cmd/insideout-import/discover.go) and so were reachable only
+// by the CLI — a downstream caller that builds its own aws.Config (notably
+// luthersystems/reliable's reverse-import "scan my account" handler) silently
+// shipped with the stock SDK retryer (standard mode, 3 attempts) and hit
+// throttle aborts the CLI never saw. Centralizing the values here gives every
+// caller one source of truth.
+package awsdiscover
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+const (
+	// RetryMaxAttempts raises the SDK retryer's attempt budget above the v2
+	// default of 3 so transient Throttling errors during a multi-thousand-
+	// resource discover run don't abort mid-batch. 8 covers the empirical
+	// worst case observed in audit data (a saturated ListResources /
+	// ListTags fan-out on a few-hundred-resource account); with adaptive
+	// backoff (jitter + exponential) attempt 8 lands ~30s after attempt 1.
+	RetryMaxAttempts = 8
+
+	// RetryMode pins the SDK retryer to v2's adaptive mode (#632). The
+	// default `standard` mode reacts to ThrottlingException after the fact;
+	// adaptive mode adds a client-side token bucket that *proactively* slows
+	// the send rate when the server signals throttling — the right shape for
+	// the parallel DiscoverTypes walk, where per-service goroutines share the
+	// same per-region CloudControl rate budget, so a throttle signal from one
+	// goroutine should slow the others' first calls too.
+	RetryMode = aws.RetryModeAdaptive
+)
+
+// RetryLoadOptions returns the config.LoadDefaultConfig options that enable
+// the shared adaptive retryer. Use when building an aws.Config via
+// config.LoadDefaultConfig:
+//
+//	opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
+//	opts = append(opts, awsdiscover.RetryLoadOptions()...)
+//	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+func RetryLoadOptions() []func(*config.LoadOptions) error {
+	return []func(*config.LoadOptions) error{
+		config.WithRetryMaxAttempts(RetryMaxAttempts),
+		config.WithRetryMode(RetryMode),
+	}
+}
+
+// ApplyRetryDefaults stamps the shared adaptive retryer onto an
+// already-constructed aws.Config — one built as a struct literal rather than
+// via config.LoadDefaultConfig (e.g. reliable's role-ARN vended-credentials
+// path, which assembles aws.Config{Region, Credentials} by hand). The SDK
+// clients built from this config (cloudcontrol.NewFromConfig, …) resolve
+// their retryer from cfg.RetryMode + cfg.RetryMaxAttempts when cfg.Retryer is
+// unset, so setting these two fields is sufficient. Mutates cfg in place.
+func ApplyRetryDefaults(cfg *aws.Config) {
+	cfg.RetryMode = RetryMode
+	cfg.RetryMaxAttempts = RetryMaxAttempts
+}

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -62,25 +62,13 @@ var (
 	discoverTimeoutOverall = 25 * time.Minute
 )
 
-// discoverRetryMaxAttempts raises the SDK retryer's attempt budget above
-// the v2 default of 3 so transient Throttling errors during a multi-
-// thousand-resource discover run don't abort mid-batch. 8 covers the
-// empirical worst case observed in audit data: a saturated DynamoDB
-// ListTagsOfResource fanout on a few-hundred-table account. With v2's
-// adaptive backoff (jitter + exponential) attempt 8 lands ~30s after
-// attempt 1, which matches the per-call budget the operator-facing
-// stage budgets above can absorb.
-const discoverRetryMaxAttempts = 8
-
-// discoverRetryMode pins the SDK retryer to v2's adaptive mode (#632).
-// The default `standard` mode uses exponential backoff + jitter, which
-// reacts to ThrottlingException after the fact. Adaptive mode adds a
-// client-side token bucket that *proactively* slows the send rate when
-// the server signals throttling, which is the right shape for the
-// parallel DiscoverTypes walk (#629): per-service goroutines share the
-// same per-region CloudControl rate budget, so a feedback signal from
-// one goroutine's 400 should slow the others' first calls too.
-const discoverRetryMode = aws.RetryModeAdaptive
+// discoverRetryMaxAttempts / discoverRetryMode alias the canonical
+// adaptive-retry tuning, now defined in the importable awsdiscover package
+// (awsdiscover.RetryMaxAttempts / awsdiscover.RetryMode) so the CLI and
+// downstream callers (reliable's reverse-import discovery) share one source
+// of truth. See awsdiscover/retry_config.go for the full rationale (#632).
+const discoverRetryMaxAttempts = awsdiscover.RetryMaxAttempts
+const discoverRetryMode = awsdiscover.RetryMode
 
 // discoveryAggregator is the small subset of awsdiscover.AWSDiscoverer
 // (and gcpdiscover.GCPDiscoverer) the orchestrator needs. Defining the


### PR DESCRIPTION
## Problem

A reverse-import discovery ("scan my account") makes CloudControl `ListResources` calls across many resource types. On a large/active account, AWS throttles one type and the **whole scan aborts** with e.g.:

```
aws_elasticache_replication_group: ListResources AWS::ElastiCache::ReplicationGroup (region=us-east-1): operation error CloudControl: ListResources, https response error StatusCode: 400 ... Handler returned status FAILED: Rate exceeded (Service: ElastiCache ...)
```

Root causes:
- The retry tuning (`RetryModeAdaptive` + 8 attempts, #632) lived in package `main`, so only the CLI got it — downstream callers (reliable's discovery handler) built their own `aws.Config` with the stock SDK retryer (3 attempts) and never saw the fix.
- `isThrottleError` didn't recognize CloudControl's throttle shape (a 400 handler failure, not a `ThrottlingException`/429/503).
- The `ListResources` loop had no retry and treated every error as fatal → one throttled type → errgroup fail-fast → entire scan dies.

## Changes

**1. Shared adaptive-retry config (`awsdiscover/retry_config.go`)** — export `RetryMaxAttempts` / `RetryMode` + `RetryLoadOptions()` / `ApplyRetryDefaults()` so the CLI and downstream callers (reliable) use one source of truth. CLI `discoverRetry*` consts repointed at them. (Lets reliable wire the same retryer into its discovery client — companion PR in reliable.)

**2. Throttle-aware discovery (`cloudcontrol_discoverer.go`, `enrich.go`)**
- `isThrottleError` now also matches CloudControl's 400 handler-FAILED "Rate exceeded" (and any throttle surfaced only in the message).
- Each `ListResources` page is wrapped in `retryThrottled` (generalized from `enrichWithRetry` — one shared backoff).
- A throttle that survives the retries → `ServiceWarn` + skip the rest of that type's listing in the region (**partial result**) instead of aborting. Refs gathered so far still flow through `GetResource`; other regions/types continue.

## Tests
- `TestIsThrottleError` extended for the CloudControl 400 handler-FAILED shape.
- `TestCloudControlDiscover_ThrottleSoftSkips` — a surviving throttle yields a partial result (nil error) after retrying, never aborts.
- Existing `enrichWithRetry` tests still pass (now exercise the shared `retryThrottled`).

`go build ./cmd/...`, `go vet`, and `go test ./cmd/insideout-import/...` all green.