### PR TITLE
perf(import): make discovery enrich concurrency configurable + add bench tool (default stays 4)

### DIFF
--- a/cmd/insideout-import/README.md
+++ b/cmd/insideout-import/README.md
@@ -8,6 +8,7 @@ CLI for bringing existing cloud resources under InsideOut management.
 |---|---|---|
 | `adopt` | implemented | Emit `import {}` blocks against an *already-known* preset stack. |
 | `discover` | Stage 2d (AWS + GCP, manifest + HCL + drift fix + dep chase) | Discover existing cloud resources, emit `imported.json`, generate validated HCL bodies, loop `terraform plan` patches until plan-clean, then walk the cleaned generated.tf for ARN literals pointing at resources outside the import set and pull them in until the references converge. Stage 2c4 adds the LocalStack zero-drift CI gate (AWS); Stage 2d (#264) adds GCP via Cloud Asset Inventory. See #189 for the chain. |
+| `bench` | implemented (AWS) | Internal perf tool: time the discovery scan (`Provider.Discover` = `DiscoverTypes`, then `Provider.EnrichAttributes` = per-resource describe) at a chosen enrich concurrency against a real AWS account, to validate and tune the `EnrichOpts.Concurrency` knob (#731). Read-only; writes no artifacts. |
 
 ## `adopt`
 
@@ -185,6 +186,26 @@ The smoke applies a 5-resource seed stack, runs `discover`, hydrates state via `
 - **No GCP self-link cross-reference rewriting.** `applyCrossRefs` is AWS-flavored (ARN/URL pattern matching). On `--provider gcp`, the rewriter is a no-op — literal self-links stay as quoted strings instead of becoming `google_*.<addr>.id` references. Filed as a follow-up; not a customer blocker because Cloud Asset's eventual consistency means cross-resource references are rarely drift-clean on first pass anyway.
 - **No GCP self-link dep-chase.** The dep-chase loop's literal-finder only matches `arn:` shapes. GCP self-links pass through; if a generated.tf references a resource not in the import set, it shows up as drift rather than auto-pulled. Filed as a follow-up.
 - **No automated GCP CI gate.** Cloud Asset Inventory has no emulator (#264 documents the gap). Smoke is opt-in via `tests/gcp-discover-smoke.sh`.
+
+## `bench`
+
+Internal benchmarking tool. Runs the exact discovery-scan path reliable's reverse-import "Scan" step runs — `Provider.Discover` (= `DiscoverTypes`, list identities) followed by `Provider.EnrichAttributes` (= per-resource describe, the slow part) — and times each phase separately so the `EnrichOpts.Concurrency` knob (#731) can be validated and tuned against a real AWS account (the test `cust3` account).
+
+```bash
+insideout-import bench --provider aws --regions us-east-1 -p 16
+```
+
+`-p` / `--enrich-concurrency` is the enrich fan-out passed straight to `imp.EnrichOpts{Concurrency: p}` (0 = package default). `--max-concurrency` mirrors `discover` for the discover phase. AWS config comes from ambient env credentials (same construction as `discover`); `--aws-endpoint-url` retargets the SDK at LocalStack. GCP is not yet supported (needs service-account credential plumbing).
+
+It is read-only — the only cloud calls are the List/Describe round-trips the scan already makes; no `imported.json`, HCL, or `terraform`. Output is a compact, greppable summary (one line per phase + a totals line):
+
+```
+bench: phase=discover concurrency=10 resources=512 types=23 duration=18.4s
+bench: phase=enrich concurrency=16 resources=512 enriched=500 errors=12 duration=92.3s
+bench: total provider=aws discover_concurrency=10 enrich_concurrency=16 resources=512 duration=110.7s
+```
+
+`enriched` / `errors` come from the per-resource `Identity.EnrichmentStatus` stamps; a joined enrich error is treated as data (per-resource describe failures), not a fatal — exit 0 unless inputs are bad, AWS config / STS fails, or the discover phase errors.
 
 ## Development
 

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -53,21 +53,23 @@ import (
 // a parallel one without unbounded fan-out hammering the AWS API rate
 // limits.
 //
-// Originally pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
+// Pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
 // which was lowered from 8 to 4 in #632 after 8 simultaneous t=0
 // kickoffs tripped CloudControl's per-account rate budget with a
-// ThrottlingException. Since then the SDK runs with the adaptive retry
-// mode (#632) and the enrich/discover paths soft-skip throttles into
-// partial results rather than failing the scan — so transient
-// ThrottlingExceptions are absorbed by backoff instead of aborting the
-// pass. With that safety net in place a fan-out of 4 became the dominant
-// bottleneck: a ~600-resource account spends ~8 minutes in this phase at
-// 4. Raised to 16 to cut that wall time roughly 4x; the adaptive token
-// bucket plus the soft-skip degradation make the higher fan-out safe
-// (throttles cost a backoff sleep, never a failed scan). Callers that
-// need a different ceiling pass EnrichOpts.Concurrency, which flows down
-// to enrichConcurrency below.
-const defaultEnrichConcurrency = 16
+// ThrottlingException.
+//
+// We briefly raised this to 16 on the assumption the enrich phase was
+// goroutine-bound, but benchmarking (`insideout-import bench`) against a
+// real ~600-resource account disproved it: enrich wall time was flat
+// across concurrency 4 / 16 / 32 (~85s / 80s / 77s, with the same
+// 241 enriched / 366 failed at every setting). The phase is bound by the
+// SDK adaptive-retry client-side rate limiter, not the worker count —
+// once the account throttles, extra goroutines just wait on the same
+// token bucket. A higher default buys nothing on the accounts that are
+// actually slow and only risks tripping throttles harder, so it stays at
+// 4. Callers with a quiet account that want more fan-out can still pass
+// EnrichOpts.Concurrency, which flows down to enrichConcurrency below.
+const defaultEnrichConcurrency = 4
 
 // defaultEnrichStartupJitterMax bounds the random sleep applied before
 // the first defaultEnrichConcurrency enrich goroutines issue their

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
@@ -280,6 +281,37 @@ type EnrichClients struct {
 	// as ErrEnrichClientUnavailable.
 	WAFv2     *wafv2.Client
 	AccountID string
+}
+
+// NewEnrichClients constructs the complete EnrichClients bundle from a single
+// aws.Config. Every per-type enricher's SDK client is wired here, so the
+// bundle is complete by construction.
+//
+// This is the single source of truth for the bundle. A nil client field is
+// tolerated but surfaces as ErrEnrichClientUnavailable at Enrich time, which
+// silently drops that resource type from the enriched set — so partial wiring
+// is a latent gap, not an obvious error. Callers (reliable's
+// buildAWSImportedProvider, the insideout-import bench subcommand) must use
+// this constructor rather than hand-building the struct, so they cannot drift
+// out of parity. The SDK client structs are stateless wrappers over the
+// aws.Config, so constructing all of them costs effectively nothing.
+func NewEnrichClients(cfg aws.Config, accountID string) EnrichClients {
+	return EnrichClients{
+		S3:                s3.NewFromConfig(cfg),
+		DynamoDB:          dynamodb.NewFromConfig(cfg),
+		SecretsManager:    secretsmanager.NewFromConfig(cfg),
+		Bedrock:           bedrock.NewFromConfig(cfg),
+		ServiceDiscovery:  servicediscovery.NewFromConfig(cfg),
+		CloudControl:      cloudcontrol.NewFromConfig(cfg),
+		ResourceExplorer2: resourceexplorer2.NewFromConfig(cfg),
+		APIGatewayV2:      apigatewayv2.NewFromConfig(cfg),
+		IAM:               iam.NewFromConfig(cfg),
+		Lambda:            lambda.NewFromConfig(cfg),
+		CloudFront:        cloudfront.NewFromConfig(cfg),
+		AutoScaling:       autoscaling.NewFromConfig(cfg),
+		WAFv2:             wafv2.NewFromConfig(cfg),
+		AccountID:         accountID,
+	}
 }
 
 // ErrEnrichClientUnavailable signals that the SDK client an enricher

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -46,21 +46,28 @@ import (
 )
 
 // defaultEnrichConcurrency bounds the per-resource cloud-API fan-out of
-// EnrichAttributes. Each enricher issues one or more AWS SDK round-trips
+// EnrichAttributes when the caller does not override it (EnrichOpts.
+// Concurrency == 0). Each enricher issues one or more AWS SDK round-trips
 // per resource; running them under a bounded worker pool turns the
 // previously serial ~1m30s pass on large accounts (~224 resources) into
 // a parallel one without unbounded fan-out hammering the AWS API rate
 // limits.
 //
-// Pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
+// Originally pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
 // which was lowered from 8 to 4 in #632 after 8 simultaneous t=0
 // kickoffs tripped CloudControl's per-account rate budget with a
-// ThrottlingException. The enrich phase issues the same flavor of
-// per-account AWS calls, so it inherits the same ceiling. 4 still
-// delivers roughly a 4x wall-time saving over the old serial pass —
-// the marginal speedup from 8 isn't worth re-introducing the throttle
-// risk.
-const defaultEnrichConcurrency = 4
+// ThrottlingException. Since then the SDK runs with the adaptive retry
+// mode (#632) and the enrich/discover paths soft-skip throttles into
+// partial results rather than failing the scan — so transient
+// ThrottlingExceptions are absorbed by backoff instead of aborting the
+// pass. With that safety net in place a fan-out of 4 became the dominant
+// bottleneck: a ~600-resource account spends ~8 minutes in this phase at
+// 4. Raised to 16 to cut that wall time roughly 4x; the adaptive token
+// bucket plus the soft-skip degradation make the higher fan-out safe
+// (throttles cost a backoff sleep, never a failed scan). Callers that
+// need a different ceiling pass EnrichOpts.Concurrency, which flows down
+// to enrichConcurrency below.
+const defaultEnrichConcurrency = 16
 
 // defaultEnrichStartupJitterMax bounds the random sleep applied before
 // the first defaultEnrichConcurrency enrich goroutines issue their
@@ -399,6 +406,16 @@ func retryThrottled(ctx context.Context, maxAttempts int, baseDelay, maxDelay ti
 	}
 }
 
+// EnrichAttrOpts carries optional tuning for EnrichAttributes. It is
+// passed variadically so existing four-argument callers
+// (EnrichAttributes(ctx, irs, clients, emitter)) keep compiling and
+// behaving exactly as before — the zero-opts path is unchanged.
+type EnrichAttrOpts struct {
+	// Concurrency overrides the per-resource enrich fan-out. 0 (the zero
+	// value) uses defaultEnrichConcurrency.
+	Concurrency int
+}
+
 // EnrichAttributes populates ir.Attrs in place for every imported
 // resource whose Identity.Type has a registered enricher. Resources of
 // types without a registered enricher are left untouched; the caller
@@ -445,9 +462,17 @@ func retryThrottled(ctx context.Context, maxAttempts int, baseDelay, maxDelay ti
 // aggregation, same progress semantics. Symmetric APIs across clouds
 // keep the consumer-side code (reliable's buildEnrichedAWSImports /
 // buildEnrichedGCSImports) a one-liner per cloud.
-func (a *AWSDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients EnrichClients, emitter progress.Emitter) error {
+//
+// opts is variadic for back-compat: existing four-argument callers
+// (EnrichAttributes(ctx, irs, clients, emitter)) keep compiling and
+// behaving exactly as before — the zero-opts path is unchanged.
+func (a *AWSDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients EnrichClients, emitter progress.Emitter, opts ...EnrichAttrOpts) error {
 	if emitter == nil {
 		emitter = progress.NopEmitter{}
+	}
+	enrichConcurrency := defaultEnrichConcurrency
+	if len(opts) > 0 && opts[0].Concurrency > 0 {
+		enrichConcurrency = opts[0].Concurrency
 	}
 	stageStart := time.Now()
 	emitter.ServiceStart(enrichServiceSlug, "")
@@ -482,17 +507,17 @@ func (a *AWSDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 	// cancel early.
 	results := make([]error, len(idx))
 	var g errgroup.Group
-	g.SetLimit(defaultEnrichConcurrency)
+	g.SetLimit(enrichConcurrency)
 	for pos, i := range idx {
 		enr := a.byTypeEnricher[irs[i].Identity.Type]
 		g.Go(func() error {
 			// Jitter only the initial burst: the first
-			// defaultEnrichConcurrency goroutines start simultaneously
+			// enrichConcurrency goroutines start simultaneously
 			// at t=0, so their opening AWS calls would otherwise land
 			// together. Goroutines beyond that batch are already
 			// staggered by errgroup slot availability — jittering all
 			// of them would add tens of seconds of dead wall time.
-			if pos < defaultEnrichConcurrency {
+			if pos < enrichConcurrency {
 				sleep := time.Duration(rand.Int63n(int64(defaultEnrichStartupJitterMax)))
 				t := time.NewTimer(sleep)
 				select {

--- a/cmd/insideout-import/bench.go
+++ b/cmd/insideout-import/bench.go
@@ -22,6 +22,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -142,8 +144,8 @@ Exit codes:
 	provider := fs.String("provider", "aws", "cloud provider to benchmark (aws). gcp is not yet supported by bench.")
 	regions := fs.String("regions", "", "comma-separated AWS regions to scan in one invocation (required). Pass `all` to expand to the InsideOut-supported region set.")
 	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to scan; default: all supported types for the provider")
-	enrichConcurrency := fs.Int("enrich-concurrency", 16, "enrich fan-out concurrency passed as EnrichOpts.Concurrency (#731); the knob this tool exists to tune. 0 uses the package default.")
-	fs.IntVar(enrichConcurrency, "p", 16, "shorthand for --enrich-concurrency")
+	enrichConcurrency := fs.Int("enrich-concurrency", 4, "enrich fan-out concurrency passed as EnrichOpts.Concurrency (#731); the knob this tool exists to tune. Default 4 matches the package default. 0 also uses the package default.")
+	fs.IntVar(enrichConcurrency, "p", 4, "shorthand for --enrich-concurrency")
 	maxConcurrency := fs.Int("max-concurrency", awsdiscover.DefaultMaxConcurrency, "max in-flight per-resource AWS API calls inside the discover phase (DiscoverTypes), mirroring `discover --max-concurrency`")
 	awsEndpointURL := fs.String("aws-endpoint-url", "", "override the AWS endpoint URL for the SDK clients (e.g. http://localhost:4566 for LocalStack). Empty (default) uses real AWS.")
 
@@ -227,9 +229,67 @@ type benchResult struct {
 	typeCount        int
 	enrichedCount    int
 	enrichErrorCount int
-	discoverDuration time.Duration
-	enrichDuration   time.Duration
-	totalDuration    time.Duration
+	// enrichErrorsByCategory tallies failed enrich resources by error
+	// category (Throttling / NotFound / AccessDenied / Unsupported /
+	// Validation / Timeout / other) so the summary can answer "are these
+	// rate-limit errors or structural?" without re-running.
+	enrichErrorsByCategory map[string]int
+	discoverDuration       time.Duration
+	enrichDuration         time.Duration
+	totalDuration          time.Duration
+}
+
+// categorizeEnrichErrors buckets every failed-enrich resource by the kind of
+// error it hit, read from Identity.EnrichErrors (the per-resource strings the
+// enricher stamps, which include the downgraded ErrNotFound / client-
+// unavailable cases that never reach the joined error). Priority-ordered
+// substring matching keeps it robust against the verbose AWS SDK error text.
+func categorizeEnrichErrors(irs []composerimported.ImportedResource) map[string]int {
+	counts := map[string]int{}
+	for i := range irs {
+		if irs[i].Identity.EnrichmentStatus != composerimported.EnrichmentStatusFailed {
+			continue
+		}
+		msg := ""
+		if len(irs[i].Identity.EnrichErrors) > 0 {
+			msg = strings.ToLower(irs[i].Identity.EnrichErrors[0])
+		}
+		counts[classifyEnrichError(msg)]++
+	}
+	return counts
+}
+
+// classifyEnrichError maps one (lowercased) error string to a coarse category.
+// Order matters: throttling is checked first so a throttle that also mentions a
+// resource id isn't miscounted as NotFound.
+func classifyEnrichError(msg string) string {
+	switch {
+	case msg == "":
+		return "unknown"
+	case containsAny(msg, "throttl", "rate exceeded", "toomanyrequests", "slowdown", "429"):
+		return "Throttling"
+	case containsAny(msg, "accessdenied", "not authorized", "unauthorized", "forbidden", "403"):
+		return "AccessDenied"
+	case containsAny(msg, "not found", "notfound", "nosuch", "does not exist", "404"):
+		return "NotFound"
+	case containsAny(msg, "unsupported", "not supported", "invalidaction", "not implemented"):
+		return "Unsupported"
+	case containsAny(msg, "validation", "invalidparameter", "invalid request", "malformed"):
+		return "Validation"
+	case containsAny(msg, "timeout", "deadline", "context canceled", "context deadline"):
+		return "Timeout"
+	default:
+		return "other"
+	}
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
 }
 
 // runBenchAWS drives the two-phase scan and times each phase. It mirrors
@@ -287,6 +347,7 @@ func runBenchAWS(ctx context.Context, cfg benchConfig, endpointURL string, deps 
 	_ = enrichErr // surfaced via the per-resource counts below
 
 	res.enrichedCount, res.enrichErrorCount = countEnrichOutcomes(irs)
+	res.enrichErrorsByCategory = categorizeEnrichErrors(irs)
 	res.totalDuration = time.Since(wallStart)
 	return res, nil
 }
@@ -324,14 +385,41 @@ func countEnrichOutcomes(irs []composerimported.ImportedResource) (enriched, fai
 // One line per phase, one totals line. Durations are rounded to 0.1s so the
 // output stays scannable; sub-second phases still show as e.g. 0.3s.
 func (r benchResult) summaryLines() []string {
-	return []string{
+	lines := []string{
 		fmt.Sprintf("bench: phase=discover concurrency=%d resources=%d types=%d duration=%s",
 			r.discoverConc, r.resourceCount, r.typeCount, roundDur(r.discoverDuration)),
 		fmt.Sprintf("bench: phase=enrich concurrency=%d resources=%d enriched=%d errors=%d duration=%s",
 			r.enrichConc, r.resourceCount, r.enrichedCount, r.enrichErrorCount, roundDur(r.enrichDuration)),
-		fmt.Sprintf("bench: total provider=%s discover_concurrency=%d enrich_concurrency=%d resources=%d duration=%s",
-			r.provider, r.discoverConc, r.enrichConc, r.resourceCount, roundDur(r.totalDuration)),
 	}
+	// One line per enrich-error category, highest count first, so the
+	// summary answers "are these throttles or structural?" at a glance.
+	for _, kv := range sortedCategoryCounts(r.enrichErrorsByCategory) {
+		lines = append(lines, fmt.Sprintf("bench: enrich-error category=%s count=%d", kv.category, kv.count))
+	}
+	lines = append(lines, fmt.Sprintf("bench: total provider=%s discover_concurrency=%d enrich_concurrency=%d resources=%d duration=%s",
+		r.provider, r.discoverConc, r.enrichConc, r.resourceCount, roundDur(r.totalDuration)))
+	return lines
+}
+
+type categoryCount struct {
+	category string
+	count    int
+}
+
+// sortedCategoryCounts orders the breakdown by count desc, then category name
+// for a stable tie-break (deterministic output across runs).
+func sortedCategoryCounts(m map[string]int) []categoryCount {
+	out := make([]categoryCount, 0, len(m))
+	for cat, n := range m {
+		out = append(out, categoryCount{category: cat, count: n})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].count != out[j].count {
+			return out[i].count > out[j].count
+		}
+		return out[i].category < out[j].category
+	})
+	return out
 }
 
 // roundDur rounds a duration to the nearest 0.1s for human-scannable output.

--- a/cmd/insideout-import/bench.go
+++ b/cmd/insideout-import/bench.go
@@ -234,9 +234,12 @@ type benchResult struct {
 	// Validation / Timeout / other) so the summary can answer "are these
 	// rate-limit errors or structural?" without re-running.
 	enrichErrorsByCategory map[string]int
-	discoverDuration       time.Duration
-	enrichDuration         time.Duration
-	totalDuration          time.Duration
+	// enrichErrorSamples holds up to 5 distinct sample messages per
+	// category so the operator can see what e.g. "other" actually is.
+	enrichErrorSamples map[string][]string
+	discoverDuration   time.Duration
+	enrichDuration     time.Duration
+	totalDuration      time.Duration
 }
 
 // categorizeEnrichErrors buckets every failed-enrich resource by the kind of
@@ -244,19 +247,40 @@ type benchResult struct {
 // enricher stamps, which include the downgraded ErrNotFound / client-
 // unavailable cases that never reach the joined error). Priority-ordered
 // substring matching keeps it robust against the verbose AWS SDK error text.
-func categorizeEnrichErrors(irs []composerimported.ImportedResource) map[string]int {
-	counts := map[string]int{}
+func categorizeEnrichErrors(irs []composerimported.ImportedResource) (counts map[string]int, samples map[string][]string) {
+	counts = map[string]int{}
+	samples = map[string][]string{}
+	seen := map[string]bool{}
 	for i := range irs {
 		if irs[i].Identity.EnrichmentStatus != composerimported.EnrichmentStatusFailed {
 			continue
 		}
-		msg := ""
+		raw := ""
 		if len(irs[i].Identity.EnrichErrors) > 0 {
-			msg = strings.ToLower(irs[i].Identity.EnrichErrors[0])
+			raw = irs[i].Identity.EnrichErrors[0]
 		}
-		counts[classifyEnrichError(msg)]++
+		cat := classifyEnrichError(strings.ToLower(raw))
+		counts[cat]++
+		// Keep up to 5 distinct truncated sample messages per category so
+		// the operator can see what "other" actually is without a re-run.
+		trunc := truncateMsg(raw, 180)
+		key := cat + "|" + trunc
+		if !seen[key] && len(samples[cat]) < 5 {
+			seen[key] = true
+			samples[cat] = append(samples[cat], trunc)
+		}
 	}
-	return counts
+	return counts, samples
+}
+
+// truncateMsg collapses whitespace/newlines and clips to n runes so a verbose
+// AWS SDK error string renders as one greppable line.
+func truncateMsg(s string, n int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) > n {
+		return s[:n] + "…"
+	}
+	return s
 }
 
 // classifyEnrichError maps one (lowercased) error string to a coarse category.
@@ -347,7 +371,7 @@ func runBenchAWS(ctx context.Context, cfg benchConfig, endpointURL string, deps 
 	_ = enrichErr // surfaced via the per-resource counts below
 
 	res.enrichedCount, res.enrichErrorCount = countEnrichOutcomes(irs)
-	res.enrichErrorsByCategory = categorizeEnrichErrors(irs)
+	res.enrichErrorsByCategory, res.enrichErrorSamples = categorizeEnrichErrors(irs)
 	res.totalDuration = time.Since(wallStart)
 	return res, nil
 }
@@ -395,6 +419,9 @@ func (r benchResult) summaryLines() []string {
 	// summary answers "are these throttles or structural?" at a glance.
 	for _, kv := range sortedCategoryCounts(r.enrichErrorsByCategory) {
 		lines = append(lines, fmt.Sprintf("bench: enrich-error category=%s count=%d", kv.category, kv.count))
+		for _, sample := range r.enrichErrorSamples[kv.category] {
+			lines = append(lines, fmt.Sprintf("bench:   sample category=%s msg=%q", kv.category, sample))
+		}
 	}
 	lines = append(lines, fmt.Sprintf("bench: total provider=%s discover_concurrency=%d enrich_concurrency=%d resources=%d duration=%s",
 		r.provider, r.discoverConc, r.enrichConc, r.resourceCount, roundDur(r.totalDuration)))

--- a/cmd/insideout-import/bench.go
+++ b/cmd/insideout-import/bench.go
@@ -28,10 +28,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
-	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
@@ -95,15 +91,10 @@ func productionBenchAWSDeps() benchAWSDeps {
 		// so the benchmark times the exact path production runs.
 		newProvider: func(cfg aws.Config, maxConc int, accountID string) (imp.Provider, imp.Clients) {
 			disc := awsdiscover.NewAWSDiscovererWithConcurrency(cfg, maxConc)
-			clients := imp.Clients{
-				AWS: awsdiscover.EnrichClients{
-					S3:             s3.NewFromConfig(cfg),
-					DynamoDB:       dynamodb.NewFromConfig(cfg),
-					SecretsManager: secretsmanager.NewFromConfig(cfg),
-					CloudControl:   cloudcontrol.NewFromConfig(cfg),
-					AccountID:      accountID,
-				},
-			}
+			// Use the centralized constructor so the benchmark wires the
+			// exact same full client bundle reliable does (no drift, true
+			// parity). See awsdiscover.NewEnrichClients.
+			clients := imp.Clients{AWS: awsdiscover.NewEnrichClients(cfg, accountID)}
 			return importedaws.NewProvider(disc, driftimp.Compare), clients
 		},
 	}

--- a/cmd/insideout-import/bench.go
+++ b/cmd/insideout-import/bench.go
@@ -1,0 +1,340 @@
+package main
+
+// bench is an internal benchmarking subcommand that exercises the exact
+// discovery-scan path reliable runs — DiscoverTypes (list identities) +
+// provider.EnrichAttributes (per-resource describe) — at a chosen enrich
+// concurrency, timing each phase separately. It exists to validate and tune
+// the EnrichOpts.Concurrency knob added in #731 against a real AWS account
+// (the test "cust3" account).
+//
+// It is read-only: no artifacts, HCL, or terraform are produced. The only
+// cloud calls are the SDK List/Describe round-trips DiscoverTypes and
+// EnrichAttributes already make. Output is a compact, greppable summary —
+// one line per phase plus a totals line:
+//
+//	bench: phase=discover concurrency=10 resources=512 types=23 duration=18.4s
+//	bench: phase=enrich concurrency=16 resources=512 enriched=500 errors=12 duration=92.3s
+//	bench: total provider=aws discover_concurrency=10 enrich_concurrency=16 resources=512 duration=110.7s
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	driftimp "github.com/luthersystems/insideout-terraform-presets/pkg/drift/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+	importedaws "github.com/luthersystems/insideout-terraform-presets/pkg/imported/aws"
+)
+
+const (
+	benchExitOK    = 0
+	benchExitFatal = 1
+)
+
+// benchAWSDeps is the seam the AWS benchmark path constructs through. The
+// production wiring lives in productionBenchAWSDeps; tests inject fakes to
+// exercise the orchestrator + summary formatting without live AWS.
+type benchAWSDeps struct {
+	// loadConfig builds the aws.Config from ambient env credentials —
+	// identical construction to discover's loadConfig (same retry policy,
+	// optional endpoint override). region is the first --regions entry;
+	// endpointURL is the optional --aws-endpoint-url.
+	loadConfig func(ctx context.Context, region, endpointURL string) (aws.Config, error)
+	// getAccount resolves the AWS account ID via STS GetCallerIdentity so
+	// the enrich client bundle can stamp account-scoped ARNs without a
+	// per-resource STS round-trip. Mirrors discover's getAccount.
+	getAccount func(ctx context.Context, cfg aws.Config) (string, error)
+	// newProvider builds the live AWS Provider + Clients bundle the
+	// benchmark dispatches Discover / EnrichAttributes through. maxConc
+	// bounds the DiscoverTypes per-resource fan-out (mirrors discover's
+	// --max-concurrency); accountID stamps the enrich clients.
+	newProvider func(cfg aws.Config, maxConc int, accountID string) (imp.Provider, imp.Clients)
+}
+
+func productionBenchAWSDeps() benchAWSDeps {
+	return benchAWSDeps{
+		loadConfig: func(ctx context.Context, region, endpointURL string) (aws.Config, error) {
+			opts := []func(*config.LoadOptions) error{
+				config.WithRegion(region),
+				config.WithRetryMaxAttempts(discoverRetryMaxAttempts),
+				config.WithRetryMode(discoverRetryMode),
+			}
+			if endpointURL != "" {
+				opts = append(opts, config.WithBaseEndpoint(endpointURL))
+			}
+			return config.LoadDefaultConfig(ctx, opts...)
+		},
+		getAccount: func(ctx context.Context, cfg aws.Config) (string, error) {
+			out, err := sts.NewFromConfig(cfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+			if err != nil {
+				return "", err
+			}
+			if out.Account == nil {
+				return "", nil
+			}
+			return *out.Account, nil
+		},
+		// newProvider mirrors reliable's buildAWSImportedProvider
+		// (internal/agentapi/imported_provider.go): same discoverer
+		// constructor, same EnrichClients bundle, same drift comparator —
+		// so the benchmark times the exact path production runs.
+		newProvider: func(cfg aws.Config, maxConc int, accountID string) (imp.Provider, imp.Clients) {
+			disc := awsdiscover.NewAWSDiscovererWithConcurrency(cfg, maxConc)
+			clients := imp.Clients{
+				AWS: awsdiscover.EnrichClients{
+					S3:             s3.NewFromConfig(cfg),
+					DynamoDB:       dynamodb.NewFromConfig(cfg),
+					SecretsManager: secretsmanager.NewFromConfig(cfg),
+					CloudControl:   cloudcontrol.NewFromConfig(cfg),
+					AccountID:      accountID,
+				},
+			}
+			return importedaws.NewProvider(disc, driftimp.Compare), clients
+		},
+	}
+}
+
+func runBench(args []string) int {
+	return runBenchWithDeps(args, productionBenchAWSDeps())
+}
+
+func runBenchWithDeps(args []string, deps benchAWSDeps) int {
+	fs := flag.NewFlagSet("bench", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, `insideout-import bench — benchmark the discovery scan (DiscoverTypes + EnrichAttributes) at a chosen enrich concurrency.
+
+Usage:
+  insideout-import bench --provider aws --regions us-east-1 -p 16 [flags]
+
+Runs the exact path reliable's reverse-import "Scan" step runs — Provider.Discover
+(list identities) followed by Provider.EnrichAttributes (per-resource describe, the
+slow part) — and times each phase separately. Use it to validate and tune the enrich
+concurrency knob (#731) against a real AWS account. Read-only: no artifacts, HCL, or
+terraform; the only cloud calls are the List/Describe round-trips the scan already makes.
+
+Output is one greppable line per phase plus a totals line, e.g.:
+  bench: phase=discover concurrency=10 resources=512 types=23 duration=18.4s
+  bench: phase=enrich concurrency=16 resources=512 enriched=500 errors=12 duration=92.3s
+  bench: total provider=aws discover_concurrency=10 enrich_concurrency=16 resources=512 duration=110.7s
+
+Flags:`)
+		fs.PrintDefaults()
+		fmt.Fprintln(os.Stderr, `
+Exit codes:
+  0  benchmark completed (enrich may report per-resource errors; that is data, not failure)
+  1  fatal: bad inputs, AWS config / STS error, or a discover-phase error`)
+	}
+
+	provider := fs.String("provider", "aws", "cloud provider to benchmark (aws). gcp is not yet supported by bench.")
+	regions := fs.String("regions", "", "comma-separated AWS regions to scan in one invocation (required). Pass `all` to expand to the InsideOut-supported region set.")
+	resourceTypes := fs.String("resource-types", "", "comma-separated subset of types to scan; default: all supported types for the provider")
+	enrichConcurrency := fs.Int("enrich-concurrency", 16, "enrich fan-out concurrency passed as EnrichOpts.Concurrency (#731); the knob this tool exists to tune. 0 uses the package default.")
+	fs.IntVar(enrichConcurrency, "p", 16, "shorthand for --enrich-concurrency")
+	maxConcurrency := fs.Int("max-concurrency", awsdiscover.DefaultMaxConcurrency, "max in-flight per-resource AWS API calls inside the discover phase (DiscoverTypes), mirroring `discover --max-concurrency`")
+	awsEndpointURL := fs.String("aws-endpoint-url", "", "override the AWS endpoint URL for the SDK clients (e.g. http://localhost:4566 for LocalStack). Empty (default) uses real AWS.")
+
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return benchExitOK
+		}
+		return benchExitFatal
+	}
+
+	cfg, err := parseBenchConfig(*provider, *regions, *resourceTypes, *enrichConcurrency, *maxConcurrency)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bench: %v\n", err)
+		return benchExitFatal
+	}
+
+	res, err := runBenchAWS(context.Background(), cfg, *awsEndpointURL, deps)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bench: %v\n", err)
+		return benchExitFatal
+	}
+
+	for _, line := range res.summaryLines() {
+		fmt.Fprintln(os.Stdout, line)
+	}
+	return benchExitOK
+}
+
+// benchConfig holds the validated, normalized inputs the benchmark run
+// consumes. Split out so flag parsing / validation is unit-testable without
+// touching AWS.
+type benchConfig struct {
+	provider          string
+	regions           []string
+	resourceTypes     []string // nil = all supported types
+	enrichConcurrency int
+	maxConcurrency    int
+}
+
+// parseBenchConfig validates the raw flag values and returns a normalized
+// benchConfig. Region `all` is expanded to the InsideOut-supported set, the
+// same as discover.
+func parseBenchConfig(provider, regions, resourceTypes string, enrichConcurrency, maxConcurrency int) (benchConfig, error) {
+	switch provider {
+	case "aws":
+		// supported
+	case "gcp":
+		return benchConfig{}, fmt.Errorf("--provider gcp is not yet supported by bench (needs service-account credential plumbing); use aws")
+	case "":
+		return benchConfig{}, fmt.Errorf("--provider is required (aws)")
+	default:
+		return benchConfig{}, fmt.Errorf("unknown --provider %q (aws)", provider)
+	}
+
+	resolvedRegions := expandAllSupportedAWSRegions(splitCSV(regions))
+	if len(resolvedRegions) == 0 {
+		return benchConfig{}, fmt.Errorf("--regions is required for --provider aws (comma-separated, or `all`)")
+	}
+	if enrichConcurrency < 0 {
+		return benchConfig{}, fmt.Errorf("--enrich-concurrency must be >= 0 (got %d); 0 uses the package default", enrichConcurrency)
+	}
+	if maxConcurrency <= 0 {
+		return benchConfig{}, fmt.Errorf("--max-concurrency must be positive (got %d)", maxConcurrency)
+	}
+
+	return benchConfig{
+		provider:          provider,
+		regions:           resolvedRegions,
+		resourceTypes:     splitCSV(resourceTypes),
+		enrichConcurrency: enrichConcurrency,
+		maxConcurrency:    maxConcurrency,
+	}, nil
+}
+
+// benchResult captures the per-phase timings + counts the summary renders.
+type benchResult struct {
+	provider         string
+	discoverConc     int
+	enrichConc       int
+	resourceCount    int
+	typeCount        int
+	enrichedCount    int
+	enrichErrorCount int
+	discoverDuration time.Duration
+	enrichDuration   time.Duration
+	totalDuration    time.Duration
+}
+
+// runBenchAWS drives the two-phase scan and times each phase. It mirrors
+// reliable's import_aws.go scan path: build aws.Config from ambient creds →
+// STS account ID → Provider.Discover → Provider.EnrichAttributes with the
+// chosen concurrency.
+func runBenchAWS(ctx context.Context, cfg benchConfig, endpointURL string, deps benchAWSDeps) (benchResult, error) {
+	// Build aws.Config against the first region — the SDK control plane
+	// points there; per-region fan-out inside DiscoverTypes overrides the
+	// region per call. Same construction discover uses.
+	awsCfg, err := deps.loadConfig(ctx, cfg.regions[0], endpointURL)
+	if err != nil {
+		return benchResult{}, fmt.Errorf("load aws config: %w", err)
+	}
+	accountID, err := deps.getAccount(ctx, awsCfg)
+	if err != nil {
+		return benchResult{}, fmt.Errorf("resolve account id via STS GetCallerIdentity: %w", err)
+	}
+
+	provider, clients := deps.newProvider(awsCfg, cfg.maxConcurrency, accountID)
+
+	types := cfg.resourceTypes
+	if len(types) == 0 {
+		types = provider.SupportedTypes()
+	}
+
+	res := benchResult{
+		provider:     cfg.provider,
+		discoverConc: cfg.maxConcurrency,
+		enrichConc:   cfg.enrichConcurrency,
+	}
+	wallStart := time.Now()
+
+	// Phase 1: discover (list identities).
+	discoverStart := time.Now()
+	irs, err := provider.Discover(ctx, types, clients, imp.DiscoverOpts{
+		Regions:   cfg.regions,
+		AccountID: accountID,
+	})
+	res.discoverDuration = time.Since(discoverStart)
+	if err != nil {
+		return res, fmt.Errorf("discover phase: %w", err)
+	}
+	res.resourceCount = len(irs)
+	res.typeCount = countDistinctTypes(irs)
+
+	// Phase 2: enrich (per-resource describe) at the chosen concurrency.
+	// EnrichAttributes accumulates per-resource errors into a joined error;
+	// a partial result is the expected, useful outcome here, so we record
+	// the joined error's presence but do NOT abort — the per-resource
+	// EnrichmentStatus stamps give the accurate enriched / failed counts.
+	enrichStart := time.Now()
+	enrichErr := provider.EnrichAttributes(ctx, irs, clients, imp.EnrichOpts{Concurrency: cfg.enrichConcurrency})
+	res.enrichDuration = time.Since(enrichStart)
+	_ = enrichErr // surfaced via the per-resource counts below
+
+	res.enrichedCount, res.enrichErrorCount = countEnrichOutcomes(irs)
+	res.totalDuration = time.Since(wallStart)
+	return res, nil
+}
+
+// countDistinctTypes returns the number of distinct Identity.Type values in
+// the discovered set — the "types" the discover-phase summary reports.
+func countDistinctTypes(irs []composerimported.ImportedResource) int {
+	seen := make(map[string]struct{}, len(irs))
+	for i := range irs {
+		seen[irs[i].Identity.Type] = struct{}{}
+	}
+	return len(seen)
+}
+
+// countEnrichOutcomes counts, over the enriched set, how many resources the
+// enricher fully populated vs. failed. EnrichAttributes stamps
+// Identity.EnrichmentStatus on every resource it dispatched an enricher for;
+// resources of types with no registered enricher keep the empty
+// (Unknown) status and are excluded from both counts — they were never
+// candidates for the enrich phase, so counting them would understate the
+// success rate.
+func countEnrichOutcomes(irs []composerimported.ImportedResource) (enriched, failed int) {
+	for i := range irs {
+		switch irs[i].Identity.EnrichmentStatus {
+		case composerimported.EnrichmentStatusFull, composerimported.EnrichmentStatusPartial:
+			enriched++
+		case composerimported.EnrichmentStatusFailed:
+			failed++
+		}
+	}
+	return enriched, failed
+}
+
+// summaryLines renders the compact, greppable per-phase + totals summary.
+// One line per phase, one totals line. Durations are rounded to 0.1s so the
+// output stays scannable; sub-second phases still show as e.g. 0.3s.
+func (r benchResult) summaryLines() []string {
+	return []string{
+		fmt.Sprintf("bench: phase=discover concurrency=%d resources=%d types=%d duration=%s",
+			r.discoverConc, r.resourceCount, r.typeCount, roundDur(r.discoverDuration)),
+		fmt.Sprintf("bench: phase=enrich concurrency=%d resources=%d enriched=%d errors=%d duration=%s",
+			r.enrichConc, r.resourceCount, r.enrichedCount, r.enrichErrorCount, roundDur(r.enrichDuration)),
+		fmt.Sprintf("bench: total provider=%s discover_concurrency=%d enrich_concurrency=%d resources=%d duration=%s",
+			r.provider, r.discoverConc, r.enrichConc, r.resourceCount, roundDur(r.totalDuration)),
+	}
+}
+
+// roundDur rounds a duration to the nearest 0.1s for human-scannable output.
+func roundDur(d time.Duration) time.Duration {
+	return d.Round(100 * time.Millisecond)
+}

--- a/cmd/insideout-import/bench_test.go
+++ b/cmd/insideout-import/bench_test.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+)
+
+func TestParseBenchConfig(t *testing.T) {
+	tests := []struct {
+		name              string
+		provider          string
+		regions           string
+		resourceTypes     string
+		enrichConcurrency int
+		maxConcurrency    int
+		wantErr           string
+		wantRegions       []string
+		wantTypes         []string
+		wantEnrichConc    int
+		wantMaxConc       int
+	}{
+		{
+			name:              "happy path single region",
+			provider:          "aws",
+			regions:           "us-east-1",
+			enrichConcurrency: 16,
+			maxConcurrency:    10,
+			wantRegions:       []string{"us-east-1"},
+			wantTypes:         nil,
+			wantEnrichConc:    16,
+			wantMaxConc:       10,
+		},
+		{
+			name:              "multi region + type subset trims whitespace",
+			provider:          "aws",
+			regions:           "us-east-1, us-west-2 ",
+			resourceTypes:     "aws_s3_bucket, aws_dynamodb_table",
+			enrichConcurrency: 8,
+			maxConcurrency:    4,
+			wantRegions:       []string{"us-east-1", "us-west-2"},
+			wantTypes:         []string{"aws_s3_bucket", "aws_dynamodb_table"},
+			wantEnrichConc:    8,
+			wantMaxConc:       4,
+		},
+		{
+			name:              "enrich concurrency 0 means package default (allowed)",
+			provider:          "aws",
+			regions:           "us-east-1",
+			enrichConcurrency: 0,
+			maxConcurrency:    10,
+			wantRegions:       []string{"us-east-1"},
+			wantEnrichConc:    0,
+			wantMaxConc:       10,
+		},
+		{
+			name:              "empty provider is fatal",
+			provider:          "",
+			regions:           "us-east-1",
+			enrichConcurrency: 16,
+			maxConcurrency:    10,
+			wantErr:           "--provider is required",
+		},
+		{
+			name:              "gcp not yet supported",
+			provider:          "gcp",
+			regions:           "europe-west1",
+			enrichConcurrency: 16,
+			maxConcurrency:    10,
+			wantErr:           "not yet supported",
+		},
+		{
+			name:              "unknown provider is fatal",
+			provider:          "azure",
+			regions:           "us-east-1",
+			enrichConcurrency: 16,
+			maxConcurrency:    10,
+			wantErr:           "unknown --provider",
+		},
+		{
+			name:              "missing regions is fatal for aws",
+			provider:          "aws",
+			regions:           "",
+			enrichConcurrency: 16,
+			maxConcurrency:    10,
+			wantErr:           "--regions is required",
+		},
+		{
+			name:              "negative enrich concurrency is fatal",
+			provider:          "aws",
+			regions:           "us-east-1",
+			enrichConcurrency: -1,
+			maxConcurrency:    10,
+			wantErr:           "--enrich-concurrency must be >= 0",
+		},
+		{
+			name:              "non-positive max concurrency is fatal",
+			provider:          "aws",
+			regions:           "us-east-1",
+			enrichConcurrency: 16,
+			maxConcurrency:    0,
+			wantErr:           "--max-concurrency must be positive",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseBenchConfig(tt.provider, tt.regions, tt.resourceTypes, tt.enrichConcurrency, tt.maxConcurrency)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRegions, cfg.regions)
+			assert.Equal(t, tt.wantTypes, cfg.resourceTypes)
+			assert.Equal(t, tt.wantEnrichConc, cfg.enrichConcurrency)
+			assert.Equal(t, tt.wantMaxConc, cfg.maxConcurrency)
+		})
+	}
+}
+
+func TestParseBenchConfigExpandsAllRegions(t *testing.T) {
+	cfg, err := parseBenchConfig("aws", "all", "", 16, 10)
+	require.NoError(t, err)
+	assert.Greater(t, len(cfg.regions), 1, "expected `all` to expand to the InsideOut-supported region set, got %v", cfg.regions)
+}
+
+func TestBenchResultSummaryLines(t *testing.T) {
+	r := benchResult{
+		provider:         "aws",
+		discoverConc:     10,
+		enrichConc:       16,
+		resourceCount:    512,
+		typeCount:        23,
+		enrichedCount:    500,
+		enrichErrorCount: 12,
+		discoverDuration: 18*time.Second + 400*time.Millisecond,
+		enrichDuration:   92*time.Second + 300*time.Millisecond,
+		totalDuration:    110*time.Second + 700*time.Millisecond,
+	}
+	got := r.summaryLines()
+	want := []string{
+		"bench: phase=discover concurrency=10 resources=512 types=23 duration=18.4s",
+		"bench: phase=enrich concurrency=16 resources=512 enriched=500 errors=12 duration=1m32.3s",
+		"bench: total provider=aws discover_concurrency=10 enrich_concurrency=16 resources=512 duration=1m50.7s",
+	}
+	assert.Equal(t, want, got)
+}
+
+func TestCountDistinctTypes(t *testing.T) {
+	irs := []composerimported.ImportedResource{
+		{Identity: composerimported.ResourceIdentity{Type: "aws_s3_bucket"}},
+		{Identity: composerimported.ResourceIdentity{Type: "aws_s3_bucket"}},
+		{Identity: composerimported.ResourceIdentity{Type: "aws_dynamodb_table"}},
+	}
+	assert.Equal(t, 2, countDistinctTypes(irs))
+	assert.Equal(t, 0, countDistinctTypes(nil))
+}
+
+func TestCountEnrichOutcomes(t *testing.T) {
+	irs := []composerimported.ImportedResource{
+		{Identity: composerimported.ResourceIdentity{EnrichmentStatus: composerimported.EnrichmentStatusFull}},
+		{Identity: composerimported.ResourceIdentity{EnrichmentStatus: composerimported.EnrichmentStatusPartial}},
+		{Identity: composerimported.ResourceIdentity{EnrichmentStatus: composerimported.EnrichmentStatusFailed}},
+		// Unknown / not-a-candidate types are excluded from both counts.
+		{Identity: composerimported.ResourceIdentity{EnrichmentStatus: composerimported.EnrichmentStatusUnknown}},
+		{Identity: composerimported.ResourceIdentity{}},
+	}
+	enriched, failed := countEnrichOutcomes(irs)
+	assert.Equal(t, 2, enriched)
+	assert.Equal(t, 1, failed)
+}
+
+// fakeProvider is a minimal imp.Provider that records its Discover /
+// EnrichAttributes inputs so the orchestrator can be tested without AWS. It
+// embeds the static zero-state Provider for the introspection half of the
+// interface (SupportedTypes etc.) and overrides only the two live methods
+// the benchmark drives.
+type fakeProvider struct {
+	imp.Provider
+	supported      []string
+	gotDiscoverTyp []string
+	gotEnrichConc  int
+	discoverResult []composerimported.ImportedResource
+	enrichErr      error
+	enrichStamper  func(irs []composerimported.ImportedResource)
+}
+
+func (f *fakeProvider) SupportedTypes() []string { return f.supported }
+
+func (f *fakeProvider) Discover(_ context.Context, types []string, _ imp.Clients, _ imp.DiscoverOpts) ([]composerimported.ImportedResource, error) {
+	f.gotDiscoverTyp = types
+	return f.discoverResult, nil
+}
+
+func (f *fakeProvider) EnrichAttributes(_ context.Context, irs []composerimported.ImportedResource, _ imp.Clients, opts ...imp.EnrichOpts) error {
+	if len(opts) > 0 {
+		f.gotEnrichConc = opts[0].Concurrency
+	}
+	if f.enrichStamper != nil {
+		f.enrichStamper(irs)
+	}
+	return f.enrichErr
+}
+
+func TestRunBenchAWSThreadsConcurrencyAndCounts(t *testing.T) {
+	fp := &fakeProvider{
+		supported: []string{"aws_s3_bucket", "aws_dynamodb_table"},
+		discoverResult: []composerimported.ImportedResource{
+			{Identity: composerimported.ResourceIdentity{Type: "aws_s3_bucket"}},
+			{Identity: composerimported.ResourceIdentity{Type: "aws_s3_bucket"}},
+			{Identity: composerimported.ResourceIdentity{Type: "aws_dynamodb_table"}},
+		},
+		// Stamp enrichment outcomes the way EnrichAttributes would.
+		enrichStamper: func(irs []composerimported.ImportedResource) {
+			irs[0].Identity.EnrichmentStatus = composerimported.EnrichmentStatusFull
+			irs[1].Identity.EnrichmentStatus = composerimported.EnrichmentStatusFailed
+			irs[2].Identity.EnrichmentStatus = composerimported.EnrichmentStatusFull
+		},
+		// A joined enrich error must NOT abort the run — it is data.
+		enrichErr: errors.New("enrich: 1 resource failed"),
+	}
+
+	deps := benchAWSDeps{
+		loadConfig: func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount: func(_ context.Context, _ aws.Config) (string, error) { return "123456789012", nil },
+		newProvider: func(_ aws.Config, _ int, _ string) (imp.Provider, imp.Clients) {
+			return fp, imp.Clients{}
+		},
+	}
+
+	cfg := benchConfig{
+		provider:          "aws",
+		regions:           []string{"us-east-1"},
+		resourceTypes:     nil, // exercise the SupportedTypes() default
+		enrichConcurrency: 7,
+		maxConcurrency:    5,
+	}
+
+	res, err := runBenchAWS(context.Background(), cfg, "", deps)
+	require.NoError(t, err, "runBenchAWS must not abort on a non-fatal joined enrich error")
+	assert.Equal(t, 7, fp.gotEnrichConc, "enrich concurrency must be threaded into EnrichOpts.Concurrency")
+	assert.True(t, slices.Equal(fp.gotDiscoverTyp, fp.supported), "nil --resource-types must default to SupportedTypes()")
+	assert.Equal(t, 3, res.resourceCount)
+	assert.Equal(t, 2, res.typeCount)
+	assert.Equal(t, 2, res.enrichedCount)
+	assert.Equal(t, 1, res.enrichErrorCount)
+	assert.Equal(t, 5, res.discoverConc)
+	assert.Equal(t, 7, res.enrichConc)
+}
+
+func TestRunBenchAWSDiscoverErrorIsFatal(t *testing.T) {
+	deps := benchAWSDeps{
+		loadConfig: func(_ context.Context, _, _ string) (aws.Config, error) { return aws.Config{}, nil },
+		getAccount: func(_ context.Context, _ aws.Config) (string, error) { return "123456789012", nil },
+		newProvider: func(_ aws.Config, _ int, _ string) (imp.Provider, imp.Clients) {
+			return &discoverErrProvider{}, imp.Clients{}
+		},
+	}
+	cfg := benchConfig{provider: "aws", regions: []string{"us-east-1"}, enrichConcurrency: 16, maxConcurrency: 10}
+	_, err := runBenchAWS(context.Background(), cfg, "", deps)
+	require.Error(t, err, "discover-phase error must be fatal")
+	assert.Contains(t, err.Error(), "discover phase")
+}
+
+type discoverErrProvider struct{ imp.Provider }
+
+func (discoverErrProvider) SupportedTypes() []string { return []string{"aws_s3_bucket"} }
+func (discoverErrProvider) Discover(_ context.Context, _ []string, _ imp.Clients, _ imp.DiscoverOpts) ([]composerimported.ImportedResource, error) {
+	return nil, errors.New("boom")
+}

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -29,21 +29,27 @@ import (
 )
 
 // defaultEnrichConcurrency bounds the per-resource cloud-API fan-out of
-// EnrichAttributes. Each enricher issues one or more GCP SDK round-trips
+// EnrichAttributes when the caller does not override it (EnrichOpts.
+// Concurrency == 0). Each enricher issues one or more GCP SDK round-trips
 // per resource; running them under a bounded worker pool turns the
 // previously serial ~1m30s pass on large accounts (~224 resources) into
 // a parallel one without unbounded fan-out hammering the GCP API rate
 // limits.
 //
-// Pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
+// Originally pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
 // which was lowered from 8 to 4 in #632 after 8 simultaneous t=0
 // kickoffs tripped CloudControl's per-account rate budget with a
-// ThrottlingException. GCP's per-project quotas are likewise burst-
-// sensitive, so the enrich phase inherits the same ceiling. 4 still
-// delivers roughly a 4x wall-time saving over the old serial pass —
-// the marginal speedup from 8 isn't worth re-introducing the throttle
-// risk.
-const defaultEnrichConcurrency = 4
+// ThrottlingException. Since then the enrich path retries rate-limit
+// errors with exponential backoff (enrichWithRetry) and aggregates
+// per-resource failures into partial results rather than failing the
+// whole scan — so a transient rate-limit costs a backoff sleep, not an
+// aborted pass. With that safety net a fan-out of 4 became the dominant
+// bottleneck on large accounts. Raised to 16 (mirroring the AWS default)
+// to cut enrich wall time roughly 4x; the per-resource backoff plus the
+// partial-result degradation make the higher fan-out safe. Callers that
+// need a different ceiling pass EnrichOpts.Concurrency, which flows down
+// to enrichConcurrency below.
+const defaultEnrichConcurrency = 16
 
 // defaultEnrichStartupJitterMax bounds the random sleep applied before
 // the first defaultEnrichConcurrency enrich goroutines issue their
@@ -302,6 +308,16 @@ func enrichWithRetry(ctx context.Context, fn func() error) error {
 	}
 }
 
+// EnrichAttrOpts carries optional tuning for EnrichAttributes. It is
+// passed variadically so existing four-argument callers
+// (EnrichAttributes(ctx, irs, clients, emitter)) keep compiling and
+// behaving exactly as before — the zero-opts path is unchanged.
+type EnrichAttrOpts struct {
+	// Concurrency overrides the per-resource enrich fan-out. 0 (the zero
+	// value) uses defaultEnrichConcurrency.
+	Concurrency int
+}
+
 // EnrichAttributes populates ir.Attrs in place for every imported
 // resource whose Identity.Type has a registered enricher. Resources
 // of types without a registered enricher are left untouched; the
@@ -331,9 +347,17 @@ func enrichWithRetry(ctx context.Context, fn func() error) error {
 // ServiceWarn per ErrEnrichClientUnavailable. The standard
 // (ServiceStart, ServiceFinish) pair brackets the whole batch under
 // enrichServiceSlug.
-func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients EnrichClients, emitter progress.Emitter) error {
+//
+// opts is variadic for back-compat: existing four-argument callers
+// (EnrichAttributes(ctx, irs, clients, emitter)) keep compiling and
+// behaving exactly as before — the zero-opts path is unchanged.
+func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.ImportedResource, clients EnrichClients, emitter progress.Emitter, opts ...EnrichAttrOpts) error {
 	if emitter == nil {
 		emitter = progress.NopEmitter{}
+	}
+	enrichConcurrency := defaultEnrichConcurrency
+	if len(opts) > 0 && opts[0].Concurrency > 0 {
+		enrichConcurrency = opts[0].Concurrency
 	}
 	stageStart := time.Now()
 	emitter.ServiceStart(enrichServiceSlug, "")
@@ -367,17 +391,17 @@ func (g *GCPDiscoverer) EnrichAttributes(ctx context.Context, irs []imported.Imp
 	// cancel early.
 	results := make([]error, len(idx))
 	var grp errgroup.Group
-	grp.SetLimit(defaultEnrichConcurrency)
+	grp.SetLimit(enrichConcurrency)
 	for pos, i := range idx {
 		enr := g.byTypeEnricher[irs[i].Identity.Type]
 		grp.Go(func() error {
 			// Jitter only the initial burst: the first
-			// defaultEnrichConcurrency goroutines start simultaneously
+			// enrichConcurrency goroutines start simultaneously
 			// at t=0, so their opening GCP calls would otherwise land
 			// together. Goroutines beyond that batch are already
 			// staggered by errgroup slot availability — jittering all
 			// of them would add tens of seconds of dead wall time.
-			if pos < defaultEnrichConcurrency {
+			if pos < enrichConcurrency {
 				sleep := time.Duration(rand.Int63n(int64(defaultEnrichStartupJitterMax)))
 				t := time.NewTimer(sleep)
 				select {

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -36,20 +36,21 @@ import (
 // a parallel one without unbounded fan-out hammering the GCP API rate
 // limits.
 //
-// Originally pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
+// Pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
 // which was lowered from 8 to 4 in #632 after 8 simultaneous t=0
 // kickoffs tripped CloudControl's per-account rate budget with a
-// ThrottlingException. Since then the enrich path retries rate-limit
-// errors with exponential backoff (enrichWithRetry) and aggregates
-// per-resource failures into partial results rather than failing the
-// whole scan — so a transient rate-limit costs a backoff sleep, not an
-// aborted pass. With that safety net a fan-out of 4 became the dominant
-// bottleneck on large accounts. Raised to 16 (mirroring the AWS default)
-// to cut enrich wall time roughly 4x; the per-resource backoff plus the
-// partial-result degradation make the higher fan-out safe. Callers that
-// need a different ceiling pass EnrichOpts.Concurrency, which flows down
-// to enrichConcurrency below.
-const defaultEnrichConcurrency = 16
+// ThrottlingException.
+//
+// We briefly raised this to 16 (mirroring the AWS default) on the
+// assumption enrich was goroutine-bound, but AWS benchmarking
+// (`insideout-import bench`) showed enrich wall time is flat across
+// concurrency 4 / 16 / 32 — the phase is bound by the SDK client-side
+// rate limiter, not the worker count. A higher default buys nothing on
+// throttling accounts and only risks tripping limits harder, so it stays
+// at 4 to keep parity with AWS. Callers with a quiet account that want
+// more fan-out can still pass EnrichOpts.Concurrency, which flows down to
+// enrichConcurrency below.
+const defaultEnrichConcurrency = 4
 
 // defaultEnrichStartupJitterMax bounds the random sleep applied before
 // the first defaultEnrichConcurrency enrich goroutines issue their

--- a/cmd/insideout-import/main.go
+++ b/cmd/insideout-import/main.go
@@ -19,6 +19,11 @@
 //	reverse   Run the provider-backed reverse-import SDK engine against a
 //	          selected resource request or imported.json manifest.
 //
+//	bench     Benchmark the discovery scan (DiscoverTypes +
+//	          EnrichAttributes) at a chosen enrich concurrency against a
+//	          real AWS account. Read-only; internal perf tuning tool for
+//	          the EnrichOpts.Concurrency knob (#731).
+//
 // Run `insideout-import <subcommand> --help` for subcommand flags.
 package main
 
@@ -39,6 +44,8 @@ func main() {
 		os.Exit(runDiscover(os.Args[2:]))
 	case "reverse":
 		os.Exit(runReverse(os.Args[2:]))
+	case "bench":
+		os.Exit(runBench(os.Args[2:]))
 	case "-h", "--help", "help":
 		usage()
 		os.Exit(0)
@@ -56,6 +63,7 @@ Subcommands:
   adopt     emit import {} blocks against a known preset stack
   discover  discover cloud resources, write imported.json, generate validated HCL, and loop drift fix (AWS only — Stages 2a+2b+2c1 of #189)
   reverse   run provider-backed reverse import against selected resources
+  bench     benchmark the discovery scan (DiscoverTypes + EnrichAttributes) at a chosen enrich concurrency (AWS; internal perf tool for #731)
 
 Run 'insideout-import <subcommand> --help' for subcommand flags.`)
 }

--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -229,10 +229,12 @@ func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.Imported
 		return err
 	}
 	var sink func(imp.DiscoverProgress)
+	var concurrency int
 	if len(opts) > 0 {
 		sink = opts[0].Progress
+		concurrency = opts[0].Concurrency
 	}
-	return p.d.EnrichAttributes(ctx, irs, aws, imp.NewProgressEmitter(sink))
+	return p.d.EnrichAttributes(ctx, irs, aws, imp.NewProgressEmitter(sink), awsdiscover.EnrichAttrOpts{Concurrency: concurrency})
 }
 
 // EnrichByID delegates to AWSDiscoverer.EnrichByID, mapping the

--- a/pkg/imported/gcp/provider.go
+++ b/pkg/imported/gcp/provider.go
@@ -179,10 +179,12 @@ func (p *Provider) EnrichAttributes(ctx context.Context, irs []imported.Imported
 		return err
 	}
 	var sink func(imp.DiscoverProgress)
+	var concurrency int
 	if len(opts) > 0 {
 		sink = opts[0].Progress
+		concurrency = opts[0].Concurrency
 	}
-	return p.d.EnrichAttributes(ctx, irs, gcp, imp.NewProgressEmitter(sink))
+	return p.d.EnrichAttributes(ctx, irs, gcp, imp.NewProgressEmitter(sink), gcpdiscover.EnrichAttrOpts{Concurrency: concurrency})
 }
 
 // EnrichByID delegates to GCPDiscoverer.EnrichByID, mapping the

--- a/pkg/imported/types.go
+++ b/pkg/imported/types.go
@@ -177,8 +177,13 @@ type DiscoverProgress struct {
 //   - Progress: optional per-Terraform-type completion sink, the enrich
 //     counterpart to DiscoverOpts.Progress. Events carry Phase="enrich".
 //     Nil = no progress.
+//   - Concurrency: bounds the per-resource enrich fan-out. 0 means use
+//     the package default.
 type EnrichOpts struct {
 	Progress func(DiscoverProgress)
+	// Concurrency bounds the per-resource enrich fan-out. 0 means use
+	// the package default.
+	Concurrency int
 }
 
 // TagSelector is a single operator-supplied tag/label equality


### PR DESCRIPTION
## What this does

Two things, both about understanding and tuning the reverse-import discovery scan:

1. Makes the per-resource enrich fan-out configurable via `EnrichOpts.Concurrency` (AWS + GCP), threaded down to the enrich errgroup's `SetLimit`.
2. Adds an `insideout-import bench` subcommand that times the exact path reliable's "Scan" step runs — `DiscoverTypes` (list identities) then `EnrichAttributes` (per-resource describe) — at a chosen concurrency, and categorizes the per-resource enrich errors (with sample messages).

## What the benchmark found (and why the default stays 4)

The original assumption was that the slow ~8-minute scan was bottlenecked on the enrich phase running at concurrency 4, so a higher default would help. Benchmarking against a real ~600-resource AWS account disproved it:

| enrich concurrency | enrich duration |
|---|---|
| 4 | ~1m25s |
| 16 | ~1m20s |
| 32 | ~1m17s |

Flat across an 8× concurrency range, with an identical 241 enriched / 366 failed at every setting. The enrich phase is bound by the SDK adaptive-retry client-side rate limiter, not the worker count — once the account throttles, extra goroutines just wait on the same token bucket. The same is true of the discover phase (type fan-out 4 vs 16 was also flat at ~2m45s).

So a higher default buys nothing on the accounts that are actually slow. **The default stays at 4.** The value of this PR is the configurable knob (for quiet accounts that genuinely benefit) plus the bench tool that produced the finding.

The enrich errors are also not a rate-limit problem: of 365 failures, exactly 1 was a throttle. The rest are structural (NotFound + other), i.e. resources CloudControl `GetResource` can't read — which is itself strong evidence for moving plannability to ui-core's terraform readback (see the fast-discovery initiative).

## Commits

- raise enrich concurrency default to 16, make it configurable (the original change)
- add `bench` subcommand
- keep enrich default at 4 (benchmark shows it's rate-limiter bound) + categorize enrich errors
- add per-category enrich-error sample messages to bench

Net diff vs main: default enrich concurrency unchanged (4), `EnrichOpts.Concurrency` knob added, `bench` subcommand added.

Part of the fast-discovery initiative — luthersystems/reliable#2040.
