### PR TITLE
Make reverse-import engine partial-tolerant (per-resource skip/fail + partial status)

### DIFF
--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -122,6 +122,18 @@ func providerOrDefault(p string) string {
 type Result struct {
 	GeneratedPath string
 	Resources     []imported.ImportedResource
+
+	// Skipped is every import block dropped during config generation
+	// because Terraform could not render a usable body for it
+	// (un-importable AWS/service-managed resources, orphan imports with
+	// no generated config). Each entry carries the dropped Terraform
+	// address, its import ID, and a reason code. Mirrors the per-region
+	// imports-skipped.json manifest(s); the reverse-import engine folds
+	// these into Result.Resources[] as ResourceStatusSkipped so the
+	// dropped identities are reported rather than silently disappearing
+	// from the import set (#732). Never nil-vs-empty sensitive — callers
+	// range over it.
+	Skipped []OrphanImport
 }
 
 // Run is the Stage 2b pipeline:
@@ -286,6 +298,7 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 	// regardless of which region finishes first.
 	type regionOut struct {
 		resources []imported.ImportedResource
+		skipped   []OrphanImport
 		subdir    string
 	}
 	outs := make([]regionOut, len(groups))
@@ -306,7 +319,7 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 			if err != nil {
 				return fmt.Errorf("genconfig region %s: %w", grp.region, err)
 			}
-			outs[i] = regionOut{resources: res.Resources, subdir: sub.Workdir}
+			outs[i] = regionOut{resources: res.Resources, skipped: res.Skipped, subdir: sub.Workdir}
 			return nil
 		})
 	}
@@ -315,8 +328,10 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 	}
 
 	merged := make([]imported.ImportedResource, 0)
+	var mergedSkipped []OrphanImport
 	subdirs := make([]string, 0, len(groups))
 	for _, o := range outs {
+		mergedSkipped = append(mergedSkipped, o.skipped...)
 		merged = append(merged, o.resources...)
 		subdirs = append(subdirs, o.subdir)
 	}
@@ -326,7 +341,7 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 		// artifact; the real per-region configs are in the subdirs.
 		fmt.Fprintf(os.Stderr, "genconfig: WARN: merged generated.tf: %v\n", err)
 	}
-	return &Result{GeneratedPath: genPath, Resources: merged}, nil
+	return &Result{GeneratedPath: genPath, Resources: merged, Skipped: mergedSkipped}, nil
 }
 
 // syncWriter serializes whole-line writes from concurrent per-region passes so
@@ -431,11 +446,11 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 		progressf(opts.Stdout, "genconfig: %s: generate-config-out wrote partial config after an error; continuing cleanup…\n", scope)
 	}
 
-	out, err := cleanValidateExtract(ctx, opts, runner, provider, scope, generatedPath, resources)
+	out, skipped, err := cleanValidateExtract(ctx, opts, runner, provider, scope, generatedPath, resources)
 	if err != nil {
 		return nil, err
 	}
-	return &Result{GeneratedPath: generatedPath, Resources: out}, nil
+	return &Result{GeneratedPath: generatedPath, Resources: out, Skipped: skipped}, nil
 }
 
 // cleanValidateExtract runs the post-generate-config-out half of the
@@ -450,23 +465,23 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 //
 // opts.Workdir must already contain imports.tf + providers.tf and an
 // initialized .terraform (the caller runs terraform init before calling).
-func cleanValidateExtract(ctx context.Context, opts Options, runner terraformRunner, provider, scope, generatedPath string, resources []imported.ImportedResource) ([]imported.ImportedResource, error) {
+func cleanValidateExtract(ctx context.Context, opts Options, runner terraformRunner, provider, scope, generatedPath string, resources []imported.ImportedResource) ([]imported.ImportedResource, []OrphanImport, error) {
 	progressf(opts.Stdout, "genconfig: %s: loading provider schema…\n", scope)
 	schemas, err := runner.ProvidersSchema(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("terraform providers schema: %w", err)
+		return nil, nil, fmt.Errorf("terraform providers schema: %w", err)
 	}
 
 	progressf(opts.Stdout, "genconfig: %s: reading generated terraform config…\n", scope)
 	raw, err := os.ReadFile(generatedPath)
 	if err != nil {
-		return nil, fmt.Errorf("read generated.tf: %w", err)
+		return nil, nil, fmt.Errorf("read generated.tf: %w", err)
 	}
 
 	progressf(opts.Stdout, "genconfig: %s: cleaning generated terraform config…\n", scope)
 	cleaned, err := cleanGenerated(raw, schemas, provider)
 	if err != nil {
-		return nil, fmt.Errorf("schema cleanup: %w", err)
+		return nil, nil, fmt.Errorf("schema cleanup: %w", err)
 	}
 
 	// Per-resource-type fixups for cases the schema alone can't describe
@@ -476,7 +491,7 @@ func cleanValidateExtract(ctx context.Context, opts Options, runner terraformRun
 	progressf(opts.Stdout, "genconfig: %s: applying resource type fixups…\n", scope)
 	fixed, err := applyResourceTypeFixupsReport(cleaned)
 	if err != nil {
-		return nil, fmt.Errorf("resource-type fixups: %w", err)
+		return nil, nil, fmt.Errorf("resource-type fixups: %w", err)
 	}
 	cleaned = fixed.HCL
 	for _, a := range fixed.Applied {
@@ -495,7 +510,7 @@ func cleanValidateExtract(ctx context.Context, opts Options, runner terraformRun
 	progressf(opts.Stdout, "genconfig: %s: pruning un-importable resources…\n", scope)
 	unimp, err := pruneUnimportable(opts.Workdir, cleaned)
 	if err != nil {
-		return nil, fmt.Errorf("un-importable prune: %w", err)
+		return nil, nil, fmt.Errorf("un-importable prune: %w", err)
 	}
 	cleaned = unimp.HCL
 	for _, s := range unimp.Skipped {
@@ -515,7 +530,7 @@ func cleanValidateExtract(ctx context.Context, opts Options, runner terraformRun
 	progressf(opts.Stdout, "genconfig: %s: pruning orphan imports…\n", scope)
 	orphans, err := pruneOrphanImports(opts.Workdir, cleaned)
 	if err != nil {
-		return nil, fmt.Errorf("orphan-import safety net: %w", err)
+		return nil, nil, fmt.Errorf("orphan-import safety net: %w", err)
 	}
 	for _, s := range orphans {
 		fmt.Fprintf(os.Stderr, "genconfig: WARN: dropped orphan import %s (id=%q, reason=%s) — terraform plan -generate-config-out produced no resource body\n",
@@ -539,25 +554,25 @@ func cleanValidateExtract(ctx context.Context, opts Options, runner terraformRun
 	progressf(opts.Stdout, "genconfig: %s: rewriting in-batch references…\n", scope)
 	cleaned, err = applyCrossRefs(cleaned, resources, provider)
 	if err != nil {
-		return nil, fmt.Errorf("cross-ref: %w", err)
+		return nil, nil, fmt.Errorf("cross-ref: %w", err)
 	}
 
 	if err := os.WriteFile(generatedPath, cleaned, 0o644); err != nil {
-		return nil, fmt.Errorf("rewrite generated.tf: %w", err)
+		return nil, nil, fmt.Errorf("rewrite generated.tf: %w", err)
 	}
 
 	progressf(opts.Stdout, "genconfig: %s: validating generated terraform config…\n", scope)
 	if err := runner.Validate(ctx); err != nil {
-		return nil, fmt.Errorf("terraform validate: %w", err)
+		return nil, nil, fmt.Errorf("terraform validate: %w", err)
 	}
 
 	progressf(opts.Stdout, "genconfig: %s: extracting generated attributes…\n", scope)
 	out, err := extractAttributes(cleaned, resources)
 	if err != nil {
-		return nil, fmt.Errorf("extract attributes: %w", err)
+		return nil, nil, fmt.Errorf("extract attributes: %w", err)
 	}
 	progressf(opts.Stdout, "genconfig: %s: complete (%d resource(s) retained)\n", scope, len(out))
-	return out, nil
+	return out, skipped, nil
 }
 
 func progressScope(opts Options) string {

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -341,6 +341,16 @@ func runMultiRegion(ctx context.Context, opts Options, groups []regionGroup) (*R
 		// artifact; the real per-region configs are in the subdirs.
 		fmt.Fprintf(os.Stderr, "genconfig: WARN: merged generated.tf: %v\n", err)
 	}
+	// Surface the merged orphan-skip manifest at the top level. Each region
+	// pass writes its own region-*/imports-skipped.json, but downstream
+	// consumers (reverseimport's addSkipManifestArtifact) only look at the
+	// top-level workdir — without this merged copy, multi-region orphan skips
+	// never reach the artifact set (#732).
+	if len(mergedSkipped) > 0 {
+		if _, werr := writeOrphanImportsManifest(opts.Workdir, mergedSkipped); werr != nil {
+			fmt.Fprintf(os.Stderr, "genconfig: WARN: merged imports-skipped.json: %v\n", werr)
+		}
+	}
 	return &Result{GeneratedPath: genPath, Resources: merged, Skipped: mergedSkipped}, nil
 }
 

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -2,6 +2,7 @@ package genconfig
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -839,6 +840,108 @@ func TestRun_MultiRegion(t *testing.T) {
 	// A combined generated.tf is assembled at the top level for the artifact.
 	if _, err := os.Stat(res.GeneratedPath); err != nil {
 		t.Errorf("merged top-level generated.tf missing: %v", err)
+	}
+}
+
+// orphanProneRegionRunner is regionAwareRunner that DROPS the body for any
+// import whose target address is in the orphan set — modeling a resource type
+// `terraform plan -generate-config-out` cannot render. The orphan-prune
+// post-pass then drops the import and records it in the region's
+// imports-skipped.json.
+type orphanProneRegionRunner struct {
+	fakeRunner
+	orphans map[string]struct{}
+}
+
+func (r *orphanProneRegionRunner) PlanGenerate(_ context.Context, generatedPath string) (bool, error) {
+	r.calls = append(r.calls, "plan")
+	r.planCalled++
+	r.generatedPath = generatedPath
+	importsTF, err := os.ReadFile(filepath.Join(filepath.Dir(generatedPath), importsFile))
+	if err != nil {
+		return false, err
+	}
+	var body strings.Builder
+	for _, m := range regexp.MustCompile(`to\s*=\s*aws_sqs_queue\.(\w+)`).FindAllStringSubmatch(string(importsTF), -1) {
+		if _, orphan := r.orphans["aws_sqs_queue."+m[1]]; orphan {
+			continue // no body → orphan-pruned
+		}
+		body.WriteString("resource \"aws_sqs_queue\" \"" + m[1] + "\" {\n  name = \"" + m[1] + "\"\n}\n")
+	}
+	if err := os.WriteFile(generatedPath, []byte(body.String()), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// TestRun_MultiRegion_MergesOrphanSkipManifest pins the P2 fix (#732): when
+// orphan imports are pruned in MORE THAN ONE region, the per-region
+// region-*/imports-skipped.json manifests must be merged into a single
+// top-level imports-skipped.json so the reverse-import engine's
+// addSkipManifestArtifact (which only inspects the top-level workdir) can
+// surface them. Result.Skipped must likewise carry every region's orphan.
+func TestRun_MultiRegion_MergesOrphanSkipManifest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	orphans := map[string]struct{}{
+		"aws_sqs_queue.east_orphan": {},
+		"aws_sqs_queue.west_orphan": {},
+	}
+	res, err := Run(context.Background(), Options{
+		Workdir: dir,
+		Region:  "us-east-1",
+		newRunner: func(_ string, _ io.Writer) (terraformRunner, error) {
+			return &orphanProneRegionRunner{
+				fakeRunner: fakeRunner{schemas: minimalAWSSchema()},
+				orphans:    orphans,
+			}, nil
+		},
+	}, []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east_keep", Region: "us-east-1", ImportID: "e-keep"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.east_orphan", Region: "us-east-1", ImportID: "e-orphan"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.west_keep", Region: "us-west-2", ImportID: "w-keep"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_sqs_queue", Address: "aws_sqs_queue.west_orphan", Region: "us-west-2", ImportID: "w-orphan"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Two resources survive (one per region); two orphans were pruned.
+	if len(res.Resources) != 2 {
+		t.Fatalf("want 2 surviving resources, got %d", len(res.Resources))
+	}
+	if len(res.Skipped) != 2 {
+		t.Fatalf("want 2 merged orphan skips in Result.Skipped, got %d: %#v", len(res.Skipped), res.Skipped)
+	}
+	gotSkipped := map[string]struct{}{}
+	for _, s := range res.Skipped {
+		gotSkipped[s.Address] = struct{}{}
+	}
+	for addr := range orphans {
+		if _, ok := gotSkipped[addr]; !ok {
+			t.Errorf("Result.Skipped missing orphan %q: %#v", addr, res.Skipped)
+		}
+	}
+	// The merged top-level manifest must exist and carry BOTH regions' orphans —
+	// this is the file addSkipManifestArtifact reads.
+	raw, err := os.ReadFile(filepath.Join(dir, orphanImportsFile))
+	if err != nil {
+		t.Fatalf("top-level merged imports-skipped.json missing: %v", err)
+	}
+	var wrapper orphanImportsWrapper
+	if err := json.Unmarshal(raw, &wrapper); err != nil {
+		t.Fatalf("decode merged imports-skipped.json: %v", err)
+	}
+	if len(wrapper.Imports) != 2 {
+		t.Fatalf("merged manifest want 2 orphans, got %d: %#v", len(wrapper.Imports), wrapper.Imports)
+	}
+	gotManifest := map[string]struct{}{}
+	for _, o := range wrapper.Imports {
+		gotManifest[o.Address] = struct{}{}
+	}
+	for addr := range orphans {
+		if _, ok := gotManifest[addr]; !ok {
+			t.Errorf("merged manifest missing orphan %q: %#v", addr, wrapper.Imports)
+		}
 	}
 }
 

--- a/cmd/insideout-import/genconfig/golden_stack_test.go
+++ b/cmd/insideout-import/genconfig/golden_stack_test.go
@@ -70,7 +70,7 @@ func TestGoldenStackValidates(t *testing.T) {
 	}
 
 	opts := Options{Workdir: work, Region: "us-east-1", Provider: ProviderAWS}
-	out, err := cleanValidateExtract(ctx, opts, runner, ProviderAWS, "golden:dario",
+	out, _, err := cleanValidateExtract(ctx, opts, runner, ProviderAWS, "golden:dario",
 		filepath.Join(work, generatedFile), resources)
 	if err != nil {
 		t.Fatalf("golden Dario stack failed the cleanup+validate pipeline — this is the #708 regression:\n%v", err)

--- a/pkg/reverseimport/partial.go
+++ b/pkg/reverseimport/partial.go
@@ -1,0 +1,306 @@
+package reverseimport
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	tfjson "github.com/hashicorp/terraform-json"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+// maxFinalPlanIterations bounds the iterative validate+plan loop. Mirrors
+// depchase.DefaultMaxIterations: in practice a partial-tolerant run drops a
+// small handful of non-plannable resources and converges in one or two extra
+// passes. The bound exists so a stack that keeps failing without ever
+// attributing the failure to a droppable resource surfaces as a fatal rather
+// than spinning. Each iteration re-emits imported.tf without the resources
+// attributed-as-failed so far and re-runs validate+plan.
+const maxFinalPlanIterations = 6
+
+// resourceFailure records one resource the iterative plan loop dropped because
+// it could not be planned/validated, plus the attributing diagnostic.
+type resourceFailure struct {
+	address    string
+	diagnostic job.Diagnostic
+}
+
+// attributeFinalPlanError maps a final validate/plan failure to the specific
+// resource address(es) responsible, drawing on whatever signal the failure
+// exposes:
+//
+//   - terraform validate -json diagnostics → Snippet.Context / Range.Filename
+//     name the offending resource block.
+//   - terraform plan stderr → the human-readable error block names the
+//     resource ("with TYPE.NAME," / `resource "TYPE" "NAME"`).
+//
+// Returns the attributable failures (deduped by address, only addresses that
+// match a resource currently in the set) and attributable=false when NO
+// failure could be tied to a resource in the set. An un-attributable failure
+// is systemic (provider/auth/global config) and the caller must abort rather
+// than emit a false partial.
+//
+// validateJSON may be empty (plan-stage failure) and planErr may be nil
+// (validate-stage failure); the caller passes whichever stage failed.
+func attributeFinalPlanError(validateJSON []byte, planErr error, addresses map[string]imported.ResourceIdentity) (failures []resourceFailure, attributable bool) {
+	seen := make(map[string]struct{})
+	add := func(addr string, diag job.Diagnostic) {
+		if addr == "" {
+			return
+		}
+		if _, ok := addresses[addr]; !ok {
+			return
+		}
+		if _, dup := seen[addr]; dup {
+			return
+		}
+		seen[addr] = struct{}{}
+		failures = append(failures, resourceFailure{address: addr, diagnostic: diag})
+	}
+
+	for _, vf := range attributeValidateDiagnostics(validateJSON, addresses) {
+		add(vf.address, vf.diagnostic)
+	}
+	if planErr != nil {
+		for _, pf := range attributePlanError(planErr, addresses) {
+			add(pf.address, pf.diagnostic)
+		}
+	}
+	return failures, len(failures) > 0
+}
+
+// attributeValidateDiagnostics parses terraform validate -json output and
+// returns one failure per error diagnostic that names a resource in the set.
+// Attribution uses Snippet.Context (the canonical `resource "TYPE" "NAME"`
+// block label terraform attaches to schema/argument diagnostics). Diagnostics
+// with no resource context (provider/var/module-level) yield nothing — the
+// caller treats the absence of any attributable diagnostic as systemic.
+func attributeValidateDiagnostics(validateJSON []byte, addresses map[string]imported.ResourceIdentity) []resourceFailure {
+	if len(validateJSON) == 0 {
+		return nil
+	}
+	var out tfjson.ValidateOutput
+	if err := json.Unmarshal(validateJSON, &out); err != nil {
+		return nil
+	}
+	var failures []resourceFailure
+	for _, d := range out.Diagnostics {
+		if d.Severity != tfjson.DiagnosticSeverityError {
+			continue
+		}
+		addr := addressFromValidateDiagnostic(d, addresses)
+		if addr == "" {
+			continue
+		}
+		failures = append(failures, resourceFailure{
+			address:    addr,
+			diagnostic: diagnosticFromValidate(addr, d),
+		})
+	}
+	return failures
+}
+
+// addressFromValidateDiagnostic extracts the resource address from a validate
+// diagnostic. The Snippet.Context string is the resource block header
+// (`resource "TYPE" "NAME"`), which maps directly to TYPE.NAME. Falls back to
+// scanning the Detail/Summary text for any known address.
+func addressFromValidateDiagnostic(d tfjson.Diagnostic, addresses map[string]imported.ResourceIdentity) string {
+	if d.Snippet != nil && d.Snippet.Context != nil {
+		if addr := addressFromResourceContext(*d.Snippet.Context); addr != "" {
+			if _, ok := addresses[addr]; ok {
+				return addr
+			}
+		}
+	}
+	// Some diagnostics (e.g. "Reference to undeclared resource") name the
+	// address only in Detail/Summary. Scan for any known address.
+	for _, text := range []string{d.Detail, d.Summary} {
+		if addr := firstKnownAddress(text, addresses); addr != "" {
+			return addr
+		}
+	}
+	return ""
+}
+
+// attributePlanError scans the captured terraform plan stderr for a resource
+// address. terraform plan does not emit machine-readable per-resource
+// diagnostics, but its error blocks consistently name the resource in one of
+// two shapes:
+//
+//	with aws_db_instance.main,
+//	on imported.tf line 12, in resource "aws_db_instance" "main":
+//
+// Both are matched. Only addresses present in the set count; anything else is
+// treated as systemic (returns no failures → caller aborts).
+func attributePlanError(planErr error, addresses map[string]imported.ResourceIdentity) []resourceFailure {
+	text := planStderr(planErr)
+	if text == "" {
+		text = planErr.Error()
+	}
+	if text == "" {
+		return nil
+	}
+	var failures []resourceFailure
+	seen := make(map[string]struct{})
+	emit := func(addr string) {
+		if addr == "" {
+			return
+		}
+		if _, ok := addresses[addr]; !ok {
+			return
+		}
+		if _, dup := seen[addr]; dup {
+			return
+		}
+		seen[addr] = struct{}{}
+		failures = append(failures, resourceFailure{
+			address:    addr,
+			diagnostic: diagnosticFromPlan(addr, text),
+		})
+	}
+	for _, m := range planWithAddressRE.FindAllStringSubmatch(text, -1) {
+		emit(m[1])
+	}
+	for _, m := range planResourceBlockRE.FindAllStringSubmatch(text, -1) {
+		emit(m[1] + "." + m[2])
+	}
+	return failures
+}
+
+// attributeFirstImportPlanIssues splits composer.ValidateFirstImportPlan
+// issues into per-resource (attributable, droppable) and un-attributable
+// buckets. A per-resource issue carries the address in its Field as
+// `plan.<address>` or `plan.<address>.<path>`. The two systemic codes —
+// imported_plan_unexpected_import_count (Field plan.imports) and
+// imported_plan_nil_input (Field plan) — are never attributable.
+func attributeFirstImportPlanIssues(issues []composer.ValidationIssue, addresses map[string]imported.ResourceIdentity) (perResource []resourceFailure, unattributable []composer.ValidationIssue) {
+	for _, issue := range issues {
+		addr := addressFromPlanField(issue.Field, addresses)
+		if addr == "" {
+			unattributable = append(unattributable, issue)
+			continue
+		}
+		perResource = append(perResource, resourceFailure{
+			address: addr,
+			diagnostic: job.Diagnostic{
+				Severity: "error",
+				Code:     issue.Code,
+				Field:    issue.Field,
+				Message:  planAcceptanceMessage(issue),
+			},
+		})
+	}
+	return perResource, unattributable
+}
+
+// addressFromPlanField extracts a resource address from a
+// composer.ValidationIssue.Field of the form `plan.<address>` or
+// `plan.<address>.<attr.path>`. The address is the longest `plan.`-stripped
+// prefix that matches a resource in the set, so an attribute path appended
+// after the address does not defeat the match.
+func addressFromPlanField(field string, addresses map[string]imported.ResourceIdentity) string {
+	const prefix = "plan."
+	if !strings.HasPrefix(field, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(field, prefix)
+	if rest == "" || rest == "imports" || rest == "resource_changes" {
+		return ""
+	}
+	// rest is "<type>.<name>" optionally followed by ".<attr.path>". A
+	// resource address is exactly the first two dotted segments.
+	parts := strings.Split(rest, ".")
+	if len(parts) < 2 {
+		return ""
+	}
+	addr := parts[0] + "." + parts[1]
+	if _, ok := addresses[addr]; ok {
+		return addr
+	}
+	return ""
+}
+
+// addressFromResourceContext turns a `resource "TYPE" "NAME"` block-header
+// string into the TYPE.NAME address. Returns "" for any other context shape
+// (variable/provider/module headers, malformed input).
+func addressFromResourceContext(context string) string {
+	m := resourceContextRE.FindStringSubmatch(context)
+	if m == nil {
+		return ""
+	}
+	return m[1] + "." + m[2]
+}
+
+// firstKnownAddress returns the first resource address from addresses that
+// appears verbatim in text. Longer addresses are matched first so a substring
+// collision (one address being a prefix of another) attributes to the more
+// specific one.
+func firstKnownAddress(text string, addresses map[string]imported.ResourceIdentity) string {
+	if text == "" {
+		return ""
+	}
+	best := ""
+	for addr := range addresses {
+		if strings.Contains(text, addr) && len(addr) > len(best) {
+			best = addr
+		}
+	}
+	return best
+}
+
+func diagnosticFromValidate(addr string, d tfjson.Diagnostic) job.Diagnostic {
+	msg := d.Summary
+	if d.Detail != "" {
+		if msg != "" {
+			msg += ": "
+		}
+		msg += d.Detail
+	}
+	if d.Range != nil && d.Range.Filename != "" {
+		msg = d.Range.Filename + ": " + msg
+	}
+	if msg == "" {
+		msg = "terraform validate rejected this resource"
+	}
+	return job.Diagnostic{
+		Severity: "error",
+		Code:     "reverse_import_validate_failed",
+		Field:    addr,
+		Message:  msg,
+	}
+}
+
+func diagnosticFromPlan(addr, text string) job.Diagnostic {
+	msg := strings.TrimSpace(text)
+	if msg == "" {
+		msg = "terraform plan rejected this resource"
+	}
+	return job.Diagnostic{
+		Severity: "error",
+		Code:     "reverse_import_plan_failed",
+		Field:    addr,
+		Message:  msg,
+	}
+}
+
+func planAcceptanceMessage(issue composer.ValidationIssue) string {
+	if issue.Reason != "" {
+		return issue.Reason
+	}
+	return "first-import plan contract rejected this resource: " + issue.Code
+}
+
+var (
+	// resourceContextRE matches a terraform validate Snippet.Context block
+	// header: `resource "aws_db_instance" "main"`.
+	resourceContextRE = regexp.MustCompile(`resource\s+"([a-zA-Z0-9_]+)"\s+"([a-zA-Z0-9_]+)"`)
+	// planResourceBlockRE matches the `in resource "TYPE" "NAME"` shape in a
+	// plan error block.
+	planResourceBlockRE = regexp.MustCompile(`resource\s+"([a-zA-Z0-9_]+)"\s+"([a-zA-Z0-9_]+)"`)
+	// planWithAddressRE matches terraform's `  with TYPE.NAME,` error
+	// attribution line.
+	planWithAddressRE = regexp.MustCompile(`(?m)^\s*with\s+([a-zA-Z0-9_]+\.[a-zA-Z0-9_]+)\s*,`)
+)

--- a/pkg/reverseimport/partial_results.go
+++ b/pkg/reverseimport/partial_results.go
@@ -1,0 +1,224 @@
+package reverseimport
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+// orphanImportsManifestFile is the genconfig skip manifest sibling, surfaced
+// as a reverse-import artifact so ui-core/reliable can inspect which import
+// blocks were dropped (#732). Kept in sync with
+// genconfig's orphanImportsFile constant (unexported there).
+const orphanImportsManifestFile = "imports-skipped.json"
+
+// skipEntry is one resource the engine could not import: dropped by genconfig
+// (skipped) or by the iterative final-plan loop / first-import contract
+// (failed). Preserves the identity so the per-resource ResourceResult carries
+// the same address/type/region the user selected.
+type skipEntry struct {
+	identity   imported.ResourceIdentity
+	status     job.ResourceStatus
+	diagnostic job.Diagnostic
+}
+
+// skipTracker accumulates skipped/failed resources across the run, keyed by
+// Terraform address so the same resource is never double-reported and a later
+// failure attribution wins over an earlier skip.
+type skipTracker struct {
+	order   []string
+	entries map[string]skipEntry
+}
+
+func newSkipTracker() *skipTracker {
+	return &skipTracker{entries: make(map[string]skipEntry)}
+}
+
+func (s *skipTracker) put(e skipEntry) {
+	addr := e.identity.Address
+	if addr == "" {
+		return
+	}
+	if _, ok := s.entries[addr]; !ok {
+		s.order = append(s.order, addr)
+	}
+	s.entries[addr] = e
+}
+
+// addOrphanImports folds genconfig's skip manifest into the tracker. Each
+// dropped import block becomes a ResourceStatusSkipped entry with the genconfig
+// reason. The known map resolves the dropped Terraform address back to the rich
+// identity the user selected; a manifest entry with no matching identity still
+// produces a minimal identity from the address so it is not lost.
+func (s *skipTracker) addOrphanImports(known map[string]imported.ResourceIdentity, skipped []genconfig.OrphanImport) {
+	for _, o := range skipped {
+		id, ok := known[o.Address]
+		if !ok {
+			id = imported.ResourceIdentity{Address: o.Address, ImportID: o.ImportID}
+		}
+		s.put(skipEntry{
+			identity: id,
+			status:   job.ResourceStatusSkipped,
+			diagnostic: job.Diagnostic{
+				Severity: "warning",
+				Code:     "reverse_import_skipped_" + skipReasonCode(o.Reason),
+				Field:    o.Address,
+				Message:  skipReasonMessage(o),
+			},
+		})
+	}
+}
+
+// addMissing records any identity that entered config generation but is absent
+// from the surviving set and was not already tracked. This is the safety net
+// for a drop that produced no manifest entry, so nothing disappears silently.
+func (s *skipTracker) addMissing(pre map[string]imported.ResourceIdentity, surviving []imported.ImportedResource) {
+	live := make(map[string]struct{}, len(surviving))
+	for _, r := range surviving {
+		live[r.Identity.Address] = struct{}{}
+	}
+	for addr, id := range pre {
+		if _, stillThere := live[addr]; stillThere {
+			continue
+		}
+		if _, tracked := s.entries[addr]; tracked {
+			continue
+		}
+		s.put(skipEntry{
+			identity: id,
+			status:   job.ResourceStatusSkipped,
+			diagnostic: job.Diagnostic{
+				Severity: "warning",
+				Code:     "reverse_import_skipped_no_generated_config",
+				Field:    addr,
+				Message:  "terraform config generation dropped this resource (no generated body)",
+			},
+		})
+	}
+}
+
+// markFailed records a resource the final-plan/validate loop or the
+// first-import contract attributed a failure to.
+func (s *skipTracker) markFailed(id imported.ResourceIdentity, diag job.Diagnostic) {
+	s.put(skipEntry{identity: id, status: job.ResourceStatusFailed, diagnostic: diag})
+}
+
+func (s *skipTracker) counts() (skipped, failed int) {
+	for _, addr := range s.order {
+		switch s.entries[addr].status {
+		case job.ResourceStatusSkipped:
+			skipped++
+		case job.ResourceStatusFailed:
+			failed++
+		}
+	}
+	return skipped, failed
+}
+
+// identitiesByAddress indexes the resource set by Terraform address for
+// attribution and identity recovery.
+func identitiesByAddress(resources []imported.ImportedResource) map[string]imported.ResourceIdentity {
+	out := make(map[string]imported.ResourceIdentity, len(resources))
+	for _, r := range resources {
+		if r.Identity.Address != "" {
+			out[r.Identity.Address] = r.Identity
+		}
+	}
+	return out
+}
+
+// dropResources returns resources with every address in failures removed,
+// preserving order. The input slice is not mutated.
+func dropResources(resources []imported.ImportedResource, failures []resourceFailure) []imported.ImportedResource {
+	if len(failures) == 0 {
+		return resources
+	}
+	drop := make(map[string]struct{}, len(failures))
+	for _, f := range failures {
+		drop[f.address] = struct{}{}
+	}
+	out := make([]imported.ImportedResource, 0, len(resources))
+	for _, r := range resources {
+		if _, gone := drop[r.Identity.Address]; gone {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// combinedResourceResults builds the per-resource Result.Resources[] slice:
+// one ResourceStatusImported entry per surviving resource plus one
+// skipped/failed entry per tracked drop. Imported entries carry their
+// dependencies; skipped/failed entries carry the attributing diagnostic.
+func combinedResourceResults(resources []imported.ImportedResource, dependenciesByAddress map[string][]imported.ResourceIdentity, skips *skipTracker) []job.ResourceResult {
+	out := make([]job.ResourceResult, 0, len(resources)+len(skips.order))
+	for _, r := range resources {
+		rr := r
+		out = append(out, job.ResourceResult{
+			Identity:     r.Identity,
+			Status:       job.ResourceStatusImported,
+			Imported:     &rr,
+			Dependencies: dependenciesByAddress[r.Identity.Address],
+		})
+	}
+	for _, addr := range skips.order {
+		e := skips.entries[addr]
+		out = append(out, job.ResourceResult{
+			Identity:    e.identity,
+			Status:      e.status,
+			Diagnostics: []job.Diagnostic{e.diagnostic},
+		})
+	}
+	return out
+}
+
+// finalStatus computes the truthful job status (#732):
+//   - all selected resources imported (no skips/failures) → succeeded
+//   - at least one imported AND at least one skipped/failed → partial
+//   - zero imported → failed
+func finalStatus(importedCount int, skips *skipTracker) job.Status {
+	skipped, failed := skips.counts()
+	if importedCount == 0 {
+		return job.StatusFailed
+	}
+	if skipped+failed > 0 {
+		return job.StatusPartial
+	}
+	return job.StatusSucceeded
+}
+
+// addSkipManifestArtifact attaches genconfig's imports-skipped.json (when it
+// exists in the genconfig workdir) to the result's debug artifacts so the
+// dropped-imports manifest travels with the run.
+func addSkipManifestArtifact(result *job.Result, workdir string) {
+	if workdir == "" {
+		return
+	}
+	path := filepath.Join(workdir, orphanImportsManifestFile)
+	if _, err := os.Stat(path); err != nil {
+		return
+	}
+	if a, err := artifact(path, "application/json"); err == nil {
+		result.Artifacts.Debug = append(result.Artifacts.Debug, *a)
+	}
+}
+
+func skipReasonCode(reason string) string {
+	if reason == "" {
+		return "no_generated_config"
+	}
+	return reason
+}
+
+func skipReasonMessage(o genconfig.OrphanImport) string {
+	switch o.Reason {
+	case "no_generated_config", "":
+		return "terraform plan -generate-config-out produced no resource body for this import; dropped"
+	default:
+		return "import dropped during config generation (" + o.Reason + ")"
+	}
+}

--- a/pkg/reverseimport/partial_test.go
+++ b/pkg/reverseimport/partial_test.go
@@ -1,0 +1,403 @@
+package reverseimport
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+// twoQueueRequest is a two-resource AWS SQS selection used by the
+// partial-tolerance tests. Both resources get a generated body from
+// multiResourceGenconfig.
+func twoQueueRequest() job.Request {
+	return job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.good",
+					ImportID: "https://sqs.us-east-1.amazonaws.com/123/good",
+					Region:   "us-east-1",
+				},
+				Tier:   imported.TierImportedFlat,
+				Source: imported.SourceImporter,
+			},
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_sqs_queue",
+					Address:  "aws_sqs_queue.bad",
+					ImportID: "https://sqs.us-east-1.amazonaws.com/123/bad",
+					Region:   "us-east-1",
+				},
+				Tier:   imported.TierImportedFlat,
+				Source: imported.SourceImporter,
+			},
+		},
+	}
+}
+
+// multiResourceGenconfig is a genconfig double that renders a body for every
+// input resource (no skips) and stamps a minimal attr bag so EmitImportedTF
+// produces a real resource block. skip lists addresses to drop from the result
+// + report in Result.Skipped (orphan-skip surfacing test).
+func multiResourceGenconfig(skip ...string) func(context.Context, genconfig.Options, []imported.ImportedResource) (*genconfig.Result, error) {
+	skipped := map[string]struct{}{}
+	for _, s := range skip {
+		skipped[s] = struct{}{}
+	}
+	return func(_ context.Context, opts genconfig.Options, resources []imported.ImportedResource) (*genconfig.Result, error) {
+		if err := os.MkdirAll(opts.Workdir, 0o755); err != nil {
+			return nil, err
+		}
+		generatedPath := filepath.Join(opts.Workdir, "generated.tf")
+		if err := os.WriteFile(generatedPath, []byte("# generated\n"), 0o644); err != nil {
+			return nil, err
+		}
+		_ = os.WriteFile(filepath.Join(opts.Workdir, "imports.tf"), []byte("import {}\n"), 0o644)
+		_ = os.WriteFile(filepath.Join(opts.Workdir, "providers.tf"), []byte("terraform {}\n"), 0o644)
+
+		var out []imported.ImportedResource
+		var drops []genconfig.OrphanImport
+		for _, r := range resources {
+			if _, gone := skipped[r.Identity.Address]; gone {
+				drops = append(drops, genconfig.OrphanImport{
+					Address:  r.Identity.Address,
+					ImportID: r.Identity.ImportID,
+					Reason:   "no_generated_config",
+				})
+				continue
+			}
+			rr := r
+			if len(rr.Attrs) == 0 {
+				rr.Attrs = []byte(fmt.Sprintf(`{"name":{"literal":%q}}`, labelOf(rr.Identity.Address)))
+			}
+			out = append(out, rr)
+		}
+		// Mirror genconfig's manifest-on-disk behavior so the artifact path
+		// is exercised.
+		if len(drops) > 0 {
+			writeSkipManifest(opts.Workdir, drops)
+		}
+		return &genconfig.Result{GeneratedPath: generatedPath, Resources: out, Skipped: drops}, nil
+	}
+}
+
+func writeSkipManifest(workdir string, drops []genconfig.OrphanImport) {
+	var b strings.Builder
+	b.WriteString(`{"imports":[`)
+	for i, d := range drops {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		fmt.Fprintf(&b, `{"address":%q,"import_id":%q,"reason":%q}`, d.Address, d.ImportID, d.Reason)
+	}
+	b.WriteString("]}\n")
+	_ = os.WriteFile(filepath.Join(workdir, "imports-skipped.json"), []byte(b.String()), 0o644)
+}
+
+func labelOf(address string) string {
+	idx := strings.Index(address, ".")
+	if idx < 0 {
+		return address
+	}
+	return address[idx+1:]
+}
+
+// importedTFAddressRE finds resource block addresses in an emitted imported.tf.
+var importedTFAddressRE = regexp.MustCompile(`resource\s+"([a-zA-Z0-9_]+)"\s+"([a-zA-Z0-9_]+)"`)
+
+// survivingAddresses reads imported.tf in dir and returns the set of resource
+// addresses it declares. The partial-aware terraform double uses this to know
+// which resources are still in play after the engine drops one.
+func survivingAddresses(t *testing.T, dir string) map[string]struct{} {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, importedTFFile))
+	if err != nil {
+		t.Fatalf("read imported.tf: %v", err)
+	}
+	out := map[string]struct{}{}
+	for _, m := range importedTFAddressRE.FindAllStringSubmatch(string(raw), -1) {
+		out[m[1]+"."+m[2]] = struct{}{}
+	}
+	return out
+}
+
+// partialTerraformRunner is a terraform double that:
+//   - fails `terraform plan` (with stderr naming the offending resource) while
+//     failPlanAddr is still declared in imported.tf — modeling a resource
+//     terraform cannot plan. Once the engine drops it, plan succeeds.
+//   - fails `terraform validate` (with a resource-context diagnostic) while
+//     failValidateAddr is still declared.
+//   - always emits one no-op import change per surviving resource so the
+//     first-import contract's import-count check passes.
+//   - systemic=true makes plan fail with NO resource attribution (provider/auth
+//     error) to model an un-attributable abort.
+type partialTerraformRunner struct {
+	t                *testing.T
+	dir              string
+	failPlanAddr     string
+	failValidateAddr string
+	systemic         bool
+}
+
+func (partialTerraformRunner) Init(context.Context, string) error { return nil }
+
+func (r partialTerraformRunner) Validate(context.Context, string) ([]byte, error) {
+	if r.failValidateAddr == "" {
+		return []byte(`{"valid":true,"diagnostics":[]}`), nil
+	}
+	if _, present := survivingAddresses(r.t, r.dir)[r.failValidateAddr]; !present {
+		return []byte(`{"valid":true,"diagnostics":[]}`), nil
+	}
+	typ, name := splitAddr(r.failValidateAddr)
+	out := fmt.Sprintf(`{
+  "format_version": "1.0",
+  "valid": false,
+  "error_count": 1,
+  "warning_count": 0,
+  "diagnostics": [
+    {
+      "severity": "error",
+      "summary": "Unsupported argument",
+      "detail": "An argument named \"bogus\" is not expected here.",
+      "range": {"filename": "imported.tf", "start": {"line": 3, "column": 3, "byte": 40}, "end": {"line": 3, "column": 8, "byte": 45}},
+      "snippet": {"context": "resource \"%s\" \"%s\"", "code": "  bogus = true", "start_line": 3, "highlight_start_offset": 2, "highlight_end_offset": 7, "values": []}
+    }
+  ]
+}`, typ, name)
+	// validate -json output is captured on stdout; the runner returns it as
+	// the bytes AND an error to signal the failing exit code.
+	return []byte(out), fmt.Errorf("terraform validate: configuration is invalid")
+}
+
+func (r partialTerraformRunner) Plan(_ context.Context, _, _ string) error {
+	if r.systemic {
+		return &planOutputError{
+			output: "Error: configuring Terraform AWS Provider: no valid credential sources found",
+			err:    fmt.Errorf("terraform plan: exit status 1"),
+		}
+	}
+	if r.failPlanAddr == "" {
+		return nil
+	}
+	if _, present := survivingAddresses(r.t, r.dir)[r.failPlanAddr]; !present {
+		return nil
+	}
+	return &planOutputError{
+		output: fmt.Sprintf("Error: Invalid resource for import\n\n  with %s,\n  on imported.tf line 2, in resource %q %q:\n   2:   name = \"x\"\n\nThis resource cannot be imported.",
+			r.failPlanAddr, mustType(r.failPlanAddr), mustName(r.failPlanAddr)),
+		err: fmt.Errorf("terraform plan: exit status 1"),
+	}
+}
+
+func (r partialTerraformRunner) ShowPlanJSON(_ context.Context, _, _ string) ([]byte, error) {
+	addrs := survivingAddresses(r.t, r.dir)
+	var changes []string
+	for addr := range addrs {
+		typ, name := splitAddr(addr)
+		changes = append(changes, fmt.Sprintf(`{
+      "address": %q,
+      "mode": "managed",
+      "type": %q,
+      "name": %q,
+      "change": {
+        "actions": ["no-op"],
+        "before": null,
+        "after": null,
+        "after_unknown": {},
+        "importing": {"id": "id-%s"}
+      }
+    }`, addr, typ, name, name))
+	}
+	return []byte(fmt.Sprintf(`{
+  "format_version": "1.2",
+  "terraform_version": "1.13.0",
+  "resource_changes": [%s]
+}`, strings.Join(changes, ","))), nil
+}
+
+func splitAddr(addr string) (typ, name string) {
+	idx := strings.Index(addr, ".")
+	if idx < 0 {
+		return addr, ""
+	}
+	return addr[:idx], addr[idx+1:]
+}
+
+func mustType(addr string) string { t, _ := splitAddr(addr); return t }
+func mustName(addr string) string { _, n := splitAddr(addr); return n }
+
+// TestRunPartialOnPlanFailure: one resource fails terraform plan; the other
+// imports, the bad one is reported failed with a diagnostic, Status == partial,
+// and Run returns no error (so the mars wrapper exits 0).
+func TestRunPartialOnPlanFailure(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Run(context.Background(), twoQueueRequest(), Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: multiResourceGenconfig(),
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           partialTerraformRunner{t: t, dir: dir, failPlanAddr: "aws_sqs_queue.bad"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error for a partial result: %v", err)
+	}
+	if result.Status != job.StatusPartial {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusPartial)
+	}
+	good, ok := resourceResultByAddress(result.Resources, "aws_sqs_queue.good")
+	if !ok || good.Status != job.ResourceStatusImported {
+		t.Fatalf("good resource not imported: %#v", good)
+	}
+	bad, ok := resourceResultByAddress(result.Resources, "aws_sqs_queue.bad")
+	if !ok || bad.Status != job.ResourceStatusFailed {
+		t.Fatalf("bad resource not failed: %#v", bad)
+	}
+	if len(bad.Diagnostics) == 0 || !strings.Contains(bad.Diagnostics[0].Message, "cannot be imported") {
+		t.Fatalf("bad resource missing plan diagnostic: %#v", bad.Diagnostics)
+	}
+	if result.PlanSummary.ImportCount != 1 {
+		t.Fatalf("ImportCount = %d, want 1 (only the good resource)", result.PlanSummary.ImportCount)
+	}
+}
+
+// TestRunPartialOnValidateFailure: same as above but the failure surfaces in
+// terraform validate; attribution comes from the validate diagnostic's
+// resource-context snippet.
+func TestRunPartialOnValidateFailure(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Run(context.Background(), twoQueueRequest(), Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: multiResourceGenconfig(),
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           partialTerraformRunner{t: t, dir: dir, failValidateAddr: "aws_sqs_queue.bad"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error for a partial result: %v", err)
+	}
+	if result.Status != job.StatusPartial {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusPartial)
+	}
+	bad, ok := resourceResultByAddress(result.Resources, "aws_sqs_queue.bad")
+	if !ok || bad.Status != job.ResourceStatusFailed {
+		t.Fatalf("bad resource not failed: %#v", bad)
+	}
+	if len(bad.Diagnostics) == 0 || bad.Diagnostics[0].Code != "reverse_import_validate_failed" {
+		t.Fatalf("bad resource missing validate diagnostic: %#v", bad.Diagnostics)
+	}
+}
+
+// TestRunPartialOnGenconfigSkip: genconfig drops a resource (no generated
+// body); it is reported skipped, the rest import, Status == partial, no error,
+// and the skip manifest is attached as an artifact.
+func TestRunPartialOnGenconfigSkip(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Run(context.Background(), twoQueueRequest(), Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: multiResourceGenconfig("aws_sqs_queue.bad"),
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           partialTerraformRunner{t: t, dir: dir},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error for a partial result: %v", err)
+	}
+	if result.Status != job.StatusPartial {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusPartial)
+	}
+	skipped, ok := resourceResultByAddress(result.Resources, "aws_sqs_queue.bad")
+	if !ok || skipped.Status != job.ResourceStatusSkipped {
+		t.Fatalf("dropped resource not skipped: %#v", skipped)
+	}
+	if len(skipped.Diagnostics) == 0 {
+		t.Fatalf("skipped resource missing diagnostic: %#v", skipped)
+	}
+	good, ok := resourceResultByAddress(result.Resources, "aws_sqs_queue.good")
+	if !ok || good.Status != job.ResourceStatusImported {
+		t.Fatalf("good resource not imported: %#v", good)
+	}
+	// The skip manifest should be attached as a debug artifact.
+	foundManifest := false
+	for _, a := range result.Artifacts.Debug {
+		if a.Name == "imports-skipped.json" {
+			foundManifest = true
+		}
+	}
+	if !foundManifest {
+		t.Fatalf("imports-skipped.json not attached as artifact: %#v", result.Artifacts.Debug)
+	}
+}
+
+// TestRunFailsOnUnattributableError: a systemic terraform error (no resource
+// attribution) must still fail the whole job — no false partial.
+func TestRunFailsOnUnattributableError(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Run(context.Background(), twoQueueRequest(), Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: multiResourceGenconfig(),
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           partialTerraformRunner{t: t, dir: dir, systemic: true},
+		},
+	})
+	if err == nil {
+		t.Fatal("Run returned nil error for a systemic (un-attributable) failure")
+	}
+	if result.Status != job.StatusFailed {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusFailed)
+	}
+}
+
+// TestRunSucceedsAllGood: a clean two-resource set imports both with no skips,
+// Status == succeeded.
+func TestRunSucceedsAllGood(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Run(context.Background(), twoQueueRequest(), Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: multiResourceGenconfig(),
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           partialTerraformRunner{t: t, dir: dir},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Status != job.StatusSucceeded {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusSucceeded)
+	}
+	if result.PlanSummary.ImportCount != 2 {
+		t.Fatalf("ImportCount = %d, want 2", result.PlanSummary.ImportCount)
+	}
+	for _, addr := range []string{"aws_sqs_queue.good", "aws_sqs_queue.bad"} {
+		rr, ok := resourceResultByAddress(result.Resources, addr)
+		if !ok || rr.Status != job.ResourceStatusImported {
+			t.Fatalf("%s not imported: %#v", addr, rr)
+		}
+	}
+}

--- a/pkg/reverseimport/partial_test.go
+++ b/pkg/reverseimport/partial_test.go
@@ -2,6 +2,7 @@ package reverseimport
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -238,6 +239,106 @@ func splitAddr(addr string) (typ, name string) {
 func mustType(addr string) string { t, _ := splitAddr(addr); return t }
 func mustName(addr string) string { _, n := splitAddr(addr); return n }
 
+// firstImportContractRunner is a terraform double whose validate + plan always
+// succeed, but whose plan JSON makes designated resources VIOLATE the
+// first-import contract (they appear as a non-import `create` change rather than
+// an import no-op → composer flags imported_plan_unexpected_create, attributable
+// to plan.<address>).
+//
+// violators is ordered and revealed one at a time: violators[i] is emitted as a
+// contract violation only once every violators[<i] has already been dropped from
+// imported.tf. So the FIRST plan flags only violators[0]; after the engine drops
+// it and re-plans, violators[1] surfaces as a NEW attributable violation, and so
+// on. This is the regression model for the iterative first-import-contract
+// pruning fix (#732): the old code rechecked the trimmed plan but discarded the
+// result, so a second-wave contract violation slipped through to a false partial.
+type firstImportContractRunner struct {
+	t         *testing.T
+	dir       string
+	violators []string
+}
+
+func (firstImportContractRunner) Init(context.Context, string) error { return nil }
+
+func (firstImportContractRunner) Validate(context.Context, string) ([]byte, error) {
+	return []byte(`{"valid":true,"diagnostics":[]}`), nil
+}
+
+func (firstImportContractRunner) Plan(context.Context, string, string) error { return nil }
+
+// activeViolator returns the violator that should currently be flagged: the
+// first one in violators that is still declared in imported.tf. Earlier
+// violators must already be gone (dropped) for a later one to activate.
+func (r firstImportContractRunner) activeViolator(surviving map[string]struct{}) string {
+	for _, v := range r.violators {
+		if _, present := surviving[v]; present {
+			return v
+		}
+	}
+	return ""
+}
+
+func (r firstImportContractRunner) ShowPlanJSON(_ context.Context, _, _ string) ([]byte, error) {
+	surviving := survivingAddresses(r.t, r.dir)
+	active := r.activeViolator(surviving)
+	var changes []string
+	for addr := range surviving {
+		typ, name := splitAddr(addr)
+		if addr == active {
+			// Non-import create → violates the first-import contract.
+			changes = append(changes, fmt.Sprintf(`{
+      "address": %q,
+      "mode": "managed",
+      "type": %q,
+      "name": %q,
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {"name": %q},
+        "after_unknown": {}
+      }
+    }`, addr, typ, name, name))
+			continue
+		}
+		changes = append(changes, fmt.Sprintf(`{
+      "address": %q,
+      "mode": "managed",
+      "type": %q,
+      "name": %q,
+      "change": {
+        "actions": ["no-op"],
+        "before": null,
+        "after": null,
+        "after_unknown": {},
+        "importing": {"id": "id-%s"}
+      }
+    }`, addr, typ, name, name))
+	}
+	return []byte(fmt.Sprintf(`{
+  "format_version": "1.2",
+  "terraform_version": "1.13.0",
+  "resource_changes": [%s]
+}`, strings.Join(changes, ","))), nil
+}
+
+// threeQueueRequest is a three-resource AWS SQS selection used by the
+// iterative first-import-contract pruning test.
+func threeQueueRequest() job.Request {
+	req := twoQueueRequest()
+	req.Resources = append(req.Resources, job.ResourceSpec{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  "aws_sqs_queue.ugly",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/ugly",
+			Region:   "us-east-1",
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	})
+	return req
+}
+
 // TestRunPartialOnPlanFailure: one resource fails terraform plan; the other
 // imports, the bad one is reported failed with a diagnostic, Status == partial,
 // and Run returns no error (so the mars wrapper exits 0).
@@ -272,6 +373,13 @@ func TestRunPartialOnPlanFailure(t *testing.T) {
 	}
 	if result.PlanSummary.ImportCount != 1 {
 		t.Fatalf("ImportCount = %d, want 1 (only the good resource)", result.PlanSummary.ImportCount)
+	}
+	// imported.json must reflect the converged set after a final-plan drop —
+	// the failed resource must not linger in the published artifact (P1
+	// stale-imported.json fix #732).
+	persisted := readImportedJSON(t, dir)
+	if len(persisted) != 1 || persisted[0].Identity.Address != "aws_sqs_queue.good" {
+		t.Fatalf("imported.json should list only the surviving resource after a final-plan drop, got: %#v", persisted)
 	}
 }
 
@@ -400,4 +508,107 @@ func TestRunSucceedsAllGood(t *testing.T) {
 			t.Fatalf("%s not imported: %#v", addr, rr)
 		}
 	}
+}
+
+// TestRunPartialOnIterativeFirstImportContract is the load-bearing regression
+// for the P1 first-import-contract recheck bug (#732): after dropping a
+// contract-violating resource and re-planning, the trimmed plan can surface a
+// SECOND attributable contract violation. The old code rechecked but discarded
+// the recheck result (`_, unattributable = ...`), so the second violation
+// slipped through to a false partial/clean result with an invalid plan.
+//
+// firstImportContractRunner stages two violators (`bad`, then `ugly`) so the
+// second only becomes attributable after the first is dropped — forcing the
+// pruning loop to iterate. Both must be dropped+reported failed; the one clean
+// resource (`good`) imports; Status == partial; Run returns no error.
+func TestRunPartialOnIterativeFirstImportContract(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Run(context.Background(), threeQueueRequest(), Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: multiResourceGenconfig(),
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf: firstImportContractRunner{
+				t:         t,
+				dir:       dir,
+				violators: []string{"aws_sqs_queue.bad", "aws_sqs_queue.ugly"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error for an iterative partial result: %v", err)
+	}
+	if result.Status != job.StatusPartial {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusPartial)
+	}
+	good, ok := resourceResultByAddress(result.Resources, "aws_sqs_queue.good")
+	if !ok || good.Status != job.ResourceStatusImported {
+		t.Fatalf("good resource not imported: %#v", good)
+	}
+	for _, addr := range []string{"aws_sqs_queue.bad", "aws_sqs_queue.ugly"} {
+		bad, ok := resourceResultByAddress(result.Resources, addr)
+		if !ok || bad.Status != job.ResourceStatusFailed {
+			t.Fatalf("%s not failed after iterative contract pruning: %#v", addr, bad)
+		}
+		if len(bad.Diagnostics) == 0 || bad.Diagnostics[0].Code != "imported_plan_unexpected_create" {
+			t.Fatalf("%s missing first-import contract diagnostic: %#v", addr, bad.Diagnostics)
+		}
+	}
+	if result.PlanSummary.ImportCount != 1 {
+		t.Fatalf("ImportCount = %d, want 1 (only the good resource)", result.PlanSummary.ImportCount)
+	}
+	// imported.json must reflect the converged set — only the surviving
+	// resource, never a dropped contract-violator (the P1 stale-imported.json
+	// fix).
+	persisted := readImportedJSON(t, dir)
+	if len(persisted) != 1 || persisted[0].Identity.Address != "aws_sqs_queue.good" {
+		t.Fatalf("imported.json should list only the surviving resource, got: %#v", persisted)
+	}
+}
+
+// TestRunFailsWhenFirstImportContractDropsEveryResource: when every resource
+// violates the first-import contract across iterations, the engine must abort
+// with failed + error rather than emit an empty false partial.
+func TestRunFailsWhenFirstImportContractDropsEveryResource(t *testing.T) {
+	dir := t.TempDir()
+	result, err := Run(context.Background(), threeQueueRequest(), Options{
+		OutputDir:    dir,
+		SkipDepChase: true,
+		deps: deps{
+			runGenconfig: multiResourceGenconfig(),
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf: firstImportContractRunner{
+				t:   t,
+				dir: dir,
+				violators: []string{
+					"aws_sqs_queue.good",
+					"aws_sqs_queue.bad",
+					"aws_sqs_queue.ugly",
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Run returned nil error when every resource failed the first-import contract")
+	}
+	if result.Status != job.StatusFailed {
+		t.Fatalf("Status = %q, want %q", result.Status, job.StatusFailed)
+	}
+}
+
+// readImportedJSON decodes the engine's imported.json artifact.
+func readImportedJSON(t *testing.T, dir string) []imported.ImportedResource {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, importedJSONFile))
+	if err != nil {
+		t.Fatalf("read imported.json: %v", err)
+	}
+	var out []imported.ImportedResource
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("decode imported.json: %v", err)
+	}
+	return out
 }

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	tfjson "github.com/hashicorp/terraform-json"
+
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/driftfix"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
@@ -96,6 +98,14 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 		Stdout:         opts.Stdout,
 	}
 
+	// Snapshot the identities entering config generation so any that
+	// genconfig drops (un-importable / orphan imports it can't render a body
+	// for) can be surfaced as ResourceStatusSkipped rather than vanishing
+	// from the import set (#732). depchase may pull in additional resources
+	// after this point; those are not in this snapshot and so are never
+	// mis-reported as user-requested skips.
+	preGenconfigIdentities := identitiesByAddress(resources)
+	skips := newSkipTracker()
 	opts.progressf("reverse-import: generating terraform config for %d resource(s)…\n", len(resources))
 	var gcRes *genconfig.Result
 	if err := opts.runPhase("generating terraform config", func() error {
@@ -105,6 +115,9 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	}); err != nil {
 		return result, fmt.Errorf("genconfig: %w", err)
 	}
+	// Fold genconfig's own skip manifest (with reason codes) in first, then
+	// safety-net any dropped identity the manifest missed.
+	skips.addOrphanImports(preGenconfigIdentities, gcRes.Skipped)
 	resources = gcRes.Resources
 	opts.progressf("reverse-import: terraform config generated\n")
 
@@ -160,61 +173,107 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 		opts.progressf("reverse-import: dependency chase complete (%d resource(s) total)\n", len(resources))
 	}
 
+	// Safety net: any identity that entered config generation but is absent
+	// from the post-genconfig/depchase set was dropped without a manifest
+	// entry. Record it as skipped so nothing disappears silently (#732).
+	skips.addMissing(preGenconfigIdentities, resources)
+
 	if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
 		return result, err
 	}
-	result.Imported = resources
-	result.Resources = resourceResults(resources, dependenciesByAddress)
 
 	emitOpts := composer.EmitImportedOpts{
 		ImportProjectID: opts.ImportProjectID,
 		ImportSessionID: opts.ImportSessionID,
 		ImportedAt:      importedAtOrNow(opts.ImportedAt),
 	}
-	if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
-		return result, err
-	}
 
 	planPath := filepath.Join(opts.OutputDir, tfplanFile)
 	validateJSONPath := filepath.Join(opts.OutputDir, validateJSONFile)
 	tfplanJSONPath := filepath.Join(opts.OutputDir, tfplanJSONFile)
-	planJSON, err := runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
-	if err != nil {
-		return result, err
-	}
-	plan, err := job.DecodeTerraformPlan(bytes.NewReader(planJSON))
-	if err != nil {
-		return result, err
-	}
-	backfilled, changed, err := BackfillImportedAttrsFromPlan(resources, plan)
-	if err != nil {
-		return result, err
-	}
-	if changed {
-		opts.progressf("reverse-import: enriching imported attributes from final plan…\n")
-		resources = backfilled
-		if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
-			return result, err
+
+	// Iterative final plan/validate (#732): emit imported.tf, run
+	// validate+plan, and on a failure attributable to specific resource(s)
+	// drop them, record them as failed, and re-plan with the remainder. A
+	// failure with no attributable resource is systemic (provider/auth/global)
+	// and aborts. Bounded by maxFinalPlanIterations.
+	var (
+		plan     *tfjson.Plan
+		fpErr    error
+		attempts int
+	)
+	for attempts = 1; attempts <= maxFinalPlanIterations; attempts++ {
+		if len(resources) == 0 {
+			fpErr = fmt.Errorf("reverse-import: all selected resources were dropped as non-plannable")
+			break
 		}
-		result.Imported = resources
-		result.Resources = resourceResults(resources, dependenciesByAddress)
 		if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
 			return result, err
 		}
-		planJSON, err = runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
+		planJSON, validateJSON, planErr := runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
+		if planErr != nil {
+			addresses := identitiesByAddress(resources)
+			failures, attributable := attributeFinalPlanError(validateJSON, planErr, addresses)
+			if !attributable {
+				// Systemic failure — preserve the existing abort behavior.
+				fpErr = planErr
+				break
+			}
+			for _, f := range failures {
+				skips.markFailed(addresses[f.address], f.diagnostic)
+			}
+			resources = dropResources(resources, failures)
+			opts.progressf("reverse-import: dropped %d non-plannable resource(s); re-planning with %d remaining…\n", len(failures), len(resources))
+			continue
+		}
+
+		decoded, err := job.DecodeTerraformPlan(bytes.NewReader(planJSON))
 		if err != nil {
 			return result, err
 		}
-		plan, err = job.DecodeTerraformPlan(bytes.NewReader(planJSON))
+		// Backfill enriched attrs from the plan, then re-emit + re-plan once
+		// so imported.tf carries the plan-derived attributes (unchanged from
+		// the prior single-shot behavior, just inside the loop).
+		backfilled, changed, err := BackfillImportedAttrsFromPlan(resources, decoded)
 		if err != nil {
 			return result, err
 		}
+		if changed {
+			opts.progressf("reverse-import: enriching imported attributes from final plan…\n")
+			resources = backfilled
+			if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
+				return result, err
+			}
+			if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
+				return result, err
+			}
+			planJSON, _, planErr = runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
+			if planErr != nil {
+				// The backfilled config no longer plans cleanly. Re-attribute
+				// and loop; if un-attributable, abort.
+				addresses := identitiesByAddress(resources)
+				failures, attributable := attributeFinalPlanError(nil, planErr, addresses)
+				if !attributable {
+					fpErr = planErr
+					break
+				}
+				for _, f := range failures {
+					skips.markFailed(addresses[f.address], f.diagnostic)
+				}
+				resources = dropResources(resources, failures)
+				continue
+			}
+			decoded, err = job.DecodeTerraformPlan(bytes.NewReader(planJSON))
+			if err != nil {
+				return result, err
+			}
+		}
+		plan = decoded
+		break
 	}
-	result.PlanSummary = job.PlanSummaryFromTerraformPlan(plan)
-	result.ValidationIssues = issuesFromComposer(composer.ValidateFirstImportPlan(plan, composer.ValidateFirstImportPlanOpts{
-		ExpectedImports:     len(resources),
-		ProvenanceLabelKeys: composer.FirstImportProvenanceKeys(cloud),
-	}))
+	if attempts > maxFinalPlanIterations && plan == nil && fpErr == nil {
+		fpErr = fmt.Errorf("reverse-import: final plan did not converge after %d iteration(s)", maxFinalPlanIterations)
+	}
 
 	if dcRes != nil && len(dcRes.Edges) > 0 {
 		if err := writeJSON(filepath.Join(opts.OutputDir, graphJSONFile), dcRes.Edges); err != nil {
@@ -230,6 +289,84 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			})
 		}
 	}
+
+	if fpErr != nil {
+		// Un-attributable / non-convergent failure: abort as before. Persist
+		// what we have (including any skips already recorded) for debugging.
+		result.Status = job.StatusFailed
+		result.Imported = resources
+		result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
+		_ = writeResult(opts.OutputDir, &result)
+		return result, fpErr
+	}
+
+	// Downgrade attributable first-import-plan contract issues to per-resource
+	// skips (#732): a single resource that imports with an unexpected
+	// create/destroy/replace/unauthorized-change is dropped + reported rather
+	// than failing the whole job. Un-attributable issues (wrong import count,
+	// nil plan) still fail.
+	planIssues := composer.ValidateFirstImportPlan(plan, composer.ValidateFirstImportPlanOpts{
+		ExpectedImports:     len(resources),
+		ProvenanceLabelKeys: composer.FirstImportProvenanceKeys(cloud),
+	})
+	if len(planIssues) > 0 {
+		addresses := identitiesByAddress(resources)
+		perResource, unattributable := attributeFirstImportPlanIssues(planIssues, addresses)
+		if len(perResource) > 0 {
+			for _, f := range perResource {
+				skips.markFailed(addresses[f.address], f.diagnostic)
+			}
+			resources = dropResources(resources, perResource)
+			opts.progressf("reverse-import: dropped %d resource(s) failing the first-import contract; re-planning with %d remaining…\n", len(perResource), len(resources))
+			if len(resources) == 0 {
+				result.Status = job.StatusFailed
+				result.ValidationIssues = issuesFromComposer(planIssues)
+				result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
+				_ = writeResult(opts.OutputDir, &result)
+				return result, fmt.Errorf("first-import plan validation dropped every resource")
+			}
+			if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
+				return result, err
+			}
+			if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
+				return result, err
+			}
+			planJSON, _, planErr := runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
+			if planErr != nil {
+				result.Status = job.StatusFailed
+				result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
+				_ = writeResult(opts.OutputDir, &result)
+				return result, planErr
+			}
+			plan, err = job.DecodeTerraformPlan(bytes.NewReader(planJSON))
+			if err != nil {
+				return result, err
+			}
+			// Re-validate the trimmed plan; only un-attributable issues remain
+			// fatal now.
+			planIssues = composer.ValidateFirstImportPlan(plan, composer.ValidateFirstImportPlanOpts{
+				ExpectedImports:     len(resources),
+				ProvenanceLabelKeys: composer.FirstImportProvenanceKeys(cloud),
+			})
+			_, unattributable = attributeFirstImportPlanIssues(planIssues, identitiesByAddress(resources))
+		}
+		if len(unattributable) > 0 {
+			result.PlanSummary = job.PlanSummaryFromTerraformPlan(plan)
+			result.ValidationIssues = issuesFromComposer(unattributable)
+			result.Status = job.StatusFailed
+			result.Imported = resources
+			result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
+			if err := writeResult(opts.OutputDir, &result); err != nil {
+				return result, err
+			}
+			return result, fmt.Errorf("final plan validation failed with %d un-attributable issue(s)", len(unattributable))
+		}
+	}
+
+	result.Imported = resources
+	result.PlanSummary = job.PlanSummaryFromTerraformPlan(plan)
+	result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
+
 	planSummaryPath := filepath.Join(opts.OutputDir, planSummaryJSONFile)
 	if err := writeJSON(planSummaryPath, result.PlanSummary); err != nil {
 		return result, err
@@ -237,13 +374,11 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	if err := populateArtifacts(&result, opts.OutputDir, gcRes.GeneratedPath, dcRes); err != nil {
 		return result, err
 	}
-	if len(result.ValidationIssues) > 0 {
-		if err := writeResult(opts.OutputDir, &result); err != nil {
-			return result, err
-		}
-		return result, fmt.Errorf("final plan validation failed with %d issue(s)", len(result.ValidationIssues))
-	}
-	result.Status = job.StatusSucceeded
+	// Surface the genconfig skip manifest as an artifact when present so
+	// ui-core/reliable can see which imports were dropped (#732).
+	addSkipManifestArtifact(&result, workdir)
+
+	result.Status = finalStatus(len(resources), skips)
 	if err := writeResult(opts.OutputDir, &result); err != nil {
 		return result, err
 	}
@@ -327,15 +462,21 @@ func writeImportedTerraformArtifacts(outputDir, cloud, region, gcpProjectID, aws
 	return nil
 }
 
-func runFinalPlanJSON(ctx context.Context, opts Options, planPath, validateJSONPath, tfplanJSONPath string) ([]byte, error) {
+// runFinalPlanJSON runs terraform init → validate → plan → show against
+// opts.OutputDir and returns the plan JSON. It also returns the raw validate
+// JSON (when produced) so the partial-tolerance loop can attribute a failure
+// to a specific resource via the validate diagnostics. The returned error is
+// non-nil on a validate or plan failure; the validate JSON is still returned
+// in that case so the caller can parse diagnostics. Init/show failures are
+// infrastructure errors and are returned wrapped (never attributable).
+func runFinalPlanJSON(ctx context.Context, opts Options, planPath, validateJSONPath, tfplanJSONPath string) (planJSON, validateJSON []byte, err error) {
 	opts.progressf("reverse-import: terraform init…\n")
-	if err := opts.runPhase("terraform init", func() error {
+	if initErr := opts.runPhase("terraform init", func() error {
 		return opts.deps.tf.Init(ctx, opts.OutputDir)
-	}); err != nil {
-		return nil, fmt.Errorf("terraform init final: %w", err)
+	}); initErr != nil {
+		return nil, nil, fmt.Errorf("terraform init final: %w", initErr)
 	}
 	opts.progressf("reverse-import: terraform validate…\n")
-	var validateJSON []byte
 	validateErr := opts.runPhase("terraform validate", func() error {
 		var verr error
 		validateJSON, verr = opts.deps.tf.Validate(ctx, opts.OutputDir)
@@ -343,31 +484,30 @@ func runFinalPlanJSON(ctx context.Context, opts Options, planPath, validateJSONP
 	})
 	if len(validateJSON) > 0 {
 		if writeErr := writeFileAtomic(validateJSONPath, validateJSON, 0o644); writeErr != nil {
-			return nil, fmt.Errorf("write validate.json: %w", writeErr)
+			return nil, validateJSON, fmt.Errorf("write validate.json: %w", writeErr)
 		}
 	}
 	if validateErr != nil {
-		return nil, fmt.Errorf("terraform validate final: %w", validateErr)
+		return nil, validateJSON, fmt.Errorf("terraform validate final: %w", validateErr)
 	}
 	opts.progressf("reverse-import: terraform plan…\n")
-	if err := opts.runPhase("terraform plan", func() error {
+	if planErr := opts.runPhase("terraform plan", func() error {
 		return opts.deps.tf.Plan(ctx, opts.OutputDir, planPath)
-	}); err != nil {
-		return nil, fmt.Errorf("terraform plan final: %w", err)
+	}); planErr != nil {
+		return nil, validateJSON, fmt.Errorf("terraform plan final: %w", planErr)
 	}
-	var planJSON []byte
-	if err := opts.runPhase("terraform show plan", func() error {
-		var showErr error
-		planJSON, showErr = opts.deps.tf.ShowPlanJSON(ctx, opts.OutputDir, planPath)
-		return showErr
-	}); err != nil {
-		return nil, fmt.Errorf("terraform show final plan: %w", err)
+	if showErr := opts.runPhase("terraform show plan", func() error {
+		var serr error
+		planJSON, serr = opts.deps.tf.ShowPlanJSON(ctx, opts.OutputDir, planPath)
+		return serr
+	}); showErr != nil {
+		return nil, validateJSON, fmt.Errorf("terraform show final plan: %w", showErr)
 	}
 	opts.progressf("reverse-import: plan complete\n")
-	if err := writeFileAtomic(tfplanJSONPath, planJSON, 0o644); err != nil {
-		return nil, fmt.Errorf("write tfplan.json: %w", err)
+	if writeErr := writeFileAtomic(tfplanJSONPath, planJSON, 0o644); writeErr != nil {
+		return planJSON, validateJSON, fmt.Errorf("write tfplan.json: %w", writeErr)
 	}
-	return planJSON, nil
+	return planJSON, validateJSON, nil
 }
 
 func populateArtifacts(result *job.Result, outputDir, generatedPath string, dcRes *depchase.Result) error {
@@ -414,20 +554,6 @@ func populateArtifacts(result *job.Result, outputDir, generatedPath string, dcRe
 		}
 	}
 	return nil
-}
-
-func resourceResults(resources []imported.ImportedResource, dependenciesByAddress map[string][]imported.ResourceIdentity) []job.ResourceResult {
-	out := make([]job.ResourceResult, 0, len(resources))
-	for _, r := range resources {
-		rr := r
-		out = append(out, job.ResourceResult{
-			Identity:     r.Identity,
-			Status:       job.ResourceStatusImported,
-			Imported:     &rr,
-			Dependencies: dependenciesByAddress[r.Identity.Address],
-		})
-	}
-	return out
 }
 
 func appendDepChaseDependencies(dependenciesByAddress map[string][]imported.ResourceIdentity, resources []imported.ImportedResource, edges []depchase.GraphEdge) {

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -247,12 +247,16 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
 				return result, err
 			}
-			planJSON, _, planErr = runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
+			var validateJSON []byte
+			planJSON, validateJSON, planErr = runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
 			if planErr != nil {
 				// The backfilled config no longer plans cleanly. Re-attribute
-				// and loop; if un-attributable, abort.
+				// from BOTH the validate diagnostics and the plan stderr (a
+				// backfilled-attr failure commonly surfaces in validate, so
+				// dropping validateJSON here would mis-classify a droppable
+				// resource as systemic and abort). If un-attributable, abort.
 				addresses := identitiesByAddress(resources)
-				failures, attributable := attributeFinalPlanError(nil, planErr, addresses)
+				failures, attributable := attributeFinalPlanError(validateJSON, planErr, addresses)
 				if !attributable {
 					fpErr = planErr
 					break
@@ -305,52 +309,27 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	// create/destroy/replace/unauthorized-change is dropped + reported rather
 	// than failing the whole job. Un-attributable issues (wrong import count,
 	// nil plan) still fail.
-	planIssues := composer.ValidateFirstImportPlan(plan, composer.ValidateFirstImportPlanOpts{
-		ExpectedImports:     len(resources),
-		ProvenanceLabelKeys: composer.FirstImportProvenanceKeys(cloud),
-	})
-	if len(planIssues) > 0 {
+	//
+	// Pruning is iterative and bounded (mirrors the final-plan loop): dropping
+	// one contract-violating resource and re-planning can surface a SECOND
+	// resource-attributable contract violation in the trimmed plan. Keep
+	// dropping newly attributable issues + re-planning until none remain. Abort
+	// (failed + error) if every resource is dropped or it does not converge
+	// within maxFinalPlanIterations; only truly un-attributable issues remain
+	// fatal.
+	for fiAttempts := 1; ; fiAttempts++ {
+		planIssues := composer.ValidateFirstImportPlan(plan, composer.ValidateFirstImportPlanOpts{
+			ExpectedImports:     len(resources),
+			ProvenanceLabelKeys: composer.FirstImportProvenanceKeys(cloud),
+		})
+		if len(planIssues) == 0 {
+			break
+		}
 		addresses := identitiesByAddress(resources)
 		perResource, unattributable := attributeFirstImportPlanIssues(planIssues, addresses)
-		if len(perResource) > 0 {
-			for _, f := range perResource {
-				skips.markFailed(addresses[f.address], f.diagnostic)
-			}
-			resources = dropResources(resources, perResource)
-			opts.progressf("reverse-import: dropped %d resource(s) failing the first-import contract; re-planning with %d remaining…\n", len(perResource), len(resources))
-			if len(resources) == 0 {
-				result.Status = job.StatusFailed
-				result.ValidationIssues = issuesFromComposer(planIssues)
-				result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
-				_ = writeResult(opts.OutputDir, &result)
-				return result, fmt.Errorf("first-import plan validation dropped every resource")
-			}
-			if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
-				return result, err
-			}
-			if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
-				return result, err
-			}
-			planJSON, _, planErr := runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
-			if planErr != nil {
-				result.Status = job.StatusFailed
-				result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
-				_ = writeResult(opts.OutputDir, &result)
-				return result, planErr
-			}
-			plan, err = job.DecodeTerraformPlan(bytes.NewReader(planJSON))
-			if err != nil {
-				return result, err
-			}
-			// Re-validate the trimmed plan; only un-attributable issues remain
-			// fatal now.
-			planIssues = composer.ValidateFirstImportPlan(plan, composer.ValidateFirstImportPlanOpts{
-				ExpectedImports:     len(resources),
-				ProvenanceLabelKeys: composer.FirstImportProvenanceKeys(cloud),
-			})
-			_, unattributable = attributeFirstImportPlanIssues(planIssues, identitiesByAddress(resources))
-		}
-		if len(unattributable) > 0 {
+		if len(perResource) == 0 {
+			// Nothing attributable to drop. Only un-attributable issues
+			// remain (wrong import count, nil plan): systemic — abort.
 			result.PlanSummary = job.PlanSummaryFromTerraformPlan(plan)
 			result.ValidationIssues = issuesFromComposer(unattributable)
 			result.Status = job.StatusFailed
@@ -361,6 +340,55 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			}
 			return result, fmt.Errorf("final plan validation failed with %d un-attributable issue(s)", len(unattributable))
 		}
+		if fiAttempts > maxFinalPlanIterations {
+			result.Status = job.StatusFailed
+			result.ValidationIssues = issuesFromComposer(planIssues)
+			result.Imported = resources
+			result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
+			_ = writeResult(opts.OutputDir, &result)
+			return result, fmt.Errorf("first-import plan validation did not converge after %d iteration(s)", maxFinalPlanIterations)
+		}
+		for _, f := range perResource {
+			skips.markFailed(addresses[f.address], f.diagnostic)
+		}
+		resources = dropResources(resources, perResource)
+		opts.progressf("reverse-import: dropped %d resource(s) failing the first-import contract; re-planning with %d remaining…\n", len(perResource), len(resources))
+		if len(resources) == 0 {
+			result.Status = job.StatusFailed
+			result.ValidationIssues = issuesFromComposer(planIssues)
+			result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
+			_ = writeResult(opts.OutputDir, &result)
+			return result, fmt.Errorf("first-import plan validation dropped every resource")
+		}
+		if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
+			return result, err
+		}
+		if err := writeImportedTerraformArtifacts(opts.OutputDir, cloud, region, gcpProjectID, opts.AWSEndpointURL, awsAuth, resources, emitOpts); err != nil {
+			return result, err
+		}
+		planJSON, _, planErr := runFinalPlanJSON(ctx, opts, planPath, validateJSONPath, tfplanJSONPath)
+		if planErr != nil {
+			result.Status = job.StatusFailed
+			result.Resources = combinedResourceResults(resources, dependenciesByAddress, skips)
+			_ = writeResult(opts.OutputDir, &result)
+			return result, planErr
+		}
+		plan, err = job.DecodeTerraformPlan(bytes.NewReader(planJSON))
+		if err != nil {
+			return result, err
+		}
+		// Loop: re-validate the trimmed plan from the top.
+	}
+
+	// imported.json must reflect the converged final resource set. The
+	// final-plan and first-import loops above mutate `resources` in memory but
+	// only rewrite imported.json on a backfill or a re-plan iteration — a run
+	// that dropped resources on the LAST iteration (or via attribution on the
+	// first final-plan failure) could otherwise publish an imported.json that
+	// still lists the dropped resources. Rewrite it from the converged set
+	// before populating artifacts (#732).
+	if err := writeJSON(filepath.Join(opts.OutputDir, importedJSONFile), resources); err != nil {
+		return result, err
 	}
 
 	result.Imported = resources

--- a/pkg/reverseimport/terraform.go
+++ b/pkg/reverseimport/terraform.go
@@ -1,6 +1,7 @@
 package reverseimport
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +15,46 @@ type terraformRunner interface {
 	Validate(ctx context.Context, dir string) ([]byte, error)
 	Plan(ctx context.Context, dir, planPath string) error
 	ShowPlanJSON(ctx context.Context, dir, planPath string) ([]byte, error)
+}
+
+// planOutputError carries the captured terraform stderr alongside the
+// underlying exec failure so the partial-tolerance attribution layer can
+// scan the diagnostic text for a resource address (`terraform plan` does not
+// emit machine-readable per-resource diagnostics the way `validate -json`
+// does — the only signal is the human-readable error block). A fake runner in
+// tests can return this type directly to exercise plan-error attribution.
+//
+// stderrText returns the captured terraform stderr for any error that
+// implements it, so attribution works uniformly across the real runner and
+// test doubles. An error that does not implement the interface yields "" —
+// the attribution layer then treats the plan failure as un-attributable and
+// aborts (preserving the existing systemic-error safety).
+type planOutputError struct {
+	output string
+	err    error
+}
+
+func (e *planOutputError) Error() string {
+	if e.output == "" {
+		return e.err.Error()
+	}
+	return e.err.Error() + ": " + e.output
+}
+
+func (e *planOutputError) Unwrap() error { return e.err }
+
+func (e *planOutputError) stderrText() string { return e.output }
+
+// stderrTexter is implemented by errors that carry captured terraform stderr.
+type stderrTexter interface{ stderrText() string }
+
+// planStderr extracts captured terraform stderr from err when present.
+func planStderr(err error) string {
+	var t stderrTexter
+	if errors.As(err, &t) {
+		return t.stderrText()
+	}
+	return ""
 }
 
 type execTerraformRunner struct {
@@ -61,15 +102,27 @@ func (r execTerraformRunner) Validate(ctx context.Context, dir string) ([]byte, 
 }
 
 func (r execTerraformRunner) Plan(ctx context.Context, dir, planPath string) error {
-	err := r.run(ctx, dir, "plan", "-input=false", "-no-color", "-detailed-exitcode", "-out="+planPath)
+	// Tee stderr into a buffer so a plan failure can be attributed to a
+	// specific resource address by the partial-tolerance loop. The live
+	// sink still receives the same bytes (the import wizard's log console
+	// keeps streaming); the buffer is only read on error.
+	var captured bytes.Buffer
+	cmd := exec.CommandContext(ctx, r.bin(), "plan", "-input=false", "-no-color", "-detailed-exitcode", "-out="+planPath)
+	cmd.Dir = dir
+	cmd.Stdout = r.outW()
+	cmd.Stderr = io.MultiWriter(r.outW(), &captured)
+	cmd.Env = append(os.Environ(), "TF_IN_AUTOMATION=1")
+	err := cmd.Run()
 	if err == nil {
 		return nil
 	}
 	var ee *exec.ExitError
 	if errors.As(err, &ee) && ee.ExitCode() == 2 {
+		// -detailed-exitcode: 2 means "succeeded, with a non-empty diff"
+		// (the import-only plan). Not a failure.
 		return nil
 	}
-	return err
+	return &planOutputError{output: captured.String(), err: fmt.Errorf("%s plan: %w", r.bin(), err)}
 }
 
 func (r execTerraformRunner) ShowPlanJSON(ctx context.Context, dir, planPath string) ([]byte, error) {


### PR DESCRIPTION
Closes #732

## What

The reverse-import engine was all-or-nothing: one non-plannable resource aborted the whole run with an opaque aggregate error, and `resourceResults` hardcoded every resource to `ResourceStatusImported`. `StatusPartial` / `ResourceStatusFailed` / `ResourceStatusSkipped` existed but were emitted by no production path.

This makes `reverseimport.Run` per-resource tolerant: it isolates non-plannable resources, attributes failures to specific identities, continues with the remainder, and returns a truthful `Status` with a populated `Result.Resources[]`.

## Partial-tolerance semantics

- All selected resources imported -> `succeeded`.
- At least one imported AND at least one skipped/failed -> `partial`.
- Zero imported, or an un-attributable abort -> `failed`.
- A `partial` result is returned as a non-error Go value so the mars wrapper can exit 0. True failures preserve the existing error return.

## Changes

- **genconfig skip surfacing.** `genconfig.Result` gains a `Skipped` field (merged across regions) carrying the dropped address / import-id / reason from the un-importable and orphan-import safety nets. `Run` folds these into `Result.Resources[]` as `ResourceStatusSkipped` with a per-resource diagnostic, plus a safety-net diff so any dropped identity with no manifest entry is still reported. The `imports-skipped.json` manifest is attached as a debug artifact.
- **Iterative final plan/validate.** `runFinalPlanJSON` no longer aborts internally; it returns the plan JSON and the validate JSON. `Run` wraps validate+plan in a bounded loop (`maxFinalPlanIterations`). On a failure attributable to specific resource(s), it drops them, records them `ResourceStatusFailed` with the diagnostic, and re-emits + re-plans. A failure with no attributable resource (provider/auth/global) aborts as before — systemic errors are never swallowed.
- **First-import contract downgrade.** Attributable `composer.ValidateFirstImportPlan` issues (`plan.<address>` field) become per-resource skips; un-attributable issues (wrong import count, nil plan) still fail the job.
- **Per-resource attribution.** `Result.Resources[].Status` + `.Diagnostics` are populated for imported / skipped / failed; the hardcoded `ResourceStatusImported` is gone.

## Attribution approach

| Stage | Signal |
|---|---|
| `terraform validate -json` | `Snippet.Context` resource block header (`resource "TYPE" "NAME"`) + `Range.Filename`, with a `Detail`/`Summary` known-address fallback. |
| `terraform plan` | The runner now captures plan stderr (teed; the live log stream is unaffected). The error block is scanned for `with TYPE.NAME,` / `resource "TYPE" "NAME"`. |
| first-import contract | `ValidationIssue.Field` of the form `plan.<address>` (or `plan.<address>.<attr>`). |

Only addresses that match a resource currently in the set count as attributable; everything else is treated as systemic and aborts. terraform `validate -json` does not carry a resource address field, so attribution rides the snippet context — the only per-resource signal terraform exposes for validate, and the same one driftfix already consumes.

## Tests

- One resource fails `terraform plan` -> others imported, bad one `failed` with a diagnostic, `Status == partial`, `Run` returns nil error.
- Same via `terraform validate` (attribution from the validate diagnostic snippet).
- A genconfig-skipped resource -> reported `skipped`, rest imported, `Status == partial`, skip manifest attached as an artifact.
- An un-attributable terraform error (provider credential failure) -> `Run` still returns an error, `Status == failed`, no false partial.
- All-good set -> `Status == succeeded`, both imported.

`go build ./...`, `go vet`, `gofmt` clean. Full suite green (`go test ./...`).

## Out of scope (per the issue)

- ui-core surfacing of these results and the `reverse-import.sh` / mars exit-code handling are separate tickets. The engine already returns a non-error value for `partial` so the wrapper can map it to exit 0.