### PR TITLE
feat(discover): fast-mode closure parity — lift FK fields into NativeIDs (#733)

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -151,9 +151,13 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 			}
 			return identifier
 		},
-		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+		// Lift the topic's CMK (CFN `KmsMasterKeyId`) into NativeIDs so the
+		// closure resolver recovers the sns→aws_kms_key edge (presets#733).
+		NativeIDsFromProperties: fkNativeIDs(func(identifier string, _ map[string]any) map[string]string {
 			return map[string]string{"arn": identifier}
 		},
+			fkRef{cfnProp: "KmsMasterKeyId", nativeKey: "kms_master_key_id"},
+		),
 		TagsFromProperties: tagsFromKey("Tags"),
 	},
 	{
@@ -165,13 +169,17 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		// aws_sqs_queue also takes the URL — passthrough.
 		ImportIDFromIdentifier: passthroughImportID,
 		NameHintFromProperties: nameOrIdentifier("QueueName"),
-		NativeIDsFromProperties: func(_ string, props map[string]any) map[string]string {
+		// Lift the queue's CMK (CFN `KmsMasterKeyId`) into NativeIDs so the
+		// closure resolver recovers the sqs→aws_kms_key edge (presets#733).
+		NativeIDsFromProperties: fkNativeIDs(func(_ string, props map[string]any) map[string]string {
 			arn := extractString(props, "Arn")
 			if arn == "" {
 				return nil
 			}
 			return map[string]string{"arn": arn}
 		},
+			fkRef{cfnProp: "KmsMasterKeyId", nativeKey: "kms_master_key_id"},
+		),
 		TagsFromProperties: tagsFromKey("Tags"),
 		// #501 Normalizer: CFN AWS::SQS::Queue uses primary-name
 		// `QueueName` (TF: `name`), seconds-suffix-elided
@@ -216,10 +224,15 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		Slug:               "cloudwatchlogs",
 		// Cloud Control identifier = LogGroupName. Terraform import
 		// also takes LogGroupName — passthrough.
-		ImportIDFromIdentifier:  passthroughImportID,
-		NameHintFromProperties:  nameOrIdentifier("LogGroupName"),
-		NativeIDsFromProperties: arnUnderKey("Arn"),
-		TagsFromProperties:      tagsFromKey("Tags"),
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: nameOrIdentifier("LogGroupName"),
+		// Lift the log group's CMK (CFN `KmsKeyId`, an ARN) into NativeIDs
+		// so the closure resolver recovers the log_group→aws_kms_key edge
+		// (presets#733).
+		NativeIDsFromProperties: fkNativeIDs(arnUnderKey("Arn"),
+			fkRef{cfnProp: "KmsKeyId", nativeKey: "kms_key_id"},
+		),
+		TagsFromProperties: tagsFromKey("Tags"),
 		// #501/#502 Normalizer: CFN AWS::Logs::LogGroup uses primary-name
 		// `LogGroupName` (TF: `name`), an `Arn` that includes the
 		// trailing `:*` log-stream wildcard (TF strips it), and a
@@ -362,13 +375,22 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 	// Compute — Lambda
 	// =====================================================================
 	{
-		TFType:                  "aws_lambda_function",
-		CloudFormationType:      "AWS::Lambda::Function",
-		Slug:                    "lambda",
-		ImportIDFromIdentifier:  passthroughImportID,
-		NameHintFromProperties:  nameOrIdentifier("FunctionName"),
-		NativeIDsFromProperties: arnUnderKey("Arn"),
-		TagsFromProperties:      tagsFromKey("Tags"),
+		TFType:                 "aws_lambda_function",
+		CloudFormationType:     "AWS::Lambda::Function",
+		Slug:                   "lambda",
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: nameOrIdentifier("FunctionName"),
+		// Lift the execution-role ARN (CFN `Role`) and CMK ARN (CFN
+		// `KmsKeyArn`) into NativeIDs so the enrich-free closure resolver
+		// recovers the lambda→aws_iam_role and lambda→aws_kms_key edges
+		// reliable's picker shows today (presets#733). `Role` is a top-
+		// level required property carrying the full role ARN; `KmsKeyArn`
+		// is the optional CMK that encrypts env vars / snapshots.
+		NativeIDsFromProperties: fkNativeIDs(arnUnderKey("Arn"),
+			fkRef{cfnProp: "Role", nativeKey: "role_arn"},
+			fkRef{cfnProp: "KmsKeyArn", nativeKey: "kms_key_arn"},
+		),
+		TagsFromProperties: tagsFromKey("Tags"),
 		// Normalizer: CFN AWS::Lambda::Function models each singleton
 		// nested config (Environment, TracingConfig, VpcConfig, …) as a
 		// plain JSON *object*, but the Terraform provider exposes them as
@@ -456,13 +478,17 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		),
 	},
 	{
-		TFType:                  "aws_dynamodb_table",
-		CloudFormationType:      "AWS::DynamoDB::Table",
-		Slug:                    "dynamodb",
-		ImportIDFromIdentifier:  passthroughImportID,
-		NameHintFromProperties:  nameOrIdentifier("TableName"),
-		NativeIDsFromProperties: arnUnderKey("Arn"),
-		TagsFromProperties:      tagsFromKey("Tags"),
+		TFType:                 "aws_dynamodb_table",
+		CloudFormationType:     "AWS::DynamoDB::Table",
+		Slug:                   "dynamodb",
+		ImportIDFromIdentifier: passthroughImportID,
+		NameHintFromProperties: nameOrIdentifier("TableName"),
+		// Lift the table's SSE CMK (CFN nested
+		// `SSESpecification.KMSMasterKeyId`) into NativeIDs so the closure
+		// resolver recovers the dynamodb→aws_kms_key edge (presets#733).
+		NativeIDsFromProperties: fkNativeIDsNested(arnUnderKey("Arn"),
+			"SSESpecification", "KMSMasterKeyId", "kms_key_arn"),
+		TagsFromProperties: tagsFromKey("Tags"),
 	},
 	{
 		TFType:             "aws_secretsmanager_secret",
@@ -472,9 +498,13 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		// the ARN — passthrough.
 		ImportIDFromIdentifier: passthroughImportID,
 		NameHintFromProperties: nameOrIdentifier("Name"),
-		NativeIDsFromProperties: func(identifier string, _ map[string]any) map[string]string {
+		// Lift the secret's CMK (CFN `KmsKeyId`) into NativeIDs so the
+		// closure resolver recovers the secret→aws_kms_key edge (presets#733).
+		NativeIDsFromProperties: fkNativeIDs(func(identifier string, _ map[string]any) map[string]string {
 			return map[string]string{"arn": identifier}
 		},
+			fkRef{cfnProp: "KmsKeyId", nativeKey: "kms_key_id"},
+		),
 		TagsFromProperties: tagsFromKey("Tags"),
 	},
 
@@ -791,8 +821,14 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		// the #650 parent-instance resolver can link an
 		// aws_db_parameter_group child back to the instance that uses
 		// it (the parameter group's own model has no instance back-ref).
-		NativeIDsFromProperties: arnAndKey("DBInstanceArn", "DBParameterGroupName", "db_parameter_group"),
-		TagsFromProperties:      tagsFromKey("Tags"),
+		// Additionally lift the storage CMK (CFN `KmsKeyId`, an ARN) into
+		// NativeIDs so the closure resolver recovers the
+		// db_instance→aws_kms_key edge (presets#733).
+		NativeIDsFromProperties: fkNativeIDs(
+			arnAndKey("DBInstanceArn", "DBParameterGroupName", "db_parameter_group"),
+			fkRef{cfnProp: "KmsKeyId", nativeKey: "kms_key_id"},
+		),
+		TagsFromProperties: tagsFromKey("Tags"),
 	},
 	{
 		TFType:                 "aws_db_subnet_group",
@@ -2961,6 +2997,95 @@ func arnAndKey(arnKey, extraKey, extraNativeKey string) func(string, map[string]
 		}
 		if len(out) == 0 {
 			return nil
+		}
+		return out
+	}
+}
+
+// fkRef pairs a CloudFormation property name with the NativeIDs key it
+// is lifted under at discover time. The NativeIDs key MUST be a
+// dependencies.FieldRefs() cross-ref field (role_arn, kms_key_arn,
+// kms_key_id, kms_master_key_id, vpc_id, subnet_id, …) so the enrich-free
+// closure resolver (composer/imported.DependencyEdges →
+// dependencies.ResolveFromIdentities) can recover the same free-form FK
+// edges reliable's Attrs-based picker closure produces today
+// (presets#733). The CloudFormation property carrying the FK value is
+// usually a different casing than the Terraform attribute (e.g. CFN
+// `Role` → TF `role` → FieldRefs `role_arn`); fkRef makes the mapping
+// explicit and testable.
+type fkRef struct {
+	// cfnProp is the CloudFormation GetResource property name carrying
+	// the foreign-key value (an ARN / id / name pointing at another
+	// resource), e.g. "Role", "KmsKeyArn", "KmsMasterKeyId".
+	cfnProp string
+	// nativeKey is the NativeIDs key to stamp the value under. It must
+	// be a dependencies.FieldRefs() key so the closure resolver matches
+	// it; TestFKLift_PerType pins this invariant for every wired type.
+	nativeKey string
+}
+
+// fkNativeIDs returns a NativeIDsFromProperties extractor that lifts
+// the cross-reference foreign-key fields in refs into NativeIDs at
+// discover time, in addition to the resource's own canonical
+// identifiers built by base. base may be nil for source types that have
+// no own native identifiers worth carrying beyond the FK fields.
+//
+// Lifting these FK fields is the core presets#733 change: it makes the
+// picker's free-form dependency closure (role → iam_role, kms_key_arn →
+// kms_key, …) derivable from Identity alone, with no per-resource
+// EnrichAttributes describe call. The FK value comes straight from the
+// Cloud Control GetResource payload the discoverer already fetches.
+//
+// AWS allows a KMS FK to be a key id, key ARN, or alias — the closure
+// resolver indexes the parent aws_kms_key by both its ImportID (key id)
+// and NativeIDs["arn"], so a key-id or key-ARN reference joins; an
+// alias-only reference resolves only when that alias is itself a
+// discovered aws_kms_alias of the same target type (it is not, so an
+// alias FK is conservatively dropped — matching reliable's Attrs path,
+// which also only matches against arn/id, never alias).
+func fkNativeIDs(base func(string, map[string]any) map[string]string, refs ...fkRef) func(string, map[string]any) map[string]string {
+	return func(identifier string, props map[string]any) map[string]string {
+		var out map[string]string
+		if base != nil {
+			out = base(identifier, props)
+		}
+		for _, r := range refs {
+			val := extractString(props, r.cfnProp)
+			if val == "" {
+				continue
+			}
+			if out == nil {
+				out = map[string]string{}
+			}
+			// First writer wins: never clobber a canonical identifier a
+			// base extractor already set under the same key.
+			if _, exists := out[r.nativeKey]; !exists {
+				out[r.nativeKey] = val
+			}
+		}
+		return out
+	}
+}
+
+// fkNativeIDsNested is fkNativeIDs for a single FK value that lives one
+// level down in the Cloud Control payload (e.g.
+// AWS::DynamoDB::Table.SSESpecification.KMSMasterKeyId). objKey is the
+// parent object property; cfnProp/nativeKey are as in fkRef.
+func fkNativeIDsNested(base func(string, map[string]any) map[string]string, objKey, cfnProp, nativeKey string) func(string, map[string]any) map[string]string {
+	return func(identifier string, props map[string]any) map[string]string {
+		var out map[string]string
+		if base != nil {
+			out = base(identifier, props)
+		}
+		if obj, ok := props[objKey].(map[string]any); ok {
+			if val := extractString(obj, cfnProp); val != "" {
+				if out == nil {
+					out = map[string]string{}
+				}
+				if _, exists := out[nativeKey]; !exists {
+					out[nativeKey] = val
+				}
+			}
 		}
 		return out
 	}

--- a/cmd/insideout-import/awsdiscover/fk_native_ids_test.go
+++ b/cmd/insideout-import/awsdiscover/fk_native_ids_test.go
@@ -1,0 +1,208 @@
+package awsdiscover
+
+import (
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/dependencies"
+)
+
+// fk_native_ids_test.go pins the presets#733 change: the Cloud Control
+// extractors lift cross-reference foreign-key fields into
+// Identity.NativeIDs at discover time, under the dependencies.FieldRefs()
+// key, so the picker's free-form dependency closure (lambda→iam_role,
+// *→kms_key, …) is derivable with NO EnrichAttributes call.
+
+// TestFKLift_PerType pins that each source type's NativeIDsFromProperties
+// extractor lifts the expected FK field, given a representative Cloud
+// Control GetResource properties payload. The CFN property names are the
+// authoritative schema names (verified against the public CloudFormation
+// type schemas) — a rename in AWS's schema that we don't track here would
+// fail these pins.
+func TestFKLift_PerType(t *testing.T) {
+	t.Parallel()
+	roleARN := "arn:aws:iam::123456789012:role/exec"
+	kmsARN := "arn:aws:kms:us-east-1:123456789012:key/abcd-1234"
+
+	cases := []struct {
+		tfType     string
+		identifier string
+		props      map[string]any
+		wantKey    string
+		wantVal    string
+	}{
+		{
+			tfType: "aws_lambda_function", identifier: "fn",
+			props:   map[string]any{"Arn": "arn:aws:lambda:us-east-1:1:function:fn", "Role": roleARN},
+			wantKey: "role_arn", wantVal: roleARN,
+		},
+		{
+			tfType: "aws_lambda_function", identifier: "fn",
+			props:   map[string]any{"Arn": "arn:aws:lambda:us-east-1:1:function:fn", "KmsKeyArn": kmsARN},
+			wantKey: "kms_key_arn", wantVal: kmsARN,
+		},
+		{
+			tfType: "aws_sqs_queue", identifier: "https://sqs/q",
+			props:   map[string]any{"Arn": "arn:aws:sqs:us-east-1:1:q", "KmsMasterKeyId": "alias/aws/sqs"},
+			wantKey: "kms_master_key_id", wantVal: "alias/aws/sqs",
+		},
+		{
+			tfType: "aws_sns_topic", identifier: "arn:aws:sns:us-east-1:1:t",
+			props:   map[string]any{"KmsMasterKeyId": kmsARN},
+			wantKey: "kms_master_key_id", wantVal: kmsARN,
+		},
+		{
+			tfType: "aws_dynamodb_table", identifier: "t",
+			props:   map[string]any{"Arn": "arn:aws:dynamodb:us-east-1:1:table/t", "SSESpecification": map[string]any{"KMSMasterKeyId": kmsARN}},
+			wantKey: "kms_key_arn", wantVal: kmsARN,
+		},
+		{
+			tfType: "aws_db_instance", identifier: "db",
+			props:   map[string]any{"DBInstanceArn": "arn:aws:rds:us-east-1:1:db:db", "KmsKeyId": kmsARN},
+			wantKey: "kms_key_id", wantVal: kmsARN,
+		},
+		{
+			tfType: "aws_secretsmanager_secret", identifier: "arn:aws:secretsmanager:us-east-1:1:secret:s",
+			props:   map[string]any{"KmsKeyId": kmsARN},
+			wantKey: "kms_key_id", wantVal: kmsARN,
+		},
+		{
+			tfType: "aws_cloudwatch_log_group", identifier: "/app",
+			props:   map[string]any{"Arn": "arn:aws:logs:us-east-1:1:log-group:/app", "KmsKeyId": kmsARN},
+			wantKey: "kms_key_id", wantVal: kmsARN,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.tfType+"/"+tc.wantKey, func(t *testing.T) {
+			t.Parallel()
+			cfg := configByTFType(t, tc.tfType)
+			if cfg.NativeIDsFromProperties == nil {
+				t.Fatalf("%s has no NativeIDsFromProperties extractor", tc.tfType)
+			}
+			got := cfg.NativeIDsFromProperties(tc.identifier, tc.props)
+			if got[tc.wantKey] != tc.wantVal {
+				t.Fatalf("%s NativeIDs[%q] = %q, want %q (got map %v)", tc.tfType, tc.wantKey, got[tc.wantKey], tc.wantVal, got)
+			}
+			// The lifted key must be a real FieldRefs() cross-ref field —
+			// otherwise the closure resolver would never read it.
+			if _, ok := dependencies.Lookup(tc.wantKey); !ok {
+				t.Fatalf("lifted NativeIDs key %q is not a dependencies.FieldRefs() field", tc.wantKey)
+			}
+		})
+	}
+}
+
+// TestFKLift_AbsentSafe pins that the FK lift never breaks the base
+// extractor when the FK property is absent: the canonical identifiers are
+// still produced and no empty FK key is stamped.
+func TestFKLift_AbsentSafe(t *testing.T) {
+	t.Parallel()
+	cfg := configByTFType(t, "aws_lambda_function")
+	got := cfg.NativeIDsFromProperties("fn", map[string]any{"Arn": "arn:aws:lambda:us-east-1:1:function:fn"})
+	if got["arn"] != "arn:aws:lambda:us-east-1:1:function:fn" {
+		t.Fatalf("base arn lost: %v", got)
+	}
+	if _, ok := got["role_arn"]; ok {
+		t.Fatalf("role_arn stamped despite absent Role property: %v", got)
+	}
+	if _, ok := got["kms_key_arn"]; ok {
+		t.Fatalf("kms_key_arn stamped despite absent KmsKeyArn property: %v", got)
+	}
+}
+
+// TestFKLift_DoesNotClobberBase pins first-writer-wins: a base extractor's
+// canonical id under a key is never overwritten by an FK lift sharing that
+// key (defensive — none of the wired pairs collide today).
+func TestFKLift_DoesNotClobberBase(t *testing.T) {
+	t.Parallel()
+	base := func(_ string, _ map[string]any) map[string]string {
+		return map[string]string{"kms_key_id": "base-wins"}
+	}
+	ext := fkNativeIDs(base, fkRef{cfnProp: "KmsKeyId", nativeKey: "kms_key_id"})
+	got := ext("x", map[string]any{"KmsKeyId": "fk-loses"})
+	if got["kms_key_id"] != "base-wins" {
+		t.Fatalf("fk lift clobbered base: %v", got)
+	}
+}
+
+// TestDiscoverOnlyClosure_NoAttrs is the end-to-end parity proof: an IR
+// set with EMPTY Attrs — exactly what discovery fast mode returns — still
+// produces the full picker closure. Parent/child edges come from
+// resolveParentAddresses (ParentAddress); free-form FK edges come from
+// composer/imported.DependencyEdges (NativeIDs). Together they reproduce
+// what reliable's Attrs-based path shows today.
+func TestDiscoverOnlyClosure_NoAttrs(t *testing.T) {
+	t.Parallel()
+
+	roleARN := "arn:aws:iam::1:role/exec"
+	kmsARN := "arn:aws:kms:us-east-1:1:key/k1"
+
+	irs := []imported.ImportedResource{
+		// Targets. res() builds a discover-only IR (Identity set, Attrs nil).
+		res("aws_iam_role", "aws_iam_role.exec", "exec", map[string]string{"arn": roleARN}),
+		res("aws_kms_key", "aws_kms_key.k", "k1", map[string]string{"arn": kmsARN}),
+		res("aws_vpc", "aws_vpc.main", "vpc-1", map[string]string{"id": "vpc-1"}),
+		res("aws_s3_bucket", "aws_s3_bucket.logs", "logs", map[string]string{"name": "logs"}),
+		// Free-form FK source: lambda → iam_role + kms_key.
+		res("aws_lambda_function", "aws_lambda_function.api", "api",
+			map[string]string{"arn": "arn:aws:lambda:us-east-1:1:function:api", "role_arn": roleARN, "kms_key_arn": kmsARN}),
+		// Parent/child source: subnet → vpc (vpc_id is BOTH a FieldRefs FK
+		// and a parent/child FK).
+		res("aws_subnet", "aws_subnet.web", "subnet-1", map[string]string{"id": "subnet-1", "vpc_id": "vpc-1"}),
+		// Parent/child source: s3 sub-resource → bucket.
+		res("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.logs", "logs", map[string]string{"bucket": "logs"}),
+	}
+
+	// All Attrs are nil/empty — assert that before resolving.
+	for _, r := range irs {
+		if len(r.Attrs) != 0 {
+			t.Fatalf("fixture has non-empty Attrs for %s — fast mode is Attrs-free", r.Identity.Address)
+		}
+	}
+
+	// Parent/child closure (discover-time, no AWS calls).
+	resolveParentAddresses(irs)
+	parentByAddr := map[string]string{}
+	for _, r := range irs {
+		parentByAddr[r.Identity.Address] = r.Identity.ParentAddress
+	}
+	if parentByAddr["aws_subnet.web"] != "aws_vpc.main" {
+		t.Errorf("subnet parent = %q, want aws_vpc.main", parentByAddr["aws_subnet.web"])
+	}
+	if parentByAddr["aws_s3_bucket_versioning.logs"] != "aws_s3_bucket.logs" {
+		t.Errorf("versioning parent = %q, want aws_s3_bucket.logs", parentByAddr["aws_s3_bucket_versioning.logs"])
+	}
+
+	// Free-form FK closure (discover-time, no Attrs).
+	edges := imported.DependencyEdges(irs)
+	want := map[string][]string{
+		"aws_lambda_function.api": {"aws_iam_role.exec", "aws_kms_key.k"},
+		// vpc_id is a FieldRefs FK too, so the subnet→vpc edge surfaces here
+		// as well — consistent with reliable's Attrs path (which also reads
+		// vpc_id from Attrs). The picker dedupes against the parent edge.
+		"aws_subnet.web": {"aws_vpc.main"},
+	}
+	if !mapsEqual(edges, want) {
+		t.Fatalf("DependencyEdges = %v, want %v", edges, want)
+	}
+}
+
+func mapsEqual(a, b map[string][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if av[i] != bv[i] {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/cmd/insideout-import/discover.go
+++ b/cmd/insideout-import/discover.go
@@ -915,6 +915,32 @@ Exit codes:
 			len(unimportableRows), unimportableReasonsSummary(unimportableRows))
 	}
 
+	// #736: cascade-drop orphaned children. partitionUnimportable above (and
+	// the per-region/per-type scope of discovery) can remove a parent from the
+	// set while its sub-resources remain — e.g. an InsideOut-managed
+	// `luther-*-tfstate` S3 bucket is excluded as ReasonInsideOutImported but
+	// its aws_s3_bucket_ownership_controls / _versioning / _sse / _public_access_block
+	// children were discovered independently and still carry a ParentAddress
+	// pointing at the now-absent bucket. Importing a sub-resource whose bucket
+	// you are deliberately not managing is wrong, and left in the set the
+	// dangling ParentAddress would (pre-#736) fail composer.ValidateImportedResources
+	// and abort the whole scan. Drop the orphans transitively (grandparent gone
+	// → child dropped → grandchild orphaned → dropped) and route them into the
+	// unsupported set so the wizard can show why.
+	resources, orphanRows := imported.DropOrphanedChildren(resources)
+	if len(orphanRows) > 0 {
+		orphanUnsupported := make([]UnsupportedResource, 0, len(orphanRows))
+		for _, ir := range orphanRows {
+			orphanUnsupported = append(orphanUnsupported, unsupportedFromImported(ir, imported.DanglingParentReason))
+		}
+		unimportableRows = append(unimportableRows, orphanUnsupported...)
+		fmt.Fprintf(os.Stderr,
+			"discover: dropped %d orphaned child resource(s) from imported.json "+
+				"(parent resource excluded/absent from the set — dangling ParentAddress, "+
+				"e.g. S3 sub-resources of an InsideOut-managed tfstate bucket): %s\n",
+			len(orphanRows), orphanAddressesSummary(orphanRows))
+	}
+
 	out, n, err := writeManifest(*outputDir, cloud, resources)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "discover: %v\n", err)

--- a/cmd/insideout-import/discover_test.go
+++ b/cmd/insideout-import/discover_test.go
@@ -697,6 +697,78 @@ func TestRunDiscoverWithDeps_ValidatorFailsExitsFatal(t *testing.T) {
 	}
 }
 
+// TestRunDiscoverWithDeps_OrphanedChildrenDoNotAbortScan is the #736
+// regression: an InsideOut-managed S3 bucket carries the imported marker so
+// partitionUnimportable drops it from the importable set, but its discovered
+// S3 sub-resources keep a ParentAddress pointing at the now-absent bucket.
+// Before #736 the dangling ParentAddress tripped
+// composer.ValidateImportedResources and aborted the WHOLE scan (exit 2, no
+// imported.json). After the cascade-drop, the orphaned children are removed,
+// the scan completes (exit 0), imported.json is written, and the orphans are
+// absent from it.
+func TestRunDiscoverWithDeps_OrphanedChildrenDoNotAbortScan(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	const bucket = "aws_s3_bucket.luther_34f220f6_default_tfstate_s3_dwk3"
+	// InsideOut-managed bucket — the imported marker tag makes
+	// imported.UnimportableReason classify it ReasonInsideOutImported, so
+	// partitionUnimportable excludes it from imported.json.
+	insideOutBucket := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  bucket,
+			ImportID: "luther-34f220f6-default-tfstate-s3-dwk3",
+			Tags:     map[string]string{"InsideOutImported": "true"},
+		},
+		Tier:   imported.TierImportedFlat,
+		Source: imported.SourceImporter,
+	}
+	child := func(typ, addr string) imported.ImportedResource {
+		ir := validResource(addr)
+		ir.Identity.Type = typ
+		ir.Identity.ParentAddress = bucket
+		return ir
+	}
+	agg := &fakeAggregator{out: []imported.ImportedResource{
+		insideOutBucket,
+		child("aws_s3_bucket_ownership_controls", "aws_s3_bucket_ownership_controls.luther_34f220f6_default_tfstate_s3_dwk3_ownership"),
+		child("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.luther_34f220f6_default_tfstate_s3_dwk3_versioning"),
+		child("aws_s3_bucket_server_side_encryption_configuration", "aws_s3_bucket_server_side_encryption_configuration.luther_34f220f6_default_tfstate_s3_dwk3_sse"),
+		child("aws_s3_bucket_public_access_block", "aws_s3_bucket_public_access_block.luther_34f220f6_default_tfstate_s3_dwk3_public_access_block"),
+		// an unrelated, fully-intact resource must survive.
+		validResource("aws_sqs_queue.dlq"),
+	}}
+
+	rc := runDiscoverWithDeps([]string{
+		"--provider", "aws", "--project", "p", "--region", "us-east-1", "--output-dir", dir, "--no-hcl",
+	}, okDeps(agg))
+	if rc != discoverExitOK {
+		t.Fatalf("rc=%d, want OK — orphaned S3 sub-resources must not abort the scan (#736)", rc)
+	}
+
+	body, err := os.ReadFile(filepath.Join(dir, "imported.json"))
+	if err != nil {
+		t.Fatalf("imported.json must be written (the prior failure mode wrote nothing): %v", err)
+	}
+	var got []imported.ImportedResource
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("imported.json decode: %v", err)
+	}
+	gotAddrs := make([]string, 0, len(got))
+	for _, ir := range got {
+		gotAddrs = append(gotAddrs, ir.Identity.Address)
+	}
+	// Only the unrelated queue survives: the InsideOut bucket is excluded as
+	// un-importable, and every orphaned S3 sub-resource is cascade-dropped.
+	assert.Equal(t, []string{"aws_sqs_queue.dlq"}, gotAddrs,
+		"manifest must contain only the intact, parent-resolvable resource")
+	for _, a := range gotAddrs {
+		assert.NotContains(t, a, "tfstate", "no orphaned S3 sub-resource of the excluded bucket may leak into imported.json")
+	}
+}
+
 // TestRunDiscoverWithDeps_GenconfigInvokedOnHappyPath pins that Stage 2b's
 // HCL pipeline runs by default after a successful manifest write. A mutation
 // that drops the genconfig dispatch (e.g. flipping --no-hcl's default to

--- a/cmd/insideout-import/manifest.go
+++ b/cmd/insideout-import/manifest.go
@@ -105,7 +105,43 @@ func writeManifest(dir, cloud string, resources []imported.ImportedResource) (st
 	})
 
 	if issues := composer.ValidateImportedResources(cloud, resources); len(issues) > 0 {
-		return "", 0, fmt.Errorf("manifest validation failed (%d issue(s)): %s", len(issues), formatIssues(issues))
+		// #736 backstop: the imported_resource_dangling_parent orphan
+		// condition is recoverable — drop the offending child and continue —
+		// not a reason to abort the whole scan. discover.go's cascade-drop
+		// (imported.DropOrphanedChildren) already removes these before
+		// writeManifest, so reaching here with danglers means a future caller
+		// fed an un-cascaded set; rather than re-abort, drop them, warn, and
+		// re-validate the survivors. Every other validation code (wrong cloud,
+		// missing address/import-id, decode failure, address collision, …)
+		// stays fatal.
+		fatal, dangling := composer.PartitionDanglingParentIssues(issues)
+		if len(dangling) > 0 {
+			resources = dropDanglingParents(resources, dangling)
+			fmt.Fprintf(os.Stderr,
+				"manifest: dropped %d orphaned child resource(s) with a dangling ParentAddress (recoverable; continuing): %s\n",
+				len(dangling), formatIssues(dangling))
+			// Re-validate survivors: dropping a child can itself orphan a
+			// grandchild whose parent was that child. ValidateImportedResources
+			// re-derives the full address index, so a second pass catches any
+			// newly-dangling reference; loop until clean or a genuinely-fatal
+			// issue surfaces.
+			for {
+				reIssues := composer.ValidateImportedResources(cloud, resources)
+				if len(reIssues) == 0 {
+					fatal = nil
+					break
+				}
+				reFatal, reDangling := composer.PartitionDanglingParentIssues(reIssues)
+				if len(reDangling) == 0 {
+					fatal = reFatal
+					break
+				}
+				resources = dropDanglingParents(resources, reDangling)
+			}
+		}
+		if len(fatal) > 0 {
+			return "", 0, fmt.Errorf("manifest validation failed (%d issue(s)): %s", len(fatal), formatIssues(fatal))
+		}
 	}
 
 	body, err := json.MarshalIndent(resources, "", "  ")
@@ -122,6 +158,35 @@ func writeManifest(dir, cloud string, resources []imported.ImportedResource) (st
 		return "", 0, fmt.Errorf("write %s: %w", out, err)
 	}
 	return out, len(resources), nil
+}
+
+// dropDanglingParents returns resources with every row flagged by a
+// imported_resource_dangling_parent issue removed (#736). dangling is the
+// subset of ValidationIssues whose Code is
+// composer.CodeImportedDanglingParent; each issue's Field is
+// "imported.<child-address>" (importedField). The orphaned child references a
+// parent no longer in the set, so importing it is wrong and would re-trip the
+// validator — drop it and keep the rest of the manifest importable.
+//
+// The input slice is never mutated; a new slice is returned. Rows with an empty
+// Address (which the validator flags separately as imported_resource_missing_address,
+// a fatal code) are never matched here.
+func dropDanglingParents(resources []imported.ImportedResource, dangling []composer.ValidationIssue) []imported.ImportedResource {
+	if len(dangling) == 0 {
+		return resources
+	}
+	refused := make(map[string]bool, len(dangling))
+	for _, is := range dangling {
+		refused[strings.TrimPrefix(is.Field, "imported.")] = true
+	}
+	out := make([]imported.ImportedResource, 0, len(resources))
+	for _, ir := range resources {
+		if refused[strings.TrimSpace(ir.Identity.Address)] {
+			continue
+		}
+		out = append(out, ir)
+	}
+	return out
 }
 
 // readManifest reads <path> from disk, decodes the JSON array of

--- a/cmd/insideout-import/manifest_test.go
+++ b/cmd/insideout-import/manifest_test.go
@@ -142,6 +142,123 @@ func TestWriteManifest_AddressCollisionDetectedByValidator(t *testing.T) {
 	}
 }
 
+// validChildIR builds an importable child resource whose ParentAddress points
+// at parent — the S3-sub-resource shape that #736 leaves orphaned when its
+// bucket is excluded from the set.
+func validChildIR(typ, addr, importID, parent string) imported.ImportedResource {
+	ir := validIR(typ, addr, importID)
+	ir.Identity.ParentAddress = parent
+	return ir
+}
+
+// TestWriteManifest_DanglingParentNonFatalBackstop pins the #736 backstop:
+// imported_resource_dangling_parent must NOT abort writeManifest. Before #736
+// the dangling-parent code was fatal (no imported.json written, exit 2 in the
+// CLI). With the backstop, writeManifest drops the orphaned children, writes a
+// clean manifest of the survivors, and never surfaces the dangling-parent code
+// as an error.
+func TestWriteManifest_DanglingParentNonFatalBackstop(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	const bucket = "aws_s3_bucket.luther_tfstate"
+	// bucket itself is NOT in the set (excluded upstream). Its sub-resources
+	// remain with a dangling ParentAddress — the exact pre-#736 fatal case.
+	in := []imported.ImportedResource{
+		validChildIR("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.luther_tfstate_versioning", "luther-tfstate", bucket),
+		validChildIR("aws_s3_bucket_public_access_block", "aws_s3_bucket_public_access_block.luther_tfstate_pab", "luther-tfstate", bucket),
+		validIR("aws_sqs_queue", "aws_sqs_queue.dlq", "https://example/dlq"),
+	}
+
+	path, n, err := writeManifest(dir, "aws", in)
+	if err != nil {
+		t.Fatalf("writeManifest must not abort on a dangling parent (#736); got: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("manifest count=%d, want 1 (orphaned S3 sub-resources dropped, queue kept)", n)
+	}
+
+	// The prior failure mode is gone: imported.json exists and the validator
+	// passes on the survivors.
+	got, rerr := readManifest(path, "aws")
+	if rerr != nil {
+		t.Fatalf("survivors must re-validate clean (no imported_resource_dangling_parent); got: %v", rerr)
+	}
+	if len(got) != 1 || got[0].Identity.Address != "aws_sqs_queue.dlq" {
+		t.Errorf("survivors=%v, want only aws_sqs_queue.dlq", addrsOf(got))
+	}
+}
+
+// TestWriteManifest_DanglingParentTransitiveBackstop covers the transitive
+// re-validation loop: dropping a child can orphan a grandchild whose parent was
+// that child. writeManifest must converge — no grandchild leaks into the
+// manifest, and no fatal dangling-parent error surfaces.
+func TestWriteManifest_DanglingParentTransitiveBackstop(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// grandparent aws_vpc.gone is absent. child references it; grandchild
+	// references child.
+	in := []imported.ImportedResource{
+		validChildIR("aws_subnet", "aws_subnet.child", "subnet-1", "aws_vpc.gone"),
+		validChildIR("aws_route_table_association", "aws_route_table_association.grandchild", "rtbassoc-1", "aws_subnet.child"),
+		validIR("aws_sqs_queue", "aws_sqs_queue.keep", "https://example/keep"),
+	}
+	path, n, err := writeManifest(dir, "aws", in)
+	if err != nil {
+		t.Fatalf("writeManifest must converge on transitive orphans (#736); got: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("manifest count=%d, want 1 (both orphan + grandchild dropped)", n)
+	}
+	got, rerr := readManifest(path, "aws")
+	if rerr != nil {
+		t.Fatalf("survivors must re-validate clean; got: %v", rerr)
+	}
+	if len(got) != 1 || got[0].Identity.Address != "aws_sqs_queue.keep" {
+		t.Errorf("survivors=%v, want only aws_sqs_queue.keep", addrsOf(got))
+	}
+}
+
+// TestWriteManifest_GenuinelyFatalStillFatalWithDangler proves the backstop is
+// narrowly scoped: a genuinely-fatal issue (missing import id) is NOT swallowed
+// just because a dangling-parent issue is also present. The validator stays
+// toothless-proof — only the dangling-parent code is recoverable.
+func TestWriteManifest_GenuinelyFatalStillFatalWithDangler(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	in := []imported.ImportedResource{
+		// dangling parent — recoverable.
+		validChildIR("aws_s3_bucket_versioning", "aws_s3_bucket_versioning.orphan", "id", "aws_s3_bucket.gone"),
+		// missing import id — genuinely fatal; must still abort.
+		{
+			Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.bad"},
+			Tier:     imported.TierImportedFlat,
+			Source:   imported.SourceImporter,
+		},
+	}
+	_, _, err := writeManifest(dir, "aws", in)
+	if err == nil {
+		t.Fatal("a genuinely-fatal issue must still abort even alongside a dangling parent")
+	}
+	if !strings.Contains(err.Error(), "imported_resource_missing_import_id") {
+		t.Errorf("error must mention the fatal missing-import-id code; got: %v", err)
+	}
+	if strings.Contains(err.Error(), "imported_resource_dangling_parent") {
+		t.Errorf("the recoverable dangling-parent code must not be reported as fatal; got: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "imported.json")); !os.IsNotExist(statErr) {
+		t.Errorf("imported.json must NOT be written when a genuinely-fatal issue remains")
+	}
+}
+
+// addrsOf extracts the Address of each resource for compact assertions.
+func addrsOf(irs []imported.ImportedResource) []string {
+	out := make([]string, 0, len(irs))
+	for _, ir := range irs {
+		out = append(out, ir.Identity.Address)
+	}
+	return out
+}
+
 // readManifest is the inverse of writeManifest: writes-then-reads round
 // trip pins the wire-shape contract end-to-end. A regression that drops
 // the validator (or runs only one direction) would still pass the

--- a/cmd/insideout-import/unsupported_partition.go
+++ b/cmd/insideout-import/unsupported_partition.go
@@ -70,6 +70,25 @@ func unsupportedFromImported(ir imported.ImportedResource, reason string) Unsupp
 	}
 }
 
+// orphanAddressesSummary renders a compact, deterministic
+// "child.address (-> parent.address)" breakdown for the #736 orphaned-child
+// stderr line. Sorted by child Address so the message is stable across runs.
+// Capped at a handful of entries with a "(+N more)" suffix so a pathological
+// run with hundreds of orphans does not flood stderr.
+func orphanAddressesSummary(rows []imported.ImportedResource) string {
+	const maxShown = 8
+	lines := make([]string, 0, len(rows))
+	for _, ir := range rows {
+		lines = append(lines, fmt.Sprintf("%s (-> %s)", ir.Identity.Address, ir.Identity.ParentAddress))
+	}
+	sort.Strings(lines)
+	if len(lines) <= maxShown {
+		return strings.Join(lines, ", ")
+	}
+	more := len(lines) - maxShown
+	return strings.Join(lines[:maxShown], ", ") + fmt.Sprintf(", (+%d more)", more)
+}
+
 // unimportableReasonsSummary renders a compact, deterministic
 // "<count> <reason>" breakdown (e.g. "5 aws_managed_kms_alias, 1
 // service_managed_eni") for the stderr exclusion line. Sorted by reason code

--- a/pkg/composer/imported/dependency_edges.go
+++ b/pkg/composer/imported/dependency_edges.go
@@ -1,0 +1,51 @@
+package imported
+
+import (
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/dependencies"
+)
+
+// dependency_edges.go bridges a discovered []ImportedResource set to the
+// enrich-free cross-reference resolver in pkg/imported/dependencies. It
+// lets reliable's import wizard compute the picker's "auto-included N
+// dependencies" closure from discover-time data alone — no per-resource
+// EnrichAttributes describe call and no Attrs (presets#733 /
+// reliable#2040).
+//
+// The edges produced here are the free-form foreign-key edges
+// (role → aws_iam_role, kms_key_arn → aws_kms_key, vpc_id → aws_vpc, …)
+// declared in dependencies.FieldRefs(). They are the discover-only
+// equivalent of reliable's Attrs-based resolveImportedDependencies,
+// derived from Identity.NativeIDs that the discoverers lift at discover
+// time. They are complementary to the parent/child ParentAddress edges
+// stamped by the AWS parent resolver — together the two cover the full
+// closure the picker shows today.
+
+// DependencyEdges returns a map keyed by each resource's
+// Identity.Address with the sorted, de-duplicated list of sibling
+// Addresses its cross-reference FK fields resolve to. Pure: no I/O, no
+// Attrs — it reads Identity.NativeIDs only, so it works on a discover-only
+// IR set whose Attrs are empty.
+//
+// This is the parity surface for the discovery fast mode: given a
+// discovered set with empty Attrs, the edges returned here match what
+// reliable's enriched-Attrs resolver produces today, provided the
+// discoverers lifted the FieldRefs() FK fields into NativeIDs (the AWS
+// Cloud Control extractors do — see
+// cmd/insideout-import/awsdiscover/cloudcontrol_types.go).
+//
+// Returns nil when no edges resolve.
+func DependencyEdges(irs []ImportedResource) map[string][]string {
+	if len(irs) == 0 {
+		return nil
+	}
+	sources := make([]dependencies.EdgeSource, 0, len(irs))
+	for _, ir := range irs {
+		sources = append(sources, dependencies.EdgeSource{
+			Address:   ir.Identity.Address,
+			Type:      ir.Identity.Type,
+			NativeIDs: ir.Identity.NativeIDs,
+			ImportID:  ir.Identity.ImportID,
+		})
+	}
+	return dependencies.ResolveFromIdentities(sources)
+}

--- a/pkg/composer/imported/orphans.go
+++ b/pkg/composer/imported/orphans.go
@@ -1,0 +1,98 @@
+package imported
+
+import "strings"
+
+// DanglingParentReason is the stable reason code stamped on a child resource
+// that DropOrphanedChildren removes because its Identity.ParentAddress points
+// at a resource no longer present in the set. It mirrors the composer's
+// imported_resource_dangling_parent validation code but lives here so discovery
+// callers can route dropped children into an unsupported/skipped manifest with
+// a consistent reason without importing the composer package (which would be a
+// dependency cycle — composer imports imported, not the reverse).
+const DanglingParentReason = "imported_resource_dangling_parent"
+
+// DropOrphanedChildren removes every resource whose Identity.ParentAddress
+// transitively references a resource that is not present in the kept set, and
+// returns the surviving resources plus the dropped orphans (each unchanged).
+//
+// Background (#736): discovery excludes some resources from the importable set
+// — e.g. InsideOut-managed `luther-*-tfstate` S3 buckets are dropped as
+// un-importable (ReasonInsideOutImported). But their sub-resources
+// (aws_s3_bucket_ownership_controls, _versioning,
+// _server_side_encryption_configuration, _public_access_block, …) are
+// discovered independently and keep a ParentAddress pointing at the now-absent
+// bucket. Left in the set those children are dangling: they reference a parent
+// the operator is deliberately not managing, and the composer's
+// imported_resource_dangling_parent check would (in the CLI) abort the entire
+// scan. Importing an S3 sub-resource whose bucket you are not managing is also
+// semantically wrong. So when a parent is dropped, its dependent children must
+// be dropped too.
+//
+// The pass runs to a fixed point so a transitive chain collapses correctly:
+// if a grandparent is absent, its child is dropped, which in turn orphans the
+// grandchild, which is then dropped on the next iteration. Resources with an
+// empty ParentAddress, or whose ParentAddress resolves to a kept resource, are
+// always retained.
+//
+// Both return slices preserve the input order and are always non-nil.
+// The common case (no orphans) returns the input order with an empty dropped
+// slice and does not reorder kept.
+func DropOrphanedChildren(irs []ImportedResource) (kept []ImportedResource, dropped []ImportedResource) {
+	kept = make([]ImportedResource, 0, len(irs))
+	dropped = []ImportedResource{}
+	if len(irs) == 0 {
+		return kept, dropped
+	}
+
+	// present indexes the Addresses currently in the kept set. Built once,
+	// then shrunk in place as orphans are removed across iterations.
+	present := make(map[string]bool, len(irs))
+	for _, ir := range irs {
+		if addr := strings.TrimSpace(ir.Identity.Address); addr != "" {
+			present[addr] = true
+		}
+	}
+
+	// removed records Addresses we have decided to drop so we never re-add a
+	// resource on a later sweep (and so order-preservation reads from a
+	// stable verdict map at the end).
+	removed := map[string]bool{}
+	droppedIdx := map[int]bool{}
+
+	for {
+		changed := false
+		for i, ir := range irs {
+			if droppedIdx[i] {
+				continue
+			}
+			parent := strings.TrimSpace(ir.Identity.ParentAddress)
+			if parent == "" {
+				continue
+			}
+			if present[parent] {
+				continue
+			}
+			// Orphan: parent is absent (never discovered or already
+			// dropped). Remove this child and, if it had an Address,
+			// retract it from present so its own children orphan next sweep.
+			droppedIdx[i] = true
+			changed = true
+			if addr := strings.TrimSpace(ir.Identity.Address); addr != "" {
+				delete(present, addr)
+				removed[addr] = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	for i, ir := range irs {
+		if droppedIdx[i] {
+			dropped = append(dropped, ir)
+			continue
+		}
+		kept = append(kept, ir)
+	}
+	return kept, dropped
+}

--- a/pkg/composer/imported/orphans_test.go
+++ b/pkg/composer/imported/orphans_test.go
@@ -1,0 +1,124 @@
+package imported
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// res is a tiny constructor for an ImportedResource with just the fields the
+// orphan-cascade pass reads (Address + ParentAddress).
+func res(addr, parent string) ImportedResource {
+	return ImportedResource{
+		Identity: ResourceIdentity{
+			Cloud:         "aws",
+			Address:       addr,
+			ParentAddress: parent,
+		},
+	}
+}
+
+func addrsOf(irs []ImportedResource) []string {
+	out := make([]string, 0, len(irs))
+	for _, ir := range irs {
+		out = append(out, ir.Identity.Address)
+	}
+	return out
+}
+
+// TestDanglingParentReason_WireStable pins the reason code DropOrphanedChildren
+// stamps on dropped orphans — it must match the composer's
+// imported_resource_dangling_parent validation code (cross-package contract,
+// #736).
+func TestDanglingParentReason_WireStable(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "imported_resource_dangling_parent", DanglingParentReason)
+}
+
+func TestDropOrphanedChildren_Empty(t *testing.T) {
+	t.Parallel()
+	kept, dropped := DropOrphanedChildren(nil)
+	assert.Empty(t, kept)
+	assert.Empty(t, dropped)
+	assert.NotNil(t, kept, "kept must be non-nil even on empty input")
+	assert.NotNil(t, dropped, "dropped must be non-nil even on empty input")
+}
+
+func TestDropOrphanedChildren_NoOrphans(t *testing.T) {
+	t.Parallel()
+	in := []ImportedResource{
+		res("aws_s3_bucket.b", ""),
+		res("aws_s3_bucket_versioning.b_versioning", "aws_s3_bucket.b"),
+		res("aws_sqs_queue.q", ""),
+	}
+	kept, dropped := DropOrphanedChildren(in)
+	assert.Equal(t, []string{
+		"aws_s3_bucket.b",
+		"aws_s3_bucket_versioning.b_versioning",
+		"aws_sqs_queue.q",
+	}, addrsOf(kept), "every child resolves its parent — nothing dropped, order preserved")
+	assert.Empty(t, dropped)
+}
+
+// TestDropOrphanedChildren_ParentExcluded is the exact #736 scenario: the
+// parent bucket was excluded from the set (e.g. ReasonInsideOutImported), but
+// its S3 sub-resources remained with a dangling ParentAddress. The children
+// must be dropped.
+func TestDropOrphanedChildren_ParentExcluded(t *testing.T) {
+	t.Parallel()
+	const bucket = "aws_s3_bucket.luther_34f220f6_default_tfstate_s3_dwk3"
+	in := []ImportedResource{
+		// bucket itself is NOT in the set (excluded upstream as un-importable).
+		res("aws_s3_bucket_ownership_controls.luther_34f220f6_default_tfstate_s3_dwk3_ownership", bucket),
+		res("aws_s3_bucket_versioning.luther_34f220f6_default_tfstate_s3_dwk3_versioning", bucket),
+		res("aws_s3_bucket_server_side_encryption_configuration.luther_34f220f6_default_tfstate_s3_dwk3_sse", bucket),
+		res("aws_s3_bucket_public_access_block.luther_34f220f6_default_tfstate_s3_dwk3_public_access_block", bucket),
+		// an unrelated, fully-intact resource must survive.
+		res("aws_sqs_queue.dlq", ""),
+	}
+	kept, dropped := DropOrphanedChildren(in)
+
+	assert.Equal(t, []string{"aws_sqs_queue.dlq"}, addrsOf(kept),
+		"every orphaned S3 sub-resource of the excluded bucket must be dropped; the unrelated queue survives")
+	require.Len(t, dropped, 4)
+	for _, d := range dropped {
+		assert.Equal(t, bucket, d.Identity.ParentAddress,
+			"dropped orphan retains its dangling ParentAddress for reporting")
+	}
+}
+
+// TestDropOrphanedChildren_Transitive covers grandparent excluded → parent (its
+// child) dropped → grandchild dropped too. Requires the fixed-point loop.
+func TestDropOrphanedChildren_Transitive(t *testing.T) {
+	t.Parallel()
+	in := []ImportedResource{
+		// grandparent "aws_vpc.gone" is NOT present.
+		res("aws_subnet.child", "aws_vpc.gone"),                           // orphaned directly
+		res("aws_route_table_association.grandchild", "aws_subnet.child"), // orphaned once child goes
+		res("aws_vpc.kept", ""),                                           // intact root survives
+		res("aws_subnet.kept_child", "aws_vpc.kept"),                      // resolves → survives
+	}
+	kept, dropped := DropOrphanedChildren(in)
+
+	assert.ElementsMatch(t, []string{"aws_vpc.kept", "aws_subnet.kept_child"}, addrsOf(kept),
+		"only the resources with a fully-resolvable parent chain survive")
+	assert.ElementsMatch(t,
+		[]string{"aws_subnet.child", "aws_route_table_association.grandchild"},
+		addrsOf(dropped),
+		"both the direct orphan and the transitively-orphaned grandchild are dropped")
+}
+
+// TestDropOrphanedChildren_OrderPreserved confirms kept preserves input order
+// (the on-disk manifest sorts later, but the pass itself must be stable).
+func TestDropOrphanedChildren_OrderPreserved(t *testing.T) {
+	t.Parallel()
+	in := []ImportedResource{
+		res("aws_z.last", ""),
+		res("aws_orphan.x", "aws_missing.parent"),
+		res("aws_a.first", ""),
+	}
+	kept, _ := DropOrphanedChildren(in)
+	assert.Equal(t, []string{"aws_z.last", "aws_a.first"}, addrsOf(kept),
+		"kept preserves input order; the orphan in the middle is removed")
+}

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -184,6 +184,41 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 	return issues
 }
 
+// CodeImportedDanglingParent is the validation code emitted by
+// ValidateImportedResources when a resource's Identity.ParentAddress does not
+// resolve to any Address in the set. It is exported so callers can classify it
+// as a per-resource drop-and-continue condition rather than a fatal abort
+// (#736) — see IsDanglingParentIssue and PartitionDanglingParentIssues.
+const CodeImportedDanglingParent = imported.DanglingParentReason
+
+// IsDanglingParentIssue reports whether a ValidationIssue is the
+// imported_resource_dangling_parent orphan condition (#736). That condition is
+// recoverable: the offending child references a parent no longer in the set, so
+// the caller can drop the orphan and continue rather than abort the whole
+// operation. Every other code returned by ValidateImportedResources signals a
+// genuinely malformed resource (wrong cloud, missing address/import-id, decode
+// failure, address collision, …) and stays fatal.
+func IsDanglingParentIssue(i ValidationIssue) bool {
+	return i.Code == CodeImportedDanglingParent
+}
+
+// PartitionDanglingParentIssues splits issues into the genuinely-fatal set and
+// the recoverable imported_resource_dangling_parent orphan set (#736). Callers
+// that want partial tolerance — drop the orphaned child + warn, abort only on
+// fatal issues — use this to scope the non-fatal downgrade narrowly to the
+// dangling-parent case. Both slices preserve input order and are nil when
+// empty.
+func PartitionDanglingParentIssues(issues []ValidationIssue) (fatal []ValidationIssue, dangling []ValidationIssue) {
+	for _, i := range issues {
+		if IsDanglingParentIssue(i) {
+			dangling = append(dangling, i)
+			continue
+		}
+		fatal = append(fatal, i)
+	}
+	return fatal, dangling
+}
+
 // ValidateImportedEmitReadiness runs the emit-time-only checks on irs:
 // checks that are meaningful only once discovery has finished and the
 // composer is about to render `/imported.tf`. Unlike

--- a/pkg/composer/imported_validate_test.go
+++ b/pkg/composer/imported_validate_test.go
@@ -284,6 +284,54 @@ func TestDropUncomposable(t *testing.T) {
 	assert.Len(t, dropUncomposable([]imported.ImportedResource{good}, nil), 1)
 }
 
+// TestCodeImportedDanglingParent_WireStable pins that the exported classifier
+// constant matches the literal code ValidateImportedResources emits (#736), so
+// callers that branch on CodeImportedDanglingParent never drift from the
+// validator.
+func TestCodeImportedDanglingParent_WireStable(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "imported_resource_dangling_parent", CodeImportedDanglingParent)
+}
+
+// TestIsDanglingParentIssue confirms the classifier flags only the recoverable
+// orphan code and nothing else.
+func TestIsDanglingParentIssue(t *testing.T) {
+	t.Parallel()
+	assert.True(t, IsDanglingParentIssue(ValidationIssue{Code: "imported_resource_dangling_parent"}))
+	assert.False(t, IsDanglingParentIssue(ValidationIssue{Code: "imported_resource_missing_import_id"}))
+	assert.False(t, IsDanglingParentIssue(ValidationIssue{Code: "imported_resource_address_collision"}))
+	assert.False(t, IsDanglingParentIssue(ValidationIssue{}))
+}
+
+// TestPartitionDanglingParentIssues pins the fatal/recoverable split (#736):
+// only the dangling-parent code lands in the recoverable bucket; every other
+// validator code stays fatal, so the backstop can never make validation
+// toothless.
+func TestPartitionDanglingParentIssues(t *testing.T) {
+	t.Parallel()
+	issues := []ValidationIssue{
+		{Code: "imported_resource_missing_import_id", Field: "imported.a"},
+		{Code: "imported_resource_dangling_parent", Field: "imported.b"},
+		{Code: "imported_resource_address_collision", Field: "imported.c"},
+		{Code: "imported_resource_dangling_parent", Field: "imported.d"},
+	}
+	fatal, dangling := PartitionDanglingParentIssues(issues)
+
+	assert.Equal(t, []string{
+		"imported_resource_missing_import_id",
+		"imported_resource_address_collision",
+	}, issueCodes(fatal), "every non-dangling code stays fatal, input order preserved")
+	assert.Equal(t, []string{
+		"imported_resource_dangling_parent",
+		"imported_resource_dangling_parent",
+	}, issueCodes(dangling))
+
+	// Nil-safe: no issues -> both nil.
+	gotFatal, gotDangling := PartitionDanglingParentIssues(nil)
+	assert.Nil(t, gotFatal)
+	assert.Nil(t, gotDangling)
+}
+
 func TestValidateProvenanceConflicts_Empty(t *testing.T) {
 	t.Parallel()
 	assert.Nil(t, ValidateProvenanceConflicts("aws", nil, ProvenanceOpts{ImportProjectID: "io-1"}))

--- a/pkg/imported/dependencies/resolve.go
+++ b/pkg/imported/dependencies/resolve.go
@@ -1,0 +1,160 @@
+package dependencies
+
+// resolve.go is the discover-time, enrich-free half of cross-reference
+// resolution. It produces the SAME free-form foreign-key dependency
+// edges reliable's import wizard computes today from a resource's
+// enriched Attrs — but reads them from Identity.NativeIDs instead, so
+// the picker's "auto-included N dependencies" closure survives the move
+// to a discover-only scan (presets#733 / reliable#2040).
+//
+// The contract is a strict mirror of reliable's Attrs-based resolver
+// (internal/agentapi/import_dependencies.go::resolveImportedDependencies):
+//
+//   - For each resource, for each FieldRefs() cross-ref field, read the
+//     FK value and look it up against sibling resources' canonical
+//     identifiers (arn / self_link / full_name / id / ImportID).
+//   - The matched sibling must be of the target Terraform type the
+//     cross-ref declares.
+//   - Self-references and unresolved values are dropped (best-effort:
+//     a partial closure beats total failure).
+//
+// The ONLY difference is the source of the FK value: the Attrs-based
+// resolver reads `attrs[field]`; this one reads
+// `Identity.NativeIDs[field]`. For the two paths to agree byte-for-byte,
+// the discoverers must lift each FieldRefs() FK field into NativeIDs
+// under the SAME field name (e.g. an aws_lambda_function stamps
+// NativeIDs["role_arn"] / NativeIDs["kms_key_arn"]). The AWS Cloud
+// Control extractors do this at discover time with no extra API calls
+// (cmd/insideout-import/awsdiscover/cloudcontrol_types.go); see
+// TestResolveFromIdentities for the parity assertions.
+
+import "sort"
+
+// EdgeSource is the minimal identity view ResolveFromIdentities needs:
+// the resource's Terraform address + type, its native FK fields, and the
+// identifier set it can be referenced by. It is a structural subset of
+// composer/imported.ResourceIdentity so this package stays free of any
+// composer/cloud dependency and can be called from anywhere (reliable,
+// the discover CLI, the engine) without an import cycle.
+type EdgeSource struct {
+	// Address is the resource's Terraform address (map key in the output).
+	Address string
+	// Type is the resource's Terraform type, matched against the
+	// FieldRefs() target type to filter false-positive edges.
+	Type string
+	// NativeIDs is the discover-time native-identifier map. Cross-ref FK
+	// fields (role_arn, kms_key_arn, vpc_id, …) are read by FieldRefs()
+	// key from here; the canonical identifiers (arn, self_link, …) are
+	// indexed so siblings can resolve a value back to an address.
+	NativeIDs map[string]string
+	// ImportID is the provider import ID (ARN / name / self-link / URL),
+	// used as the last-resort identifier candidate — mirrors reliable's
+	// candidateIdentifiers fallback.
+	ImportID string
+}
+
+// identifierKeys is the ordered set of NativeIDs keys treated as a
+// resource's canonical, referenceable identifiers — the keys a FK value
+// on another resource is matched against. Mirrors reliable's
+// candidateIdentifiers (arn, self_link, full_name, id) plus ImportID,
+// which is added separately because it is a top-level field, not a
+// NativeIDs entry.
+var identifierKeys = []string{"arn", "self_link", "full_name", "id"}
+
+// ResolveFromIdentities returns a map keyed by each resource's Address
+// with the sorted, de-duplicated list of sibling Addresses its
+// cross-reference FK fields resolve to — computed from NativeIDs alone,
+// with no Attrs and no I/O.
+//
+// It is the discover-only equivalent of reliable's
+// resolveImportedDependencies and is guaranteed to produce the same edge
+// set whenever the discoverers have lifted the FieldRefs() FK fields into
+// NativeIDs (the parity invariant enforced by TestResolveFromIdentities
+// and the awsdiscover lift tests).
+//
+// Best-effort: a FK value pointing outside the discovered set, or at a
+// resource of the wrong type, is silently dropped. Returns nil when no
+// edges resolve, matching reliable's nil-on-empty contract.
+func ResolveFromIdentities(sources []EdgeSource) map[string][]string {
+	if len(sources) == 0 {
+		return nil
+	}
+
+	// Build the identifier → Address index. One entry per canonical
+	// identifier each resource exposes; first writer wins on a collision
+	// (deterministic by input order), matching reliable's
+	// buildIdentifierIndex.
+	idIndex := make(map[string]string, len(sources)*3)
+	typeByAddr := make(map[string]string, len(sources))
+	put := func(id, addr string) {
+		if id == "" || addr == "" {
+			return
+		}
+		if _, exists := idIndex[id]; exists {
+			return
+		}
+		idIndex[id] = addr
+	}
+	for _, s := range sources {
+		if s.Address == "" {
+			continue
+		}
+		typeByAddr[s.Address] = s.Type
+		for _, k := range identifierKeys {
+			put(s.NativeIDs[k], s.Address)
+		}
+		put(s.ImportID, s.Address)
+	}
+
+	out := make(map[string][]string, len(sources))
+	for _, s := range sources {
+		addr := s.Address
+		if addr == "" || len(s.NativeIDs) == 0 {
+			continue
+		}
+		var deps []string
+		for field, targetType := range fieldRefs {
+			value := s.NativeIDs[field]
+			if value == "" {
+				continue
+			}
+			matchedAddr, ok := idIndex[value]
+			if !ok || matchedAddr == addr {
+				// Unresolved, or a self-reference (defended in depth —
+				// the same value indexing a resource to itself).
+				continue
+			}
+			// Type filter: the matched sibling must be of the type the
+			// cross-reference declares. Guards against the degenerate
+			// case where two FK fields resolve to the same identifier on
+			// resources of different types.
+			if typeByAddr[matchedAddr] != targetType {
+				continue
+			}
+			deps = append(deps, matchedAddr)
+		}
+		if len(deps) > 0 {
+			sort.Strings(deps)
+			out[addr] = dedupeSorted(deps)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// dedupeSorted collapses consecutive duplicates in a sorted slice in
+// place. Called after a sort so duplicates land adjacent.
+func dedupeSorted(in []string) []string {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, s := range in[1:] {
+		if s != out[len(out)-1] {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/pkg/imported/dependencies/resolve_test.go
+++ b/pkg/imported/dependencies/resolve_test.go
@@ -1,0 +1,303 @@
+package dependencies
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// attrsResolve is a faithful, self-contained re-implementation of
+// reliable's Attrs-based resolveImportedDependencies
+// (internal/agentapi/import_dependencies.go). It is the oracle the
+// discover-only ResolveFromIdentities must match byte-for-byte: same
+// FieldRefs registry, same identifier candidate set, same target-type
+// filter, same self-ref guard, same sorted-deduped output. Keeping a
+// copy here lets the parity test prove equivalence without importing
+// reliable. If reliable's resolver changes, this oracle (and the
+// invariant) must change in lockstep.
+func attrsResolve(rows []fixtureRow) map[string][]string {
+	if len(rows) == 0 {
+		return nil
+	}
+	// Build identifier → address index from the SAME candidate set
+	// reliable uses: NativeIDs[arn|self_link|full_name|id] + ImportID.
+	idIndex := map[string]string{}
+	typeByAddr := map[string]string{}
+	for _, r := range rows {
+		if r.address == "" {
+			continue
+		}
+		typeByAddr[r.address] = r.tfType
+		for _, k := range []string{"arn", "self_link", "full_name", "id"} {
+			if v := r.nativeIDs[k]; v != "" {
+				if _, ok := idIndex[v]; !ok {
+					idIndex[v] = r.address
+				}
+			}
+		}
+		if r.importID != "" {
+			if _, ok := idIndex[r.importID]; !ok {
+				idIndex[r.importID] = r.address
+			}
+		}
+	}
+	out := map[string][]string{}
+	for _, r := range rows {
+		if r.address == "" {
+			continue
+		}
+		var deps []string
+		for field, targetType := range fieldRefs {
+			value, ok := r.attrs[field]
+			if !ok || value == "" {
+				continue
+			}
+			matched, ok := idIndex[value]
+			if !ok || matched == r.address {
+				continue
+			}
+			if typeByAddr[matched] != targetType {
+				continue
+			}
+			deps = append(deps, matched)
+		}
+		if len(deps) > 0 {
+			sort.Strings(deps)
+			out[r.address] = dedupeSorted(deps)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// fixtureRow models one discovered resource with BOTH the enriched-Attrs
+// view (attrs) and the discover-only view (nativeIDs). For a given FK
+// field the two views must agree: attrs[field] is what reliable reads
+// from the enriched payload today; nativeIDs[field] is what the
+// discoverer lifts into Identity.NativeIDs. The parity test asserts that
+// resolving from either view yields the identical edge set.
+type fixtureRow struct {
+	tfType    string
+	address   string
+	importID  string
+	nativeIDs map[string]string // canonical IDs (arn/id/…) + lifted FK fields
+	attrs     map[string]string // enriched cross-ref fields keyed by FieldRefs name
+}
+
+func (r fixtureRow) edgeSource() EdgeSource {
+	return EdgeSource{
+		Address:   r.address,
+		Type:      r.tfType,
+		NativeIDs: r.nativeIDs,
+		ImportID:  r.importID,
+	}
+}
+
+func sources(rows []fixtureRow) []EdgeSource {
+	out := make([]EdgeSource, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, r.edgeSource())
+	}
+	return out
+}
+
+// fkFixtures covers EVERY free-form FK field in FieldRefs(): the AWS
+// fields wired into the Cloud Control extractors (role/role_arn,
+// kms_key_arn, kms_key_id, kms_master_key_id, vpc_id, subnet_id) and the
+// GCP fields (network, subnetwork, kms_key_name). Each fixture pairs a
+// referencing resource (carrying the FK under both attrs[field] and
+// nativeIDs[field]) with the target it points at.
+func fkFixtures() map[string][]fixtureRow {
+	return map[string][]fixtureRow{
+		"role_arn → aws_iam_role": {
+			{tfType: "aws_iam_role", address: "aws_iam_role.exec", importID: "exec-role",
+				nativeIDs: map[string]string{"arn": "arn:aws:iam::1:role/exec-role"}},
+			{tfType: "aws_lambda_function", address: "aws_lambda_function.api", importID: "api",
+				nativeIDs: map[string]string{"arn": "arn:aws:lambda:us-east-1:1:function:api", "role_arn": "arn:aws:iam::1:role/exec-role"},
+				attrs:     map[string]string{"role_arn": "arn:aws:iam::1:role/exec-role"}},
+		},
+		"role → aws_iam_role (by name/import-id)": {
+			{tfType: "aws_iam_role", address: "aws_iam_role.r", importID: "my-role",
+				nativeIDs: map[string]string{"arn": "arn:aws:iam::1:role/my-role"}},
+			{tfType: "aws_iam_role_policy_attachment", address: "aws_iam_role_policy_attachment.a", importID: "my-role/arn:aws:iam::aws:policy/X",
+				nativeIDs: map[string]string{"role": "my-role"},
+				attrs:     map[string]string{"role": "my-role"}},
+		},
+		"kms_key_arn → aws_kms_key (lambda)": {
+			{tfType: "aws_kms_key", address: "aws_kms_key.k", importID: "1234abcd-key",
+				nativeIDs: map[string]string{"arn": "arn:aws:kms:us-east-1:1:key/1234abcd-key"}},
+			{tfType: "aws_lambda_function", address: "aws_lambda_function.enc", importID: "enc",
+				nativeIDs: map[string]string{"arn": "arn:aws:lambda:us-east-1:1:function:enc", "kms_key_arn": "arn:aws:kms:us-east-1:1:key/1234abcd-key"},
+				attrs:     map[string]string{"kms_key_arn": "arn:aws:kms:us-east-1:1:key/1234abcd-key"}},
+		},
+		"kms_key_arn → aws_kms_key (dynamodb sse)": {
+			{tfType: "aws_kms_key", address: "aws_kms_key.ddb", importID: "ddb-key",
+				nativeIDs: map[string]string{"arn": "arn:aws:kms:us-east-1:1:key/ddb-key"}},
+			{tfType: "aws_dynamodb_table", address: "aws_dynamodb_table.t", importID: "t",
+				nativeIDs: map[string]string{"arn": "arn:aws:dynamodb:us-east-1:1:table/t", "kms_key_arn": "arn:aws:kms:us-east-1:1:key/ddb-key"},
+				attrs:     map[string]string{"kms_key_arn": "arn:aws:kms:us-east-1:1:key/ddb-key"}},
+		},
+		"kms_key_id → aws_kms_key (rds, by arn)": {
+			{tfType: "aws_kms_key", address: "aws_kms_key.rds", importID: "rds-key",
+				nativeIDs: map[string]string{"arn": "arn:aws:kms:us-east-1:1:key/rds-key"}},
+			{tfType: "aws_db_instance", address: "aws_db_instance.db", importID: "db",
+				nativeIDs: map[string]string{"arn": "arn:aws:rds:us-east-1:1:db:db", "kms_key_id": "arn:aws:kms:us-east-1:1:key/rds-key"},
+				attrs:     map[string]string{"kms_key_id": "arn:aws:kms:us-east-1:1:key/rds-key"}},
+		},
+		"kms_key_id → aws_kms_key (log group, by key id)": {
+			{tfType: "aws_kms_key", address: "aws_kms_key.lg", importID: "lg-key-id",
+				nativeIDs: map[string]string{"arn": "arn:aws:kms:us-east-1:1:key/lg-key-id"}},
+			{tfType: "aws_cloudwatch_log_group", address: "aws_cloudwatch_log_group.app", importID: "/app",
+				nativeIDs: map[string]string{"arn": "arn:aws:logs:us-east-1:1:log-group:/app", "kms_key_id": "lg-key-id"},
+				attrs:     map[string]string{"kms_key_id": "lg-key-id"}},
+		},
+		"kms_master_key_id → aws_kms_key (sqs)": {
+			{tfType: "aws_kms_key", address: "aws_kms_key.q", importID: "q-key",
+				nativeIDs: map[string]string{"arn": "arn:aws:kms:us-east-1:1:key/q-key"}},
+			{tfType: "aws_sqs_queue", address: "aws_sqs_queue.dlq", importID: "https://sqs/dlq",
+				nativeIDs: map[string]string{"arn": "arn:aws:sqs:us-east-1:1:dlq", "kms_master_key_id": "q-key"},
+				attrs:     map[string]string{"kms_master_key_id": "q-key"}},
+		},
+		"kms_master_key_id → aws_kms_key (sns)": {
+			{tfType: "aws_kms_key", address: "aws_kms_key.t", importID: "topic-key",
+				nativeIDs: map[string]string{"arn": "arn:aws:kms:us-east-1:1:key/topic-key"}},
+			{tfType: "aws_sns_topic", address: "aws_sns_topic.alerts", importID: "arn:aws:sns:us-east-1:1:alerts",
+				nativeIDs: map[string]string{"arn": "arn:aws:sns:us-east-1:1:alerts", "kms_master_key_id": "topic-key"},
+				attrs:     map[string]string{"kms_master_key_id": "topic-key"}},
+		},
+		"vpc_id → aws_vpc": {
+			{tfType: "aws_vpc", address: "aws_vpc.main", importID: "vpc-0abc",
+				nativeIDs: map[string]string{"id": "vpc-0abc"}},
+			{tfType: "aws_subnet", address: "aws_subnet.web", importID: "subnet-1",
+				nativeIDs: map[string]string{"id": "subnet-1", "vpc_id": "vpc-0abc"},
+				attrs:     map[string]string{"vpc_id": "vpc-0abc"}},
+		},
+		"subnet_id → aws_subnet": {
+			{tfType: "aws_subnet", address: "aws_subnet.web", importID: "subnet-1",
+				nativeIDs: map[string]string{"id": "subnet-1"}},
+			{tfType: "aws_db_subnet_group", address: "aws_db_subnet_group.g", importID: "g",
+				nativeIDs: map[string]string{"id": "g", "subnet_id": "subnet-1"},
+				attrs:     map[string]string{"subnet_id": "subnet-1"}},
+		},
+		"network → google_compute_network": {
+			{tfType: "google_compute_network", address: "google_compute_network.vpc", importID: "projects/p/global/networks/vpc",
+				nativeIDs: map[string]string{"self_link": "https://www.googleapis.com/compute/v1/projects/p/global/networks/vpc"}},
+			{tfType: "google_compute_subnetwork", address: "google_compute_subnetwork.sub", importID: "projects/p/regions/r/subnetworks/sub",
+				nativeIDs: map[string]string{"self_link": "https://www.googleapis.com/compute/v1/projects/p/regions/r/subnetworks/sub", "network": "https://www.googleapis.com/compute/v1/projects/p/global/networks/vpc"},
+				attrs:     map[string]string{"network": "https://www.googleapis.com/compute/v1/projects/p/global/networks/vpc"}},
+		},
+		"subnetwork → google_compute_subnetwork": {
+			{tfType: "google_compute_subnetwork", address: "google_compute_subnetwork.sub", importID: "projects/p/regions/r/subnetworks/sub",
+				nativeIDs: map[string]string{"self_link": "https://www.googleapis.com/compute/v1/projects/p/regions/r/subnetworks/sub"}},
+			{tfType: "google_compute_instance", address: "google_compute_instance.vm", importID: "projects/p/zones/z/instances/vm",
+				nativeIDs: map[string]string{"self_link": "https://www.googleapis.com/compute/v1/projects/p/zones/z/instances/vm", "subnetwork": "https://www.googleapis.com/compute/v1/projects/p/regions/r/subnetworks/sub"},
+				attrs:     map[string]string{"subnetwork": "https://www.googleapis.com/compute/v1/projects/p/regions/r/subnetworks/sub"}},
+		},
+		"kms_key_name → google_kms_crypto_key": {
+			{tfType: "google_kms_crypto_key", address: "google_kms_crypto_key.k", importID: "projects/p/locations/l/keyRings/kr/cryptoKeys/k",
+				nativeIDs: map[string]string{"id": "projects/p/locations/l/keyRings/kr/cryptoKeys/k"}},
+			{tfType: "google_storage_bucket", address: "google_storage_bucket.b", importID: "b",
+				nativeIDs: map[string]string{"self_link": "https://www.googleapis.com/storage/v1/b/b", "kms_key_name": "projects/p/locations/l/keyRings/kr/cryptoKeys/k"},
+				attrs:     map[string]string{"kms_key_name": "projects/p/locations/l/keyRings/kr/cryptoKeys/k"}},
+		},
+	}
+}
+
+// TestResolveFromIdentities_ParityWithAttrs is the load-bearing parity
+// assertion (presets#733): for EVERY FieldRefs() FK field, the
+// discover-only resolver (reading NativeIDs) must produce the exact same
+// edge set the Attrs-based oracle produces — proving the picker's
+// "auto-included N dependencies" closure does not regress when scan-time
+// enrichment is dropped.
+func TestResolveFromIdentities_ParityWithAttrs(t *testing.T) {
+	t.Parallel()
+	for name, rows := range fkFixtures() {
+		rows := rows
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			wantAttrs := attrsResolve(rows)
+			gotNative := ResolveFromIdentities(sources(rows))
+			if !reflect.DeepEqual(gotNative, wantAttrs) {
+				t.Fatalf("discover-only edges diverge from Attrs edges\n native=%v\n  attrs=%v", gotNative, wantAttrs)
+			}
+			if len(gotNative) == 0 {
+				t.Fatalf("fixture %q produced no edge — fixture is not exercising the FK path", name)
+			}
+		})
+	}
+}
+
+// TestResolveFromIdentities_CoversEveryFieldRef pins that the fixture set
+// exercises every FieldRefs() field, so a future registry addition that
+// lands without a parity fixture fails loudly rather than silently
+// skipping the new edge.
+func TestResolveFromIdentities_CoversEveryFieldRef(t *testing.T) {
+	t.Parallel()
+	covered := map[string]bool{}
+	for _, rows := range fkFixtures() {
+		for _, r := range rows {
+			for field := range r.attrs {
+				covered[field] = true
+			}
+		}
+	}
+	for field := range FieldRefs() {
+		if !covered[field] {
+			t.Errorf("FieldRefs()[%q] has no parity fixture in fkFixtures()", field)
+		}
+	}
+}
+
+// TestResolveFromIdentities_AllFixturesCombined runs the resolver over the
+// union of every fixture at once — the realistic discover-output shape
+// where all source + target rows coexist — and asserts the combined edge
+// set still matches the Attrs oracle. This catches cross-fixture
+// identifier collisions the per-field runs cannot.
+func TestResolveFromIdentities_AllFixturesCombined(t *testing.T) {
+	t.Parallel()
+	var all []fixtureRow
+	for _, rows := range fkFixtures() {
+		all = append(all, rows...)
+	}
+	wantAttrs := attrsResolve(all)
+	gotNative := ResolveFromIdentities(sources(all))
+	if !reflect.DeepEqual(gotNative, wantAttrs) {
+		t.Fatalf("combined discover-only edges diverge from Attrs edges\n native=%v\n  attrs=%v", gotNative, wantAttrs)
+	}
+}
+
+// TestResolveFromIdentities_DropsUnresolvedAndSelfAndWrongType pins the
+// best-effort guards that mirror reliable's resolver.
+func TestResolveFromIdentities_DropsUnresolvedAndSelfAndWrongType(t *testing.T) {
+	t.Parallel()
+	rows := []EdgeSource{
+		// FK pointing outside the discovered set — dropped.
+		{Type: "aws_lambda_function", Address: "aws_lambda_function.dangling",
+			NativeIDs: map[string]string{"role_arn": "arn:aws:iam::1:role/not-discovered"}},
+		// FK whose value resolves to a sibling of the WRONG type — dropped
+		// (an aws_sqs_queue is not an aws_iam_role).
+		{Type: "aws_sqs_queue", Address: "aws_sqs_queue.q",
+			NativeIDs: map[string]string{"arn": "arn:aws:sqs:us-east-1:1:q"}},
+		{Type: "aws_lambda_function", Address: "aws_lambda_function.wrongtype",
+			NativeIDs: map[string]string{"role_arn": "arn:aws:sqs:us-east-1:1:q"}},
+		// Self-reference — dropped.
+		{Type: "aws_iam_role", Address: "aws_iam_role.selfref", ImportID: "self",
+			NativeIDs: map[string]string{"arn": "self", "role_arn": "self"}},
+	}
+	if got := ResolveFromIdentities(rows); got != nil {
+		t.Fatalf("expected no edges, got %v", got)
+	}
+}
+
+// TestResolveFromIdentities_Empty pins the nil-on-empty contract.
+func TestResolveFromIdentities_Empty(t *testing.T) {
+	t.Parallel()
+	if got := ResolveFromIdentities(nil); got != nil {
+		t.Fatalf("ResolveFromIdentities(nil) = %v, want nil", got)
+	}
+	if got := ResolveFromIdentities([]EdgeSource{{Type: "aws_vpc", Address: "aws_vpc.x"}}); got != nil {
+		t.Fatalf("ResolveFromIdentities(no-fk) = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## What

Discovery fast mode (presets#733, part of reliable#2040) drops scan-time `EnrichAttributes`. The one feature that must not regress is the picker's dependency closure ("auto-included N dependencies"). Today reliable computes the **free-form FK** half of that closure from each resource's enriched `Attrs` (the `dependencies.FieldRefs()` fields: `role`, `kms_key_arn`, …). With `Attrs` empty, those edges break unless the FK values are derivable from `Identity` alone.

This PR makes the free-form FK edges derivable at **discover time**, with no per-resource describe call.

Closes #733

## FK-field audit (what reliable's closure reads vs what's now derivable at discover time)

Reliable's picker closure (`internal/agentapi/import_dependencies.go::resolveImportedDependencies`) reads the cross-ref fields from `dependencies.FieldRefs()` — it does **not** hardcode a local list. Those 10 fields are the definitive set of free-form edges:

| FieldRefs field | Target type | Was derivable at discover? | Now |
|---|---|---|---|
| `vpc_id` | aws_vpc | yes (already lifted) | yes |
| `subnet_id` | aws_subnet | yes (subnet/route-table lift `vpc_id`; subnet itself is the target) | yes |
| `role` | aws_iam_role | partial (iam_role_policy_attachment lifts `role`) | yes |
| `role_arn` | aws_iam_role | no | **lifted** (lambda `Role`) |
| `kms_key_arn` | aws_kms_key | no | **lifted** (lambda `KmsKeyArn`, dynamodb `SSESpecification.KMSMasterKeyId`) |
| `kms_key_id` | aws_kms_key | no | **lifted** (rds `KmsKeyId`, secret `KmsKeyId`, log group `KmsKeyId`) |
| `kms_master_key_id` | aws_kms_key | no | **lifted** (sqs/sns `KmsMasterKeyId`) |
| `network` | google_compute_network | no | **exception (GCP)** |
| `subnetwork` | google_compute_subnetwork | no | **exception (GCP)** |
| `kms_key_name` | google_kms_crypto_key | no | **exception (GCP)** |

Parent/child edges (subnet→vpc, sg_rule→sg, alias→key, s3 sub-resources→bucket, iam attachments→role, log_stream→log_group, param groups) were already free at discover time via `resolveParentAddresses` → `Identity.ParentAddress`.

## Changes

- **`cloudcontrol_types.go`** — new `fkNativeIDs` / `fkNativeIDsNested` helpers + a `fkRef{cfnProp, nativeKey}` type. Wired the FK lift into the 7 AWS source types above. The FK value comes straight from the Cloud Control `GetResource` payload the discoverer already fetches at discover time (independent of the slow `EnrichAttributes` byTypeEnricher pass). Absent-safe and first-writer-wins (never clobbers a base extractor's canonical id). CFN property names verified against the public CloudFormation type schemas.
- **`pkg/imported/dependencies/resolve.go`** — `ResolveFromIdentities([]EdgeSource)`: the enrich-free equivalent of reliable's `resolveImportedDependencies`, reading `NativeIDs` instead of `Attrs`. Same `FieldRefs` registry, identifier candidate set (`arn`/`self_link`/`full_name`/`id`/ImportID), target-type filter, self-ref guard, and sorted-deduped output.
- **`pkg/composer/imported/dependency_edges.go`** — `DependencyEdges([]ImportedResource)` adapter so reliable can call the resolver directly on a discovered set.

## Parity test (the load-bearing assertion)

- `resolve_test.go` — a faithful in-test re-implementation of reliable's Attrs-based resolver acts as an **oracle**; the test asserts the discover-only `ResolveFromIdentities` produces the **identical edge set** for **every** `FieldRefs()` field (parent/child FKs + free-form FKs), individually and combined, plus a coverage test that fails if a future `FieldRefs` entry lands without a parity fixture.
- `fk_native_ids_test.go` — pins each per-type AWS lift against a representative `GetResource` payload, asserts each lifted key is a real `FieldRefs` field, and runs an end-to-end discover-only (empty `Attrs`) closure combining `resolveParentAddresses` (ParentAddress) + `DependencyEdges` (NativeIDs).

## Documented exception (conscious, not silent)

GCP's three free-form FK edges (`network`, `subnetwork`, `kms_key_name`) **cannot** be lifted at discover time. The discover-time `gcpAssetResult` from Cloud Asset `SearchAllResources` carries only `Name`/`AssetType`/`Project`/`Location`/`Labels` — the FK references live in the CAI `versionedResources` body, fetched per-resource by the enricher (the `gcpAssetGetter` side-interface). Lifting them would require a per-resource body fetch = enrichment. Example: a `google_compute_subnetwork`'s `network` self-link and a `google_storage_bucket`'s `kms_key_name` are read from the enriched body in `compute_*_enrich.go`, not from the asset summary. **AWS parity is complete; GCP free-form FK closure remains enrich-dependent.**

## Scope

Presets-only. Does not touch reliable (the scan switch is #2041). Parent/child closure and the discover CLI fast path (`discover --no-hcl`, which already returns discover + closure with empty `Attrs`) were unchanged — this closes the free-form FK gap so a discover-only IR set carries the same closure edges reliable's Attrs path produces.

## Tests

`go build ./...`, `go vet ./...`, `gofmt` clean. `go test` green for the touched packages: `pkg/imported/dependencies`, `pkg/composer/imported`, `cmd/insideout-import/awsdiscover`, `cmd/insideout-import`, `pkg/reverseimport`.