### PR TITLE
feat(reverse-import): export shared closure-capable discoverer constructor

### DIFF
--- a/cmd/insideout-import/reverse.go
+++ b/cmd/insideout-import/reverse.go
@@ -10,11 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-
-	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
-	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/reversedisco"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
 	reversejob "github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
 )
@@ -102,7 +99,7 @@ Flags:`)
 	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeoutOverall)
 	defer cancel()
 
-	discoverer, cleanup, err := newReverseDiscoverer(ctx, cloud, firstReqRegion(req, *region), firstReqProjectID(req, *gcpProjectID), *awsEndpointURL)
+	discoverer, cleanup, err := reversedisco.New(ctx, cloud, firstReqRegion(req, *region), firstReqProjectID(req, *gcpProjectID), *awsEndpointURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "reverse: build discoverer: %v\n", err)
 		return reverseExitFatal
@@ -142,33 +139,6 @@ Flags:`)
 		result.PlanSummary.ChangeCount,
 		result.PlanSummary.DestroyCount)
 	return reverseExitOK
-}
-
-func newReverseDiscoverer(ctx context.Context, cloud, region, gcpProjectID, awsEndpointURL string) (reverseimport.Discoverer, func(), error) {
-	switch cloud {
-	case "aws":
-		opts := []func(*config.LoadOptions) error{
-			config.WithRegion(region),
-			config.WithRetryMaxAttempts(discoverRetryMaxAttempts),
-			config.WithRetryMode(discoverRetryMode),
-		}
-		if awsEndpointURL != "" {
-			opts = append(opts, config.WithBaseEndpoint(awsEndpointURL))
-		}
-		cfg, err := config.LoadDefaultConfig(ctx, opts...)
-		if err != nil {
-			return nil, func() {}, err
-		}
-		return awsAggAdapter{d: awsdiscover.NewAWSDiscovererWithConcurrency(cfg, awsdiscover.DefaultMaxConcurrency)}, func() {}, nil
-	case "gcp":
-		searcher, err := gcpdiscover.NewRealAssetSearcher(ctx)
-		if err != nil {
-			return nil, func() {}, err
-		}
-		return gcpAggAdapter{d: gcpdiscover.NewGCPDiscoverer(searcher, gcpProjectID, gcpdiscover.GCPDiscovererOpts{})}, func() { _ = searcher.Close() }, nil
-	default:
-		return nil, func() {}, fmt.Errorf("unknown cloud %q", cloud)
-	}
 }
 
 func firstReqRegion(req reversejob.Request, fallback string) string {

--- a/cmd/insideout-import/reversedisco/reversedisco.go
+++ b/cmd/insideout-import/reversedisco/reversedisco.go
@@ -1,0 +1,126 @@
+// Package reversedisco builds a closure-capable cloud discoverer for the
+// reverse-import engine (pkg/reverseimport).
+//
+// The reverse-import engine (pkg/reverseimport) optionally expands the
+// operator's selected parent resources into their registered child resources
+// ("auto-included N dependencies") and chases dangling references during
+// dep-chase. Both behaviors require a discoverer that implements the engine's
+// reverseimport.Discoverer (DiscoverByID) and reverseimport.ClosureDiscoverer
+// (DiscoverClosure) surfaces. When neither is wired the engine silently emits
+// the `selection_closure_unavailable` diagnostic and skips closure + dep-chase.
+//
+// This package is the single shared wiring used by both the local CLI
+// (cmd/insideout-import reverse) and the Mars reverse-import job
+// (luthersystems/mars internal/reverseimportjob). It previously lived in the
+// CLI's package main (newReverseDiscoverer + awsAggAdapter/gcpAggAdapter), so
+// Mars could not reach it and shipped with no discoverer at all — closure
+// expansion no-op'd in production. See luthersystems/mars#195.
+package reversedisco
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
+)
+
+// New constructs a closure-capable discoverer for the given cloud, suitable
+// for reverseimport.Options.Discoverer (the returned value also satisfies
+// reverseimport.ClosureDiscoverer, so the engine resolves both the dep-chase
+// and selection-closure surfaces from it).
+//
+// region/gcpProjectID/awsEndpointURL mirror the reverseimport.Options of the
+// same name: region is the AWS region (or GCP provider region) the underlying
+// SDK clients target, gcpProjectID is the real GCP project ID scoping Cloud
+// Asset Inventory, and awsEndpointURL optionally retargets every AWS SDK client
+// at a compatible endpoint (e.g. LocalStack).
+//
+// The returned cleanup func releases any cloud connections (the GCP asset
+// searcher's gRPC client); it is always non-nil and safe to call even on the
+// AWS path (where it is a no-op). Callers should defer it.
+func New(ctx context.Context, cloud, region, gcpProjectID, awsEndpointURL string) (reverseimport.Discoverer, func(), error) {
+	switch cloud {
+	case "aws":
+		opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
+		opts = append(opts, awsdiscover.RetryLoadOptions()...)
+		if awsEndpointURL != "" {
+			opts = append(opts, config.WithBaseEndpoint(awsEndpointURL))
+		}
+		cfg, err := config.LoadDefaultConfig(ctx, opts...)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return awsAggAdapter{d: awsdiscover.NewAWSDiscovererWithConcurrency(cfg, awsdiscover.DefaultMaxConcurrency)}, func() {}, nil
+	case "gcp":
+		searcher, err := gcpdiscover.NewRealAssetSearcher(ctx)
+		if err != nil {
+			return nil, func() {}, err
+		}
+		return gcpAggAdapter{d: gcpdiscover.NewGCPDiscoverer(searcher, gcpProjectID, gcpdiscover.GCPDiscovererOpts{})}, func() { _ = searcher.Close() }, nil
+	default:
+		return nil, func() {}, fmt.Errorf("unknown cloud %q", cloud)
+	}
+}
+
+// awsAggAdapter wraps *awsdiscover.AWSDiscoverer so it satisfies both
+// reverseimport.Discoverer (DiscoverByID) and reverseimport.ClosureDiscoverer
+// (DiscoverClosure).
+type awsAggAdapter struct {
+	d *awsdiscover.AWSDiscoverer
+}
+
+func (a awsAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
+	return a.d.DiscoverByID(ctx, tfType, id, region, accountID)
+}
+
+func (a awsAggAdapter) DiscoverClosure(ctx context.Context, req reverseimport.ClosureRequest) ([]imported.ImportedResource, error) {
+	types := unionStrings(req.ParentTypes, req.ChildTypes)
+	return a.d.DiscoverTypes(ctx, types, awsdiscover.DiscoverArgs{
+		Project:   req.Project,
+		Regions:   req.Regions,
+		AccountID: req.AccountID,
+	})
+}
+
+// gcpAggAdapter is the GCP analogue of awsAggAdapter.
+type gcpAggAdapter struct {
+	d *gcpdiscover.GCPDiscoverer
+}
+
+func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, accountID string) (imported.ImportedResource, error) {
+	return a.d.DiscoverByID(ctx, tfType, id, region, accountID)
+}
+
+func (a gcpAggAdapter) DiscoverClosure(ctx context.Context, req reverseimport.ClosureRequest) ([]imported.ImportedResource, error) {
+	types := unionStrings(req.ParentTypes, req.ChildTypes)
+	return a.d.DiscoverTypes(ctx, types, gcpdiscover.DiscoverArgs{
+		Project: req.Project,
+		Regions: req.Regions,
+	})
+}
+
+func unionStrings(groups ...[]string) []string {
+	seen := map[string]struct{}{}
+	for _, group := range groups {
+		for _, value := range group {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			seen[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for value := range seen {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/insideout-import/reversedisco/reversedisco_test.go
+++ b/cmd/insideout-import/reversedisco/reversedisco_test.go
@@ -1,0 +1,48 @@
+package reversedisco
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
+)
+
+// Both adapters must satisfy the engine's dep-chase (Discoverer) and
+// selection-closure (ClosureDiscoverer) surfaces, otherwise the engine falls
+// back to the selection_closure_unavailable diagnostic and skips closure +
+// dep-chase (luthersystems/mars#195).
+var (
+	_ reverseimport.Discoverer        = awsAggAdapter{}
+	_ reverseimport.ClosureDiscoverer = awsAggAdapter{}
+	_ reverseimport.Discoverer        = gcpAggAdapter{}
+	_ reverseimport.ClosureDiscoverer = gcpAggAdapter{}
+)
+
+func TestNewRejectsUnknownCloud(t *testing.T) {
+	d, cleanup, err := New(context.Background(), "azure", "", "", "")
+	if err == nil {
+		t.Fatalf("New(cloud=azure) err = nil, want unknown-cloud error")
+	}
+	if d != nil {
+		t.Fatalf("New(cloud=azure) discoverer = %v, want nil", d)
+	}
+	// cleanup is always non-nil and safe to call even on the error path.
+	cleanup()
+}
+
+func TestNewAWSReturnsClosureCapableDiscoverer(t *testing.T) {
+	// The AWS path only loads SDK config (no network call), so it is safe in
+	// a unit test. The point is to prove New returns a value that satisfies
+	// the closure surface — the wiring the Mars job was missing.
+	d, cleanup, err := New(context.Background(), "aws", "us-west-2", "", "")
+	if err != nil {
+		t.Fatalf("New(cloud=aws) err = %v", err)
+	}
+	defer cleanup()
+	if d == nil {
+		t.Fatal("New(cloud=aws) discoverer = nil, want non-nil")
+	}
+	if _, ok := d.(reverseimport.ClosureDiscoverer); !ok {
+		t.Fatalf("New(cloud=aws) discoverer %T does not implement reverseimport.ClosureDiscoverer", d)
+	}
+}


### PR DESCRIPTION
Extracts the closure-capable reverse-import discoverer wiring out of the CLI `package main` into a new exported package, `cmd/insideout-import/reversedisco`, so downstream callers (the Mars reverse-import job) can share the exact same wiring the CLI uses.

## Why

The reverse-import engine (`pkg/reverseimport`) only runs selection-closure expansion ("auto-included N dependencies") and dep-chase when `Options.ClosureDiscoverer` or a `ClosureDiscoverer`-capable `Options.Discoverer` is set. The only wiring that built one (`newReverseDiscoverer` + `awsAggAdapter`/`gcpAggAdapter`) lived in the CLI `package main`, unreachable by other binaries.

As a result the Mars reverse-import job set neither field, the engine emitted the `selection_closure_unavailable` diagnostic, and closure + dep-chase silently no-op'd in production. See luthersystems/mars#195.

## Change

- New package `cmd/insideout-import/reversedisco` with `New(ctx, cloud, region, gcpProjectID, awsEndpointURL)` returning a `reverseimport.Discoverer` that also satisfies `reverseimport.ClosureDiscoverer`, plus a cleanup func.
- CLI `reverse.go` now calls `reversedisco.New` instead of the local `newReverseDiscoverer` (deleted). Behavior is identical.
- The discover orchestrator keeps its own `AggArgs`-shaped adapters — a different interface (`DiscoverTypes(AggArgs)`) gated on the concrete `gcpAggAdapter` type for the GCP unsupported-enumerator rebind — so it is intentionally left untouched.

## Tests

- Compile-time assertions that both adapters implement `reverseimport.Discoverer` and `reverseimport.ClosureDiscoverer`.
- `New` rejects unknown clouds; AWS path returns a closure-capable discoverer.
- Existing CLI reverse tests still pass; whole module builds and is gofmt-clean.

Unblocks the Mars fix in luthersystems/mars#195.
