### PR TITLE
fix: closure discoverer creds + scoping + graceful degradation (#739)

### DIFF
--- a/cmd/insideout-import/awsdiscover/args.go
+++ b/cmd/insideout-import/awsdiscover/args.go
@@ -56,11 +56,11 @@ type DiscoverArgs struct {
 	PerTypeTimeout time.Duration
 
 	// ParentScope, when non-empty, restricts parent-scoped child discovery
-	// to a fixed set of selected parent identifiers per parent CloudFormation
-	// type — the #739 selection-closure scoping fix. It is keyed by the
-	// parent's CloudFormation type (e.g. "AWS::S3::Bucket") and lists the
-	// parent identifiers the operator selected (e.g. the bucket names of the
-	// selected aws_s3_bucket resources).
+	// to a fixed set of selected parents per parent CloudFormation type —
+	// the #739 selection-closure scoping fix. It is keyed by the parent's
+	// CloudFormation type (e.g. "AWS::S3::Bucket") and lists the parents the
+	// operator selected (e.g. the bucket names of the selected aws_s3_bucket
+	// resources), each carrying the region it lives in (ScopedParent).
 	//
 	// When set, parent-scoped discoverers (the SDK-only sub-resource
 	// discoverer's ListParents path and the Cloud Control discoverer's
@@ -72,6 +72,12 @@ type DiscoverArgs struct {
 	// pre-#739 account-wide sweep (top-level discovery surveys, the local
 	// CLI's full account scan, and any parent type not represented in the
 	// scope all still enumerate account-wide).
+	//
+	// The scope is REGION-AWARE: each per-region enumeration pass asks
+	// scopedParents only for the parents in the region being swept, so a
+	// multi-region closure fetches a parent's sub-resources once (in the
+	// parent's region) rather than once per region. See ParentScope and
+	// scopedParents.
 	ParentScope ParentScope
 
 	// rgtCache is the package-internal RGT prefetch result threaded
@@ -84,39 +90,71 @@ type DiscoverArgs struct {
 	rgtCache *rgtCache
 }
 
-// ParentScope maps a parent CloudFormation type to the set of selected parent
-// identifiers a closure run should restrict child discovery to. See
-// DiscoverArgs.ParentScope. Construct with NewParentScope.
-type ParentScope map[string][]string
+// ScopedParent is one selected parent in a ParentScope: an identifier (e.g. a
+// bucket name or log-group name) paired with the AWS region it lives in. The
+// Region is load-bearing for multi-region closure requests — see ParentScope
+// and DiscoverArgs.scopedParents. A region-less parent (Region == "") is a
+// global / region-agnostic type (e.g. a future IAM parent) that must be
+// enumerated exactly once across a multi-region request rather than once per
+// region.
+type ScopedParent struct {
+	Identifier string
+	Region     string
+}
 
-// NewParentScope builds a ParentScope from (parentCFNType, identifier) pairs,
-// de-duplicating identifiers per type and dropping empties. Returns nil when
-// no usable pair is supplied so callers can leave DiscoverArgs.ParentScope
-// at its zero value (which means "no scoping — account-wide sweep").
-func NewParentScope(byCFNType map[string][]string) ParentScope {
+// ParentScope maps a parent CloudFormation type to the set of selected parents
+// a closure run should restrict child discovery to, each carrying the region it
+// was discovered in. See DiscoverArgs.ParentScope. Construct with
+// NewParentScope.
+//
+// The Region is load-bearing: the per-region enumeration loop in each scoped
+// seam (sdkOnlySubresourceDiscoverer, cloudControlDiscoverer, the CloudWatch
+// Logs lister) asks scopedParents for the parents belonging to the region it is
+// currently sweeping. Without the region, a multi-region closure would fetch
+// every selected parent's sub-resources once PER region — duplicating (and
+// mis-region-tagging) the closure imports, because pre-#739 the account-wide
+// listers were region-filtered (s3:ListBuckets then filter by bucket region;
+// per-region logs:DescribeLogGroups).
+type ParentScope map[string][]ScopedParent
+
+// NewParentScope builds a ParentScope from (parentCFNType -> ScopedParent)
+// pairs, de-duplicating parents per type by (identifier, region), trimming
+// whitespace, dropping empties, and sorting by (identifier, region). Returns
+// nil when no usable pair is supplied so callers can leave
+// DiscoverArgs.ParentScope at its zero value (which means "no scoping —
+// account-wide sweep").
+func NewParentScope(byCFNType map[string][]ScopedParent) ParentScope {
 	out := ParentScope{}
-	for cfnType, ids := range byCFNType {
+	for cfnType, parents := range byCFNType {
 		cfnType = strings.TrimSpace(cfnType)
 		if cfnType == "" {
 			continue
 		}
-		seen := map[string]struct{}{}
-		var deduped []string
-		for _, id := range ids {
-			id = strings.TrimSpace(id)
+		type key struct{ id, region string }
+		seen := map[key]struct{}{}
+		var deduped []ScopedParent
+		for _, p := range parents {
+			id := strings.TrimSpace(p.Identifier)
 			if id == "" {
 				continue
 			}
-			if _, ok := seen[id]; ok {
+			region := strings.TrimSpace(p.Region)
+			k := key{id: id, region: region}
+			if _, ok := seen[k]; ok {
 				continue
 			}
-			seen[id] = struct{}{}
-			deduped = append(deduped, id)
+			seen[k] = struct{}{}
+			deduped = append(deduped, ScopedParent{Identifier: id, Region: region})
 		}
 		if len(deduped) == 0 {
 			continue
 		}
-		sort.Strings(deduped)
+		sort.Slice(deduped, func(i, j int) bool {
+			if deduped[i].Identifier != deduped[j].Identifier {
+				return deduped[i].Identifier < deduped[j].Identifier
+			}
+			return deduped[i].Region < deduped[j].Region
+		})
 		out[cfnType] = deduped
 	}
 	if len(out) == 0 {
@@ -125,19 +163,77 @@ func NewParentScope(byCFNType map[string][]string) ParentScope {
 	return out
 }
 
-// scopedParents returns the selected parent identifiers for parentCFNType and
-// true when ParentScope restricts this type, otherwise (nil, false) so the
+// scopedParents returns the selected parent identifiers for parentCFNType that
+// belong to the given enumeration region, plus true when ParentScope restricts
+// this type. When the type is NOT in the scope it returns (nil, false) so the
 // caller falls back to its account-wide enumeration. A nil/empty ParentScope
 // always returns (nil, false).
-func (a DiscoverArgs) scopedParents(parentCFNType string) ([]string, bool) {
+//
+// Region matching depends on whether the enumeration is a SINGLE pass or a
+// per-region loop:
+//
+//   - region == "" is the SINGLE-pass enumeration: either an IsGlobal-
+//     enumerated type (the discoverer scans once with region="", e.g.
+//     aws_s3_bucket / aws_iam_role) or the empty-Regions back-compat path
+//     ("" means "the configured region"). There is exactly one pass and no
+//     per-region duplication to guard against, so EVERY scoped parent is
+//     included — regardless of the region stamped on it. This is load-bearing
+//     for IsGlobal types that still carry a real Identity.Region: an
+//     aws_s3_bucket is enumerated region-less but stored under its TRUE region
+//     (us-west-2, …) by its PostDiscover, so region-filtering the single ""
+//     pass would drop the selected bucket entirely (codex #770 P1).
+//
+//   - region != "" is a PER-REGION loop pass. A parent is included when
+//     p.Region == region (it lives in the region being swept). A region-less
+//     parent (p.Region == "") is included in EXACTLY ONE region — the first of
+//     args.Regions — so it is fetched once, never duplicated across the loop.
+//     Any other parent is excluded for this region.
+//
+// CRITICAL: when the CFN type IS present in the scope but ZERO parents match
+// this region, scopedParents returns ([]string{}, true) — an EMPTY slice with
+// ok=true. The caller MUST treat (empty, true) as "no parents in this region,
+// skip enumeration" and NOT fall back to the account-wide sweep. Returning ok
+// here is what scopes a multi-region closure: the type is owned by the scope,
+// there just are no selected parents in this particular region.
+func (a DiscoverArgs) scopedParents(parentCFNType, region string) ([]string, bool) {
 	if len(a.ParentScope) == 0 {
 		return nil, false
 	}
-	ids, ok := a.ParentScope[strings.TrimSpace(parentCFNType)]
-	if !ok || len(ids) == 0 {
+	parents, ok := a.ParentScope[strings.TrimSpace(parentCFNType)]
+	if !ok || len(parents) == 0 {
 		return nil, false
 	}
-	return append([]string(nil), ids...), true
+	// Single-pass enumeration (IsGlobal type, or empty-Regions back-compat):
+	// include every scoped parent once. No per-region duplication to guard.
+	if region == "" {
+		out := make([]string, 0, len(parents))
+		for _, p := range parents {
+			out = append(out, p.Identifier)
+		}
+		return out, true
+	}
+	// Per-region loop: include the parents in THIS region, plus region-less
+	// parents in the first region (so they enumerate exactly once).
+	out := make([]string, 0, len(parents))
+	for _, p := range parents {
+		switch {
+		case p.Region == region:
+			out = append(out, p.Identifier)
+		case p.Region == "" && a.regionLessParentEnumeratesHere(region):
+			out = append(out, p.Identifier)
+		}
+	}
+	return out, true
+}
+
+// regionLessParentEnumeratesHere reports whether the given (non-empty)
+// enumeration region is the first of args.Regions — the single region a
+// region-less (Region == "") scoped parent should be emitted in during a
+// per-region loop, so such a parent is fetched exactly once across a
+// multi-region request. (The region == "" single-pass case is handled
+// directly in scopedParents and never reaches here.)
+func (a DiscoverArgs) regionLessParentEnumeratesHere(region string) bool {
+	return len(a.Regions) > 0 && region == a.Regions[0]
 }
 
 // withRGTCache returns a copy of args with rgtCache set. Used once at

--- a/cmd/insideout-import/awsdiscover/args.go
+++ b/cmd/insideout-import/awsdiscover/args.go
@@ -1,6 +1,8 @@
 package awsdiscover
 
 import (
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
@@ -53,6 +55,25 @@ type DiscoverArgs struct {
 	// the right shape for a best-effort discovery survey.
 	PerTypeTimeout time.Duration
 
+	// ParentScope, when non-empty, restricts parent-scoped child discovery
+	// to a fixed set of selected parent identifiers per parent CloudFormation
+	// type — the #739 selection-closure scoping fix. It is keyed by the
+	// parent's CloudFormation type (e.g. "AWS::S3::Bucket") and lists the
+	// parent identifiers the operator selected (e.g. the bucket names of the
+	// selected aws_s3_bucket resources).
+	//
+	// When set, parent-scoped discoverers (the SDK-only sub-resource
+	// discoverer's ListParents path and the Cloud Control discoverer's
+	// ParentLister path) use these identifiers DIRECTLY as the parent set
+	// instead of issuing an account-wide parent enumeration
+	// (s3:ListBuckets, logs:DescribeLogGroups, …). This both scopes the
+	// closure to the selected parents and removes the need for account-wide
+	// list permissions. An empty/absent ParentScope preserves the
+	// pre-#739 account-wide sweep (top-level discovery surveys, the local
+	// CLI's full account scan, and any parent type not represented in the
+	// scope all still enumerate account-wide).
+	ParentScope ParentScope
+
 	// rgtCache is the package-internal RGT prefetch result threaded
 	// through DiscoverTypes (#406). Per-type discoverers that opt into
 	// the unified RGT path read this via the package-private accessor
@@ -61,6 +82,62 @@ type DiscoverArgs struct {
 	// and so tests that construct DiscoverArgs directly default to
 	// nil cache (per-type list fallback).
 	rgtCache *rgtCache
+}
+
+// ParentScope maps a parent CloudFormation type to the set of selected parent
+// identifiers a closure run should restrict child discovery to. See
+// DiscoverArgs.ParentScope. Construct with NewParentScope.
+type ParentScope map[string][]string
+
+// NewParentScope builds a ParentScope from (parentCFNType, identifier) pairs,
+// de-duplicating identifiers per type and dropping empties. Returns nil when
+// no usable pair is supplied so callers can leave DiscoverArgs.ParentScope
+// at its zero value (which means "no scoping — account-wide sweep").
+func NewParentScope(byCFNType map[string][]string) ParentScope {
+	out := ParentScope{}
+	for cfnType, ids := range byCFNType {
+		cfnType = strings.TrimSpace(cfnType)
+		if cfnType == "" {
+			continue
+		}
+		seen := map[string]struct{}{}
+		var deduped []string
+		for _, id := range ids {
+			id = strings.TrimSpace(id)
+			if id == "" {
+				continue
+			}
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			deduped = append(deduped, id)
+		}
+		if len(deduped) == 0 {
+			continue
+		}
+		sort.Strings(deduped)
+		out[cfnType] = deduped
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// scopedParents returns the selected parent identifiers for parentCFNType and
+// true when ParentScope restricts this type, otherwise (nil, false) so the
+// caller falls back to its account-wide enumeration. A nil/empty ParentScope
+// always returns (nil, false).
+func (a DiscoverArgs) scopedParents(parentCFNType string) ([]string, bool) {
+	if len(a.ParentScope) == 0 {
+		return nil, false
+	}
+	ids, ok := a.ParentScope[strings.TrimSpace(parentCFNType)]
+	if !ok || len(ids) == 0 {
+		return nil, false
+	}
+	return append([]string(nil), ids...), true
 }
 
 // withRGTCache returns a copy of args with rgtCache set. Used once at

--- a/cmd/insideout-import/awsdiscover/closure_scope_test.go
+++ b/cmd/insideout-import/awsdiscover/closure_scope_test.go
@@ -95,6 +95,49 @@ func TestCloudControlDiscover_ParentScopeSkipsListResources(t *testing.T) {
 	}
 }
 
+// TestCloudControlDiscover_IdentifierSharedChildScoped proves the codex #770
+// follow-up: aws_s3_bucket_policy (CFN AWS::S3::BucketPolicy), whose CC
+// identifier IS the bucket name, is scoped by the selected bucket names too —
+// it GetResources only the selected buckets' policies and never lists the
+// AWS::S3::BucketPolicy type account-wide.
+func TestCloudControlDiscover_IdentifierSharedChildScoped(t *testing.T) {
+	t.Parallel()
+	if got := IdentifierSharedChildCFNTypes("AWS::S3::Bucket"); !reflect.DeepEqual(got, []string{"AWS::S3::BucketPolicy"}) {
+		t.Fatalf("IdentifierSharedChildCFNTypes(AWS::S3::Bucket) = %v, want [AWS::S3::BucketPolicy]", got)
+	}
+	fake := &fakeCloudControlClient{
+		listPages: []cloudcontrol.ListResourcesOutput{
+			listPage("", "bucket-a", "bucket-b", "bucket-unselected"),
+		},
+		propsByIdentifier: map[string]map[string]any{
+			"bucket-a":          {},
+			"bucket-unselected": {},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::S3::BucketPolicy"
+	cfg.SkipProjectTagFilter = true
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:     []string{"us-east-1"},
+		AccountID:   "123",
+		ParentScope: NewParentScope(map[string][]string{"AWS::S3::BucketPolicy": {"bucket-a"}}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls = %d, want 0 (scoped child must skip the account-wide list)", fake.listCalls)
+	}
+	if ids := importIDs(got); !reflect.DeepEqual(ids, []string{"bucket-a"}) {
+		t.Errorf("discovered = %v, want only the selected bucket's policy [bucket-a]", ids)
+	}
+}
+
 // TestCloudControlDiscover_ParentScopeBypassesTagFilter proves a scoped parent
 // is NOT dropped by the Project tag filter — the operator selected it by
 // identity, so a missing Project tag must not exclude it.

--- a/cmd/insideout-import/awsdiscover/closure_scope_test.go
+++ b/cmd/insideout-import/awsdiscover/closure_scope_test.go
@@ -1,0 +1,253 @@
+package awsdiscover
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudcontrol"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// #739 selection-closure scoping. These tests pin the parent-scope seam that
+// restricts child + parent re-discovery to the operator's selected parents,
+// removing the account-wide ListResources / ListParents enumeration (and the
+// account-wide list permissions it requires).
+
+// TestNewParentScope_DedupesSortsAndDropsEmpties pins the scope constructor's
+// normalization: per-type de-dup, sort, empty drop, and a nil result when no
+// usable pair survives.
+func TestNewParentScope_DedupesSortsAndDropsEmpties(t *testing.T) {
+	t.Parallel()
+	scope := NewParentScope(map[string][]string{
+		"AWS::S3::Bucket":     {"b-2", "b-1", "b-2", "  ", "b-1"},
+		"AWS::Logs::LogGroup": {" lg ", "lg"},
+		"  ":                  {"ignored"}, // empty CFN type dropped
+		"AWS::Empty::Type":    {"", "   "}, // no usable ids dropped
+	})
+	if got := scope["AWS::S3::Bucket"]; !reflect.DeepEqual(got, []string{"b-1", "b-2"}) {
+		t.Errorf("S3 scope = %v, want sorted de-duped [b-1 b-2]", got)
+	}
+	if got := scope["AWS::Logs::LogGroup"]; !reflect.DeepEqual(got, []string{"lg"}) {
+		t.Errorf("Logs scope = %v, want trimmed de-duped [lg]", got)
+	}
+	if _, ok := scope["  "]; ok {
+		t.Error("empty CFN type should be dropped")
+	}
+	if _, ok := scope["AWS::Empty::Type"]; ok {
+		t.Error("type with no usable ids should be dropped")
+	}
+	if NewParentScope(map[string][]string{"x": {""}}) != nil {
+		t.Error("scope with no usable pair should be nil")
+	}
+}
+
+// TestCloudControlDiscover_ParentScopeSkipsListResources proves the parent-type
+// scope short-circuit: when ParentScope restricts this type's CloudFormation
+// type, the discoverer GetResources EXACTLY the scoped identifiers and issues
+// ZERO ListResources calls — eliminating the account-wide list (and its
+// permission). Pre-#739 it always swept ListResources.
+func TestCloudControlDiscover_ParentScopeSkipsListResources(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		// A full account sweep would surface bucket-a..c; the scope must
+		// keep us from ever listing them.
+		listPages: []cloudcontrol.ListResourcesOutput{
+			listPage("", "bucket-a", "bucket-b", "bucket-c", "bucket-unselected"),
+		},
+		propsByIdentifier: map[string]map[string]any{
+			"bucket-a":          {"Tags": map[string]any{}},
+			"bucket-b":          {"Tags": map[string]any{}},
+			"bucket-c":          {"Tags": map[string]any{}},
+			"bucket-unselected": {"Tags": map[string]any{}},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::S3::Bucket"
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:     []string{"us-east-1"},
+		AccountID:   "123",
+		ParentScope: NewParentScope(map[string][]string{"AWS::S3::Bucket": {"bucket-a", "bucket-b"}}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls = %d, want 0 (scope must skip the account-wide list)", fake.listCalls)
+	}
+	gotIDs := importIDs(got)
+	if !reflect.DeepEqual(gotIDs, []string{"bucket-a", "bucket-b"}) {
+		t.Errorf("discovered = %v, want exactly the scoped parents [bucket-a bucket-b]", gotIDs)
+	}
+	sort.Strings(fake.getResourceCalls)
+	if !reflect.DeepEqual(fake.getResourceCalls, []string{"bucket-a", "bucket-b"}) {
+		t.Errorf("GetResource calls = %v, want only the scoped parents", fake.getResourceCalls)
+	}
+}
+
+// TestCloudControlDiscover_ParentScopeBypassesTagFilter proves a scoped parent
+// is NOT dropped by the Project tag filter — the operator selected it by
+// identity, so a missing Project tag must not exclude it.
+func TestCloudControlDiscover_ParentScopeBypassesTagFilter(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		propsByIdentifier: map[string]map[string]any{
+			// No Project tag — the account-wide path would drop this under
+			// args.Project filtering.
+			"bucket-a": {"Tags": map[string]any{}},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::S3::Bucket"
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:     []string{"us-east-1"},
+		AccountID:   "123",
+		Project:     "io-some-project",
+		ParentScope: NewParentScope(map[string][]string{"AWS::S3::Bucket": {"bucket-a"}}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ids := importIDs(got); !reflect.DeepEqual(ids, []string{"bucket-a"}) {
+		t.Errorf("discovered = %v, want the scoped parent kept despite the Project filter", ids)
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_ParentScopeSkipsListParents proves the SDK-only
+// sub-resource scope: when ParentScope restricts the parent CFN type, the
+// per-parent FetchItem fan-out runs against the SCOPED parents and ListParents
+// (the account-wide s3:ListBuckets) is never called.
+func TestSDKOnlySubresourceDiscover_ParentScopeSkipsListParents(t *testing.T) {
+	t.Parallel()
+	var listParentsCalls atomic.Int64
+	outcomes := map[string]fakeFetchOutcome{
+		"bucket-a": {exists: true, props: map[string]any{}, nativeIDs: map[string]string{"bucket": "bucket-a"}},
+		"bucket-b": {exists: true, props: map[string]any{}, nativeIDs: map[string]string{"bucket": "bucket-b"}},
+		"bucket-c": {exists: true, props: map[string]any{}, nativeIDs: map[string]string{"bucket": "bucket-c"}},
+	}
+	cfg := sdkOnlyTestConfig()
+	cfg.ParentCFNType = "AWS::S3::Bucket"
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		listParentsCalls.Add(1)
+		return []string{"bucket-a", "bucket-b", "bucket-c"}, nil
+	}
+	var fetchCalls atomic.Int64
+	cfg.FetchItem = fakeFetchItem(outcomes, &fetchCalls)
+
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:     []string{"us-east-1"},
+		AccountID:   "123",
+		ParentScope: NewParentScope(map[string][]string{"AWS::S3::Bucket": {"bucket-a", "bucket-b"}}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listParentsCalls.Load() != 0 {
+		t.Errorf("ListParents calls = %d, want 0 (scope must skip the account-wide parent list)", listParentsCalls.Load())
+	}
+	if fetchCalls.Load() != 2 {
+		t.Errorf("FetchItem calls = %d, want 2 (only the scoped parents)", fetchCalls.Load())
+	}
+	if ids := importIDs(got); !reflect.DeepEqual(ids, []string{"bucket-a", "bucket-b"}) {
+		t.Errorf("discovered = %v, want only the scoped parents", ids)
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_NoScopeSweepsAllParents pins the back-compat
+// path: an absent ParentScope leaves the account-wide ListParents sweep intact
+// (top-level discovery + the local CLI's full scan keep working).
+func TestSDKOnlySubresourceDiscover_NoScopeSweepsAllParents(t *testing.T) {
+	t.Parallel()
+	var listParentsCalls atomic.Int64
+	outcomes := map[string]fakeFetchOutcome{
+		"bucket-a": {exists: true, nativeIDs: map[string]string{"bucket": "bucket-a"}},
+		"bucket-b": {exists: true, nativeIDs: map[string]string{"bucket": "bucket-b"}},
+	}
+	cfg := sdkOnlyTestConfig()
+	cfg.ParentCFNType = "AWS::S3::Bucket"
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		listParentsCalls.Add(1)
+		return []string{"bucket-a", "bucket-b"}, nil
+	}
+	cfg.FetchItem = fakeFetchItem(outcomes, nil)
+
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listParentsCalls.Load() != 1 {
+		t.Errorf("ListParents calls = %d, want 1 (no scope ⇒ account-wide sweep)", listParentsCalls.Load())
+	}
+	if len(got) != 2 {
+		t.Errorf("discovered %d, want 2 (full sweep)", len(got))
+	}
+}
+
+// TestLogGroupParentLister_ParentScopeSkipsDescribe proves the CloudWatch Logs
+// parent lister honors the scope: with a ParentScope it wraps the scoped log
+// group names directly into resource models and never calls the account-wide
+// logs:DescribeLogGroups. A nil client would panic if Describe were attempted.
+func TestLogGroupParentLister_ParentScopeSkipsDescribe(t *testing.T) {
+	t.Parallel()
+	args := DiscoverArgs{
+		ParentScope: NewParentScope(map[string][]string{logGroupParentCFNType: {"/lg/b", "/lg/a"}}),
+	}
+	// awsCfg is a zero Config; if the lister fell through to the SDK path it
+	// would construct a real client and (lacking creds/region) the test would
+	// not be hermetic. The scope path must short-circuit before that.
+	models, err := listCloudWatchLogGroupsAsResourceModels(context.Background(), aws.Config{}, "us-east-1", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{`{"LogGroupName":"/lg/a"}`, `{"LogGroupName":"/lg/b"}`}
+	if !reflect.DeepEqual(models, want) {
+		t.Errorf("scoped models = %v, want %v", models, want)
+	}
+}
+
+// TestLogGroupResourceModels_ScopedMatchesSwept proves the scoped wrap and the
+// account-wide wrap emit byte-identical resource models for the same log group
+// names — so scoping cannot change downstream LogStream ListResources behavior.
+func TestLogGroupResourceModels_ScopedMatchesSwept(t *testing.T) {
+	t.Parallel()
+	names := []string{"/lg/a", "/lg/b"}
+	scoped := logGroupNamesAsResourceModels(names)
+	swept, err := listCloudWatchLogGroupsAsResourceModelsWithClient(context.Background(), &fakeCloudWatchLogGroupsLister{
+		pages: []cloudwatchlogs.DescribeLogGroupsOutput{cwlLogGroupsPage("", names...)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(scoped, swept) {
+		t.Errorf("scoped wrap %v != swept wrap %v", scoped, swept)
+	}
+}
+
+func importIDs(rs []imported.ImportedResource) []string {
+	out := make([]string, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, r.Identity.ImportID)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/cmd/insideout-import/awsdiscover/closure_scope_test.go
+++ b/cmd/insideout-import/awsdiscover/closure_scope_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"reflect"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -24,17 +25,33 @@ import (
 // usable pair survives.
 func TestNewParentScope_DedupesSortsAndDropsEmpties(t *testing.T) {
 	t.Parallel()
-	scope := NewParentScope(map[string][]string{
-		"AWS::S3::Bucket":     {"b-2", "b-1", "b-2", "  ", "b-1"},
-		"AWS::Logs::LogGroup": {" lg ", "lg"},
-		"  ":                  {"ignored"}, // empty CFN type dropped
-		"AWS::Empty::Type":    {"", "   "}, // no usable ids dropped
+	scope := NewParentScope(map[string][]ScopedParent{
+		"AWS::S3::Bucket": {
+			{Identifier: "b-2", Region: "us-east-1"},
+			{Identifier: "b-1", Region: "us-east-1"},
+			{Identifier: "b-2", Region: "us-east-1"}, // dup (id,region) dropped
+			{Identifier: "  ", Region: "us-east-1"},  // empty id dropped
+			{Identifier: "b-1", Region: "us-east-1"}, // dup dropped
+			// Same identifier, different region: NOT a dup — kept separately.
+			{Identifier: "b-1", Region: "eu-west-1"},
+		},
+		"AWS::Logs::LogGroup": {
+			{Identifier: " lg ", Region: " us-east-1 "}, // trimmed
+			{Identifier: "lg", Region: "us-east-1"},     // dup after trim dropped
+		},
+		"  ":               {{Identifier: "ignored"}},               // empty CFN type dropped
+		"AWS::Empty::Type": {{Identifier: ""}, {Identifier: "   "}}, // no usable ids dropped
 	})
-	if got := scope["AWS::S3::Bucket"]; !reflect.DeepEqual(got, []string{"b-1", "b-2"}) {
-		t.Errorf("S3 scope = %v, want sorted de-duped [b-1 b-2]", got)
+	wantS3 := []ScopedParent{
+		{Identifier: "b-1", Region: "eu-west-1"},
+		{Identifier: "b-1", Region: "us-east-1"},
+		{Identifier: "b-2", Region: "us-east-1"},
 	}
-	if got := scope["AWS::Logs::LogGroup"]; !reflect.DeepEqual(got, []string{"lg"}) {
-		t.Errorf("Logs scope = %v, want trimmed de-duped [lg]", got)
+	if got := scope["AWS::S3::Bucket"]; !reflect.DeepEqual(got, wantS3) {
+		t.Errorf("S3 scope = %v, want sorted de-duped by (id,region) %v", got, wantS3)
+	}
+	if got := scope["AWS::Logs::LogGroup"]; !reflect.DeepEqual(got, []ScopedParent{{Identifier: "lg", Region: "us-east-1"}}) {
+		t.Errorf("Logs scope = %v, want trimmed de-duped [{lg us-east-1}]", got)
 	}
 	if _, ok := scope["  "]; ok {
 		t.Error("empty CFN type should be dropped")
@@ -42,7 +59,7 @@ func TestNewParentScope_DedupesSortsAndDropsEmpties(t *testing.T) {
 	if _, ok := scope["AWS::Empty::Type"]; ok {
 		t.Error("type with no usable ids should be dropped")
 	}
-	if NewParentScope(map[string][]string{"x": {""}}) != nil {
+	if NewParentScope(map[string][]ScopedParent{"x": {{Identifier: ""}}}) != nil {
 		t.Error("scope with no usable pair should be nil")
 	}
 }
@@ -77,7 +94,7 @@ func TestCloudControlDiscover_ParentScopeSkipsListResources(t *testing.T) {
 	got, err := d.Discover(context.Background(), DiscoverArgs{
 		Regions:     []string{"us-east-1"},
 		AccountID:   "123",
-		ParentScope: NewParentScope(map[string][]string{"AWS::S3::Bucket": {"bucket-a", "bucket-b"}}),
+		ParentScope: NewParentScope(map[string][]ScopedParent{"AWS::S3::Bucket": {{Identifier: "bucket-a", Region: "us-east-1"}, {Identifier: "bucket-b", Region: "us-east-1"}}}),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -125,7 +142,7 @@ func TestCloudControlDiscover_IdentifierSharedChildScoped(t *testing.T) {
 	got, err := d.Discover(context.Background(), DiscoverArgs{
 		Regions:     []string{"us-east-1"},
 		AccountID:   "123",
-		ParentScope: NewParentScope(map[string][]string{"AWS::S3::BucketPolicy": {"bucket-a"}}),
+		ParentScope: NewParentScope(map[string][]ScopedParent{"AWS::S3::BucketPolicy": {{Identifier: "bucket-a", Region: "us-east-1"}}}),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -161,7 +178,7 @@ func TestCloudControlDiscover_ParentScopeBypassesTagFilter(t *testing.T) {
 		Regions:     []string{"us-east-1"},
 		AccountID:   "123",
 		Project:     "io-some-project",
-		ParentScope: NewParentScope(map[string][]string{"AWS::S3::Bucket": {"bucket-a"}}),
+		ParentScope: NewParentScope(map[string][]ScopedParent{"AWS::S3::Bucket": {{Identifier: "bucket-a", Region: "us-east-1"}}}),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -196,7 +213,7 @@ func TestSDKOnlySubresourceDiscover_ParentScopeSkipsListParents(t *testing.T) {
 	got, err := d.Discover(context.Background(), DiscoverArgs{
 		Regions:     []string{"us-east-1"},
 		AccountID:   "123",
-		ParentScope: NewParentScope(map[string][]string{"AWS::S3::Bucket": {"bucket-a", "bucket-b"}}),
+		ParentScope: NewParentScope(map[string][]ScopedParent{"AWS::S3::Bucket": {{Identifier: "bucket-a", Region: "us-east-1"}, {Identifier: "bucket-b", Region: "us-east-1"}}}),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -253,7 +270,8 @@ func TestSDKOnlySubresourceDiscover_NoScopeSweepsAllParents(t *testing.T) {
 func TestLogGroupParentLister_ParentScopeSkipsDescribe(t *testing.T) {
 	t.Parallel()
 	args := DiscoverArgs{
-		ParentScope: NewParentScope(map[string][]string{logGroupParentCFNType: {"/lg/b", "/lg/a"}}),
+		Regions:     []string{"us-east-1"},
+		ParentScope: NewParentScope(map[string][]ScopedParent{logGroupParentCFNType: {{Identifier: "/lg/b", Region: "us-east-1"}, {Identifier: "/lg/a", Region: "us-east-1"}}}),
 	}
 	// awsCfg is a zero Config; if the lister fell through to the SDK path it
 	// would construct a real client and (lacking creds/region) the test would
@@ -283,6 +301,414 @@ func TestLogGroupResourceModels_ScopedMatchesSwept(t *testing.T) {
 	}
 	if !reflect.DeepEqual(scoped, swept) {
 		t.Errorf("scoped wrap %v != swept wrap %v", scoped, swept)
+	}
+}
+
+// =====================================================================
+// #739 codex follow-up: region-aware ParentScope. These tests FAIL on the
+// region-blind code (where scopedParents returned the same identifiers for
+// every enumeration region) and pass once scopedParents region-filters.
+// =====================================================================
+
+// TestSDKOnlySubresourceDiscover_ParentScopeRegionAware proves a parent scoped
+// to us-east-1 is fetched ONLY in us-east-1 across a multi-region request — it
+// is NOT re-fetched in eu-west-1. Pre-fix the scoped shortcut returned the same
+// identifier for every region, so FetchItem ran in BOTH regions and the closure
+// produced duplicate (and eu-west-1-mis-tagged) child imports.
+func TestSDKOnlySubresourceDiscover_ParentScopeRegionAware(t *testing.T) {
+	t.Parallel()
+	// Per-region FetchItem call counter — the region-blind bug doubles this.
+	var (
+		mu       sync.Mutex
+		byRegion = map[string]int{}
+	)
+	cfg := sdkOnlyTestConfig()
+	cfg.ParentCFNType = "AWS::S3::Bucket"
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		t.Error("ListParents must not be called when the type is scoped")
+		return nil, nil
+	}
+	cfg.FetchItem = func(_ context.Context, _ aws.Config, region, parentID string) (bool, map[string]any, map[string]string, error) {
+		mu.Lock()
+		byRegion[region]++
+		mu.Unlock()
+		return true, map[string]any{}, map[string]string{"bucket": parentID}, nil
+	}
+
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			"AWS::S3::Bucket": {{Identifier: "bucket-a", Region: "us-east-1"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if byRegion["us-east-1"] != 1 {
+		t.Errorf("FetchItem in us-east-1 = %d, want 1 (the scoped parent's region)", byRegion["us-east-1"])
+	}
+	if byRegion["eu-west-1"] != 0 {
+		t.Errorf("FetchItem in eu-west-1 = %d, want 0 (parent does not live there — region-blind bug re-fetches it)", byRegion["eu-west-1"])
+	}
+	if len(got) != 1 {
+		t.Fatalf("discovered %d child sets, want exactly 1 (region-blind bug duplicates)", len(got))
+	}
+	if got[0].Identity.Region != "us-east-1" {
+		t.Errorf("child region = %q, want us-east-1 (region-blind bug mis-tags the eu-west-1 copy)", got[0].Identity.Region)
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_ScopedTypeNoParentInRegionSkipsSweep proves the
+// (empty, true) contract: a region the scoped type has NO parent in must SKIP
+// enumeration entirely, NOT fall back to the account-wide ListParents sweep.
+// Pre-fix this region either re-ran the scoped parent (region-blind) or — if
+// scopedParents had naively returned (nil, false) for a no-match region — fell
+// back to ListParents. Either way ListParents in eu-west-1 must stay at 0.
+func TestSDKOnlySubresourceDiscover_ScopedTypeNoParentInRegionSkipsSweep(t *testing.T) {
+	t.Parallel()
+	var listParentsCalls atomic.Int64
+	cfg := sdkOnlyTestConfig()
+	cfg.ParentCFNType = "AWS::S3::Bucket"
+	cfg.ListParents = func(_ context.Context, _ aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+		listParentsCalls.Add(1)
+		return []string{"swept-" + region}, nil
+	}
+	var fetchCalls atomic.Int64
+	cfg.FetchItem = func(_ context.Context, _ aws.Config, _, parentID string) (bool, map[string]any, map[string]string, error) {
+		fetchCalls.Add(1)
+		return true, map[string]any{}, map[string]string{"bucket": parentID}, nil
+	}
+
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			// Only a us-east-1 parent. eu-west-1 is scoped-but-empty.
+			"AWS::S3::Bucket": {{Identifier: "bucket-a", Region: "us-east-1"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listParentsCalls.Load() != 0 {
+		t.Errorf("ListParents calls = %d, want 0 (scoped-but-no-parent region must NOT sweep account-wide)", listParentsCalls.Load())
+	}
+	if fetchCalls.Load() != 1 {
+		t.Errorf("FetchItem calls = %d, want 1 (only the us-east-1 parent)", fetchCalls.Load())
+	}
+	if ids := importIDs(got); !reflect.DeepEqual(ids, []string{"bucket-a"}) {
+		t.Errorf("discovered = %v, want only [bucket-a] (no swept-* from a fallback sweep)", ids)
+	}
+}
+
+// TestSDKOnlySubresourceDiscover_RegionLessParentEnumeratesOnce proves a
+// region-less scoped parent (Region == "", e.g. a global type) is enumerated
+// EXACTLY once across a multi-region request — in the first region — not once
+// per region. Pre-fix the region-blind shortcut returned it in every region.
+func TestSDKOnlySubresourceDiscover_RegionLessParentEnumeratesOnce(t *testing.T) {
+	t.Parallel()
+	var (
+		mu       sync.Mutex
+		byRegion = map[string]int{}
+	)
+	cfg := sdkOnlyTestConfig()
+	cfg.ParentCFNType = "AWS::S3::Bucket"
+	cfg.ListParents = func(_ context.Context, _ aws.Config, _ string, _ DiscoverArgs) ([]string, error) {
+		t.Error("ListParents must not be called when the type is scoped")
+		return nil, nil
+	}
+	cfg.FetchItem = func(_ context.Context, _ aws.Config, region, parentID string) (bool, map[string]any, map[string]string, error) {
+		mu.Lock()
+		byRegion[region]++
+		mu.Unlock()
+		return true, map[string]any{}, map[string]string{"bucket": parentID}, nil
+	}
+
+	d := newSDKOnlySubresourceDiscoverer(cfg, aws.Config{}, DefaultMaxConcurrency)
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1", "ap-south-1"},
+		AccountID: "123",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			// Region-less parent.
+			"AWS::S3::Bucket": {{Identifier: "global-parent", Region: ""}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if byRegion["us-east-1"] != 1 {
+		t.Errorf("FetchItem in us-east-1 (first region) = %d, want 1", byRegion["us-east-1"])
+	}
+	if byRegion["eu-west-1"] != 0 || byRegion["ap-south-1"] != 0 {
+		t.Errorf("FetchItem in non-first regions = eu-west-1:%d ap-south-1:%d, want 0/0 (region-less parent must enumerate once)", byRegion["eu-west-1"], byRegion["ap-south-1"])
+	}
+	if len(got) != 1 {
+		t.Fatalf("discovered %d child sets, want exactly 1 (region-less parent enumerated once)", len(got))
+	}
+}
+
+// TestCloudControlDiscover_ParentScopeRegionAware proves the Cloud Control
+// scoped-refs seam region-filters: a bucket scoped to us-east-1 is GetResource'd
+// only in us-east-1 across a multi-region request — never re-fetched in
+// eu-west-1, and the lone result is region-tagged us-east-1.
+func TestCloudControlDiscover_ParentScopeRegionAware(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		propsByIdentifier: map[string]map[string]any{
+			"bucket-a": {"Tags": map[string]any{}},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::S3::Bucket"
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			"AWS::S3::Bucket": {{Identifier: "bucket-a", Region: "us-east-1"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls = %d, want 0", fake.listCalls)
+	}
+	// Region-blind bug: GetResource runs once per region ⇒ 2 calls, 2 IRs.
+	if got := len(fake.getResourceCalls); got != 1 {
+		t.Errorf("GetResource calls = %d, want 1 (scoped parent fetched only in its region)", got)
+	}
+	if len(got) != 1 {
+		t.Fatalf("discovered %d, want 1 (region-blind bug duplicates across regions)", len(got))
+	}
+	if got[0].Identity.Region != "us-east-1" {
+		t.Errorf("region = %q, want us-east-1", got[0].Identity.Region)
+	}
+}
+
+// TestCloudControlDiscover_ScopedTypeNoParentInRegionSkipsSweep proves the CC
+// seam treats (empty, true) as "no parents here, skip" — a region with no scoped
+// parent issues ZERO ListResources and ZERO GetResource (no account-wide
+// fallback). The us-east-1 region still fetches its one scoped parent.
+func TestCloudControlDiscover_ScopedTypeNoParentInRegionSkipsSweep(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		// A fallback sweep would surface these — the scope must never list them.
+		listPages: []cloudcontrol.ListResourcesOutput{
+			listPage("", "swept-x", "swept-y"),
+		},
+		propsByIdentifier: map[string]map[string]any{
+			"bucket-a": {"Tags": map[string]any{}},
+			"swept-x":  {"Tags": map[string]any{}},
+			"swept-y":  {"Tags": map[string]any{}},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::S3::Bucket"
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1"},
+		AccountID: "123",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			"AWS::S3::Bucket": {{Identifier: "bucket-a", Region: "us-east-1"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls = %d, want 0 (scoped-but-empty region must not sweep)", fake.listCalls)
+	}
+	if ids := importIDs(got); !reflect.DeepEqual(ids, []string{"bucket-a"}) {
+		t.Errorf("discovered = %v, want only [bucket-a] (no swept-* from a fallback sweep)", ids)
+	}
+}
+
+// TestLogGroupParentLister_RegionAware proves the CloudWatch Logs lister scope
+// honors the enumeration region: a log group scoped to us-east-1 yields its
+// resource model only when enumerated in us-east-1, and an EMPTY (non-nil)
+// model slice in eu-west-1 — so the LogStream discoverer skips eu-west-1 rather
+// than re-listing the us-east-1 log group's streams there. Pre-fix the scoped
+// shortcut returned the same names for every region.
+func TestLogGroupParentLister_RegionAware(t *testing.T) {
+	t.Parallel()
+	args := DiscoverArgs{
+		Regions: []string{"us-east-1", "eu-west-1"},
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			logGroupParentCFNType: {{Identifier: "/lg/a", Region: "us-east-1"}},
+		}),
+	}
+	// us-east-1: the scoped log group's model.
+	east, err := listCloudWatchLogGroupsAsResourceModels(context.Background(), aws.Config{}, "us-east-1", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(east, []string{`{"LogGroupName":"/lg/a"}`}) {
+		t.Errorf("us-east-1 models = %v, want the scoped log group", east)
+	}
+	// eu-west-1: empty (non-nil) — scoped but no parent here, skip without sweep.
+	// A zero aws.Config would build a real client and (lacking creds) the test
+	// would not be hermetic if the lister fell through to DescribeLogGroups.
+	west, err := listCloudWatchLogGroupsAsResourceModels(context.Background(), aws.Config{}, "eu-west-1", args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if west == nil || len(west) != 0 {
+		t.Errorf("eu-west-1 models = %v, want empty non-nil slice (scoped-but-no-parent ⇒ skip, no sweep)", west)
+	}
+}
+
+// TestCloudControlDiscover_ParentScopeWinsOverRGTCache closes codex #770 P2-2:
+// a configured ParentScope must take precedence over the RGT prefetch cache.
+// The RGT cache only surfaces ARNs that match args.Project, so an explicitly
+// selected parent that LACKS the Project tag would be absent from the cache;
+// if the cache won, that selected parent would be silently dropped from
+// re-discovery and its scoped children would fail to resolve. The scope must
+// drive the work set and the cache (a different, tag-matched bucket) must be
+// ignored entirely.
+func TestCloudControlDiscover_ParentScopeWinsOverRGTCache(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		propsByIdentifier: map[string]map[string]any{
+			// The selected bucket carries NO Project tag.
+			"bucket-selected": {"Tags": map[string]any{}},
+			// The cache-only bucket would be the work set if the cache won.
+			"bucket-cached": {"Tags": map[string]any{"Project": "io-foo"}},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::S3::Bucket"
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	// RGT prefetch cache holds only the tag-matched bucket-cached.
+	cache := &rgtCache{byRegionAndType: map[string]map[string][]arnInfo{
+		"us-east-1": {
+			"AWS::S3::Bucket": {
+				{ARN: "arn:aws:s3:::bucket-cached", Identifier: "bucket-cached", Tags: map[string]string{"Project": "io-foo"}},
+			},
+		},
+	}}
+	args := DiscoverArgs{
+		Project:   "io-foo",
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			"AWS::S3::Bucket": {{Identifier: "bucket-selected", Region: "us-east-1"}},
+		}),
+	}.withRGTCache(cache)
+
+	got, err := d.Discover(context.Background(), args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls = %d, want 0", fake.listCalls)
+	}
+	// The scope drives the work set, NOT the cache.
+	if ids := importIDs(got); !reflect.DeepEqual(ids, []string{"bucket-selected"}) {
+		t.Errorf("discovered = %v, want only the scoped bucket [bucket-selected] (cache must not win, and the untagged scoped bucket must not be tag-dropped)", ids)
+	}
+}
+
+// TestCloudControlDiscover_GlobalChildScopedRegionLessParent: a region-less
+// scoped parent (Region == "") feeding a GLOBAL discoverer (enumerates with
+// region == "") is included even when args.Regions is non-empty — the single
+// "" pass includes every scoped parent.
+func TestCloudControlDiscover_GlobalChildScopedRegionLessParent(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		propsByIdentifier: map[string]map[string]any{
+			"role-a": {"Tags": map[string]any{}},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::IAM::Role"
+	cfg.IsGlobal = true
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1"}, // non-empty, but type is global
+		AccountID: "123",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			"AWS::IAM::Role": {{Identifier: "role-a", Region: ""}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ids := importIDs(got); !reflect.DeepEqual(ids, []string{"role-a"}) {
+		t.Errorf("discovered = %v, want [role-a] (region-less parent must be included in the global pass)", ids)
+	}
+	if got[0].Identity.Region != "" {
+		t.Errorf("region = %q, want \"\" (global resource)", got[0].Identity.Region)
+	}
+}
+
+// TestCloudControlDiscover_GlobalTypeScopedRealRegionParent closes codex #770
+// P1: aws_s3_bucket is IsGlobal-ENUMERATED (single region=="" scan) but its
+// IRs carry a REAL Identity.Region (us-west-2, …) promoted by PostDiscover, so
+// awsParentScope records the bucket under its true region. The IsGlobal scan
+// passes region == "" to scopedParents, which must STILL include the selected
+// bucket — region-filtering the single "" pass would drop the bucket entirely
+// and break its scoped children. args.Regions is non-empty (the common case).
+func TestCloudControlDiscover_GlobalTypeScopedRealRegionParent(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		// A full sweep would surface bucket-other; the scope must skip listing.
+		listPages: []cloudcontrol.ListResourcesOutput{
+			listPage("", "bucket-west", "bucket-other"),
+		},
+		propsByIdentifier: map[string]map[string]any{
+			"bucket-west":  {"Tags": map[string]any{}},
+			"bucket-other": {"Tags": map[string]any{}},
+		},
+	}
+	cfg := testConfig()
+	cfg.CloudFormationType = "AWS::S3::Bucket"
+	cfg.IsGlobal = true // S3 is enumerated region-less.
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1", "eu-west-1"}, // non-empty
+		AccountID: "123",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			// The selected bucket lives in us-west-2 (its TRUE region),
+			// NOT us-east-1 and NOT region-less.
+			"AWS::S3::Bucket": {{Identifier: "bucket-west", Region: "us-west-2"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.listCalls != 0 {
+		t.Errorf("ListResources calls = %d, want 0 (scope must skip the account-wide list)", fake.listCalls)
+	}
+	if ids := importIDs(got); !reflect.DeepEqual(ids, []string{"bucket-west"}) {
+		t.Errorf("discovered = %v, want [bucket-west] (P1: global single pass must include the scoped real-region bucket, not drop it)", ids)
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -289,6 +289,38 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 		}
 		var refs []itemRef
 
+		// Selection-closure scoping (#739): when the caller restricted this
+		// type to a fixed set of selected identifiers, those ARE the work set
+		// — the operator already chose exactly these parents. Use them as refs
+		// directly (each flows through the standard GetResource fan-out below)
+		// and SKIP the account-wide ListResources / SDKLister / ParentLister
+		// enumeration. This scopes a parent type's closure re-discovery to the
+		// selected parents and removes the need for account-wide list
+		// permissions (s3:ListAllMyBuckets, …). Tag filtering is bypassed for
+		// scoped refs — the operator's explicit selection already won.
+		//
+		// Checked BEFORE the RGT cache (#739 codex follow-up, P2-2): the
+		// explicit selection is the strongest signal. The RGT prefetch only
+		// surfaces ARNs that match args.Project / args.TagSelectors, so a
+		// scoped parent that lacks the Project tag would be ABSENT from the
+		// cache; letting the cache win would silently drop a parent the
+		// operator explicitly selected and break its scoped children. So when
+		// the type is scoped we take the scope and never consult the cache.
+		//
+		// Region-aware (#739 codex follow-up): scopedParents returns only the
+		// identifiers that live in THIS region (plus region-less parents in the
+		// first region). When the type is scoped but NO parents match this
+		// region it returns (empty, true): scopeUsed stays true so we still
+		// SKIP the account-wide sweep — a multi-region closure must not
+		// re-GetResource a us-east-1 bucket in eu-west-1.
+		scopeUsed := false
+		if scoped, ok := args.scopedParents(d.cfg.CloudFormationType, region); ok {
+			for _, id := range scoped {
+				refs = append(refs, itemRef{identifier: id})
+			}
+			scopeUsed = true
+		}
+
 		// RGT prefetch cache short-circuit: when the orchestrator's
 		// pre-pass found ARNs for our CloudFormation type, skip
 		// ListResources entirely. The cache is empty (or absent) for
@@ -297,7 +329,8 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 		// failed (downgraded to warn, not error). See rgt_prefetcher.go
 		// and #406. The cache also bypasses the ParentLister branch —
 		// each cached ARN is a self-contained CC identifier, no
-		// parent context required.
+		// parent context required. Skipped entirely when the type is
+		// scoped (above) — the scope already chose the exact work set.
 		//
 		// Untaggable types (SkipProjectTagFilter=true) bypass the cache
 		// entirely. RGT can only see tagged ARNs, so for genuinely
@@ -307,7 +340,7 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 		// only path that can surface these; the legacy Project filter
 		// further down is already skipped for these types.
 		cacheUsed := false
-		if !d.cfg.SkipProjectTagFilter {
+		if !scopeUsed && !d.cfg.SkipProjectTagFilter {
 			if d.cfg.IsGlobal {
 				if cached, ok := args.RGTCacheForGlobalCFN(d.cfg.CloudFormationType); ok {
 					for _, info := range cached {
@@ -320,25 +353,6 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 					refs = append(refs, itemRef{identifier: info.Identifier, rgtTags: info.Tags})
 				}
 				cacheUsed = true
-			}
-		}
-
-		// Selection-closure scoping (#739): when the caller restricted this
-		// type to a fixed set of selected identifiers, those ARE the work set
-		// — the operator already chose exactly these parents. Use them as refs
-		// directly (each flows through the standard GetResource fan-out below)
-		// and SKIP the account-wide ListResources / SDKLister / ParentLister
-		// enumeration. This scopes a parent type's closure re-discovery to the
-		// selected parents and removes the need for account-wide list
-		// permissions (s3:ListAllMyBuckets, …). Tag filtering is bypassed for
-		// scoped refs — the operator's explicit selection already won.
-		scopeUsed := false
-		if !cacheUsed {
-			if scoped, ok := args.scopedParents(d.cfg.CloudFormationType); ok {
-				for _, id := range scoped {
-					refs = append(refs, itemRef{identifier: id})
-				}
-				scopeUsed = true
 			}
 		}
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -323,7 +323,26 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 			}
 		}
 
+		// Selection-closure scoping (#739): when the caller restricted this
+		// type to a fixed set of selected identifiers, those ARE the work set
+		// — the operator already chose exactly these parents. Use them as refs
+		// directly (each flows through the standard GetResource fan-out below)
+		// and SKIP the account-wide ListResources / SDKLister / ParentLister
+		// enumeration. This scopes a parent type's closure re-discovery to the
+		// selected parents and removes the need for account-wide list
+		// permissions (s3:ListAllMyBuckets, …). Tag filtering is bypassed for
+		// scoped refs — the operator's explicit selection already won.
+		scopeUsed := false
 		if !cacheUsed {
+			if scoped, ok := args.scopedParents(d.cfg.CloudFormationType); ok {
+				for _, id := range scoped {
+					refs = append(refs, itemRef{identifier: id})
+				}
+				scopeUsed = true
+			}
+		}
+
+		if !cacheUsed && !scopeUsed {
 			if d.cfg.SDKLister != nil {
 				// Native-SDK enumeration: types whose CC ListResources
 				// returns UnsupportedActionException despite CC
@@ -533,11 +552,17 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 			// item. Operators scoping a discover via --project get all
 			// instances of these types account-wide.
 			cacheUsedForRef := cacheUsed
-			if !cacheUsedForRef && !d.cfg.SkipProjectTagFilter && args.Project != "" && f.tags["Project"] != args.Project {
-				continue
-			}
-			if !MatchesAll(f.tags, args.TagSelectors) {
-				continue
+			// Scoped refs (#739) bypass tag filtering: the operator
+			// selected exactly these parents by identity, so a missing
+			// Project tag or an unrelated --tag-selector must not drop a
+			// resource the closure was explicitly told to pull in.
+			if !scopeUsed {
+				if !cacheUsedForRef && !d.cfg.SkipProjectTagFilter && args.Project != "" && f.tags["Project"] != args.Project {
+					continue
+				}
+				if !MatchesAll(f.tags, args.TagSelectors) {
+					continue
+				}
 			}
 			importID := f.identifier
 			if d.cfg.ImportIDFromIdentifier != nil {

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -1077,11 +1077,20 @@ func listCloudWatchLogGroupsWithClient(ctx context.Context, client cloudWatchLog
 // pipeline (#255 contract).
 func listCloudWatchLogGroupsAsResourceModels(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error) {
 	// Selection-closure scoping (#739): when the caller restricted the parent
-	// log groups to a fixed set of selected names, wrap those directly into
-	// resource models and SKIP the account-wide logs:DescribeLogGroups call.
-	// This scopes the LogStream closure to the selected parents and removes
-	// the need for the account-wide logs:DescribeLogGroups permission.
-	if scoped, ok := args.scopedParents(logGroupParentCFNType); ok {
+	// log groups to a fixed set of selected names, wrap the names in THIS
+	// region directly into resource models and SKIP the account-wide
+	// logs:DescribeLogGroups call. This scopes the LogStream closure to the
+	// selected parents and removes the need for the account-wide
+	// logs:DescribeLogGroups permission.
+	//
+	// Region-aware (#739 codex follow-up): scopedParents returns only the log
+	// groups in `region` (plus region-less parents in the first region). When
+	// the type is scoped but NO names match this region it returns
+	// (empty, true): we return the empty (non-nil) resource-model slice and
+	// the CC LogStream discoverer skips this region — no account-wide
+	// DescribeLogGroups fallback, so a multi-region closure does not re-list a
+	// us-east-1 log group's streams in eu-west-1.
+	if scoped, ok := args.scopedParents(logGroupParentCFNType, region); ok {
 		return logGroupNamesAsResourceModels(scoped), nil
 	}
 	client := cloudwatchlogs.NewFromConfig(awsCfg, func(o *cloudwatchlogs.Options) {

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_listers.go
@@ -1075,13 +1075,38 @@ func listCloudWatchLogGroupsWithClient(ctx context.Context, client cloudWatchLog
 // Returns a non-nil empty slice on accounts with zero log groups so
 // downstream consumers see "[]" not "null" through the JSON-marshal
 // pipeline (#255 contract).
-func listCloudWatchLogGroupsAsResourceModels(ctx context.Context, awsCfg aws.Config, region string, _ DiscoverArgs) ([]string, error) {
+func listCloudWatchLogGroupsAsResourceModels(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error) {
+	// Selection-closure scoping (#739): when the caller restricted the parent
+	// log groups to a fixed set of selected names, wrap those directly into
+	// resource models and SKIP the account-wide logs:DescribeLogGroups call.
+	// This scopes the LogStream closure to the selected parents and removes
+	// the need for the account-wide logs:DescribeLogGroups permission.
+	if scoped, ok := args.scopedParents(logGroupParentCFNType); ok {
+		return logGroupNamesAsResourceModels(scoped), nil
+	}
 	client := cloudwatchlogs.NewFromConfig(awsCfg, func(o *cloudwatchlogs.Options) {
 		if region != "" {
 			o.Region = region
 		}
 	})
 	return listCloudWatchLogGroupsAsResourceModelsWithClient(ctx, client)
+}
+
+// logGroupParentCFNType is the CloudFormation type of the parent log group an
+// aws_cloudwatch_log_stream closure scopes to. Kept next to the lister so the
+// scope lookup and the ListStream parent-model wrap stay in lockstep.
+const logGroupParentCFNType = "AWS::Logs::LogGroup"
+
+// logGroupNamesAsResourceModels wraps log-group names into the
+// `{"LogGroupName":"…"}` Cloud Control resource models AWS::Logs::LogStream's
+// ListResources handler requires. Shared by the scoped and account-wide paths
+// so both emit byte-identical models.
+func logGroupNamesAsResourceModels(names []string) []string {
+	models := make([]string, 0, len(names))
+	for _, n := range names {
+		models = append(models, fmt.Sprintf(`{"LogGroupName":%q}`, n))
+	}
+	return models
 }
 
 // listCloudWatchLogGroupsAsResourceModelsWithClient is the test seam
@@ -1094,11 +1119,7 @@ func listCloudWatchLogGroupsAsResourceModelsWithClient(ctx context.Context, clie
 	if err != nil {
 		return nil, err
 	}
-	models := make([]string, 0, len(names))
-	for _, n := range names {
-		models = append(models, fmt.Sprintf(`{"LogGroupName":%q}`, n))
-	}
-	return models, nil
+	return logGroupNamesAsResourceModels(names), nil
 }
 
 // =====================================================================

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -1,6 +1,38 @@
 package awsdiscover
 
-import "strings"
+import (
+	"strings"
+	"sync"
+)
+
+// cfnTypeByTF lazily indexes the Terraform-type → CloudFormation-type map from
+// the production discoverer registries (cloudControlTypeConfigs and the SDK-only
+// sub-resource configs). Built once on first use so the index reflects whatever
+// the registries declare without a second source of truth.
+var cfnTypeByTF = sync.OnceValue(func() map[string]string {
+	out := make(map[string]string)
+	for _, cfg := range cloudControlTypeConfigs {
+		if cfg.TFType != "" && cfg.CloudFormationType != "" {
+			out[cfg.TFType] = cfg.CloudFormationType
+		}
+	}
+	// SDK-only sub-resource types (sdkOnlySubresourceTypeConfigs) are
+	// intentionally excluded: they have no CloudFormation type of their own
+	// (they record their PARENT's CFN type), and this index answers "what CFN
+	// type backs this Terraform type" for Cloud Control resources only.
+	return out
+})
+
+// CloudFormationTypeForTF returns the CloudFormation type that backs the given
+// Terraform type, and true when the type is a Cloud Control resource in the
+// production registry. It exists so closure-scoping callers (reversedisco) can
+// key a parent-scope by the parent's CloudFormation type without duplicating
+// the presets-owned TF↔CFN vocabulary. Returns ("", false) for types not routed
+// through Cloud Control (hand-rolled SDK discoverers, SDK-only sub-resources).
+func CloudFormationTypeForTF(tfType string) (string, bool) {
+	cfn, ok := cfnTypeByTF()[strings.TrimSpace(tfType)]
+	return cfn, ok
+}
 
 // cloudControlTypeConfigs is the registry of Terraform resource types
 // routed through the generic Cloud Control discoverer. Each entry maps

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -34,6 +34,36 @@ func CloudFormationTypeForTF(tfType string) (string, bool) {
 	return cfn, ok
 }
 
+// identifierSharedChildCFNTypes maps a parent CloudFormation type to the child
+// Cloud Control types whose CC primary identifier IS the parent's identifier
+// (a 1:1, identifier-sharing child). For these, a parent-scope keyed by the
+// parent's identifier also scopes the child: e.g. aws_s3_bucket_policy's CC
+// identifier is the bucket name (the parent aws_s3_bucket's identifier), so the
+// selected bucket names scope the policy discovery directly — no account-wide
+// AWS::S3::BucketPolicy ListResources (and no broad list permission) needed.
+//
+// Only identifier-SHARING children belong here. Children with a compound or
+// independent identifier (aws_cloudwatch_log_stream's "<group>:<stream>", KMS
+// aliases, VPC children, SG rules) are NOT listed — they are scoped via their
+// own parent lister (log streams) or discovered account-wide and filtered by
+// the engine's mergeClosureResources (the in-memory-join families).
+var identifierSharedChildCFNTypes = map[string][]string{
+	"AWS::S3::Bucket": {"AWS::S3::BucketPolicy"},
+}
+
+// IdentifierSharedChildCFNTypes returns the child Cloud Control types whose CC
+// identifier equals the given parent CFN type's identifier, so a closure-scoping
+// caller can scope those children with the same selected-parent identifiers.
+// Returns nil for a parent type with no identifier-sharing children. The
+// returned slice is a fresh copy; callers may mutate it.
+func IdentifierSharedChildCFNTypes(parentCFNType string) []string {
+	children := identifierSharedChildCFNTypes[strings.TrimSpace(parentCFNType)]
+	if len(children) == 0 {
+		return nil
+	}
+	return append([]string(nil), children...)
+}
+
 // cloudControlTypeConfigs is the registry of Terraform resource types
 // routed through the generic Cloud Control discoverer. Each entry maps
 // one TFType to a Cloud-Formation TypeName plus per-type extractors for

--- a/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer.go
@@ -317,12 +317,19 @@ func (d *sdkOnlySubresourceDiscoverer) Discover(ctx context.Context, args Discov
 func (d *sdkOnlySubresourceDiscoverer) enumerateParents(ctx context.Context, region string, args DiscoverArgs) ([]string, error) {
 	// Selection-closure scoping (#739): when the caller restricted this
 	// discoverer's parent CFN type to a fixed set of selected parents, use
-	// those identifiers DIRECTLY as the parent set. This skips the
+	// the parents in THIS region DIRECTLY as the parent set. This skips the
 	// account-wide ListParents enumeration (e.g. s3:ListBuckets) entirely —
 	// scoping the closure to the selected parents AND removing the need for
 	// account-wide list permissions. The per-parent FetchItem fan-out below
 	// reads only the selected parents' sub-resources.
-	if scoped, ok := args.scopedParents(d.cfg.ParentCFNType); ok {
+	//
+	// Region-aware (#739 codex follow-up): scopedParents returns only the
+	// parents that live in `region` (plus region-less parents in the first
+	// region). When the type is scoped but NO parents match this region it
+	// returns (empty, true) — we return the empty slice WITHOUT falling
+	// through to the account-wide sweep, so a multi-region closure does not
+	// re-fetch a us-east-1 parent's sub-resources in eu-west-1.
+	if scoped, ok := args.scopedParents(d.cfg.ParentCFNType, region); ok {
 		return scoped, nil
 	}
 	if !d.cfg.SkipProjectTagFilter && d.cfg.ParentCFNType != "" {

--- a/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/sdkonly_subresource_discoverer.go
@@ -315,6 +315,16 @@ func (d *sdkOnlySubresourceDiscoverer) Discover(ctx context.Context, args Discov
 // intentionally agnostic to parent taggability so the same code path
 // handles future families whose parents are also untaggable.
 func (d *sdkOnlySubresourceDiscoverer) enumerateParents(ctx context.Context, region string, args DiscoverArgs) ([]string, error) {
+	// Selection-closure scoping (#739): when the caller restricted this
+	// discoverer's parent CFN type to a fixed set of selected parents, use
+	// those identifiers DIRECTLY as the parent set. This skips the
+	// account-wide ListParents enumeration (e.g. s3:ListBuckets) entirely —
+	// scoping the closure to the selected parents AND removing the need for
+	// account-wide list permissions. The per-parent FetchItem fan-out below
+	// reads only the selected parents' sub-resources.
+	if scoped, ok := args.scopedParents(d.cfg.ParentCFNType); ok {
+		return scoped, nil
+	}
 	if !d.cfg.SkipProjectTagFilter && d.cfg.ParentCFNType != "" {
 		var (
 			cached []arnInfo

--- a/cmd/insideout-import/reverse.go
+++ b/cmd/insideout-import/reverse.go
@@ -99,7 +99,23 @@ Flags:`)
 	ctx, cancel := context.WithTimeout(context.Background(), discoverTimeoutOverall)
 	defer cancel()
 
-	discoverer, cleanup, err := reversedisco.New(ctx, cloud, firstReqRegion(req, *region), firstReqProjectID(req, *gcpProjectID), *awsEndpointURL)
+	// Resolve the customer-account assume-role identity from the generated
+	// stack (env / outputs/cloud-provision.json / tf/auto-vars) so the
+	// discoverer's direct AWS SDK calls run as the SAME principal Terraform's
+	// provider blocks assume (#739). Empty RoleARN (the common local-CLI case,
+	// where the operator already has customer creds ambient) leaves the
+	// discoverer on ambient credentials — assume-role is OPTIONAL.
+	var awsAuth reversedisco.AWSAssumeRole
+	if cloud == "aws" {
+		auth, authErr := reverseimport.ResolveAWSProviderAuth(*outputDir)
+		if authErr != nil {
+			fmt.Fprintf(os.Stderr, "reverse: resolve AWS provider auth: %v\n", authErr)
+			return reverseExitFatal
+		}
+		awsAuth = reversedisco.AWSAssumeRole{RoleARN: auth.RoleARN, ExternalID: auth.ExternalID}
+	}
+
+	discoverer, cleanup, err := reversedisco.New(ctx, cloud, firstReqRegion(req, *region), firstReqProjectID(req, *gcpProjectID), *awsEndpointURL, awsAuth)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "reverse: build discoverer: %v\n", err)
 		return reverseExitFatal

--- a/cmd/insideout-import/reversedisco/closure_scope_live_test.go
+++ b/cmd/insideout-import/reversedisco/closure_scope_live_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+// closure_scope_live_test.go is the live-AWS pre-merge repro check for the
+// #739 selection-closure defects. The unit suite proves each fix against
+// fakes; this harness proves the deployed behavior against a real account —
+// the gap that let the original #738 wiring ship green and then break on
+// staging (account-wide sweep + AccessDenied hard-fail).
+//
+// What it locks: selecting exactly ONE S3 bucket parent and running the same
+// DiscoverClosure call the engine makes must enumerate ONLY that bucket and
+// its child sub-resources. Pre-#739 this returned every bucket in the
+// account (observed live: 1 selected -> all 44 buckets / 216 resources), so
+// this test fails loudly on the old adapter.
+//
+// Like roundtrip_live_test.go it is gated three ways so it never runs in
+// normal `go test ./...` or CI: the `integration` build tag, the
+// RUN_LIVE_CLOSURE=1 env guard, and a credential probe that skips cleanly
+// when no AWS creds are loaded. Run it with read-only creds for a test
+// account (e.g. after `aws_jump <acct> <role>`):
+//
+//	RUN_LIVE_CLOSURE=1 go test -tags integration \
+//	  ./cmd/insideout-import/reversedisco -run TestLiveClosureScope -v
+package reversedisco_test
+
+import (
+	"context"
+	"os"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/reversedisco"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/labels"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
+)
+
+func TestLiveClosureScope(t *testing.T) {
+	if os.Getenv("RUN_LIVE_CLOSURE") != "1" {
+		t.Skip("live closure-scope harness disabled; set RUN_LIVE_CLOSURE=1 with AWS creds for a test account")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Credential probe: list buckets directly. Skip (not fail) when creds are
+	// absent so the tag alone never breaks a keyless environment.
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-east-1"))
+	if err != nil {
+		t.Skipf("no AWS config: %v", err)
+	}
+	probeCtx, probeCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer probeCancel()
+	listOut, err := s3.NewFromConfig(cfg).ListBuckets(probeCtx, &s3.ListBucketsInput{})
+	if err != nil {
+		t.Skipf("no usable AWS credentials (s3:ListBuckets probe failed): %v", err)
+	}
+	if len(listOut.Buckets) < 2 {
+		t.Skipf("need >=2 buckets to prove scoping; account has %d", len(listOut.Buckets))
+	}
+	selected := *listOut.Buckets[0].Name
+	t.Logf("account has %d buckets; selecting only %q", len(listOut.Buckets), selected)
+
+	// Child types from the same registry the engine's closure uses.
+	var childTypes []string
+	for _, ct := range labels.ChildTfTypes() {
+		if pt, ok := labels.ParentTfType(ct); ok && pt == "aws_s3_bucket" {
+			childTypes = append(childTypes, ct)
+		}
+	}
+	sort.Strings(childTypes)
+	if len(childTypes) == 0 {
+		t.Fatal("labels registry has no aws_s3_bucket child types; closure would be a no-op and this harness is vacuous")
+	}
+
+	// Ambient creds (empty AWSAssumeRole) — this harness runs in CLI context
+	// where the test-account creds are already loaded. The assume-role path is
+	// locked by TestNewAWSAssumesRoleWhenAuthPresent.
+	disco, cleanup, err := reversedisco.New(ctx, "aws", "us-east-1", "", "", reversedisco.AWSAssumeRole{})
+	if err != nil {
+		t.Fatalf("reversedisco.New: %v", err)
+	}
+	defer cleanup()
+	closure, ok := disco.(reverseimport.ClosureDiscoverer)
+	if !ok {
+		t.Fatal("discoverer is not closure-capable")
+	}
+
+	start := time.Now()
+	found, err := closure.DiscoverClosure(ctx, reverseimport.ClosureRequest{
+		Cloud:   "aws",
+		Regions: []string{"us-east-1"},
+		ParentResources: []imported.ImportedResource{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.live_scope",
+				NameHint: selected,
+				ImportID: selected,
+			},
+		}},
+		ParentTypes: []string{"aws_s3_bucket"},
+		ChildTypes:  childTypes,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverClosure: %v", err)
+	}
+	t.Logf("DiscoverClosure returned %d resources in %s", len(found), time.Since(start))
+
+	// The #739 regression assertion: only the selected parent may appear, and
+	// no resource may belong to any other bucket in the account.
+	otherBuckets := map[string]struct{}{}
+	for _, b := range listOut.Buckets[1:] {
+		otherBuckets[*b.Name] = struct{}{}
+	}
+	distinctBuckets := map[string]struct{}{}
+	for _, r := range found {
+		if r.Identity.Type == "aws_s3_bucket" {
+			distinctBuckets[r.Identity.NameHint] = struct{}{}
+		}
+		if _, leaked := otherBuckets[r.Identity.NameHint]; leaked {
+			t.Errorf("closure leaked unselected bucket's resource: %s %s (#739 account-wide sweep)", r.Identity.Type, r.Identity.NameHint)
+		}
+	}
+	if len(distinctBuckets) != 1 {
+		t.Errorf("closure returned %d distinct buckets, want exactly the 1 selected (#739 account-wide sweep)", len(distinctBuckets))
+	}
+	if _, ok := distinctBuckets[selected]; len(distinctBuckets) > 0 && !ok {
+		t.Errorf("closure result is missing the selected bucket %q", selected)
+	}
+}

--- a/cmd/insideout-import/reversedisco/reversedisco.go
+++ b/cmd/insideout-import/reversedisco/reversedisco.go
@@ -147,13 +147,20 @@ func (a awsAggAdapter) DiscoverClosure(ctx context.Context, req reverseimport.Cl
 // #739 closure-scoping fix uses to restrict child + parent re-discovery to the
 // operator's selected parents. For each selected parent whose Terraform type is
 // a known Cloud Control type it records the parent's identifier (its ImportID,
-// falling back to NameHint) under the parent's CloudFormation type. Parent types
-// not routed through Cloud Control are skipped — their children are discovered
-// account-wide and the engine's mergeClosureResources still filters them to the
-// selected parents, so closure semantics are unchanged. Returns nil when no
-// usable scope can be built (the caller then sweeps account-wide as before).
+// falling back to NameHint) AND its region (Identity.Region) under the parent's
+// CloudFormation type. Parent types not routed through Cloud Control are
+// skipped — their children are discovered account-wide and the engine's
+// mergeClosureResources still filters them to the selected parents, so closure
+// semantics are unchanged. Returns nil when no usable scope can be built (the
+// caller then sweeps account-wide as before).
+//
+// The region is load-bearing for multi-region closures: each scoped seam
+// enumerates a parent's sub-resources only in the parent's region, so the same
+// bucket / log group is not re-fetched once per requested region. A region-less
+// parent (Identity.Region == "", e.g. a global type) is enumerated exactly once
+// across the request (see ParentScope.scopedParents).
 func awsParentScope(parents []imported.ImportedResource) awsdiscover.ParentScope {
-	byCFN := map[string][]string{}
+	byCFN := map[string][]awsdiscover.ScopedParent{}
 	for _, p := range parents {
 		cfnType, ok := awsdiscover.CloudFormationTypeForTF(p.Identity.Type)
 		if !ok {
@@ -166,14 +173,17 @@ func awsParentScope(parents []imported.ImportedResource) awsdiscover.ParentScope
 		if id == "" {
 			continue
 		}
-		byCFN[cfnType] = append(byCFN[cfnType], id)
+		region := strings.TrimSpace(p.Identity.Region)
+		sp := awsdiscover.ScopedParent{Identifier: id, Region: region}
+		byCFN[cfnType] = append(byCFN[cfnType], sp)
 		// Also scope any child whose CC identifier IS this parent's
 		// identifier (e.g. aws_s3_bucket_policy, whose identifier is the
 		// bucket name) so its discovery is restricted to the selected
-		// parents too — no account-wide list of the child type (#739
-		// codex follow-up).
+		// parents too — no account-wide list of the child type. The child
+		// inherits the parent's region so the per-region enumeration is
+		// scoped identically (#739 codex follow-up).
 		for _, childCFN := range awsdiscover.IdentifierSharedChildCFNTypes(cfnType) {
-			byCFN[childCFN] = append(byCFN[childCFN], id)
+			byCFN[childCFN] = append(byCFN[childCFN], sp)
 		}
 	}
 	return awsdiscover.NewParentScope(byCFN)

--- a/cmd/insideout-import/reversedisco/reversedisco.go
+++ b/cmd/insideout-import/reversedisco/reversedisco.go
@@ -136,10 +136,39 @@ func (a awsAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, acc
 func (a awsAggAdapter) DiscoverClosure(ctx context.Context, req reverseimport.ClosureRequest) ([]imported.ImportedResource, error) {
 	types := unionStrings(req.ParentTypes, req.ChildTypes)
 	return a.d.DiscoverTypes(ctx, types, awsdiscover.DiscoverArgs{
-		Project:   req.Project,
-		Regions:   req.Regions,
-		AccountID: req.AccountID,
+		Project:     req.Project,
+		Regions:     req.Regions,
+		AccountID:   req.AccountID,
+		ParentScope: awsParentScope(req.ParentResources),
 	})
+}
+
+// awsParentScope builds the per-CloudFormation-type selected-parent scope the
+// #739 closure-scoping fix uses to restrict child + parent re-discovery to the
+// operator's selected parents. For each selected parent whose Terraform type is
+// a known Cloud Control type it records the parent's identifier (its ImportID,
+// falling back to NameHint) under the parent's CloudFormation type. Parent types
+// not routed through Cloud Control are skipped — their children are discovered
+// account-wide and the engine's mergeClosureResources still filters them to the
+// selected parents, so closure semantics are unchanged. Returns nil when no
+// usable scope can be built (the caller then sweeps account-wide as before).
+func awsParentScope(parents []imported.ImportedResource) awsdiscover.ParentScope {
+	byCFN := map[string][]string{}
+	for _, p := range parents {
+		cfnType, ok := awsdiscover.CloudFormationTypeForTF(p.Identity.Type)
+		if !ok {
+			continue
+		}
+		id := strings.TrimSpace(p.Identity.ImportID)
+		if id == "" {
+			id = strings.TrimSpace(p.Identity.NameHint)
+		}
+		if id == "" {
+			continue
+		}
+		byCFN[cfnType] = append(byCFN[cfnType], id)
+	}
+	return awsdiscover.NewParentScope(byCFN)
 }
 
 // gcpAggAdapter is the GCP analogue of awsAggAdapter.

--- a/cmd/insideout-import/reversedisco/reversedisco.go
+++ b/cmd/insideout-import/reversedisco/reversedisco.go
@@ -167,6 +167,14 @@ func awsParentScope(parents []imported.ImportedResource) awsdiscover.ParentScope
 			continue
 		}
 		byCFN[cfnType] = append(byCFN[cfnType], id)
+		// Also scope any child whose CC identifier IS this parent's
+		// identifier (e.g. aws_s3_bucket_policy, whose identifier is the
+		// bucket name) so its discovery is restricted to the selected
+		// parents too — no account-wide list of the child type (#739
+		// codex follow-up).
+		for _, childCFN := range awsdiscover.IdentifierSharedChildCFNTypes(cfnType) {
+			byCFN[childCFN] = append(byCFN[childCFN], id)
+		}
 	}
 	return awsdiscover.NewParentScope(byCFN)
 }

--- a/cmd/insideout-import/reversedisco/reversedisco.go
+++ b/cmd/insideout-import/reversedisco/reversedisco.go
@@ -23,13 +23,32 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
 )
+
+// AWSAssumeRole is the optional customer-account assume-role identity the AWS
+// discoverer adopts before issuing any direct SDK call. It mirrors the
+// reverseimport.AWSProviderAuth Terraform's generated provider blocks use, so
+// the discoverer's SDK calls run as the SAME principal Terraform's
+// assume_role { role_arn } blocks reach the customer account with (#739).
+//
+// When RoleARN is empty the discoverer uses ambient credentials unchanged —
+// the correct behavior for the local CLI, which is typically run with the
+// customer credentials already in the environment. When RoleARN is set, the
+// base config is wrapped with an STS AssumeRole credentials provider targeting
+// that role (and ExternalID, when present).
+type AWSAssumeRole struct {
+	RoleARN    string
+	ExternalID string
+}
 
 // New constructs a closure-capable discoverer for the given cloud, suitable
 // for reverseimport.Options.Discoverer (the returned value also satisfies
@@ -45,7 +64,14 @@ import (
 // The returned cleanup func releases any cloud connections (the GCP asset
 // searcher's gRPC client); it is always non-nil and safe to call even on the
 // AWS path (where it is a no-op). Callers should defer it.
-func New(ctx context.Context, cloud, region, gcpProjectID, awsEndpointURL string) (reverseimport.Discoverer, func(), error) {
+//
+// awsAuth carries the optional customer-account assume-role identity. On the
+// AWS path, a non-empty awsAuth.RoleARN makes the discoverer's SDK calls run as
+// that role (the same one Terraform's provider blocks assume), rather than the
+// ambient pod/CLI credentials — the #739 fix. It is ignored on the GCP path.
+// The same wrapped config backs both DiscoverByID (dep-chase) and
+// DiscoverClosure, so both surfaces inherit the fixed credentials.
+func New(ctx context.Context, cloud, region, gcpProjectID, awsEndpointURL string, awsAuth AWSAssumeRole) (reverseimport.Discoverer, func(), error) {
 	switch cloud {
 	case "aws":
 		opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
@@ -57,6 +83,7 @@ func New(ctx context.Context, cloud, region, gcpProjectID, awsEndpointURL string
 		if err != nil {
 			return nil, func() {}, err
 		}
+		cfg = applyAWSAssumeRole(cfg, awsAuth)
 		return awsAggAdapter{d: awsdiscover.NewAWSDiscovererWithConcurrency(cfg, awsdiscover.DefaultMaxConcurrency)}, func() {}, nil
 	case "gcp":
 		searcher, err := gcpdiscover.NewRealAssetSearcher(ctx)
@@ -67,6 +94,32 @@ func New(ctx context.Context, cloud, region, gcpProjectID, awsEndpointURL string
 	default:
 		return nil, func() {}, fmt.Errorf("unknown cloud %q", cloud)
 	}
+}
+
+// applyAWSAssumeRole returns cfg unchanged when no role is requested, otherwise
+// a copy whose Credentials are an STS AssumeRole provider for awsAuth.RoleARN
+// (and ExternalID, when set). The AssumeRole provider lazily calls
+// sts:AssumeRole on first credential retrieval and caches/refreshes the
+// short-lived session, so construction issues no network call — a discoverer
+// built for an unreachable role still constructs and only fails when it makes
+// its first real SDK call (surfaced as an AccessDenied that the engine's #739
+// graceful degradation now tolerates).
+//
+// It is a package-level var so unit tests can swap in a recorder that asserts
+// the role/external-id without standing up a live STS endpoint.
+var applyAWSAssumeRole = func(cfg aws.Config, awsAuth AWSAssumeRole) aws.Config {
+	roleARN := strings.TrimSpace(awsAuth.RoleARN)
+	if roleARN == "" {
+		return cfg
+	}
+	stsClient := sts.NewFromConfig(cfg)
+	provider := stscreds.NewAssumeRoleProvider(stsClient, roleARN, func(o *stscreds.AssumeRoleOptions) {
+		if externalID := strings.TrimSpace(awsAuth.ExternalID); externalID != "" {
+			o.ExternalID = aws.String(externalID)
+		}
+	})
+	cfg.Credentials = aws.NewCredentialsCache(provider)
+	return cfg
 }
 
 // awsAggAdapter wraps *awsdiscover.AWSDiscoverer so it satisfies both

--- a/cmd/insideout-import/reversedisco/reversedisco_test.go
+++ b/cmd/insideout-import/reversedisco/reversedisco_test.go
@@ -2,10 +2,16 @@ package reversedisco
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
@@ -152,5 +158,64 @@ func TestApplyAWSAssumeRole(t *testing.T) {
 	wrapped := applyAWSAssumeRole(base, AWSAssumeRole{RoleARN: "arn:aws:iam::000000000000:role/x"})
 	if wrapped.Credentials == base.Credentials || wrapped.Credentials == nil {
 		t.Fatalf("non-empty RoleARN did not swap in an assume-role provider: %T", wrapped.Credentials)
+	}
+}
+
+// TestApplyAWSAssumeRoleTargetsRequestedRole closes the qa-professor #770
+// surviving mutation: a provider could be swapped in (passing
+// TestApplyAWSAssumeRole) yet target the WRONG role — the exact #739 defect-2
+// failure mode (SDK calls running as the wrong principal). Drive the wrapped
+// config's credential retrieval against a stub STS transport and assert the
+// sts:AssumeRole request carries the requested RoleArn and ExternalId.
+func TestApplyAWSAssumeRoleTargetsRequestedRole(t *testing.T) {
+	const (
+		wantRole       = "arn:aws:iam::031780745048:role/customer-inspector"
+		wantExternalID = "expected-external-id"
+	)
+	var captured url.Values
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured, _ = url.ParseQuery(string(body))
+		// Minimal valid AssumeRole XML so Retrieve succeeds end-to-end.
+		w.Header().Set("Content-Type", "text/xml")
+		fmt.Fprint(w, `<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIASTUB</AccessKeyId>
+      <SecretAccessKey>stubsecret</SecretAccessKey>
+      <SessionToken>stubtoken</SessionToken>
+      <Expiration>2030-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <Arn>`+wantRole+`</Arn>
+      <AssumedRoleId>AROASTUB:session</AssumedRoleId>
+    </AssumedRoleUser>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`)
+	}))
+	defer stub.Close()
+
+	base := aws.Config{
+		Region:       "us-east-1",
+		Credentials:  credentials.NewStaticCredentialsProvider("AKIABASE", "basesecret", ""),
+		BaseEndpoint: aws.String(stub.URL),
+	}
+	wrapped := applyAWSAssumeRole(base, AWSAssumeRole{RoleARN: wantRole, ExternalID: wantExternalID})
+
+	creds, err := wrapped.Credentials.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("Retrieve through stub STS: %v", err)
+	}
+	if creds.AccessKeyID != "ASIASTUB" {
+		t.Fatalf("Retrieve returned %q, want the stub's assumed-role credentials", creds.AccessKeyID)
+	}
+	if captured == nil {
+		t.Fatal("stub STS never received an AssumeRole request")
+	}
+	if got := captured.Get("RoleArn"); got != wantRole {
+		t.Fatalf("AssumeRole RoleArn = %q, want %q (wrong-principal mutation)", got, wantRole)
+	}
+	if got := captured.Get("ExternalId"); got != wantExternalID {
+		t.Fatalf("AssumeRole ExternalId = %q, want %q", got, wantExternalID)
 	}
 }

--- a/cmd/insideout-import/reversedisco/reversedisco_test.go
+++ b/cmd/insideout-import/reversedisco/reversedisco_test.go
@@ -109,11 +109,18 @@ func TestAWSParentScope_KeysByParentCFNType(t *testing.T) {
 	if got := scope["AWS::S3::Bucket"]; !reflect.DeepEqual(got, wantBuckets) {
 		t.Errorf("AWS::S3::Bucket scope = %v, want %v", got, wantBuckets)
 	}
+	// The bucket-policy child shares the bucket's identifier, so it is scoped
+	// by the same selected bucket names — no account-wide BucketPolicy list.
+	if got := scope["AWS::S3::BucketPolicy"]; !reflect.DeepEqual(got, wantBuckets) {
+		t.Errorf("AWS::S3::BucketPolicy scope = %v, want %v (identifier-shared child)", got, wantBuckets)
+	}
 	if got := scope["AWS::Logs::LogGroup"]; !reflect.DeepEqual(got, []string{"/app/api"}) {
 		t.Errorf("AWS::Logs::LogGroup scope = %v, want [/app/api]", got)
 	}
 	for cfn := range scope {
-		if cfn != "AWS::S3::Bucket" && cfn != "AWS::Logs::LogGroup" {
+		switch cfn {
+		case "AWS::S3::Bucket", "AWS::S3::BucketPolicy", "AWS::Logs::LogGroup":
+		default:
 			t.Errorf("unexpected scope key %q (unknown-type parent should be skipped)", cfn)
 		}
 	}

--- a/cmd/insideout-import/reversedisco/reversedisco_test.go
+++ b/cmd/insideout-import/reversedisco/reversedisco_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+
 	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
 )
 
@@ -19,7 +21,7 @@ var (
 )
 
 func TestNewRejectsUnknownCloud(t *testing.T) {
-	d, cleanup, err := New(context.Background(), "azure", "", "", "")
+	d, cleanup, err := New(context.Background(), "azure", "", "", "", AWSAssumeRole{})
 	if err == nil {
 		t.Fatalf("New(cloud=azure) err = nil, want unknown-cloud error")
 	}
@@ -34,7 +36,7 @@ func TestNewAWSReturnsClosureCapableDiscoverer(t *testing.T) {
 	// The AWS path only loads SDK config (no network call), so it is safe in
 	// a unit test. The point is to prove New returns a value that satisfies
 	// the closure surface — the wiring the Mars job was missing.
-	d, cleanup, err := New(context.Background(), "aws", "us-west-2", "", "")
+	d, cleanup, err := New(context.Background(), "aws", "us-west-2", "", "", AWSAssumeRole{})
 	if err != nil {
 		t.Fatalf("New(cloud=aws) err = %v", err)
 	}
@@ -44,5 +46,64 @@ func TestNewAWSReturnsClosureCapableDiscoverer(t *testing.T) {
 	}
 	if _, ok := d.(reverseimport.ClosureDiscoverer); !ok {
 		t.Fatalf("New(cloud=aws) discoverer %T does not implement reverseimport.ClosureDiscoverer", d)
+	}
+}
+
+// TestNewAWSAssumesRoleWhenAuthPresent proves the #739 credential fix: when a
+// RoleARN is resolved, New wraps the discoverer's AWS config with an STS
+// AssumeRole provider for that role/external-id, so the discoverer's direct SDK
+// calls run as the customer-account role (the same principal Terraform's
+// provider blocks assume) — not the ambient pod/CLI credentials. When no role
+// is present the config is left on ambient credentials so the local CLI keeps
+// working unchanged.
+func TestNewAWSAssumesRoleWhenAuthPresent(t *testing.T) {
+	// Swap the assume-role applier for a recorder so the test asserts the
+	// wiring without standing up a live STS endpoint.
+	var got AWSAssumeRole
+	calls := 0
+	orig := applyAWSAssumeRole
+	applyAWSAssumeRole = func(cfg aws.Config, auth AWSAssumeRole) aws.Config {
+		got = auth
+		calls++
+		return orig(cfg, auth)
+	}
+	t.Cleanup(func() { applyAWSAssumeRole = orig })
+
+	want := AWSAssumeRole{
+		RoleARN:    "arn:aws:iam::031780745048:role/customer-terraform",
+		ExternalID: "io-ext-id",
+	}
+	_, cleanup, err := New(context.Background(), "aws", "us-east-1", "", "", want)
+	if err != nil {
+		t.Fatalf("New(cloud=aws) err = %v", err)
+	}
+	defer cleanup()
+	if calls != 1 {
+		t.Fatalf("applyAWSAssumeRole called %d times, want 1", calls)
+	}
+	if got != want {
+		t.Fatalf("assume-role auth = %#v, want %#v", got, want)
+	}
+}
+
+// TestApplyAWSAssumeRole verifies the credential-provider wiring directly: an
+// empty RoleARN leaves Credentials untouched (ambient, local-CLI path), and a
+// non-empty RoleARN swaps in a distinct provider (the assume-role hop). It does
+// not call STS — construction is lazy — so it is a pure unit test.
+func TestApplyAWSAssumeRole(t *testing.T) {
+	base := aws.Config{Region: "us-east-1", Credentials: aws.AnonymousCredentials{}}
+
+	unchanged := applyAWSAssumeRole(base, AWSAssumeRole{})
+	if unchanged.Credentials != base.Credentials {
+		t.Fatalf("empty RoleARN changed Credentials: %T", unchanged.Credentials)
+	}
+	// Whitespace-only RoleARN is treated as absent.
+	if blank := applyAWSAssumeRole(base, AWSAssumeRole{RoleARN: "   "}); blank.Credentials != base.Credentials {
+		t.Fatalf("whitespace RoleARN changed Credentials: %T", blank.Credentials)
+	}
+
+	wrapped := applyAWSAssumeRole(base, AWSAssumeRole{RoleARN: "arn:aws:iam::000000000000:role/x"})
+	if wrapped.Credentials == base.Credentials || wrapped.Credentials == nil {
+		t.Fatalf("non-empty RoleARN did not swap in an assume-role provider: %T", wrapped.Credentials)
 	}
 }

--- a/cmd/insideout-import/reversedisco/reversedisco_test.go
+++ b/cmd/insideout-import/reversedisco/reversedisco_test.go
@@ -2,10 +2,13 @@ package reversedisco
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/awsdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
 )
 
@@ -83,6 +86,43 @@ func TestNewAWSAssumesRoleWhenAuthPresent(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("assume-role auth = %#v, want %#v", got, want)
+	}
+}
+
+// TestAWSParentScope_KeysByParentCFNType proves the #739 scoping fix builds the
+// per-CloudFormation-type selected-parent scope from the closure request: each
+// selected parent whose Terraform type is a known Cloud Control type contributes
+// its identifier (ImportID, falling back to NameHint) under the parent's CFN
+// type; parents not routed through Cloud Control are skipped.
+func TestAWSParentScope_KeysByParentCFNType(t *testing.T) {
+	parents := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", ImportID: "io-uploads"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", ImportID: "io-logs"}},
+		// NameHint fallback when ImportID is empty.
+		{Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "/app/api"}},
+		// A type with no Cloud Control backing is skipped (no panic, no entry).
+		{Identity: imported.ResourceIdentity{Type: "aws_not_a_real_type", ImportID: "x"}},
+	}
+	scope := awsParentScope(parents)
+
+	wantBuckets := []string{"io-logs", "io-uploads"}
+	if got := scope["AWS::S3::Bucket"]; !reflect.DeepEqual(got, wantBuckets) {
+		t.Errorf("AWS::S3::Bucket scope = %v, want %v", got, wantBuckets)
+	}
+	if got := scope["AWS::Logs::LogGroup"]; !reflect.DeepEqual(got, []string{"/app/api"}) {
+		t.Errorf("AWS::Logs::LogGroup scope = %v, want [/app/api]", got)
+	}
+	for cfn := range scope {
+		if cfn != "AWS::S3::Bucket" && cfn != "AWS::Logs::LogGroup" {
+			t.Errorf("unexpected scope key %q (unknown-type parent should be skipped)", cfn)
+		}
+	}
+	// Guard the awsdiscover seam this relies on.
+	if cfn, ok := awsdiscover.CloudFormationTypeForTF("aws_s3_bucket"); !ok || cfn != "AWS::S3::Bucket" {
+		t.Errorf("CloudFormationTypeForTF(aws_s3_bucket) = (%q, %v), want (AWS::S3::Bucket, true)", cfn, ok)
+	}
+	if _, ok := awsdiscover.CloudFormationTypeForTF("aws_not_a_real_type"); ok {
+		t.Error("CloudFormationTypeForTF should return false for an unknown type")
 	}
 }
 

--- a/cmd/insideout-import/reversedisco/reversedisco_test.go
+++ b/cmd/insideout-import/reversedisco/reversedisco_test.go
@@ -102,26 +102,35 @@ func TestNewAWSAssumesRoleWhenAuthPresent(t *testing.T) {
 // type; parents not routed through Cloud Control are skipped.
 func TestAWSParentScope_KeysByParentCFNType(t *testing.T) {
 	parents := []imported.ImportedResource{
-		{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", ImportID: "io-uploads"}},
-		{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", ImportID: "io-logs"}},
-		// NameHint fallback when ImportID is empty.
-		{Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "/app/api"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", ImportID: "io-uploads", Region: "us-east-1"}},
+		// Same identifier semantics, a DIFFERENT region — must be carried
+		// through so a multi-region closure scopes each bucket to its own
+		// region (#739 codex follow-up).
+		{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket", ImportID: "io-logs", Region: "eu-west-1"}},
+		// NameHint fallback when ImportID is empty; region carried through.
+		{Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_log_group", NameHint: "/app/api", Region: "us-east-1"}},
 		// A type with no Cloud Control backing is skipped (no panic, no entry).
 		{Identity: imported.ResourceIdentity{Type: "aws_not_a_real_type", ImportID: "x"}},
 	}
 	scope := awsParentScope(parents)
 
-	wantBuckets := []string{"io-logs", "io-uploads"}
+	// Sorted by (identifier, region): io-logs (eu-west-1) before io-uploads
+	// (us-east-1), each tagged with the region the selected bucket lives in.
+	wantBuckets := []awsdiscover.ScopedParent{
+		{Identifier: "io-logs", Region: "eu-west-1"},
+		{Identifier: "io-uploads", Region: "us-east-1"},
+	}
 	if got := scope["AWS::S3::Bucket"]; !reflect.DeepEqual(got, wantBuckets) {
 		t.Errorf("AWS::S3::Bucket scope = %v, want %v", got, wantBuckets)
 	}
-	// The bucket-policy child shares the bucket's identifier, so it is scoped
-	// by the same selected bucket names — no account-wide BucketPolicy list.
+	// The bucket-policy child shares the bucket's identifier AND its region,
+	// so it is scoped by the same selected buckets — no account-wide
+	// BucketPolicy list, and the per-region enumeration matches the parent.
 	if got := scope["AWS::S3::BucketPolicy"]; !reflect.DeepEqual(got, wantBuckets) {
-		t.Errorf("AWS::S3::BucketPolicy scope = %v, want %v (identifier-shared child)", got, wantBuckets)
+		t.Errorf("AWS::S3::BucketPolicy scope = %v, want %v (identifier-shared child inherits region)", got, wantBuckets)
 	}
-	if got := scope["AWS::Logs::LogGroup"]; !reflect.DeepEqual(got, []string{"/app/api"}) {
-		t.Errorf("AWS::Logs::LogGroup scope = %v, want [/app/api]", got)
+	if got := scope["AWS::Logs::LogGroup"]; !reflect.DeepEqual(got, []awsdiscover.ScopedParent{{Identifier: "/app/api", Region: "us-east-1"}}) {
+		t.Errorf("AWS::Logs::LogGroup scope = %v, want [{/app/api us-east-1}]", got)
 	}
 	for cfn := range scope {
 		switch cfn {

--- a/pkg/reverseimport/aws_auth.go
+++ b/pkg/reverseimport/aws_auth.go
@@ -15,13 +15,29 @@ const (
 	tfEnvPrefix        = "TF_VAR_"
 )
 
-type awsProviderAuth struct {
+// AWSProviderAuth is the customer-account assume-role identity the
+// reverse-import engine reaches the customer's AWS account with. Terraform's
+// generated provider blocks assume RoleARN (with the optional ExternalID); the
+// closure/dep-chase discoverer MUST assume the same role so its direct AWS SDK
+// calls run as the same principal rather than the ambient pod/CLI credentials
+// (#739). Exported so the discoverer-construction site (reversedisco / Mars /
+// the CLI) and the engine share one resolution path.
+type AWSProviderAuth struct {
 	RoleARN    string
 	ExternalID string
 }
 
-func resolveAWSProviderAuth(outputDir string) (awsProviderAuth, error) {
-	auth := awsProviderAuth{
+// ResolveAWSProviderAuth resolves the customer-account assume-role identity
+// from (in priority order) the TF_VAR_bootstrap_role / TF_VAR_aws_external_id
+// environment, the generated outputs/cloud-provision.json terraform_role
+// output, and the tf/auto-vars bundle — the same sources Terraform's provider
+// blocks use. outputDir is any path inside the generated stack; the project
+// root is discovered by walking upward. A zero-value result (empty RoleARN) is
+// not an error: it means "no assume-role hop" — the caller then uses ambient
+// credentials, which is the correct behavior for the local CLI run directly
+// with customer creds.
+func ResolveAWSProviderAuth(outputDir string) (AWSProviderAuth, error) {
+	auth := AWSProviderAuth{
 		RoleARN:    strings.TrimSpace(os.Getenv(tfEnvPrefix + tfVarBootstrapRole)),
 		ExternalID: strings.TrimSpace(os.Getenv(tfEnvPrefix + tfVarAWSExternalID)),
 	}

--- a/pkg/reverseimport/aws_auth_test.go
+++ b/pkg/reverseimport/aws_auth_test.go
@@ -21,9 +21,9 @@ func TestResolveAWSProviderAuthUsesProjectTerraformRoleOutput(t *testing.T) {
 
 	t.Setenv("TF_VAR_bootstrap_role", "")
 	t.Setenv("TF_VAR_aws_external_id", "")
-	auth, err := resolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
+	auth, err := ResolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
 	if err != nil {
-		t.Fatalf("resolveAWSProviderAuth() error = %v", err)
+		t.Fatalf("ResolveAWSProviderAuth() error = %v", err)
 	}
 	if auth.RoleARN != "arn:aws:iam::123456789012:role/io-terraform" {
 		t.Fatalf("RoleARN = %q, want project terraform_role output", auth.RoleARN)
@@ -41,9 +41,9 @@ func TestResolveAWSProviderAuthAllowsEnvOverride(t *testing.T) {
 	t.Setenv("TF_VAR_bootstrap_role", "arn:aws:iam::222222222222:role/override")
 	t.Setenv("TF_VAR_aws_external_id", "override-external")
 
-	auth, err := resolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
+	auth, err := ResolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
 	if err != nil {
-		t.Fatalf("resolveAWSProviderAuth() error = %v", err)
+		t.Fatalf("ResolveAWSProviderAuth() error = %v", err)
 	}
 	if auth.RoleARN != "arn:aws:iam::222222222222:role/override" {
 		t.Fatalf("RoleARN = %q, want env override", auth.RoleARN)
@@ -61,9 +61,9 @@ func TestResolveAWSProviderAuthFallsBackToBootstrapRoleAutoVar(t *testing.T) {
 	t.Setenv("TF_VAR_bootstrap_role", "")
 	t.Setenv("TF_VAR_aws_external_id", "")
 
-	auth, err := resolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
+	auth, err := ResolveAWSProviderAuth(filepath.Join(root, "outputs", "reverse-import"))
 	if err != nil {
-		t.Fatalf("resolveAWSProviderAuth() error = %v", err)
+		t.Fatalf("ResolveAWSProviderAuth() error = %v", err)
 	}
 	if auth.RoleARN != "arn:aws:iam::999999999999:role/bootstrap" {
 		t.Fatalf("RoleARN = %q, want bootstrap_role fallback", auth.RoleARN)

--- a/pkg/reverseimport/closure.go
+++ b/pkg/reverseimport/closure.go
@@ -2,6 +2,7 @@ package reverseimport
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -77,6 +78,13 @@ func expandSelectionClosure(ctx context.Context, in selectionClosureInput) (sele
 		ChildTypes:      childTypes,
 	})
 	if err != nil {
+		// Cancellation / deadline is NOT a best-effort failure: the operator
+		// cancelled the import or the overall run deadline expired. Propagate
+		// it so the run stops promptly instead of continuing into
+		// genconfig/driftfix/import after the context is already done.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return out, fmt.Errorf("selection closure: %w", err)
+		}
 		// Selection-closure expansion is best-effort enrichment: it pulls a
 		// selected parent's registered children into the import set so the
 		// operator does not have to re-select each one by hand. A discoverer

--- a/pkg/reverseimport/closure.go
+++ b/pkg/reverseimport/closure.go
@@ -77,7 +77,23 @@ func expandSelectionClosure(ctx context.Context, in selectionClosureInput) (sele
 		ChildTypes:      childTypes,
 	})
 	if err != nil {
-		return out, fmt.Errorf("selection closure: %w", err)
+		// Selection-closure expansion is best-effort enrichment: it pulls a
+		// selected parent's registered children into the import set so the
+		// operator does not have to re-select each one by hand. A discoverer
+		// failure here (e.g. an AccessDenied on a per-parent child read) must
+		// NOT abort the whole plan — the operator's explicitly-selected parents
+		// can still be imported without closure. Degrade exactly like the
+		// nil-discoverer `selection_closure_unavailable` path above: emit a
+		// warning diagnostic naming the underlying error and continue with the
+		// un-expanded selection. This matches the partial-tolerant engine
+		// philosophy (#732/#734) and un-breaks every parent-with-children plan
+		// the hard abort previously killed (#739).
+		out.diagnostics = append(out.diagnostics, job.Diagnostic{
+			Severity: "warning",
+			Code:     "selection_closure_failed",
+			Message:  fmt.Sprintf("selection closure discovery failed; continuing without auto-included child resources: %v", err),
+		})
+		return out, nil
 	}
 	merged, deps, diags := mergeClosureResources(mergeClosureInput{
 		current:         in.resources,

--- a/pkg/reverseimport/closure.go
+++ b/pkg/reverseimport/closure.go
@@ -2,7 +2,6 @@ package reverseimport
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -78,11 +77,15 @@ func expandSelectionClosure(ctx context.Context, in selectionClosureInput) (sele
 		ChildTypes:      childTypes,
 	})
 	if err != nil {
-		// Cancellation / deadline is NOT a best-effort failure: the operator
-		// cancelled the import or the overall run deadline expired. Propagate
-		// it so the run stops promptly instead of continuing into
-		// genconfig/driftfix/import after the context is already done.
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		// Cancellation / deadline of the RUN's context is NOT a best-effort
+		// failure: the operator cancelled the import or the overall run
+		// deadline expired. Propagate it so the run stops promptly instead of
+		// continuing into genconfig/driftfix/import after the context is
+		// already done. Gate on ctx.Err() — not errors.Is on the returned
+		// error — because AWS SDK attempt/HTTP timeouts wrap
+		// context.DeadlineExceeded even when the run's context is alive, and
+		// those transient per-call timeouts must degrade, not abort.
+		if ctx.Err() != nil {
 			return out, fmt.Errorf("selection closure: %w", err)
 		}
 		// Selection-closure expansion is best-effort enrichment: it pulls a

--- a/pkg/reverseimport/closure_unimportable_test.go
+++ b/pkg/reverseimport/closure_unimportable_test.go
@@ -1,10 +1,103 @@
 package reverseimport
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// TestMergeClosure_ScopedMatchesSweep is the #739 scoping-parity lock. The
+// discoverer now scopes child enumeration to the selected parents instead of
+// sweeping the whole account. Because mergeClosureResources ALREADY filters
+// discovered children back to the selected parents, feeding it the scoped
+// (selected-parent-only) discovery result must produce byte-identical merged
+// resources + dependency edges as feeding it the full account sweep. This test
+// pins that invariant so a future change to either the scoping or the merge
+// filter that drifts them apart fails here.
+func TestMergeClosure_ScopedMatchesSweep(t *testing.T) {
+	selectedBucket := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.selected",
+			ImportID: "io-selected",
+			Region:   "us-east-1",
+		},
+	}
+	selectedChild := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:         "aws",
+			Type:          "aws_s3_bucket_versioning",
+			Address:       "aws_s3_bucket_versioning.selected",
+			ImportID:      "io-selected",
+			Region:        "us-east-1",
+			ParentAddress: "aws_s3_bucket.selected",
+			NativeIDs:     map[string]string{"bucket": "io-selected"},
+		},
+	}
+	// Resources only the account-wide sweep would surface: an unselected
+	// bucket and its child. mergeClosureResources must drop these because
+	// they don't match a selected parent.
+	otherBucket := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.other",
+			ImportID: "io-other",
+			Region:   "us-east-1",
+		},
+	}
+	otherChild := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:         "aws",
+			Type:          "aws_s3_bucket_versioning",
+			Address:       "aws_s3_bucket_versioning.other",
+			ImportID:      "io-other",
+			Region:        "us-east-1",
+			ParentAddress: "aws_s3_bucket.other",
+			NativeIDs:     map[string]string{"bucket": "io-other"},
+		},
+	}
+
+	in := mergeClosureInput{
+		current:         []imported.ImportedResource{selectedBucket},
+		selectedParents: []imported.ImportedResource{selectedBucket},
+		parentTypes:     []string{"aws_s3_bucket"},
+		childTypes:      []string{"aws_s3_bucket_versioning"},
+	}
+
+	scopedIn := in
+	scopedIn.discovered = []imported.ImportedResource{selectedBucket, selectedChild}
+	scopedMerged, scopedDeps, _ := mergeClosureResources(scopedIn)
+
+	sweptIn := in
+	sweptIn.discovered = []imported.ImportedResource{selectedBucket, selectedChild, otherBucket, otherChild}
+	sweptMerged, sweptDeps, _ := mergeClosureResources(sweptIn)
+
+	if !reflect.DeepEqual(scopedMerged, sweptMerged) {
+		t.Errorf("merged resources differ between scoped and swept inputs:\nscoped=%#v\nswept=%#v", scopedMerged, sweptMerged)
+	}
+	if !reflect.DeepEqual(scopedDeps, sweptDeps) {
+		t.Errorf("dependency edges differ between scoped and swept inputs:\nscoped=%#v\nswept=%#v", scopedDeps, sweptDeps)
+	}
+	// Sanity: the selected child IS pulled in, the unselected one is NOT.
+	var sawSelected, sawOther bool
+	for _, r := range scopedMerged {
+		switch r.Identity.Address {
+		case "aws_s3_bucket_versioning.selected":
+			sawSelected = true
+		case "aws_s3_bucket_versioning.other":
+			sawOther = true
+		}
+	}
+	if !sawSelected {
+		t.Error("selected parent's child was not pulled into the closure")
+	}
+	if sawOther {
+		t.Error("unselected parent's child leaked into the closure")
+	}
+}
 
 // TestMergeClosure_SkipsAWSManagedKMSAlias is the #cust3 item-2
 // regression. The selection closure re-discovers EVERY child of each

--- a/pkg/reverseimport/providers.go
+++ b/pkg/reverseimport/providers.go
@@ -28,7 +28,7 @@ type importedProviderRenderOptions struct {
 	GCPProjectID   string
 	AWSEndpointURL string
 	ProvidersUsed  map[string]bool
-	AWSAuth        awsProviderAuth
+	AWSAuth        AWSProviderAuth
 
 	// AWSRegions is the sorted set of distinct AWS regions across the
 	// imported resource set (composer.ImportedAWSRegions). When it holds
@@ -120,7 +120,7 @@ func appendAWSImportedProvider(body *hclwrite.Body, alias, region string, opts i
 	appendAWSAssumeRole(prov.Body(), opts.AWSAuth)
 }
 
-func appendAWSAssumeRole(body *hclwrite.Body, auth awsProviderAuth) {
+func appendAWSAssumeRole(body *hclwrite.Body, auth AWSProviderAuth) {
 	if strings.TrimSpace(auth.RoleARN) == "" {
 		return
 	}

--- a/pkg/reverseimport/providers_test.go
+++ b/pkg/reverseimport/providers_test.go
@@ -14,7 +14,7 @@ func TestRenderImportedProvidersTF_AWSAssumesProjectRole(t *testing.T) {
 		ProvidersUsed: map[string]bool{
 			composer.ProvidersUsedKeyAWS: true,
 		},
-		AWSAuth: awsProviderAuth{
+		AWSAuth: AWSProviderAuth{
 			RoleARN:    "arn:aws:iam::123456789012:role/io-terraform",
 			ExternalID: "external-123",
 		},
@@ -50,7 +50,7 @@ func TestRenderImportedProvidersTF_MultiRegion(t *testing.T) {
 		ProvidersUsed: map[string]bool{
 			composer.ProvidersUsedKeyAWS: true,
 		},
-		AWSAuth: awsProviderAuth{
+		AWSAuth: AWSProviderAuth{
 			RoleARN: "arn:aws:iam::123456789012:role/io-terraform",
 		},
 	})

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -75,9 +75,9 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	dependenciesByAddress := closure.dependencies
 	opts.progressf("reverse-import: selection closure complete (%d resource(s))\n", len(resources))
 
-	var awsAuth awsProviderAuth
+	var awsAuth AWSProviderAuth
 	if cloud == "aws" {
-		awsAuth, err = resolveAWSProviderAuth(opts.OutputDir)
+		awsAuth, err = ResolveAWSProviderAuth(opts.OutputDir)
 		if err != nil {
 			return result, fmt.Errorf("resolve AWS provider auth: %w", err)
 		}
@@ -443,7 +443,7 @@ func selectedUnimportableIssues(resources []imported.ImportedResource) []compose
 	return issues
 }
 
-func writeImportedTerraformArtifacts(outputDir, cloud, region, gcpProjectID, awsEndpointURL string, awsAuth awsProviderAuth, resources []imported.ImportedResource, emitOpts composer.EmitImportedOpts) error {
+func writeImportedTerraformArtifacts(outputDir, cloud, region, gcpProjectID, awsEndpointURL string, awsAuth AWSProviderAuth, resources []imported.ImportedResource, emitOpts composer.EmitImportedOpts) error {
 	importedTF, providersUsed := composer.EmitImportedTF(cloud, resources, emitOpts)
 	if len(importedTF) == 0 {
 		return fmt.Errorf("reverseimport: EmitImportedTF produced no HCL")

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -514,13 +514,22 @@ func TestRunContinuesWhenClosureDiscoveryFails(t *testing.T) {
 	}
 }
 
-// TestRunPropagatesClosureCancellation proves the codex #770 follow-up: a
-// context cancellation / deadline during closure discovery is NOT downgraded to
-// a warning — it propagates so the run stops promptly instead of continuing
-// into genconfig/import after the context is already done.
+// TestRunPropagatesClosureCancellation proves the codex #770 follow-up: when
+// the RUN's context is cancelled during closure discovery (operator cancelled
+// the import / overall deadline expired), the error is NOT downgraded to a
+// warning — it propagates so the run stops promptly instead of continuing
+// into genconfig/import after the context is already done. The discoverer
+// cancels the run context itself, modeling the genuine operator-cancel: the
+// engine gates on ctx.Err(), not on unwrapping the returned error (see
+// TestRunDegradesOnSDKWrappedDeadline for why).
 func TestRunPropagatesClosureCancellation(t *testing.T) {
 	dir := t.TempDir()
-	discoverer := &errClosureDiscoverer{err: fmt.Errorf("discover aborted: %w", context.Canceled)}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	discoverer := &cancelingClosureDiscoverer{
+		cancel: cancel,
+		err:    fmt.Errorf("discover aborted: %w", context.Canceled),
+	}
 	req := job.Request{
 		Version: job.Version,
 		Resources: []job.ResourceSpec{{
@@ -536,7 +545,7 @@ func TestRunPropagatesClosureCancellation(t *testing.T) {
 		}},
 	}
 
-	_, err := Run(context.Background(), req, Options{
+	_, err := Run(ctx, req, Options{
 		OutputDir:         dir,
 		SkipDepChase:      true,
 		DiscoverRegions:   []string{"us-east-1"},
@@ -553,6 +562,62 @@ func TestRunPropagatesClosureCancellation(t *testing.T) {
 	}
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("Run err = %v, want errors.Is(err, context.Canceled)", err)
+	}
+}
+
+// TestRunDegradesOnSDKWrappedDeadline locks the ctx.Err() gating of the
+// cancellation carve-out: AWS SDK attempt/HTTP timeouts wrap
+// context.DeadlineExceeded even when the run's context is alive. Such a
+// transient per-call timeout must DEGRADE (selection_closure_failed warning,
+// run continues) — unwrapping the returned error instead would resurrect the
+// #739 hard abort for any slow type.
+func TestRunDegradesOnSDKWrappedDeadline(t *testing.T) {
+	dir := t.TempDir()
+	discoverer := &errClosureDiscoverer{
+		err: fmt.Errorf("operation error S3: ListBuckets, request canceled: %w", context.DeadlineExceeded),
+	}
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.uploads",
+				ImportID: "io-uploads",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	result, err := Run(context.Background(), req, Options{
+		OutputDir:         dir,
+		SkipDepChase:      true,
+		DiscoverRegions:   []string{"us-east-1"},
+		ClosureDiscoverer: discoverer,
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           fakeTerraformRunner{importCount: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error for SDK-wrapped deadline with live run context, want graceful degradation: %v", err)
+	}
+	if result.PlanSummary.ImportCount != 1 {
+		t.Fatalf("ImportCount = %d, want 1", result.PlanSummary.ImportCount)
+	}
+	found := false
+	for _, d := range result.Diagnostics {
+		if d.Code == "selection_closure_failed" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("missing selection_closure_failed diagnostic: %#v", result.Diagnostics)
 	}
 }
 
@@ -774,6 +839,19 @@ type errClosureDiscoverer struct {
 
 func (e *errClosureDiscoverer) DiscoverClosure(_ context.Context, _ ClosureRequest) ([]imported.ImportedResource, error) {
 	return nil, e.err
+}
+
+// cancelingClosureDiscoverer cancels the run's context before failing — models
+// the genuine operator-cancel/run-deadline case the engine must propagate
+// (gated on ctx.Err(), see expandSelectionClosure).
+type cancelingClosureDiscoverer struct {
+	cancel context.CancelFunc
+	err    error
+}
+
+func (c *cancelingClosureDiscoverer) DiscoverClosure(_ context.Context, _ ClosureRequest) ([]imported.ImportedResource, error) {
+	c.cancel()
+	return nil, c.err
 }
 
 func containsString(values []string, want string) bool {

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -440,6 +441,79 @@ func TestRunExpandsSelectedParentClosure(t *testing.T) {
 	}
 }
 
+// TestRunContinuesWhenClosureDiscoveryFails proves the #739 graceful-degradation
+// fix: a DiscoverClosure error must NOT abort the run. The run completes,
+// imports the explicitly-selected parent, and surfaces a
+// `selection_closure_failed` warning diagnostic that names the underlying error.
+// Pre-fix this returned a fatal `selection closure: …` error with zero artifacts.
+func TestRunContinuesWhenClosureDiscoveryFails(t *testing.T) {
+	dir := t.TempDir()
+	discoverer := &errClosureDiscoverer{
+		err: errors.New("s3:ListAllMyBuckets AccessDenied"),
+	}
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.uploads",
+				ImportID: "io-uploads",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	result, err := Run(context.Background(), req, Options{
+		OutputDir:         dir,
+		SkipDepChase:      true,
+		DiscoverRegions:   []string{"us-east-1"},
+		ClosureDiscoverer: discoverer,
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           fakeTerraformRunner{importCount: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error, want graceful degradation: %v", err)
+	}
+	// The selected parent still imports — closure failure does not drop it.
+	if result.PlanSummary.ImportCount != 1 {
+		t.Fatalf("ImportCount = %d, want 1", result.PlanSummary.ImportCount)
+	}
+	if len(result.Imported) != 1 {
+		t.Fatalf("Imported len = %d, want 1", len(result.Imported))
+	}
+	// A warning diagnostic names the failure mode and the underlying error.
+	var diag *job.Diagnostic
+	for i := range result.Diagnostics {
+		if result.Diagnostics[i].Code == "selection_closure_failed" {
+			diag = &result.Diagnostics[i]
+			break
+		}
+	}
+	if diag == nil {
+		t.Fatalf("missing selection_closure_failed diagnostic: %#v", result.Diagnostics)
+	}
+	if diag.Severity != "warning" {
+		t.Fatalf("diagnostic severity = %q, want warning", diag.Severity)
+	}
+	if !strings.Contains(diag.Message, "AccessDenied") {
+		t.Fatalf("diagnostic message = %q, want it to include the underlying error", diag.Message)
+	}
+	// Artifacts are written — the hard abort wrote none.
+	if _, err := os.Stat(filepath.Join(dir, "reverse-result.json")); err != nil {
+		t.Fatalf("reverse-result.json not written: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "imported.json")); err != nil {
+		t.Fatalf("imported.json not written: %v", err)
+	}
+}
+
 func TestRunBackfillsImportedAttrsFromFinalPlan(t *testing.T) {
 	dir := t.TempDir()
 	req := job.Request{
@@ -648,6 +722,16 @@ type fakeClosureDiscoverer struct {
 func (f *fakeClosureDiscoverer) DiscoverClosure(_ context.Context, req ClosureRequest) ([]imported.ImportedResource, error) {
 	f.req = req
 	return f.resources, nil
+}
+
+// errClosureDiscoverer always fails DiscoverClosure — models the staging
+// AccessDenied that the #739 hard abort turned into a fatal plan failure.
+type errClosureDiscoverer struct {
+	err error
+}
+
+func (e *errClosureDiscoverer) DiscoverClosure(_ context.Context, _ ClosureRequest) ([]imported.ImportedResource, error) {
+	return nil, e.err
 }
 
 func containsString(values []string, want string) bool {

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -514,6 +514,48 @@ func TestRunContinuesWhenClosureDiscoveryFails(t *testing.T) {
 	}
 }
 
+// TestRunPropagatesClosureCancellation proves the codex #770 follow-up: a
+// context cancellation / deadline during closure discovery is NOT downgraded to
+// a warning — it propagates so the run stops promptly instead of continuing
+// into genconfig/import after the context is already done.
+func TestRunPropagatesClosureCancellation(t *testing.T) {
+	dir := t.TempDir()
+	discoverer := &errClosureDiscoverer{err: fmt.Errorf("discover aborted: %w", context.Canceled)}
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_s3_bucket",
+				Address:  "aws_s3_bucket.uploads",
+				ImportID: "io-uploads",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	_, err := Run(context.Background(), req, Options{
+		OutputDir:         dir,
+		SkipDepChase:      true,
+		DiscoverRegions:   []string{"us-east-1"},
+		ClosureDiscoverer: discoverer,
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  fakeDepChase,
+			tf:           fakeTerraformRunner{importCount: 1},
+		},
+	})
+	if err == nil {
+		t.Fatal("Run returned nil, want cancellation to propagate")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run err = %v, want errors.Is(err, context.Canceled)", err)
+	}
+}
+
 func TestRunBackfillsImportedAttrsFromFinalPlan(t *testing.T) {
 	dir := t.TempDir()
 	req := job.Request{


### PR DESCRIPTION
Closes #739

P0: the closure discoverer shipped in #738 broke every reverse-import plan that selected a parent-with-children resource. Three compounding defects, fixed in three commits.

## 1. Hard abort → graceful degradation (`pkg/reverseimport/closure.go`)
A `DiscoverClosure` error aborted the whole plan with zero artifacts. Now it emits a `selection_closure_failed` warning diagnostic (message includes the underlying error) and continues with the un-expanded selection — parallel to the existing `selection_closure_unavailable` nil-discoverer path. Matches the partial-tolerant engine philosophy (#732/#734) and un-breaks staging on its own.

Dep-chase keeps its existing semantics: it already warn-and-continues for `ErrNotFound`/`ErrNotSupported` and treats a genuine SDK error as fatal. The credentials fix below removes the spurious AccessDenied that was hitting that path, so no change to dep-chase error handling was needed.

## 2. Wrong credentials → assume the customer role (`cmd/insideout-import/reversedisco`)
`reversedisco.New` used `config.LoadDefaultConfig` (ambient pod/CLI creds), so in the Mars job the discoverer ran as the Argo pod role — wrong account, AccessDenied. `New` now takes an optional `AWSAssumeRole{RoleARN, ExternalID}`; when set it wraps the config with an STS AssumeRole provider so the discoverer's SDK calls (both `DiscoverClosure` and `DiscoverByID` dep-chase) run as the same principal Terraform's provider blocks assume. Empty RoleARN keeps ambient creds — the local CLI is unchanged. Exported `reverseimport.ResolveAWSProviderAuth` / `AWSProviderAuth` so the engine and the discoverer-construction site share one resolution path; the CLI resolves auth from the output dir and passes it through.

## 3. Unscoped enumeration → scope to selected parents (`cmd/insideout-import/awsdiscover`)
`DiscoverClosure` swept the whole account. Live repro: 1 selected bucket → 216 resources / all 44 buckets / 30.7s. Added `DiscoverArgs.ParentScope` (keyed by parent CloudFormation type → selected parent identifiers), honored at every parent-enumeration seam:
- cloudControl: GetResource exactly the scoped identifiers, skip `ListResources` (scoped refs bypass tag filtering — the explicit selection already won).
- sdkOnly sub-resources: use the scoped parents directly, skip `ListParents` (`s3:ListBuckets`).
- CloudWatch Logs lister: wrap scoped names into models, skip `logs:DescribeLogGroups`.

`reversedisco.DiscoverClosure` builds the scope via the new `awsdiscover.CloudFormationTypeForTF` helper (reads the presets-owned registry — no duplicated vocabulary). The engine's `mergeClosureResources` already filters children to selected parents, so scoping the fetch cannot change merge semantics — locked by `TestMergeClosure_ScopedMatchesSweep`. Empty scope ⇒ account-wide sweep (top-level discovery + local CLI unchanged).

## Tests (each fails pre-fix, passes post-fix)
- `TestRunContinuesWhenClosureDiscoveryFails` — erroring discoverer ⇒ run continues, `selection_closure_failed` diagnostic, artifacts written.
- `TestNewAWSAssumesRoleWhenAuthPresent` / `TestApplyAWSAssumeRole` — config assumes the role when auth is present.
- `TestCloudControlDiscover_ParentScopeSkipsListResources`, `TestSDKOnlySubresourceDiscover_ParentScopeSkipsListParents`, `TestLogGroupParentLister_ParentScopeSkipsDescribe`, `TestCloudControlDiscover_ParentScopeBypassesTagFilter`, `TestMergeClosure_ScopedMatchesSweep`, `TestAWSParentScope_KeysByParentCFNType`, `TestNewParentScope_*`.

## Live validation (cust3 test account, read-only)
Adapted the repro to the fixed path: selecting 1 bucket now returns 1 bucket + only its 4 children (5 resources) in 3.0s, vs 216 resources / 44 buckets / 30.7s pre-fix.

## Mars follow-up needed (not in this PR)
Mars consumes `reversedisco.New`. After pinning this presets version, mars must:
- Update the `reversedisco.New(ctx, cloud, region, gcpProjectID, awsEndpointURL)` call to the new signature `reversedisco.New(ctx, cloud, region, gcpProjectID, awsEndpointURL, reversedisco.AWSAssumeRole{RoleARN, ExternalID})`.
- Resolve the assume-role the same way the engine does — from `TF_VAR_bootstrap_role` (and `TF_VAR_aws_external_id`), which are present in the job pod env. The exported `reverseimport.ResolveAWSProviderAuth(outputDir)` can be reused, or mars can read the env vars directly and build `reversedisco.AWSAssumeRole`.
- The lazyDiscoverer wiring needs the auth threaded in alongside the region/cloud it already resolves from the request.
