### PR TITLE
feat(bedrock): provision Knowledge Base with S3 Vectors default store (#757)

### DIFF
--- a/aws/bedrock/main.tf
+++ b/aws/bedrock/main.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 6.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 }
 
@@ -103,6 +107,29 @@ locals {
       Resource = var.opensearch_collection_arn
     }
   ]
+
+  # When the KB uses the in-module S3 Vectors store, the KB service role needs
+  # data-plane access on the vector bucket + index it was given. Granted only
+  # for the s3vectors path; the opensearch path uses the aoss statement above.
+  use_s3vectors = var.enable_knowledge_base && var.vector_store == "s3vectors"
+
+  bedrock_s3vectors_statements = local.use_s3vectors ? [
+    {
+      Action = [
+        "s3vectors:GetIndex",
+        "s3vectors:QueryVectors",
+        "s3vectors:GetVectors",
+        "s3vectors:PutVectors",
+        "s3vectors:ListVectors",
+        "s3vectors:DeleteVectors",
+      ]
+      Effect = "Allow"
+      Resource = [
+        aws_s3vectors_vector_bucket.kb[0].vector_bucket_arn,
+        aws_s3vectors_index.kb[0].index_arn,
+      ]
+    }
+  ] : []
 }
 
 resource "aws_iam_role_policy" "bedrock_kb" {
@@ -115,21 +142,156 @@ resource "aws_iam_role_policy" "bedrock_kb" {
       [local.bedrock_invoke_statement],
       local.bedrock_s3_statements,
       local.bedrock_aoss_statements,
+      local.bedrock_s3vectors_statements,
     )
   })
 }
 
-# The Bedrock Knowledge Base (aws_bedrockagent_knowledge_base) and its S3
-# data source are intentionally NOT managed by this module. Creating the KB
-# at terraform time requires (1) a pre-existing AOSS vector index with the
-# k-NN field mapping Bedrock expects keyed to a chosen embedding model and
-# dimension, and (2) resolving assumed-role session ARNs to their underlying
-# roles. Both are application-layer concerns — the application that ingests
-# data into the KB is the right place to create the KB and the vector index,
-# because only it knows which embedding model / dimension / field names it
-# needs. This module provisions the IAM role + AOSS data-access policy +
-# invocation logging + guardrail so the application has a usable, observable
-# substrate to call CreateKnowledgeBase and StartIngestionJob against.
+# --- Knowledge Base + vector store -----------------------------------------
+#
+# When enable_knowledge_base is true this module provisions a real managed-RAG
+# Knowledge Base: a vector store, the aws_bedrockagent_knowledge_base wired to
+# the KB IAM role above, and an aws_bedrockagent_data_source pointed at the S3
+# docs bucket. This reverses the earlier "KB is app-layer" decision (#757):
+# with the S3 Vectors store the dimension/field-mapping bootstrapping that used
+# to require an application is now a couple of plain terraform resources, so
+# the whole RAG substrate composes declaratively.
+#
+# Two vector stores are supported:
+#   - s3vectors (default): an aws_s3vectors_vector_bucket + aws_s3vectors_index
+#     created here. Cheapest managed option, no cluster. Bedrock's s3_vectors
+#     storage type does NOT need a field_mapping block — the index schema is
+#     fixed by the s3vectors index itself.
+#   - opensearch: the AOSS collection wired via opensearch_collection_arn. The
+#     vector index (with the field mapping Bedrock expects) must already exist
+#     on that collection; this module grants the data-access policy below.
+
+locals {
+  embedding_model_arn = "arn:aws:bedrock:${var.region}::foundation-model/${var.embedding_model_id}"
+
+  # Field names Bedrock writes/reads on the AOSS vector index. These are the
+  # conventional names the application's index-creation step must mirror.
+  aoss_vector_field   = "bedrock-knowledge-base-default-vector"
+  aoss_text_field     = "AMAZON_BEDROCK_TEXT_CHUNK"
+  aoss_metadata_field = "AMAZON_BEDROCK_METADATA"
+}
+
+# S3 Vectors store (default). force_destroy defaults false so a destroy of a
+# populated KB fails loud instead of silently dropping ingested vectors.
+resource "aws_s3vectors_vector_bucket" "kb" {
+  count              = local.use_s3vectors ? 1 : 0
+  vector_bucket_name = "${var.project}-br-vectors"
+  force_destroy      = var.knowledge_base_force_destroy
+  tags               = merge(module.name.tags, var.tags)
+}
+
+resource "aws_s3vectors_index" "kb" {
+  count              = local.use_s3vectors ? 1 : 0
+  vector_bucket_name = aws_s3vectors_vector_bucket.kb[0].vector_bucket_name
+  index_name         = "${var.project}-br-index"
+  data_type          = "float32"
+  dimension          = var.embedding_dimension
+  # Cosine is the metric Bedrock's Titan embeddings are tuned for.
+  distance_metric = "cosine"
+  tags            = merge(module.name.tags, var.tags)
+
+  lifecycle {
+    # Cross-check the index dimension against the known Titan models so a wrong
+    # pairing fails at plan time rather than producing a non-retrievable index.
+    # Unknown/custom models skip the check (any in-range dimension is accepted).
+    precondition {
+      condition = (
+        var.embedding_model_id == "amazon.titan-embed-text-v2:0" ? var.embedding_dimension == 1024 :
+        var.embedding_model_id == "amazon.titan-embed-text-v1" ? var.embedding_dimension == 1536 :
+        true
+      )
+      error_message = "embedding_dimension must match embedding_model_id: amazon.titan-embed-text-v2:0 → 1024, amazon.titan-embed-text-v1 → 1536."
+    }
+  }
+}
+
+# IAM is eventually consistent: the KB role/policy created above can take a few
+# seconds to propagate before Bedrock's CreateKnowledgeBase will accept it,
+# otherwise it 403s on the first apply. A short sleep between the policy and the
+# KB resource turns a flaky first apply into a reliable one.
+resource "time_sleep" "kb_iam_propagation" {
+  count           = var.enable_knowledge_base ? 1 : 0
+  depends_on      = [aws_iam_role_policy.bedrock_kb]
+  create_duration = "20s"
+}
+
+resource "aws_bedrockagent_knowledge_base" "this" {
+  count    = var.enable_knowledge_base ? 1 : 0
+  name     = "${var.project}-kb"
+  role_arn = aws_iam_role.bedrock_kb.arn
+
+  knowledge_base_configuration {
+    type = "VECTOR"
+    vector_knowledge_base_configuration {
+      embedding_model_arn = local.embedding_model_arn
+    }
+  }
+
+  storage_configuration {
+    type = local.use_s3vectors ? "S3_VECTORS" : "OPENSEARCH_SERVERLESS"
+
+    dynamic "s3_vectors_configuration" {
+      for_each = local.use_s3vectors ? [1] : []
+      content {
+        index_arn = aws_s3vectors_index.kb[0].index_arn
+      }
+    }
+
+    dynamic "opensearch_serverless_configuration" {
+      for_each = local.use_s3vectors ? [] : [1]
+      content {
+        collection_arn    = var.opensearch_collection_arn
+        vector_index_name = "${var.project}-br-index"
+        field_mapping {
+          vector_field   = local.aoss_vector_field
+          text_field     = local.aoss_text_field
+          metadata_field = local.aoss_metadata_field
+        }
+      }
+    }
+  }
+
+  tags = merge(module.name.tags, var.tags)
+
+  # Wait for the KB role/policy to propagate, and (opensearch path) for the
+  # AOSS data-access policy to exist before Bedrock validates index access.
+  depends_on = [
+    time_sleep.kb_iam_propagation,
+    aws_opensearchserverless_access_policy.bedrock,
+  ]
+
+  lifecycle {
+    # The S3 docs source is mandatory for any KB regardless of vector store.
+    precondition {
+      condition     = var.s3_bucket_arn != null
+      error_message = "enable_knowledge_base=true requires s3_bucket_arn (the S3 docs source the Knowledge Base ingests from)."
+    }
+    # The opensearch store needs the AOSS collection ARN wired.
+    precondition {
+      condition     = var.vector_store != "opensearch" || var.opensearch_collection_arn != null
+      error_message = "vector_store=opensearch requires opensearch_collection_arn to be set (wire from aws/opensearch.collection_arn)."
+    }
+  }
+}
+
+resource "aws_bedrockagent_data_source" "s3_docs" {
+  count             = var.enable_knowledge_base ? 1 : 0
+  knowledge_base_id = aws_bedrockagent_knowledge_base.this[0].id
+  name              = "${var.project}-kb-s3"
+
+  data_source_configuration {
+    type = "S3"
+    s3_configuration {
+      bucket_arn         = var.s3_bucket_arn
+      inclusion_prefixes = length(var.knowledge_base_inclusion_prefixes) > 0 ? var.knowledge_base_inclusion_prefixes : null
+    }
+  }
+}
 
 # --- AOSS data-access policy -----------------------------------------------
 #

--- a/aws/bedrock/outputs.tf
+++ b/aws/bedrock/outputs.tf
@@ -28,6 +28,31 @@ output "invocation_logging_role_arn" {
   description = "ARN of the IAM role Bedrock assumes to write invocation logs. null when disabled."
 }
 
+output "knowledge_base_id" {
+  value       = var.enable_knowledge_base ? aws_bedrockagent_knowledge_base.this[0].id : null
+  description = "ID of the Bedrock Knowledge Base. null when enable_knowledge_base is false. Pass to aws_bedrockagent_agent_knowledge_base_association or RetrieveAndGenerate at runtime."
+}
+
+output "knowledge_base_arn" {
+  value       = var.enable_knowledge_base ? aws_bedrockagent_knowledge_base.this[0].arn : null
+  description = "ARN of the Bedrock Knowledge Base. null when disabled."
+}
+
+output "data_source_id" {
+  value       = var.enable_knowledge_base ? aws_bedrockagent_data_source.s3_docs[0].data_source_id : null
+  description = "ID of the S3 data source attached to the Knowledge Base. null when disabled. Pass to StartIngestionJob to (re)ingest the S3 docs bucket."
+}
+
+output "s3_vectors_bucket_arn" {
+  value       = local.use_s3vectors ? aws_s3vectors_vector_bucket.kb[0].vector_bucket_arn : null
+  description = "ARN of the in-module S3 Vectors bucket backing the Knowledge Base. null unless vector_store=s3vectors and the KB is enabled."
+}
+
+output "s3_vectors_index_arn" {
+  value       = local.use_s3vectors ? aws_s3vectors_index.kb[0].index_arn : null
+  description = "ARN of the in-module S3 Vectors index. null unless vector_store=s3vectors and the KB is enabled."
+}
+
 output "guardrail_id" {
   value       = var.enable_guardrail ? aws_bedrock_guardrail.this[0].guardrail_id : null
   description = "ID of the Bedrock guardrail. null when disabled. Pass to InvokeModel/Converse along with guardrail_version to apply this policy at runtime."

--- a/aws/bedrock/tests/integration.tftest.hcl
+++ b/aws/bedrock/tests/integration.tftest.hcl
@@ -14,11 +14,17 @@
 #   3. bedrock_with_invocation_logging: re-applies the same module with
 #      enable_invocation_logging = true, asserts the CloudWatch log group,
 #      IAM role + policy, and account-level configuration come up
-#   4. Tears EVERYTHING down at the end (terraform test always destroys)
+#   4. setup_docs_bucket + bedrock_knowledge_base: stands up a real S3 docs
+#      bucket and applies bedrock with enable_knowledge_base = true and the
+#      default S3 Vectors store, asserting the S3 Vectors bucket/index, the
+#      Knowledge Base, and the S3 data source all come up and wire together
+#   5. Tears EVERYTHING down at the end (terraform test always destroys)
 #
-# Bedrock Knowledge Base / vector index creation is intentionally not
-# exercised — see the comment in main.tf for why those are application-
-# layer concerns.
+# The Knowledge Base run (#4) requires the embedding model
+# (amazon.titan-embed-text-v2:0) to be enabled in the target account's
+# Bedrock model access, and an AWS region where S3 Vectors is available.
+# It is the live-apply proof for #757; the credential-free unit.tftest.hcl
+# covers the plan/validation shape.
 #
 # CAUTION: aws_bedrock_model_invocation_logging_configuration is an
 # account+region SINGLETON. Run 3 will overwrite any pre-existing
@@ -271,5 +277,96 @@ run "bedrock_with_invocation_logging" {
   assert {
     condition     = output.invocation_logging_role_arn != null
     error_message = "Invocation logging role ARN output must be populated."
+  }
+}
+
+# --- Setup: real S3 docs bucket -------------------------------------------
+#
+# The Knowledge Base data source ingests from a real S3 bucket. Stand one up
+# via the sibling s3 preset so the KB run has a concrete bucket_arn.
+run "setup_docs_bucket" {
+  command = apply
+
+  module {
+    source = "../s3"
+  }
+
+  variables {
+    project     = var.project
+    environment = var.environment
+    region      = var.region
+  }
+
+  assert {
+    condition     = output.bucket_arn != null
+    error_message = "S3 docs bucket setup must yield a bucket ARN."
+  }
+}
+
+# --- Knowledge Base: S3 Vectors default store -----------------------------
+#
+# The #757 live-apply proof. Provisions the in-module S3 Vectors bucket +
+# index, the Bedrock Knowledge Base wired to the module's IAM role, and the
+# S3 data source pointed at the docs bucket. Guardrail + logging are off so
+# the diff is purely the KB substrate. The time_sleep between the KB role and
+# the KB resource is what makes this reliable on the first apply (IAM
+# eventual consistency).
+run "bedrock_knowledge_base" {
+  command = apply
+
+  variables {
+    enable_guardrail          = false
+    enable_invocation_logging = false
+
+    enable_knowledge_base = true
+    vector_store          = "s3vectors"
+    s3_bucket_arn         = run.setup_docs_bucket.bucket_arn
+    # embedding_model_id + embedding_dimension default to Titan v2 / 1024.
+    # force_destroy so teardown can drop the vector bucket cleanly.
+    knowledge_base_force_destroy = true
+  }
+
+  # S3 Vectors store created in-module.
+  assert {
+    condition     = aws_s3vectors_vector_bucket.kb[0].vector_bucket_name == "${var.project}-br-vectors"
+    error_message = "S3 Vectors bucket must follow the {project}-br-vectors convention."
+  }
+
+  assert {
+    condition     = aws_s3vectors_index.kb[0].dimension == 1024
+    error_message = "S3 Vectors index dimension must be 1024 (Titan v2 default)."
+  }
+
+  # Knowledge Base up and wired to the module role + S3 Vectors store.
+  assert {
+    condition     = aws_bedrockagent_knowledge_base.this[0].name == "${var.project}-kb"
+    error_message = "Knowledge Base name must be {project}-kb."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_knowledge_base.this[0].storage_configuration[0].type == "S3_VECTORS"
+    error_message = "Live KB storage type must be S3_VECTORS for the default store."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_knowledge_base.this[0].role_arn == aws_iam_role.bedrock_kb.arn
+    error_message = "Live KB must use the module's bedrock_kb role."
+  }
+
+  # Data source pointed at the real docs bucket.
+  assert {
+    condition     = aws_bedrockagent_data_source.s3_docs[0].data_source_configuration[0].s3_configuration[0].bucket_arn == run.setup_docs_bucket.bucket_arn
+    error_message = "Live data source must reference the docs bucket ARN."
+  }
+
+  # Outputs populated after apply.
+  assert {
+    condition     = output.knowledge_base_id != null && length(output.knowledge_base_id) > 0
+    error_message = "knowledge_base_id output must be populated after a live KB apply."
+  }
+
+  assert {
+    condition     = output.s3_vectors_index_arn != null && output.data_source_id != null
+    error_message = "s3_vectors_index_arn + data_source_id outputs must be populated after a live KB apply."
   }
 }

--- a/aws/bedrock/tests/unit.tftest.hcl
+++ b/aws/bedrock/tests/unit.tftest.hcl
@@ -18,6 +18,26 @@ mock_provider "aws" {
       user_id    = "AIDACKCEVSQ6C2EXAMPLE"
     }
   }
+
+  # The Knowledge Base feeds aws_iam_role.bedrock_kb.arn into role_arn and the
+  # s3vectors index/bucket ARNs into storage_configuration. The provider parses
+  # those as ARNs at apply time, and mock_provider's default random string is
+  # not a valid ARN — so give these computed attributes ARN-shaped mocks.
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::111111111111:role/iotest-br-bedrock-role"
+    }
+  }
+  mock_resource "aws_s3vectors_vector_bucket" {
+    defaults = {
+      vector_bucket_arn = "arn:aws:s3vectors:us-east-1:111111111111:bucket/iotest-br-br-vectors"
+    }
+  }
+  mock_resource "aws_s3vectors_index" {
+    defaults = {
+      index_arn = "arn:aws:s3vectors:us-east-1:111111111111:bucket/iotest-br-br-vectors/index/iotest-br-br-index"
+    }
+  }
 }
 
 variables {
@@ -305,6 +325,285 @@ run "aoss_access_policy_with_no_extra_principals" {
     condition     = length(jsondecode(aws_opensearchserverless_access_policy.bedrock[0].policy)[0].Principal) == 1
     error_message = "AOSS principal list must contain exactly the bedrock role when no additional principals are passed."
   }
+}
+
+# --- Knowledge Base --------------------------------------------------------
+
+run "kb_disabled_by_default" {
+  command = plan
+
+  assert {
+    condition     = length(aws_bedrockagent_knowledge_base.this) == 0
+    error_message = "Knowledge Base must NOT be created when enable_knowledge_base is false (default)."
+  }
+
+  assert {
+    condition     = length(aws_s3vectors_vector_bucket.kb) == 0 && length(aws_s3vectors_index.kb) == 0
+    error_message = "S3 Vectors store must NOT be created when the KB is disabled."
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_data_source.s3_docs) == 0
+    error_message = "Data source must NOT be created when the KB is disabled."
+  }
+
+  assert {
+    condition     = length(time_sleep.kb_iam_propagation) == 0
+    error_message = "IAM-propagation sleep must NOT be created when the KB is disabled."
+  }
+
+  assert {
+    condition     = output.knowledge_base_id == null && output.knowledge_base_arn == null && output.data_source_id == null
+    error_message = "KB outputs must be null when enable_knowledge_base is false."
+  }
+
+  assert {
+    condition     = output.s3_vectors_bucket_arn == null && output.s3_vectors_index_arn == null
+    error_message = "S3 Vectors outputs must be null when the KB is disabled."
+  }
+}
+
+run "kb_default_s3vectors" {
+  # apply: the KB storage_configuration embeds aws_s3vectors_index.kb.index_arn,
+  # which is "(known after apply)" at plan time. mock_provider populates a mock
+  # ARN at apply time and never calls AWS, so this stays credential-free.
+  command = apply
+
+  variables {
+    enable_knowledge_base = true
+    # vector_store defaults to s3vectors; s3_bucket_arn comes from file vars.
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_knowledge_base.this) == 1
+    error_message = "Knowledge Base must be created when enable_knowledge_base is true."
+  }
+
+  # The default store is S3 Vectors: bucket + index created in-module.
+  assert {
+    condition     = length(aws_s3vectors_vector_bucket.kb) == 1 && length(aws_s3vectors_index.kb) == 1
+    error_message = "S3 Vectors bucket + index must be created for the default s3vectors store."
+  }
+
+  assert {
+    condition     = aws_s3vectors_vector_bucket.kb[0].vector_bucket_name == "iotest-br-br-vectors"
+    error_message = "S3 Vectors bucket name must follow the {project}-br-vectors convention."
+  }
+
+  assert {
+    condition     = aws_s3vectors_index.kb[0].dimension == 1024
+    error_message = "S3 Vectors index dimension must default to 1024 (Titan v2)."
+  }
+
+  assert {
+    condition     = aws_s3vectors_index.kb[0].data_type == "float32" && aws_s3vectors_index.kb[0].distance_metric == "cosine"
+    error_message = "S3 Vectors index must be float32 / cosine."
+  }
+
+  # Storage config must select S3_VECTORS and NOT emit an opensearch block.
+  assert {
+    condition     = aws_bedrockagent_knowledge_base.this[0].storage_configuration[0].type == "S3_VECTORS"
+    error_message = "KB storage type must be S3_VECTORS for the default store."
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_knowledge_base.this[0].storage_configuration[0].s3_vectors_configuration) == 1
+    error_message = "s3_vectors_configuration block must be present for the s3vectors store."
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_knowledge_base.this[0].storage_configuration[0].opensearch_serverless_configuration) == 0
+    error_message = "opensearch_serverless_configuration must be absent for the s3vectors store."
+  }
+
+  # KB wired to the module's own IAM role + embedding model ARN built from region.
+  assert {
+    condition     = aws_bedrockagent_knowledge_base.this[0].role_arn == aws_iam_role.bedrock_kb.arn
+    error_message = "KB role_arn must be the module's bedrock_kb role."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_knowledge_base.this[0].knowledge_base_configuration[0].vector_knowledge_base_configuration[0].embedding_model_arn == "arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-embed-text-v2:0"
+    error_message = "embedding_model_arn must be built from region + embedding_model_id."
+  }
+
+  # Data source points at the S3 docs bucket.
+  assert {
+    condition     = length(aws_bedrockagent_data_source.s3_docs) == 1
+    error_message = "S3 data source must be created when the KB is enabled."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_data_source.s3_docs[0].data_source_configuration[0].s3_configuration[0].bucket_arn == "arn:aws:s3:::iotest-br-bucket"
+    error_message = "Data source must reference the wired s3_bucket_arn."
+  }
+
+  # IAM-propagation sleep created exactly once.
+  assert {
+    condition     = length(time_sleep.kb_iam_propagation) == 1
+    error_message = "IAM-propagation sleep must be created when the KB is enabled."
+  }
+
+  # KB role policy must include the s3vectors data-plane statement.
+  assert {
+    condition = anytrue([
+      for s in jsondecode(aws_iam_role_policy.bedrock_kb.policy).Statement :
+      contains(try(s.Action, []), "s3vectors:QueryVectors")
+    ])
+    error_message = "KB role policy must grant s3vectors:QueryVectors when the s3vectors store is used."
+  }
+}
+
+run "kb_inclusion_prefixes" {
+  command = apply
+
+  variables {
+    enable_knowledge_base             = true
+    knowledge_base_inclusion_prefixes = ["docs/"]
+  }
+
+  assert {
+    condition     = one(aws_bedrockagent_data_source.s3_docs[0].data_source_configuration[0].s3_configuration[0].inclusion_prefixes) == "docs/"
+    error_message = "inclusion_prefixes must pass through to the data source s3_configuration."
+  }
+}
+
+run "rejects_multiple_inclusion_prefixes" {
+  command = plan
+
+  variables {
+    knowledge_base_inclusion_prefixes = ["docs/", "policies/"]
+  }
+
+  expect_failures = [var.knowledge_base_inclusion_prefixes]
+}
+
+run "kb_opensearch" {
+  command = apply
+
+  variables {
+    enable_knowledge_base = true
+    vector_store          = "opensearch"
+    # opensearch_collection_arn comes from file vars (a valid AOSS ARN).
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_knowledge_base.this) == 1
+    error_message = "Knowledge Base must be created for the opensearch store."
+  }
+
+  # No S3 Vectors store when opensearch is selected.
+  assert {
+    condition     = length(aws_s3vectors_vector_bucket.kb) == 0 && length(aws_s3vectors_index.kb) == 0
+    error_message = "S3 Vectors store must NOT be created when vector_store=opensearch."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_knowledge_base.this[0].storage_configuration[0].type == "OPENSEARCH_SERVERLESS"
+    error_message = "KB storage type must be OPENSEARCH_SERVERLESS for the opensearch store."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_knowledge_base.this[0].storage_configuration[0].opensearch_serverless_configuration[0].collection_arn == "arn:aws:aoss:us-east-1:111111111111:collection/abc123def456"
+    error_message = "opensearch_serverless_configuration must reference the wired collection ARN."
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_knowledge_base.this[0].storage_configuration[0].s3_vectors_configuration) == 0
+    error_message = "s3_vectors_configuration must be absent for the opensearch store."
+  }
+
+  # opensearch path must NOT add the s3vectors IAM statement.
+  assert {
+    condition = !anytrue([
+      for s in jsondecode(aws_iam_role_policy.bedrock_kb.policy).Statement :
+      contains(try(s.Action, []), "s3vectors:QueryVectors")
+    ])
+    error_message = "KB role policy must NOT grant s3vectors actions when the opensearch store is used."
+  }
+}
+
+run "kb_outputs_populated" {
+  command = apply
+
+  variables {
+    enable_knowledge_base = true
+  }
+
+  assert {
+    condition     = output.knowledge_base_id != null && output.knowledge_base_arn != null
+    error_message = "KB id/arn outputs must be populated when the KB is enabled."
+  }
+
+  assert {
+    condition     = output.data_source_id != null
+    error_message = "data_source_id output must be populated when the KB is enabled."
+  }
+
+  assert {
+    condition     = output.s3_vectors_bucket_arn != null && output.s3_vectors_index_arn != null
+    error_message = "S3 Vectors outputs must be populated for the default s3vectors store."
+  }
+}
+
+# --- Knowledge Base validation ---------------------------------------------
+
+run "rejects_invalid_vector_store" {
+  command = plan
+
+  variables {
+    vector_store = "pinecone"
+  }
+
+  expect_failures = [var.vector_store]
+}
+
+run "rejects_kb_without_s3_bucket" {
+  # precondition on aws_bedrockagent_knowledge_base fires at plan time.
+  command = plan
+
+  variables {
+    enable_knowledge_base = true
+    s3_bucket_arn         = null
+  }
+
+  expect_failures = [aws_bedrockagent_knowledge_base.this]
+}
+
+run "rejects_opensearch_store_without_collection_arn" {
+  command = plan
+
+  variables {
+    enable_knowledge_base     = true
+    vector_store              = "opensearch"
+    opensearch_collection_arn = null
+  }
+
+  expect_failures = [aws_bedrockagent_knowledge_base.this]
+}
+
+run "rejects_dimension_model_mismatch" {
+  # Titan v2 must be 1024; 1536 is the v1 dimension. Precondition on the
+  # s3vectors index catches the mismatch at plan time.
+  command = plan
+
+  variables {
+    enable_knowledge_base = true
+    embedding_model_id    = "amazon.titan-embed-text-v2:0"
+    embedding_dimension   = 1536
+  }
+
+  expect_failures = [aws_s3vectors_index.kb]
+}
+
+run "rejects_out_of_range_dimension" {
+  command = plan
+
+  variables {
+    embedding_dimension = 5000
+  }
+
+  expect_failures = [var.embedding_dimension]
 }
 
 # --- Guardrail variants ----------------------------------------------------

--- a/aws/bedrock/variables.tf
+++ b/aws/bedrock/variables.tf
@@ -29,8 +29,8 @@ variable "model_id" {
 
 variable "embedding_model_id" {
   type        = string
-  description = "Bedrock embedding model ID the role may invoke. Granted via the IAM policy so the application can ingest into a Knowledge Base backed by this role."
-  default     = "amazon.titan-embed-text-v1"
+  description = "Bedrock embedding model ID the role may invoke and that the Knowledge Base uses to embed chunks. Granted via the IAM policy. Default amazon.titan-embed-text-v2:0 (1024-dim, the current recommended Titan embedder) — its output dimension must match embedding_dimension."
+  default     = "amazon.titan-embed-text-v2:0"
 }
 
 variable "s3_bucket_arn" {
@@ -66,6 +66,59 @@ variable "aoss_additional_principal_arns" {
   validation {
     condition     = alltrue([for arn in var.aoss_additional_principal_arns : can(regex("^arn:aws[a-z-]*:iam::[0-9]{12}:(role|user)/", arn))])
     error_message = "aoss_additional_principal_arns must all be IAM role or user ARNs (arn:aws:iam::<account>:role/... or :user/...). Assumed-role session ARNs (arn:aws:sts::...:assumed-role/...) are not valid in AOSS data-access policies."
+  }
+}
+
+# --- Knowledge Base --------------------------------------------------------
+
+variable "enable_knowledge_base" {
+  type        = bool
+  description = "Provision a Bedrock Knowledge Base (aws_bedrockagent_knowledge_base) + an S3 data source (aws_bedrockagent_data_source) backed by a vector store. Default false — opt in deliberately. When true, s3_bucket_arn is required (the docs source the KB ingests from), and either an S3 Vectors store is created in-module (vector_store=s3vectors, the default) or the wired AOSS collection is used (vector_store=opensearch). The KB IAM role + policy this module already creates is the KB's role_arn."
+  default     = false
+}
+
+variable "vector_store" {
+  type        = string
+  description = "Vector store backing the Knowledge Base. 's3vectors' (default) provisions an aws_s3vectors_vector_bucket + aws_s3vectors_index in this module — the cheapest managed option, no cluster to run. 'opensearch' uses the AOSS collection wired via opensearch_collection_arn (requires the application/terraform-runner to have pre-created a vector index with the field mapping Bedrock expects). Ignored when enable_knowledge_base is false."
+  default     = "s3vectors"
+  validation {
+    condition     = contains(["s3vectors", "opensearch"], var.vector_store)
+    error_message = "vector_store must be one of s3vectors, opensearch."
+  }
+  # Cross-variable constraints (KB requires s3_bucket_arn; opensearch store
+  # requires opensearch_collection_arn) can't live here — a variable
+  # validation must reference its own variable. They are enforced as
+  # preconditions on aws_bedrockagent_knowledge_base in main.tf, which only
+  # evaluate when the KB is actually being created.
+}
+
+variable "embedding_dimension" {
+  type        = number
+  description = "Dimension of the embedding vectors the S3 Vectors index stores. MUST match the output dimension of embedding_model_id: Amazon Titan Text Embeddings V2 (amazon.titan-embed-text-v2:0) = 1024 (default), Titan V1 (amazon.titan-embed-text-v1) = 1536, Cohere Embed = 1024. A mismatch makes ingestion silently produce zero retrievable chunks. Only used for the s3vectors store; the AOSS index dimension is set by whoever created that index."
+  default     = 1024
+  validation {
+    condition     = var.embedding_dimension >= 1 && var.embedding_dimension <= 4096
+    error_message = "embedding_dimension must be between 1 and 4096 (S3 Vectors index limit)."
+  }
+  # The dimension-must-match-the-embedding-model cross-check references
+  # embedding_model_id, so it can't live here (a variable validation must
+  # reference its own variable). It's enforced as a precondition on the
+  # s3vectors index in main.tf, which only fires when that store is built.
+}
+
+variable "knowledge_base_force_destroy" {
+  type        = bool
+  description = "force_destroy on the in-module S3 Vectors bucket. When true, terraform destroy deletes the vector bucket even if it still contains indexes/vectors. Default false so a destroy of a populated KB fails loud rather than silently dropping ingested data. Ignored when vector_store != s3vectors."
+  default     = false
+}
+
+variable "knowledge_base_inclusion_prefixes" {
+  type        = list(string)
+  description = "Optional S3 key prefix the data source restricts ingestion to (e.g. [\"docs/\"]). Empty (default) ingests the whole bucket. The Bedrock S3 data source accepts at most ONE inclusion prefix, so this list may hold 0 or 1 element. Ignored when enable_knowledge_base is false."
+  default     = []
+  validation {
+    condition     = length(var.knowledge_base_inclusion_prefixes) <= 1
+    error_message = "knowledge_base_inclusion_prefixes accepts at most one prefix (Bedrock S3 data source limit)."
   }
 }
 

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -627,3 +627,105 @@ func TestComposeStack_BedrockOpenSearchAOSSEndToEnd(t *testing.T) {
 		mainTF,
 		"bedrock must depends_on the opensearch module")
 }
+
+// bedrockCfg builds a *Config carrying the (anonymous) AWSBedrock sub-struct.
+// The struct shape is duplicated from types.go; keeping a single builder here
+// means the Knowledge Base mapper tests below don't each restate it.
+func bedrockCfg(modelID, embeddingModelID string, enableKB *bool, vectorStore string) *Config {
+	return &Config{
+		AWSBedrock: &struct {
+			KnowledgeBaseName   string `json:"knowledgeBaseName,omitempty"`
+			ModelID             string `json:"modelId,omitempty"`
+			EmbeddingModelID    string `json:"embeddingModelId,omitempty"`
+			EnableKnowledgeBase *bool  `json:"enableKnowledgeBase,omitempty"`
+			VectorStore         string `json:"vectorStore,omitempty"`
+		}{
+			ModelID:             modelID,
+			EmbeddingModelID:    embeddingModelID,
+			EnableKnowledgeBase: enableKB,
+			VectorStore:         vectorStore,
+		},
+	}
+}
+
+// TestMapper_AWSBedrock_DefaultConfig pins that with an empty cfg the mapper
+// emits NONE of the optional bedrock variables, so every preset default —
+// including enable_knowledge_base=false and vector_store="s3vectors" — wins.
+// A regression that unconditionally emitted enable_knowledge_base=false would
+// be indistinguishable from the default here but would clobber a stack that
+// turns the KB on via a different path; pinning "absent" guards that.
+func TestMapper_AWSBedrock_DefaultConfig(t *testing.T) {
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSBedrock, &Components{}, &Config{}, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	for _, key := range []string{"model_id", "embedding_model_id", "enable_knowledge_base", "vector_store"} {
+		_, has := vals[key]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left cfg.AWSBedrock nil — preset default must win", key)
+	}
+}
+
+// TestMapper_AWSBedrock_KnowledgeBaseConfig confirms the new #757 fields flow
+// through to the namespaced module variables when the caller supplies them.
+func TestMapper_AWSBedrock_KnowledgeBaseConfig(t *testing.T) {
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(
+		KeyAWSBedrock, &Components{},
+		bedrockCfg("anthropic.claude-3-sonnet", "amazon.titan-embed-text-v2:0", ptrBool(true), "opensearch"),
+		"demo", "us-east-1",
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, "anthropic.claude-3-sonnet", vals["model_id"])
+	require.Equal(t, "amazon.titan-embed-text-v2:0", vals["embedding_model_id"])
+	require.Equal(t, true, vals["enable_knowledge_base"],
+		"enable_knowledge_base must propagate when the caller sets it")
+	require.Equal(t, "opensearch", vals["vector_store"],
+		"vector_store must propagate when the caller sets it")
+}
+
+// TestMapper_AWSBedrock_PartialConfig is the partial-config gate: the caller
+// flips the KB on but leaves vector_store unset, so the mapper must emit
+// enable_knowledge_base=true and NOT emit vector_store — letting the preset
+// default it to "s3vectors". Catches the class of bug where the mapper writes
+// an empty-string vector_store that would override (and fail) the preset's
+// enum validation.
+func TestMapper_AWSBedrock_PartialConfig(t *testing.T) {
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(
+		KeyAWSBedrock, &Components{},
+		bedrockCfg("", "", ptrBool(true), "   "), // whitespace vector_store == unset
+		"demo", "us-east-1",
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, true, vals["enable_knowledge_base"])
+
+	_, hasVectorStore := vals["vector_store"]
+	require.False(t, hasVectorStore,
+		"mapper must NOT emit vector_store when caller left it blank — preset default s3vectors must win")
+
+	for _, key := range []string{"model_id", "embedding_model_id"} {
+		_, has := vals[key]
+		require.Falsef(t, has, "mapper must NOT emit %q when caller left it blank", key)
+	}
+}
+
+// TestMapper_AWSBedrock_EnableKBFalseIsExplicit pins that an explicit
+// EnableKnowledgeBase=false (pointer set to false, not nil) DOES flow through.
+// The pointer type is what makes "unset" (nil) and "explicitly off" (false)
+// distinguishable; this test guards that distinction.
+func TestMapper_AWSBedrock_EnableKBFalseIsExplicit(t *testing.T) {
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(
+		KeyAWSBedrock, &Components{},
+		bedrockCfg("", "", ptrBool(false), ""),
+		"demo", "us-east-1",
+	)
+	require.NoError(t, err)
+
+	got, has := vals["enable_knowledge_base"]
+	require.True(t, has, "explicit EnableKnowledgeBase=false must be emitted, not dropped")
+	require.Equal(t, false, got)
+}

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -37,6 +37,7 @@ var untaggableAWS = map[string]struct{}{
 	"aws_autoscaling_group_tag":                          {},
 	"aws_backup_selection":                               {},
 	"aws_bedrock_model_invocation_logging_configuration": {},
+	"aws_bedrockagent_data_source":                       {},
 	"aws_cloudfront_monitoring_subscription":             {},
 	"aws_cloudfront_origin_access_identity":              {},
 	"aws_cloudwatch_dashboard":                           {},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -713,25 +713,38 @@ func (m DefaultMapper) BuildModuleValues(
 
 	case KeyAWSBedrock:
 		if cfg != nil && cfg.AWSBedrock != nil {
-			// KnowledgeBaseName is intentionally NOT plumbed through.
-			// The bedrock preset doesn't create the knowledge base
-			// (that's an application-layer concern; see aws/bedrock/main.tf
-			// header). The mapper used to write it anyway, which the
-			// module silently ignored — surfaced by the
-			// TestMapperKeysSubsetOfModuleVariables gate (#253 follow-up).
+			// KnowledgeBaseName is intentionally NOT plumbed through: the
+			// preset names the KB "{project}-kb" itself, so there is no
+			// knowledge_base_name module variable to map it to. Writing it
+			// anyway would trip the TestMapperKeysSubsetOfModuleVariables
+			// gate (#253 follow-up).
 			if cfg.AWSBedrock.ModelID != "" {
 				vals["model_id"] = cfg.AWSBedrock.ModelID
 			}
 			if cfg.AWSBedrock.EmbeddingModelID != "" {
 				vals["embedding_model_id"] = cfg.AWSBedrock.EmbeddingModelID
 			}
+			// The preset now provisions a real Knowledge Base (#757) — an
+			// S3 Vectors store + aws_bedrockagent_knowledge_base + S3 data
+			// source, gated on enable_knowledge_base. Partial-config: only
+			// emit a field the caller actually populated so the preset's
+			// own defaults (enable_knowledge_base=false, vector_store=
+			// "s3vectors") win when the field is left unset.
+			if cfg.AWSBedrock.EnableKnowledgeBase != nil {
+				vals["enable_knowledge_base"] = *cfg.AWSBedrock.EnableKnowledgeBase
+			}
+			if strings.TrimSpace(cfg.AWSBedrock.VectorStore) != "" {
+				vals["vector_store"] = strings.TrimSpace(cfg.AWSBedrock.VectorStore)
+			}
 		}
 		// s3_bucket_arn and opensearch_collection_arn are optional (default
 		// null) Knowledge Base inputs. In a full stack DefaultWiring supplies
 		// them from module.aws_s3 / module.aws_opensearch when those
-		// components are selected. For single-module preview compose they are
-		// simply left unset — the preset defaults them to null and the role
-		// composes as a plain model-invocation role. No stub needed.
+		// components are selected (the s3_bucket_arn the KB ingests from, the
+		// AOSS collection the opensearch vector store uses). For single-module
+		// preview compose they are left unset — the preset defaults them to
+		// null. The KB itself is off by default, so a preview compose with no
+		// config produces just the plain model-invocation role + guardrail.
 
 	case KeyAWSLambda:
 		vals["runtime"] = "nodejs20.x" // Default to nodejs

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -162,10 +162,12 @@ func kitchenSinkConfig() *Config {
 		MultiAZ        *bool  `json:"multiAz,omitempty"`
 	}{DeploymentType: "managed", InstanceType: "t3.medium.search", StorageSize: "1TB", MultiAZ: &t}
 	cfg.AWSBedrock = &struct {
-		KnowledgeBaseName string `json:"knowledgeBaseName,omitempty"`
-		ModelID           string `json:"modelId,omitempty"`
-		EmbeddingModelID  string `json:"embeddingModelId,omitempty"`
-	}{KnowledgeBaseName: "kb", ModelID: "anthropic.claude-3", EmbeddingModelID: "amazon.titan-embed"}
+		KnowledgeBaseName   string `json:"knowledgeBaseName,omitempty"`
+		ModelID             string `json:"modelId,omitempty"`
+		EmbeddingModelID    string `json:"embeddingModelId,omitempty"`
+		EnableKnowledgeBase *bool  `json:"enableKnowledgeBase,omitempty"`
+		VectorStore         string `json:"vectorStore,omitempty"`
+	}{KnowledgeBaseName: "kb", ModelID: "anthropic.claude-3", EmbeddingModelID: "amazon.titan-embed", EnableKnowledgeBase: &t, VectorStore: "s3vectors"}
 	cfg.AWSRoute53 = &struct {
 		DomainName   string   `json:"domainName,omitempty"`
 		CreateZone   *bool    `json:"createZone,omitempty"`

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -282,9 +282,11 @@ type Config struct {
 	} `json:"aws_opensearch,omitempty"`
 
 	AWSBedrock *struct {
-		KnowledgeBaseName string `json:"knowledgeBaseName,omitempty"`
-		ModelID           string `json:"modelId,omitempty"`
-		EmbeddingModelID  string `json:"embeddingModelId,omitempty"`
+		KnowledgeBaseName   string `json:"knowledgeBaseName,omitempty"`
+		ModelID             string `json:"modelId,omitempty"`
+		EmbeddingModelID    string `json:"embeddingModelId,omitempty"`
+		EnableKnowledgeBase *bool  `json:"enableKnowledgeBase,omitempty"`
+		VectorStore         string `json:"vectorStore,omitempty"`
 	} `json:"aws_bedrock,omitempty"`
 
 	AWSBackups *struct {

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -35,6 +35,7 @@ NON_TAGGABLE_AWS=(
   aws_autoscaling_group_tag
   aws_backup_selection
   aws_bedrock_model_invocation_logging_configuration
+  aws_bedrockagent_data_source
   aws_cloudfront_monitoring_subscription
   aws_cloudfront_origin_access_identity
   aws_cloudwatch_dashboard


### PR DESCRIPTION
## What

Deepens the `aws/bedrock` preset from IAM/guardrail scaffolding into a real managed-RAG component. Gated on `enable_knowledge_base` (default `false`), it now provisions a Bedrock Knowledge Base + S3 docs data source backed by a vector store. This reverses the earlier "KB is app-layer" decision.

### Preset (`aws/bedrock/`)
- `aws_bedrockagent_knowledge_base` + `aws_bedrockagent_data_source` (S3 docs source)
- `vector_store` selector:
  - `s3vectors` (default) creates an in-module `aws_s3vectors_vector_bucket` + `aws_s3vectors_index` — cheapest managed store, no cluster, no field-mapping needed
  - `opensearch` uses the existing `opensearch_collection_arn` wiring with the Bedrock field mapping
- `time_sleep` (20s) between the KB role/policy and the KB resource for IAM eventual-consistency (avoids first-apply 403s)
- s3vectors data-plane IAM statement added to the KB role for that store
- `embedding_dimension` validated (1–4096) and cross-checked against the embedding model via a precondition (Titan v2 = 1024, v1 = 1536); default embedding model bumped to `amazon.titan-embed-text-v2:0` to match the 1024 default
- New outputs: `knowledge_base_id`, `knowledge_base_arn`, `data_source_id`, `s3_vectors_bucket_arn`, `s3_vectors_index_arn`
- `module "name"` + base IAM role stay unconditional (satisfies `TestEveryPresetHasUnconditionalResource`)

### Composer (`pkg/composer/`)
- `Config.AWSBedrock` gains `EnableKnowledgeBase *bool` + `VectorStore string`
- mapper `case KeyAWSBedrock` maps them with the partial-config pattern (unset field → preset default wins); stale KB-is-app-layer comment refreshed
- `kitchenSinkConfig()` exercises the new fields
- Existing `DefaultWiring` edges (`s3_bucket_arn` + `opensearch_collection_arn`) already suffice — verified, no new edge

## How it was tested

All run locally in an isolated worktree off `origin/main`:

| Check | Result |
|---|---|
| `make test` (`go test -race ./...`) | green — 2310 composer tests pass; invariant gates (`TestMapperKeysSubsetOfModuleVariables`, `TestEveryPresetHasUnconditionalResource`, `TestPresetDefaultsSatisfyValidations`) included |
| `cd aws/bedrock && terraform test` (unit) | 35 passed, 0 failed |
| `make go-fmt-check` | clean |
| `terraform fmt -check -recursive aws/bedrock` | clean |
| `make verify-gen` | clean (no diff) |
| `make verify-supported-resources` | clean |

The four new resource types are preset-authored, **not** in the reverse-import codegen allowlist (`AWSCodegenTypes`), so `verify-gen` / `verify-supported-resources` stay clean without touching the schema dump.

New unit tests: `kb_default_s3vectors`, `kb_opensearch`, output/IAM-statement assertions, and `expect_failures` for invalid `vector_store`, missing `s3_bucket_arn`, missing collection ARN, dimension/model mismatch, and >1 inclusion prefix. New mapper partial-config Go tests pin "unset → preset default".

## Gotchas encapsulated
- Provider resolves to **`hashicorp/aws` v6.49.0** under `>= 6.0`; all four resource types (`aws_s3vectors_vector_bucket`, `aws_s3vectors_index`, `aws_bedrockagent_knowledge_base`, `aws_bedrockagent_data_source`) confirmed present in its schema.
- The Bedrock S3 data source accepts **at most one** `inclusion_prefix` (provider plan-time validator, not in the JSON schema) — variable validates `length <= 1`.
- `aws_s3vectors_index` has **no** `force_destroy` (only the bucket does) — `knowledge_base_force_destroy` applies to the bucket.
- Cross-variable constraints can't live in a variable `validation` block (must reference own var), so they're enforced as `precondition`s on the relevant resources.

## Live-apply verification: pending
Real-AWS apply is not yet run (needs operator auth). It's covered by the new `bedrock_knowledge_base` run in `integration.tftest.hcl`, which would exercise: the in-module S3 Vectors bucket+index, the Knowledge Base wired to the module IAM role, the S3 data source against a real docs bucket, and the `time_sleep` IAM-propagation path. Requires the `amazon.titan-embed-text-v2:0` embedding model enabled in the target account's Bedrock model access and a region where S3 Vectors is available.

Closes #757
Part of #755