### PR TITLE
feat(gpu): GPU support on aws_eks_nodegroup + aws_ec2 (#759)

### DIFF
--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -237,6 +237,20 @@ resource "aws_instance" "this" {
       condition     = !(var.user_data != "" && var.user_data_url != "")
       error_message = "user_data and user_data_url are mutually exclusive. Set one or the other, not both."
     }
+
+    # GPU AMI is os_type-independent (#759): when gpu_enabled and no explicit
+    # ami_id, the module always boots the AWS Deep Learning Base GPU AMI
+    # (Amazon Linux 2023) regardless of os_type. Previously os_type="ubuntu"
+    # was silently ignored on the GPU path — a caller asking for Ubuntu got an
+    # Amazon Linux node with no warning. Reject the combination loudly so the
+    # caller either drops os_type (accept the AL2023 GPU AMI) or supplies their
+    # own Ubuntu GPU ami_id. Not enforceable as a var validation block — TF
+    # forbids cross-variable conditions there — so it lives as a resource
+    # precondition.
+    precondition {
+      condition     = !(var.gpu_enabled && var.ami_id == null && var.os_type == "ubuntu")
+      error_message = "gpu_enabled=true selects the Amazon Linux 2023 GPU AMI and ignores os_type=\"ubuntu\". Drop os_type (or set it to \"amazon-linux\") to use the built-in GPU AMI, or supply an explicit Ubuntu GPU ami_id."
+    }
   }
 
   root_block_device {

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -21,12 +21,27 @@ module "name" {
 }
 
 locals {
+  # NVIDIA-GPU x86_64 EC2 families (#759). MUST stay in lockstep with the
+  # HCL `_gpu_x86_families` local in aws/eks_nodegroup/main.tf and the Go
+  # `gpuX86Families` set in pkg/composer/gpu.go — TestGPUFamiliesDrift parses
+  # all three and fails the moment any one drifts. The GPU AMI is x86_64-only,
+  # so gpu_enabled with a non-x86-GPU instance type (ARM, or a non-GPU family)
+  # is rejected at plan by the aws_instance precondition below. g5g is
+  # deliberately ABSENT: it is Graviton (ARM) + NVIDIA T4G with no x86 NVIDIA
+  # AMI, so it stays on the ARM standard path.
+  _gpu_x86_families = [
+    "g4dn", "g5", "g6", "g6e", "gr6",
+    "p3", "p3dn", "p4d", "p4de", "p5", "p5e", "p5en",
+  ]
+  _instance_family   = split(".", var.instance_type)[0]
+  _is_gpu_x86_family = contains(local._gpu_x86_families, local._instance_family)
+
   # GPU path (#759) wins over os_type: when gpu_enabled and no explicit
   # ami_id, select the AWS Deep Learning Base GPU AMI (AL2023, NVIDIA
   # driver + container toolkit baked in) so a g5/g6/p4d/p5 instance comes
   # up with /dev/nvidia* present. Non-GPU path keeps the existing
   # os_type/arch selection. The NVIDIA AMI is x86_64-only (enforced by the
-  # var.gpu_enabled validation), so this never collides with arm64.
+  # aws_instance precondition), so this never collides with arm64.
   ami_id = var.ami_id != null ? var.ami_id : (
     var.gpu_enabled ? data.aws_ami.gpu[0].id : (
       var.os_type == "ubuntu" ? data.aws_ami.ubuntu[0].id : data.aws_ami.al2023[0].id
@@ -236,6 +251,23 @@ resource "aws_instance" "this" {
     precondition {
       condition     = !(var.user_data != "" && var.user_data_url != "")
       error_message = "user_data and user_data_url are mutually exclusive. Set one or the other, not both."
+    }
+
+    # GPU AMI is x86_64-only (#759): when gpu_enabled and no explicit ami_id,
+    # the module boots the AWS Deep Learning Base GPU AMI, which exists only
+    # for x86_64 NVIDIA GPU families (g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/
+    # p5e/p5en). A non-GPU type (t3.medium) or an ARM/Graviton type (c7g, g5g)
+    # would boot a node with the GPU AMI's driver but no NVIDIA hardware, so
+    # /dev/nvidia* never appears — the EC2 analogue of the EKS #207 arch
+    # mismatch. Reject at plan rather than silently provisioning a useless GPU
+    # node. Direct module callers who supply their own ami_id are exempt (the
+    # ami_id==null guard). The composer always defaults/validates an x86 GPU
+    # family upstream, so this fires only for direct/hand-rolled module use.
+    # Not enforceable as a var validation block — TF forbids cross-variable
+    # conditions there — so it lives as a resource precondition.
+    precondition {
+      condition     = !(var.gpu_enabled && var.ami_id == null) || local._is_gpu_x86_family
+      error_message = "gpu_enabled=true requires an x86 NVIDIA GPU instance_type (one of g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/p5e/p5en) when ami_id is null — AWS GPU AMIs are x86_64-only and a non-GPU/ARM type boots without /dev/nvidia*. Pick a supported GPU instance_type, or supply an explicit ami_id."
     }
 
     # GPU AMI is os_type-independent (#759): when gpu_enabled and no explicit

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -21,8 +21,16 @@ module "name" {
 }
 
 locals {
+  # GPU path (#759) wins over os_type: when gpu_enabled and no explicit
+  # ami_id, select the AWS Deep Learning Base GPU AMI (AL2023, NVIDIA
+  # driver + container toolkit baked in) so a g5/g6/p4d/p5 instance comes
+  # up with /dev/nvidia* present. Non-GPU path keeps the existing
+  # os_type/arch selection. The NVIDIA AMI is x86_64-only (enforced by the
+  # var.gpu_enabled validation), so this never collides with arm64.
   ami_id = var.ami_id != null ? var.ami_id : (
-    var.os_type == "ubuntu" ? data.aws_ami.ubuntu[0].id : data.aws_ami.al2023[0].id
+    var.gpu_enabled ? data.aws_ami.gpu[0].id : (
+      var.os_type == "ubuntu" ? data.aws_ami.ubuntu[0].id : data.aws_ami.al2023[0].id
+    )
   )
 
   # Resolve effective user_data: inline script takes priority, URL generates a fetch wrapper.
@@ -31,9 +39,37 @@ locals {
   )
 }
 
-# Pick Amazon Linux 2023 AMI by arch (only when ami_id is not provided and os_type is amazon-linux)
+# Pick the AWS Deep Learning Base GPU AMI (Amazon Linux 2023) when GPU is
+# requested and no explicit ami_id is given (#759). This AMI is published by
+# Amazon (owner alias `amazon`) and ships the NVIDIA kernel driver + container
+# toolkit pre-installed — no app-layer driver bootstrap needed on the host.
+# x86_64-only (var.gpu_enabled requires arch=x86_64). The "Base" variant
+# carries drivers without a bundled DL framework, keeping the image lean.
+data "aws_ami" "gpu" {
+  count       = var.ami_id == null && var.gpu_enabled ? 1 : 0
+  owners      = ["amazon"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["Deep Learning Base OSS Nvidia Driver GPU AMI (Amazon Linux 2023)*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# Pick Amazon Linux 2023 AMI by arch (only when ami_id is not provided, GPU is
+# off, and os_type is amazon-linux)
 data "aws_ami" "al2023" {
-  count       = var.ami_id == null && var.os_type == "amazon-linux" ? 1 : 0
+  count       = var.ami_id == null && !var.gpu_enabled && var.os_type == "amazon-linux" ? 1 : 0
   owners      = ["137112412989"] # Amazon
   most_recent = true
 
@@ -43,9 +79,10 @@ data "aws_ami" "al2023" {
   }
 }
 
-# Pick Ubuntu 24.04 LTS AMI by arch (only when ami_id is not provided and os_type is ubuntu)
+# Pick Ubuntu 24.04 LTS AMI by arch (only when ami_id is not provided, GPU is
+# off, and os_type is ubuntu)
 data "aws_ami" "ubuntu" {
-  count       = var.ami_id == null && var.os_type == "ubuntu" ? 1 : 0
+  count       = var.ami_id == null && !var.gpu_enabled && var.os_type == "ubuntu" ? 1 : 0
   owners      = ["099720109477"] # Canonical
   most_recent = true
 

--- a/aws/ec2/tests/ec2_gpu.tftest.hcl
+++ b/aws/ec2/tests/ec2_gpu.tftest.hcl
@@ -40,6 +40,7 @@ run "gpu_enabled_selects_gpu_ami" {
   variables {
     gpu_enabled   = true
     arch          = "x86_64"
+    os_type       = "amazon-linux"
     instance_type = "g5.xlarge"
   }
 
@@ -104,4 +105,64 @@ run "gpu_with_arm64_fails_validation" {
   }
 
   expect_failures = [var.gpu_enabled]
+}
+
+# os_type override (#759): gpu_enabled selects the Amazon Linux 2023 GPU AMI
+# and ignores os_type. Previously os_type="ubuntu" was silently dropped on the
+# GPU path — a caller asking for Ubuntu got an Amazon Linux node with no
+# warning. The aws_instance precondition now rejects the combination loudly so
+# the mismatch surfaces at plan instead of booting an unexpected OS.
+run "gpu_with_ubuntu_os_type_fails_precondition" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  override_data {
+    target = data.aws_ami.gpu[0]
+    values = {
+      id = "ami-0gpu00000000000ab"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    os_type       = "ubuntu"
+    instance_type = "g5.xlarge"
+  }
+
+  expect_failures = [aws_instance.this]
+}
+
+# Explicit ami_id with gpu_enabled + os_type="ubuntu" is allowed: the caller
+# supplied their own (e.g. Ubuntu GPU) AMI, so the precondition's ami_id==null
+# guard does not trip. Locks that the precondition only fires on the
+# silent-override path, not on the bring-your-own-AMI path.
+run "gpu_with_ubuntu_and_explicit_ami_id_passes" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    os_type       = "ubuntu"
+    instance_type = "g5.xlarge"
+    ami_id        = "ami-ubuntugpu0000000"
+  }
+
+  assert {
+    condition     = aws_instance.this.ami == "ami-ubuntugpu0000000"
+    error_message = "explicit ami_id must be honored even with gpu_enabled + os_type=ubuntu"
+  }
 }

--- a/aws/ec2/tests/ec2_gpu.tftest.hcl
+++ b/aws/ec2/tests/ec2_gpu.tftest.hcl
@@ -1,0 +1,107 @@
+# Hermetic plan tests for the GPU AMI selection path added in #759.
+#
+# gpu_enabled=true selects the AWS Deep Learning Base GPU AMI (Amazon Linux
+# 2023, NVIDIA driver baked in) so a g5/g6/p4d/p5 instance comes up with
+# /dev/nvidia* present, instead of the plain OS AMI. GPU AMIs are x86_64-only,
+# so gpu_enabled=true requires arch=x86_64 — the variable validation rejects
+# the arm64 mismatch (the #207 class: wrong AMI for the chosen hardware).
+#
+# The in-cluster / on-host NVIDIA device plugin and CUDA runtime layering is
+# app-layer and out of preset scope — this module only provisions a
+# GPU-capable instance with the driver-bearing AMI.
+
+mock_provider "aws" {}
+
+variables {
+  project     = "test"
+  region      = "us-east-1"
+  environment = "test"
+  vpc_id      = "vpc-12345678"
+  subnet_id   = "subnet-12345678"
+}
+
+run "gpu_enabled_selects_gpu_ami" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  override_data {
+    target = data.aws_ami.gpu[0]
+    values = {
+      id = "ami-0gpu00000000000ab"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    instance_type = "g5.xlarge"
+  }
+
+  assert {
+    condition     = aws_instance.this.ami == "ami-0gpu00000000000ab"
+    error_message = "gpu_enabled must select the GPU AMI (data.aws_ami.gpu) for the instance (#759)"
+  }
+  assert {
+    condition     = length(data.aws_ami.al2023) == 0 && length(data.aws_ami.ubuntu) == 0
+    error_message = "gpu_enabled must short-circuit the os_type AMI lookups (#759)"
+  }
+  assert {
+    condition     = aws_instance.this.instance_type == "g5.xlarge"
+    error_message = "instance_type must be the requested GPU type g5.xlarge"
+  }
+}
+
+# Explicit ami_id still wins over the GPU AMI lookup.
+run "explicit_ami_id_overrides_gpu" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    instance_type = "g5.xlarge"
+    ami_id        = "ami-deadbeefdeadbeef0"
+  }
+
+  assert {
+    condition     = aws_instance.this.ami == "ami-deadbeefdeadbeef0"
+    error_message = "explicit ami_id must override the GPU AMI lookup"
+  }
+  assert {
+    condition     = length(data.aws_ami.gpu) == 0
+    error_message = "explicit ami_id must short-circuit the GPU AMI data source"
+  }
+}
+
+# Arch/AMI mismatch (#207 class): GPU AMIs are x86_64-only, so gpu_enabled
+# with arch=arm64 must fail validation rather than silently provisioning an
+# instance with an incompatible AMI.
+run "gpu_with_arm64_fails_validation" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    gpu_enabled = true
+    arch        = "arm64"
+  }
+
+  expect_failures = [var.gpu_enabled]
+}

--- a/aws/ec2/tests/ec2_gpu.tftest.hcl
+++ b/aws/ec2/tests/ec2_gpu.tftest.hcl
@@ -3,8 +3,11 @@
 # gpu_enabled=true selects the AWS Deep Learning Base GPU AMI (Amazon Linux
 # 2023, NVIDIA driver baked in) so a g5/g6/p4d/p5 instance comes up with
 # /dev/nvidia* present, instead of the plain OS AMI. GPU AMIs are x86_64-only,
-# so gpu_enabled=true requires arch=x86_64 — the variable validation rejects
-# the arm64 mismatch (the #207 class: wrong AMI for the chosen hardware).
+# so gpu_enabled=true requires an x86 NVIDIA GPU instance_type — the
+# aws_instance precondition rejects non-GPU/ARM types (the #207 class: wrong
+# AMI for the chosen hardware). The check is a resource precondition rather
+# than a variable validation because TF forbids cross-variable conditions in
+# variable validation blocks.
 #
 # The in-cluster / on-host NVIDIA device plugin and CUDA runtime layering is
 # app-layer and out of preset scope — this module only provisions a
@@ -87,9 +90,11 @@ run "explicit_ami_id_overrides_gpu" {
 }
 
 # Arch/AMI mismatch (#207 class): GPU AMIs are x86_64-only, so gpu_enabled
-# with arch=arm64 must fail validation rather than silently provisioning an
-# instance with an incompatible AMI.
-run "gpu_with_arm64_fails_validation" {
+# with an ARM/Graviton instance_type must fail rather than silently
+# provisioning an instance with an incompatible AMI. The check lives on the
+# aws_instance precondition (TF forbids the cross-variable condition in a
+# variable validation block), so the failure surfaces against aws_instance.this.
+run "gpu_with_arm64_instance_type_fails_precondition" {
   command = plan
 
   override_data {
@@ -99,12 +104,49 @@ run "gpu_with_arm64_fails_validation" {
     }
   }
 
-  variables {
-    gpu_enabled = true
-    arch        = "arm64"
+  override_data {
+    target = data.aws_ami.gpu[0]
+    values = {
+      id = "ami-0gpu00000000000ab"
+    }
   }
 
-  expect_failures = [var.gpu_enabled]
+  variables {
+    gpu_enabled   = true
+    arch          = "arm64"
+    instance_type = "g5g.xlarge"
+  }
+
+  expect_failures = [aws_instance.this]
+}
+
+# Non-GPU instance type with gpu_enabled (#759): a plain compute type like
+# t3.medium has no NVIDIA hardware, so booting it with the GPU AMI yields a
+# node without /dev/nvidia*. The precondition rejects it at plan.
+run "gpu_with_non_gpu_instance_type_fails_precondition" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  override_data {
+    target = data.aws_ami.gpu[0]
+    values = {
+      id = "ami-0gpu00000000000ab"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    instance_type = "t3.medium"
+  }
+
+  expect_failures = [aws_instance.this]
 }
 
 # os_type override (#759): gpu_enabled selects the Amazon Linux 2023 GPU AMI

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -79,6 +79,16 @@ variable "arch" {
   }
 }
 
+variable "gpu_enabled" {
+  description = "Select an NVIDIA-GPU AMI (AWS Deep Learning Base GPU AMI, Amazon Linux 2023) instead of the plain OS AMI when ami_id is null. Use with a GPU instance_type (g4dn/g5/g6/p4d/p5, etc.). The GPU AMI ships the NVIDIA kernel driver + container toolkit baked in. GPU AMIs are x86_64-only — gpu_enabled=true requires arch=x86_64 (validated on the aws_instance). NOTE: g/p instance families are quota-gated; an account with a 0 vCPU GPU quota fails at apply with an InsufficientInstanceCapacity / VcpuLimitExceeded error surfaced to the operator (#759)."
+  type        = bool
+  default     = false
+  validation {
+    condition     = !var.gpu_enabled || var.arch == "x86_64"
+    error_message = "gpu_enabled=true requires arch=x86_64 — AWS GPU AMIs are x86_64-only."
+  }
+}
+
 variable "key_name" {
   description = "Existing EC2 key pair name for SSH (null to rely on SSM only)"
   type        = string

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -80,13 +80,9 @@ variable "arch" {
 }
 
 variable "gpu_enabled" {
-  description = "Select an NVIDIA-GPU AMI (AWS Deep Learning Base GPU AMI, Amazon Linux 2023) instead of the plain OS AMI when ami_id is null. Use with a GPU instance_type (g4dn/g5/g6/p4d/p5, etc.). The GPU AMI ships the NVIDIA kernel driver + container toolkit baked in. GPU AMIs are x86_64-only — gpu_enabled=true requires arch=x86_64 (validated on the aws_instance). NOTE: g/p instance families are quota-gated; an account with a 0 vCPU GPU quota fails at apply with an InsufficientInstanceCapacity / VcpuLimitExceeded error surfaced to the operator (#759)."
+  description = "Select an NVIDIA-GPU AMI (AWS Deep Learning Base GPU AMI, Amazon Linux 2023) instead of the plain OS AMI when ami_id is null. Use with a GPU instance_type (g4dn/g5/g6/p4d/p5, etc.). The GPU AMI ships the NVIDIA kernel driver + container toolkit baked in. GPU AMIs are x86_64-only, so gpu_enabled=true requires an x86 NVIDIA GPU instance_type (validated on the aws_instance precondition — TF forbids cross-variable conditions in variable validation blocks). NOTE: g/p instance families are quota-gated; an account with a 0 vCPU GPU quota fails at apply with an InsufficientInstanceCapacity / VcpuLimitExceeded error surfaced to the operator (#759)."
   type        = bool
   default     = false
-  validation {
-    condition     = !var.gpu_enabled || var.arch == "x86_64"
-    error_message = "gpu_enabled=true requires arch=x86_64 — AWS GPU AMIs are x86_64-only."
-  }
 }
 
 variable "key_name" {

--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -1,3 +1,14 @@
+# EKS managed node group preset.
+#
+# GPU note (#759): selecting an NVIDIA GPU instance family (g4dn/g5/g6/g6e/
+# gr6/p3/p4d/p5, ...) auto-derives a GPU AMI type (AL2023_x86_64_NVIDIA), so
+# the worker boots with the NVIDIA kernel driver present. This preset only
+# provisions GPU-CAPABLE nodes. The in-cluster NVIDIA k8s device plugin that
+# advertises `nvidia.com/gpu` to the scheduler is APP-LAYER and intentionally
+# out of preset scope — EKS has no first-party managed addon for it and Helm
+# is excluded from this repo, so it is installed by the deploying application.
+# g/p families are quota-gated; surface capacity errors to the operator.
+
 terraform {
   required_version = ">= 1.5"
   required_providers {
@@ -36,7 +47,35 @@ locals {
   _instance_family     = split(".", local._first_instance_type)[0]
   _is_arm_family       = can(regex("^[a-z]+[0-9]+g(d|n|en|ad|adn)?$", local._instance_family))
 
-  derived_ami_type  = local._is_arm_family ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+  # NVIDIA-GPU EC2 families (#759): g4dn, g5, g5g, g6, g6e, gr6, p3, p3dn,
+  # p4d, p4de, p5, p5e, p5en. These need a GPU-bundled AMI type so the
+  # NVIDIA kernel driver + container runtime are present on the node — a
+  # plain AL2023_x86_64_STANDARD AMI on a g5.xlarge brings the worker up
+  # but exposes no /dev/nvidia* devices, so GPU pods sit Pending forever
+  # (the GPU analogue of the #207 arch mismatch). We match the family with
+  # an explicit allow-list rather than a loose regex so that non-GPU
+  # families that merely start with `g`/`p` (none today, but e.g. a future
+  # general-purpose `g`-prefixed family) don't get misclassified.
+  #
+  # g5g is Graviton (ARM) + NVIDIA T4G — it ends in `g`, so the ARM regex
+  # above already claims it; we deliberately leave g5g on the ARM path
+  # (AL2023_ARM_64_STANDARD) because EKS has no ARM NVIDIA managed AMI type.
+  # All other GPU families here are x86_64 → AL2023_x86_64_NVIDIA.
+  _gpu_x86_families = [
+    "g4dn", "g5", "g6", "g6e", "gr6",
+    "p3", "p3dn", "p4d", "p4de", "p5", "p5e", "p5en",
+  ]
+  _is_gpu_x86_family = contains(local._gpu_x86_families, local._instance_family)
+
+  # GPU x86 wins over the generic x86 default; ARM (incl. g5g) keeps the ARM
+  # standard AMI. The NVIDIA in-cluster device plugin that advertises
+  # nvidia.com/gpu to the scheduler is app-layer and intentionally out of
+  # preset scope (no first-party EKS managed addon; see README + #759).
+  derived_ami_type = (
+    local._is_arm_family ? "AL2023_ARM_64_STANDARD" : (
+      local._is_gpu_x86_family ? "AL2023_x86_64_NVIDIA" : "AL2023_x86_64_STANDARD"
+    )
+  )
   resolved_ami_type = coalesce(var.ami_type, local.derived_ami_type)
 }
 

--- a/aws/eks_nodegroup/tests/eks_nodegroup.tftest.hcl
+++ b/aws/eks_nodegroup/tests/eks_nodegroup.tftest.hcl
@@ -120,3 +120,75 @@ run "bogus_ami_type_fails_validation" {
 
   expect_failures = [var.ami_type]
 }
+
+# GPU node group (#759): an NVIDIA x86 instance family must auto-derive the
+# NVIDIA managed AMI type so the node comes up GPU-capable. Without this, a
+# g5.xlarge on the AL2023_x86_64_STANDARD default exposes no /dev/nvidia*
+# devices and GPU pods sit Pending — the GPU analogue of the #207 arch
+# mismatch.
+run "gpu_nodegroup" {
+  command = plan
+
+  variables {
+    instance_types = ["g5.xlarge"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_x86_64_NVIDIA"
+    error_message = "GPU x86 family g5.xlarge must derive AL2023_x86_64_NVIDIA (#759)"
+  }
+  assert {
+    condition     = aws_eks_node_group.this.ami_type == "AL2023_x86_64_NVIDIA"
+    error_message = "node group resource ami_type must be AL2023_x86_64_NVIDIA for a GPU instance family (#759)"
+  }
+  assert {
+    condition     = tolist(aws_eks_node_group.this.instance_types)[0] == "g5.xlarge"
+    error_message = "node group must use the requested GPU instance type g5.xlarge"
+  }
+}
+
+# p-family GPU instances also resolve the NVIDIA AMI.
+run "gpu_p_family_derives_nvidia_ami" {
+  command = plan
+
+  variables {
+    instance_types = ["p4d.24xlarge"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_x86_64_NVIDIA"
+    error_message = "GPU p-family p4d.24xlarge must derive AL2023_x86_64_NVIDIA (#759)"
+  }
+}
+
+# g5g is Graviton (ARM) + NVIDIA T4G. EKS has no ARM NVIDIA managed AMI type,
+# so g5g stays on the ARM standard AMI — locks that the GPU allow-list does
+# not steal ARM families ending in `g`.
+run "g5g_arm_stays_arm_standard" {
+  command = plan
+
+  variables {
+    instance_types = ["g5g.xlarge"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_ARM_64_STANDARD"
+    error_message = "g5g (Graviton NVIDIA) must keep AL2023_ARM_64_STANDARD — no ARM NVIDIA managed AMI type exists (#759)"
+  }
+}
+
+# Explicit var.ami_type still overrides the GPU auto-derive (e.g. picking the
+# Bottlerocket NVIDIA variant).
+run "explicit_bottlerocket_nvidia_overrides_gpu_derive" {
+  command = plan
+
+  variables {
+    instance_types = ["g5.xlarge"]
+    ami_type       = "BOTTLEROCKET_x86_64_NVIDIA"
+  }
+
+  assert {
+    condition     = output.ami_type == "BOTTLEROCKET_x86_64_NVIDIA"
+    error_message = "explicit var.ami_type must override the GPU auto-derive"
+  }
+}

--- a/aws/eks_nodegroup/variables.tf
+++ b/aws/eks_nodegroup/variables.tf
@@ -129,7 +129,7 @@ variable "enable_container_insights" {
 }
 
 variable "ami_type" {
-  description = "EKS node AMI type. When null (default), the module derives the AMI type from var.instance_types: ARM/Graviton families (c7g, m7g, r7g, t4g, c8g, m8g, r8g, etc. — names ending in `g`) get AL2023_ARM_64_STANDARD; all other families get AL2023_x86_64_STANDARD. Set explicitly to override (e.g. BOTTLEROCKET_x86_64, AL2_x86_64_GPU)."
+  description = "EKS node AMI type. When null (default), the module derives the AMI type from var.instance_types: ARM/Graviton families (c7g, m7g, r7g, t4g, c8g, m8g, r8g, etc. — names ending in `g`) get AL2023_ARM_64_STANDARD; x86 NVIDIA-GPU families (g4dn, g5, g6, g6e, gr6, p3, p4d, p5, etc.) get AL2023_x86_64_NVIDIA; all other families get AL2023_x86_64_STANDARD (#759). Set explicitly to override (e.g. BOTTLEROCKET_x86_64, BOTTLEROCKET_x86_64_NVIDIA, AL2_x86_64_GPU). NOTE: the in-cluster NVIDIA k8s device plugin that advertises nvidia.com/gpu is app-layer and out of preset scope — this module only provisions GPU-capable nodes."
   type        = string
   default     = null
 

--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -20,6 +20,7 @@ type awsEC2CfgInput struct {
 	CustomIngressPorts    []int
 	SSHPublicKey          string
 	EnableInstanceConnect *bool
+	GPUEnabled            *bool
 }
 
 // configWithAWSEC2 returns *Config with AWSEC2 populated from input, eliding
@@ -36,6 +37,7 @@ func configWithAWSEC2(in awsEC2CfgInput) *Config {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			InstanceType:          in.InstanceType,
 			NumServers:            in.NumServers,
@@ -46,6 +48,39 @@ func configWithAWSEC2(in awsEC2CfgInput) *Config {
 			CustomIngressPorts:    in.CustomIngressPorts,
 			SSHPublicKey:          in.SSHPublicKey,
 			EnableInstanceConnect: in.EnableInstanceConnect,
+			GPUEnabled:            in.GPUEnabled,
+		},
+	}
+}
+
+// awsEKSCfgInput mirrors the subset of Config.AWSEKS fields exercised by
+// mapper tests.
+type awsEKSCfgInput struct {
+	DesiredSize  string
+	MaxSize      string
+	MinSize      string
+	InstanceType string
+	GPUEnabled   *bool
+}
+
+// configWithAWSEKS returns *Config with AWSEKS populated from input, eliding
+// the anonymous-struct redeclaration at each call site.
+func configWithAWSEKS(in awsEKSCfgInput) *Config {
+	return &Config{
+		AWSEKS: &struct {
+			HaControlPlane         *bool  `json:"haControlPlane,omitempty"`
+			ControlPlaneVisibility string `json:"controlPlaneVisibility,omitempty"`
+			DesiredSize            string `json:"desiredSize,omitempty"`
+			MaxSize                string `json:"maxSize,omitempty"`
+			MinSize                string `json:"minSize,omitempty"`
+			InstanceType           string `json:"instanceType,omitempty"`
+			GPUEnabled             *bool  `json:"gpuEnabled,omitempty"`
+		}{
+			DesiredSize:  in.DesiredSize,
+			MaxSize:      in.MaxSize,
+			MinSize:      in.MinSize,
+			InstanceType: in.InstanceType,
+			GPUEnabled:   in.GPUEnabled,
 		},
 	}
 }

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -1096,6 +1096,7 @@ func TestComposeStack_MonolithEC2(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			UserData:           "#!/bin/bash\napt-get update && apt-get install -y nodejs",
 			DiskSizePerServer:  "32",
@@ -1275,6 +1276,7 @@ touch /var/log/openclaw-init-complete`
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			NumServers:         "1",
 			UserData:           cloudInitScript,
@@ -1410,6 +1412,7 @@ func TestComposeStack_OpenClawDemo_URL(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			NumServers:         "1",
 			UserDataURL:        gistURL,
@@ -1466,6 +1469,7 @@ func TestComposeStack_EC2_InstanceConnect(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			NumServers:            "1",
 			EnableInstanceConnect: &trueVal,
@@ -1515,6 +1519,7 @@ func TestComposeStack_EC2_NoInstanceConnect(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			NumServers: "1",
 		},

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -188,7 +188,44 @@ func (c *Client) ComputePresetDefaults(cfg Config, comps *Components, selected [
 			outInner.Set(reflect.Zero(outInner.Type()))
 		}
 	}
+
+	// GPU instance-type default (#759): the HCL `default` for instance_type is
+	// the non-GPU type (t3.medium for EC2, c7i.large for EKS), so a GPU stack
+	// with no explicit instance type would otherwise be priced as the non-GPU
+	// default. When the caller enabled GPU but did not pin an instance type,
+	// overlay the shared GPU default so pricing (which reads Config) sees the
+	// instance type the mapper will actually deploy. Only fills when the user's
+	// own cfg left the instance type blank — an explicit pick is preserved.
+	applyGPUInstanceTypeDefault(&cfg, &out)
+
 	return out, nil
+}
+
+// applyGPUInstanceTypeDefault overlays defaultGPUInstanceType onto the EC2/EKS
+// instance-type overlay field when GPU is enabled in the user's config and no
+// explicit instance type was supplied (#759). This keeps the pricing-facing
+// Config in sync with the GPU instance type the mapper defaults to, so a GPU
+// stack is not priced as the non-GPU HCL default. The overlay is later merged
+// zero-only, so writing the value here fills the blank without clobbering an
+// explicit user pick.
+func applyGPUInstanceTypeDefault(cfg, out *Config) {
+	if cfg.AWSEC2 != nil && boolPtrTrue(cfg.AWSEC2.GPUEnabled) && cfg.AWSEC2.InstanceType == "" {
+		// Allocate a zero value of the field's own (anonymous) type via
+		// reflection so this stays correct if the AWSEC2 shape changes —
+		// cfg.AWSEC2 and out.AWSEC2 share the type, so a new(elem) is assignable.
+		if out.AWSEC2 == nil {
+			v := reflect.New(reflect.TypeOf(out.AWSEC2).Elem())
+			reflect.ValueOf(&out.AWSEC2).Elem().Set(v)
+		}
+		out.AWSEC2.InstanceType = defaultGPUInstanceType
+	}
+	if cfg.AWSEKS != nil && boolPtrTrue(cfg.AWSEKS.GPUEnabled) && cfg.AWSEKS.InstanceType == "" {
+		if out.AWSEKS == nil {
+			v := reflect.New(reflect.TypeOf(out.AWSEKS).Elem())
+			reflect.ValueOf(&out.AWSEKS).Elem().Set(v)
+		}
+		out.AWSEKS.InstanceType = defaultGPUInstanceType
+	}
 }
 
 // ApplyPresetDefaults backfills cfg with statically-resolvable HCL defaults

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -529,6 +529,55 @@ func TestComputePresetDefaults_NilNestedStructInInput_AllocatesInOverlay(t *test
 	assert.Equal(t, "t3.medium", overlay.AWSEC2.InstanceType)
 }
 
+// TestComputePresetDefaults_GPUInstanceTypeDefault pins the pricing fix (#759):
+// a GPU-enabled EC2/EKS config with no explicit instance type must overlay the
+// GPU default instance type (g5.xlarge), NOT the non-GPU HCL default
+// (t3.medium / c7i.large). Pricing reads Config, so without this a GPU stack
+// would be priced as the non-GPU default.
+func TestComputePresetDefaults_GPUInstanceTypeDefault(t *testing.T) {
+	c := New()
+	trueVal := true
+
+	t.Run("EC2 GPU with no instance type overlays g5.xlarge", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal})
+		overlay, err := c.ComputePresetDefaults(*cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+		require.NoError(t, err)
+		require.NotNil(t, overlay.AWSEC2)
+		assert.Equal(t, defaultGPUInstanceType, overlay.AWSEC2.InstanceType,
+			"GPU EC2 must overlay the GPU default, not the non-GPU t3.medium HCL default")
+	})
+
+	t.Run("EKS GPU with no instance type overlays g5.xlarge", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal})
+		overlay, err := c.ComputePresetDefaults(*cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEKSNodeGroup})
+		require.NoError(t, err)
+		require.NotNil(t, overlay.AWSEKS)
+		assert.Equal(t, defaultGPUInstanceType, overlay.AWSEKS.InstanceType,
+			"GPU EKS node group must overlay the GPU default instance type")
+	})
+
+	t.Run("explicit GPU instance type is preserved (not overwritten)", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "p4d.24xlarge"})
+		overlay, err := c.ComputePresetDefaults(*cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+		require.NoError(t, err)
+		// The overlay is the back-fill only; an explicit user pick is in cfg,
+		// so the overlay's instance type must NOT be the GPU default (the
+		// zero-only merge keeps the user's explicit value).
+		assert.NotEqual(t, defaultGPUInstanceType, "p4d.24xlarge")
+		require.NotNil(t, overlay.AWSEC2)
+		assert.NotEqual(t, defaultGPUInstanceType, overlay.AWSEC2.InstanceType,
+			"explicit user instance type must not trigger the GPU default overlay")
+	})
+
+	t.Run("non-GPU EC2 keeps the t3.medium HCL default", func(t *testing.T) {
+		overlay, err := c.ComputePresetDefaults(Config{}, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+		require.NoError(t, err)
+		require.NotNil(t, overlay.AWSEC2)
+		assert.Equal(t, "t3.medium", overlay.AWSEC2.InstanceType,
+			"non-GPU EC2 must keep the non-GPU HCL default")
+	})
+}
+
 // TestComputePresetDefaults_UnselectedComponentsAbsentFromOverlay pins the
 // scope rule: only the selected components contribute to the overlay.
 func TestComputePresetDefaults_UnselectedComponentsAbsentFromOverlay(t *testing.T) {

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -556,17 +556,28 @@ func TestComputePresetDefaults_GPUInstanceTypeDefault(t *testing.T) {
 			"GPU EKS node group must overlay the GPU default instance type")
 	})
 
-	t.Run("explicit GPU instance type is preserved (not overwritten)", func(t *testing.T) {
+	t.Run("explicit GPU instance type is preserved through the full merge", func(t *testing.T) {
+		// Guard the premise: the user's pick must differ from the GPU default,
+		// otherwise "preserved" would be indistinguishable from "overwritten".
+		require.NotEqual(t, defaultGPUInstanceType, "p4d.24xlarge")
+
 		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "p4d.24xlarge"})
+
+		// The overlay is the back-fill only; the zero-only merge keeps the
+		// user's explicit value, so the overlay must NOT echo the GPU default.
 		overlay, err := c.ComputePresetDefaults(*cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
 		require.NoError(t, err)
-		// The overlay is the back-fill only; an explicit user pick is in cfg,
-		// so the overlay's instance type must NOT be the GPU default (the
-		// zero-only merge keeps the user's explicit value).
-		assert.NotEqual(t, defaultGPUInstanceType, "p4d.24xlarge")
 		require.NotNil(t, overlay.AWSEC2)
 		assert.NotEqual(t, defaultGPUInstanceType, overlay.AWSEC2.InstanceType,
 			"explicit user instance type must not trigger the GPU default overlay")
+
+		// Run the full ApplyPresetDefaults/merge path and positively assert the
+		// EFFECTIVE instance type is the user's explicit pick, not the GPU
+		// default — the real outcome a caller observes after defaults apply.
+		require.NoError(t, c.ApplyPresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2}))
+		require.NotNil(t, cfg.AWSEC2)
+		assert.Equal(t, "p4d.24xlarge", cfg.AWSEC2.InstanceType,
+			"the user's explicit GPU instance type must survive the full defaults merge")
 	})
 
 	t.Run("non-GPU EC2 keeps the t3.medium HCL default", func(t *testing.T) {
@@ -575,6 +586,40 @@ func TestComputePresetDefaults_GPUInstanceTypeDefault(t *testing.T) {
 		require.NotNil(t, overlay.AWSEC2)
 		assert.Equal(t, "t3.medium", overlay.AWSEC2.InstanceType,
 			"non-GPU EC2 must keep the non-GPU HCL default")
+	})
+}
+
+// TestApplyGPUInstanceTypeDefault_AllocatesNilOverlay exercises
+// applyGPUInstanceTypeDefault directly with an empty (&Config{}) overlay so the
+// reflect-based nil-allocation branch is covered. Through ComputePresetDefaults
+// the overlay's inner struct is always pre-allocated by the selection loop, so
+// that branch is otherwise dead — this calls it head-on with out.AWSEC2 ==
+// nil / out.AWSEKS == nil to prove the allocate-on-demand path works (#759).
+func TestApplyGPUInstanceTypeDefault_AllocatesNilOverlay(t *testing.T) {
+	trueVal := true
+
+	t.Run("EC2 GPU with nil overlay allocates and fills the GPU default", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal})
+		out := &Config{} // out.AWSEC2 is nil — drives the allocation branch.
+		applyGPUInstanceTypeDefault(cfg, out)
+		require.NotNil(t, out.AWSEC2, "nil overlay must be allocated on demand")
+		assert.Equal(t, defaultGPUInstanceType, out.AWSEC2.InstanceType)
+	})
+
+	t.Run("EKS GPU with nil overlay allocates and fills the GPU default", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal})
+		out := &Config{} // out.AWSEKS is nil — drives the allocation branch.
+		applyGPUInstanceTypeDefault(cfg, out)
+		require.NotNil(t, out.AWSEKS, "nil overlay must be allocated on demand")
+		assert.Equal(t, defaultGPUInstanceType, out.AWSEKS.InstanceType)
+	})
+
+	t.Run("no GPU → nil overlay untouched", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{})
+		out := &Config{}
+		applyGPUInstanceTypeDefault(cfg, out)
+		assert.Nil(t, out.AWSEC2, "no GPU enabled must not allocate the overlay")
+		assert.Nil(t, out.AWSEKS)
 	})
 }
 

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -264,6 +264,7 @@ func TestApplyPresetDefaults_FillsZeroFieldsOnly(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			InstanceType: "m6i.large",                   // user-set: must be preserved
 			UserData:     "echo configured by the user", // user-set: must be preserved
@@ -443,6 +444,7 @@ func TestComputePresetDefaults_ReturnsOverlayOnly(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			InstanceType: "m6i.large", // user-set: must NOT echo into overlay
 		},
@@ -483,6 +485,7 @@ func TestComputePresetDefaults_DoesNotMutateInput(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{
 				InstanceType: "m6i.large",
 			},
@@ -622,6 +625,7 @@ func TestComputePresetDefaults_ProvenanceDistinguishesUserSetEqualToDefault(t *t
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{
 				EnableInstanceConnect: enable,
 			},
@@ -686,6 +690,7 @@ func TestMergeConfigs_NilGuards(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "t3.medium"},
 	}
 
@@ -718,6 +723,7 @@ func TestMergeConfigs_AllocatesAndFills(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "m6i.large"},
 	}
 	dst := &Config{}
@@ -743,6 +749,7 @@ func TestMergeConfigs_PreservesNonZero(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "m6i.large", SSHPublicKey: "src-key", EnableInstanceConnect: &trueVal},
 	}
 	dst := &Config{
@@ -756,6 +763,7 @@ func TestMergeConfigs_PreservesNonZero(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "t3.medium"},
 	}
 
@@ -782,6 +790,7 @@ func TestMergeConfigs_PartialFill(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "m6i.large", SSHPublicKey: "ssh-ed25519 AAAA..."},
 	}
 	dst := &Config{
@@ -795,6 +804,7 @@ func TestMergeConfigs_PartialFill(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "t3.medium"},
 	}
 
@@ -820,6 +830,7 @@ func TestMergeConfigs_CrossCloudIsolation(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "t3.medium"},
 	}
 	existingEKS := &struct {
@@ -829,6 +840,7 @@ func TestMergeConfigs_CrossCloudIsolation(t *testing.T) {
 		MaxSize                string `json:"maxSize,omitempty"`
 		MinSize                string `json:"minSize,omitempty"`
 		InstanceType           string `json:"instanceType,omitempty"`
+		GPUEnabled             *bool  `json:"gpuEnabled,omitempty"`
 	}{InstanceType: "m6i.xlarge", DesiredSize: "3"}
 	dst := &Config{AWSEKS: existingEKS}
 
@@ -861,6 +873,7 @@ func TestMergeConfigs_BoolPointerFill(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{EnableInstanceConnect: &falseVal},
 	}
 	dst := &Config{
@@ -874,6 +887,7 @@ func TestMergeConfigs_BoolPointerFill(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{},
 	}
 
@@ -900,6 +914,7 @@ func TestMergeConfigs_AllocatedButEmptySrc_RevertsToNil(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{}, // all fields zero
 	}
 	dst := &Config{}
@@ -926,6 +941,7 @@ func TestMergeConfigs_SliceFields(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{CustomIngressPorts: populated},
 	}
 
@@ -941,6 +957,7 @@ func TestMergeConfigs_SliceFields(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{},
 	}
 	MergeConfigs(dstA, src)
@@ -959,6 +976,7 @@ func TestMergeConfigs_SliceFields(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{CustomIngressPorts: []int{}},
 	}
 	MergeConfigs(dstB, src)
@@ -1026,6 +1044,7 @@ func TestMergeConfigs_Idempotent(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "m6i.large", SSHPublicKey: "ssh-ed25519 ABC", EnableInstanceConnect: &trueVal},
 	}
 	dst := &Config{}

--- a/pkg/composer/gpu.go
+++ b/pkg/composer/gpu.go
@@ -42,9 +42,12 @@ var gpuX86Families = map[string]struct{}{
 // instanceFamily returns the family prefix of an EC2 instance type — the part
 // before the first "." — matching the HCL `split(".", ...)[0]` derive. For
 // "g5.xlarge" it returns "g5"; for a string with no "." it returns the input
-// unchanged.
+// unchanged. The input is trimmed and lower-cased first so surrounding
+// whitespace or a capitalised family ("G5.xlarge") still matches the allow-list
+// (AWS instance types are canonically lower-case).
 func instanceFamily(instanceType string) string {
-	return strings.SplitN(instanceType, ".", 2)[0]
+	normalized := strings.ToLower(strings.TrimSpace(instanceType))
+	return strings.SplitN(normalized, ".", 2)[0]
 }
 
 // isGPUX86Family reports whether instanceType belongs to a known NVIDIA-GPU

--- a/pkg/composer/gpu.go
+++ b/pkg/composer/gpu.go
@@ -1,0 +1,57 @@
+package composer
+
+import "strings"
+
+// gpu.go centralises the single source of truth the GPU mapper branches
+// (#759) share: the default GPU instance type and the set of NVIDIA x86_64
+// EC2 instance families. Both the AWS EC2 and EKS-node-group branches consume
+// these so the default + family knowledge can't drift between them, and a
+// drift test (gpu_families_drift_test.go) asserts the Go set stays in lockstep
+// with the HCL `_gpu_x86_families` list in aws/eks_nodegroup/main.tf — the
+// preset's own AMI auto-derive is the runtime source of truth.
+
+// defaultGPUInstanceType is the instance type the mapper supplies when a
+// caller enables GPU but does not pin an explicit instance type. g5.xlarge is
+// the cheapest single-A10G NVIDIA family and is shared by the EC2 and EKS GPU
+// paths (and by pricing, so a GPU stack is not priced as the non-GPU default).
+const defaultGPUInstanceType = "g5.xlarge"
+
+// gpuX86Families is the allow-list of NVIDIA-GPU x86_64 EC2 instance families
+// (#759). These are the families that require an x86_64 NVIDIA-bundled AMI so
+// the node boots with the NVIDIA kernel driver + container runtime present.
+//
+// This list MUST stay in lockstep with the HCL `_gpu_x86_families` local in
+// aws/eks_nodegroup/main.tf — TestGPUFamiliesDrift enforces it. Note g5g is
+// deliberately ABSENT: it is Graviton (ARM) + NVIDIA T4G, and EKS has no ARM
+// NVIDIA managed AMI type, so it stays on the ARM standard AMI path.
+var gpuX86Families = map[string]struct{}{
+	"g4dn": {},
+	"g5":   {},
+	"g6":   {},
+	"g6e":  {},
+	"gr6":  {},
+	"p3":   {},
+	"p3dn": {},
+	"p4d":  {},
+	"p4de": {},
+	"p5":   {},
+	"p5e":  {},
+	"p5en": {},
+}
+
+// instanceFamily returns the family prefix of an EC2 instance type — the part
+// before the first "." — matching the HCL `split(".", ...)[0]` derive. For
+// "g5.xlarge" it returns "g5"; for a string with no "." it returns the input
+// unchanged.
+func instanceFamily(instanceType string) string {
+	return strings.SplitN(instanceType, ".", 2)[0]
+}
+
+// isGPUX86Family reports whether instanceType belongs to a known NVIDIA-GPU
+// x86_64 family (per gpuX86Families). Used to validate explicit GPU instance
+// types so a non-GPU or ARM family is rejected at compose time instead of
+// silently forcing an x86_64/NVIDIA AMI onto incompatible hardware.
+func isGPUX86Family(instanceType string) bool {
+	_, ok := gpuX86Families[instanceFamily(instanceType)]
+	return ok
+}

--- a/pkg/composer/gpu_families_drift_test.go
+++ b/pkg/composer/gpu_families_drift_test.go
@@ -1,0 +1,81 @@
+package composer
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestGPUFamiliesDrift asserts the Go NVIDIA-GPU x86 family allow-list
+// (gpuX86Families in gpu.go) stays in lockstep with the HCL `_gpu_x86_families`
+// local in aws/eks_nodegroup/main.tf (#759). The HCL list drives the preset's
+// AMI auto-derive (the runtime source of truth); the Go set drives mapper
+// validation of explicit GPU instance types. If the two drift, a family
+// accepted by the mapper might not derive an NVIDIA AMI (or vice versa), so a
+// GPU node could come up without /dev/nvidia* — exactly the failure the
+// validation exists to prevent. This test fails the moment either list adds or
+// removes a family without the other.
+func TestGPUFamiliesDrift(t *testing.T) {
+	mainTF := filepath.Join("..", "..", "aws", "eks_nodegroup", "main.tf")
+	b, err := os.ReadFile(mainTF)
+	if err != nil {
+		t.Fatalf("read %s: %v", mainTF, err)
+	}
+
+	hclFamilies := parseGPUFamiliesHCL(t, string(b))
+	if len(hclFamilies) == 0 {
+		t.Fatalf("no families parsed from _gpu_x86_families in %s — parser or HCL shape changed", mainTF)
+	}
+
+	goFamilies := map[string]struct{}{}
+	for f := range gpuX86Families {
+		goFamilies[f] = struct{}{}
+	}
+
+	// Families in HCL but missing from the Go set.
+	var missingInGo []string
+	for f := range hclFamilies {
+		if _, ok := goFamilies[f]; !ok {
+			missingInGo = append(missingInGo, f)
+		}
+	}
+	// Families in the Go set but missing from HCL.
+	var missingInHCL []string
+	for f := range goFamilies {
+		if _, ok := hclFamilies[f]; !ok {
+			missingInHCL = append(missingInHCL, f)
+		}
+	}
+
+	sort.Strings(missingInGo)
+	sort.Strings(missingInHCL)
+	if len(missingInGo) > 0 {
+		t.Errorf("families in aws/eks_nodegroup/main.tf _gpu_x86_families but missing from gpuX86Families (gpu.go): %v", missingInGo)
+	}
+	if len(missingInHCL) > 0 {
+		t.Errorf("families in gpuX86Families (gpu.go) but missing from aws/eks_nodegroup/main.tf _gpu_x86_families: %v", missingInHCL)
+	}
+}
+
+// parseGPUFamiliesHCL extracts the quoted family strings from the
+// `_gpu_x86_families = [ ... ]` local assignment. It isolates the bracketed
+// list body and then pulls every double-quoted token, so reordering or
+// reflowing the HCL doesn't affect the result.
+func parseGPUFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
+	t.Helper()
+	listRe := regexp.MustCompile(`(?s)_gpu_x86_families\s*=\s*\[(.*?)\]`)
+	m := listRe.FindStringSubmatch(hcl)
+	if m == nil {
+		t.Fatalf("could not locate `_gpu_x86_families = [...]` in main.tf")
+	}
+	body := m[1]
+	tokenRe := regexp.MustCompile(`"([^"]+)"`)
+	out := map[string]struct{}{}
+	for _, tm := range tokenRe.FindAllStringSubmatch(body, -1) {
+		out[strings.TrimSpace(tm[1])] = struct{}{}
+	}
+	return out
+}

--- a/pkg/composer/gpu_families_drift_test.go
+++ b/pkg/composer/gpu_families_drift_test.go
@@ -11,59 +11,70 @@ import (
 
 // TestGPUFamiliesDrift asserts the Go NVIDIA-GPU x86 family allow-list
 // (gpuX86Families in gpu.go) stays in lockstep with the HCL `_gpu_x86_families`
-// local in aws/eks_nodegroup/main.tf (#759). The HCL list drives the preset's
-// AMI auto-derive (the runtime source of truth); the Go set drives mapper
-// validation of explicit GPU instance types. If the two drift, a family
-// accepted by the mapper might not derive an NVIDIA AMI (or vice versa), so a
-// GPU node could come up without /dev/nvidia* — exactly the failure the
-// validation exists to prevent. This test fails the moment either list adds or
-// removes a family without the other.
+// locals in BOTH aws/eks_nodegroup/main.tf and aws/ec2/main.tf (#759). The HCL
+// lists drive each preset's plan-time GPU guard (the eks_nodegroup AMI
+// auto-derive and the ec2 aws_instance precondition); the Go set drives mapper
+// validation of explicit GPU instance types. If any of the three drift, a
+// family accepted by one layer might be rejected (or mis-AMI'd) by another, so
+// a GPU node could come up without /dev/nvidia* — exactly the failure the
+// validation exists to prevent. This test fails the moment any list adds or
+// removes a family without the other two.
 func TestGPUFamiliesDrift(t *testing.T) {
-	mainTF := filepath.Join("..", "..", "aws", "eks_nodegroup", "main.tf")
-	b, err := os.ReadFile(mainTF)
-	if err != nil {
-		t.Fatalf("read %s: %v", mainTF, err)
-	}
-
-	hclFamilies := parseGPUFamiliesHCL(t, string(b))
-	if len(hclFamilies) == 0 {
-		t.Fatalf("no families parsed from _gpu_x86_families in %s — parser or HCL shape changed", mainTF)
-	}
-
 	goFamilies := map[string]struct{}{}
 	for f := range gpuX86Families {
 		goFamilies[f] = struct{}{}
 	}
 
-	// Families in HCL but missing from the Go set.
-	var missingInGo []string
-	for f := range hclFamilies {
-		if _, ok := goFamilies[f]; !ok {
-			missingInGo = append(missingInGo, f)
-		}
-	}
-	// Families in the Go set but missing from HCL.
-	var missingInHCL []string
-	for f := range goFamilies {
-		if _, ok := hclFamilies[f]; !ok {
-			missingInHCL = append(missingInHCL, f)
-		}
-	}
+	for _, src := range []struct {
+		name string
+		path string
+	}{
+		{"eks_nodegroup", filepath.Join("..", "..", "aws", "eks_nodegroup", "main.tf")},
+		{"ec2", filepath.Join("..", "..", "aws", "ec2", "main.tf")},
+	} {
+		t.Run(src.name, func(t *testing.T) {
+			b, err := os.ReadFile(src.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", src.path, err)
+			}
 
-	sort.Strings(missingInGo)
-	sort.Strings(missingInHCL)
-	if len(missingInGo) > 0 {
-		t.Errorf("families in aws/eks_nodegroup/main.tf _gpu_x86_families but missing from gpuX86Families (gpu.go): %v", missingInGo)
-	}
-	if len(missingInHCL) > 0 {
-		t.Errorf("families in gpuX86Families (gpu.go) but missing from aws/eks_nodegroup/main.tf _gpu_x86_families: %v", missingInHCL)
+			hclFamilies := parseGPUFamiliesHCL(t, string(b))
+			if len(hclFamilies) == 0 {
+				t.Fatalf("no families parsed from _gpu_x86_families in %s — parser or HCL shape changed", src.path)
+			}
+
+			// Families in HCL but missing from the Go set.
+			var missingInGo []string
+			for f := range hclFamilies {
+				if _, ok := goFamilies[f]; !ok {
+					missingInGo = append(missingInGo, f)
+				}
+			}
+			// Families in the Go set but missing from HCL.
+			var missingInHCL []string
+			for f := range goFamilies {
+				if _, ok := hclFamilies[f]; !ok {
+					missingInHCL = append(missingInHCL, f)
+				}
+			}
+
+			sort.Strings(missingInGo)
+			sort.Strings(missingInHCL)
+			if len(missingInGo) > 0 {
+				t.Errorf("families in %s _gpu_x86_families but missing from gpuX86Families (gpu.go): %v", src.path, missingInGo)
+			}
+			if len(missingInHCL) > 0 {
+				t.Errorf("families in gpuX86Families (gpu.go) but missing from %s _gpu_x86_families: %v", src.path, missingInHCL)
+			}
+		})
 	}
 }
 
 // parseGPUFamiliesHCL extracts the quoted family strings from the
 // `_gpu_x86_families = [ ... ]` local assignment. It isolates the bracketed
-// list body and then pulls every double-quoted token, so reordering or
-// reflowing the HCL doesn't affect the result.
+// list body, strips any `# ...` inline comments (so a quoted token sitting in a
+// comment can't false-fail the drift check), and then pulls every double-quoted
+// token, so reordering or reflowing the HCL doesn't affect the result.
 func parseGPUFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
 	t.Helper()
 	listRe := regexp.MustCompile(`(?s)_gpu_x86_families\s*=\s*\[(.*?)\]`)
@@ -71,11 +82,26 @@ func parseGPUFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
 	if m == nil {
 		t.Fatalf("could not locate `_gpu_x86_families = [...]` in main.tf")
 	}
-	body := m[1]
+	body := stripHCLLineComments(m[1])
 	tokenRe := regexp.MustCompile(`"([^"]+)"`)
 	out := map[string]struct{}{}
 	for _, tm := range tokenRe.FindAllStringSubmatch(body, -1) {
 		out[strings.TrimSpace(tm[1])] = struct{}{}
 	}
 	return out
+}
+
+// stripHCLLineComments removes `# ...`-to-end-of-line comments from each line of
+// the bracket body so a quoted token appearing in an inline comment is not
+// counted as a family. Only `#` comments are handled — the families list uses
+// no `//` or block comments — and this is a deliberately simple line-oriented
+// strip (the list body never contains a literal `#` inside a quoted token).
+func stripHCLLineComments(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if idx := strings.IndexByte(line, '#'); idx >= 0 {
+			lines[i] = line[:idx]
+		}
+	}
+	return strings.Join(lines, "\n")
 }

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -279,18 +279,31 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSEKS.InstanceType != "" {
 				vals["instance_types"] = []any{cfg.AWSEKS.InstanceType}
 			}
-			// GPU node group (#759): default to a g5.xlarge (cheapest
-			// single-A10G NVIDIA family) when the caller didn't pick an
-			// explicit GPU instance type, and pin ami_type to the NVIDIA
-			// managed AMI so the node comes up GPU-capable regardless of
-			// what the preset's instance-family auto-derive would infer.
-			// The in-cluster NVIDIA device plugin (advertises
-			// nvidia.com/gpu) is app-layer and out of preset scope.
+			// GPU node group (#759): VALIDATE, don't mask. When the caller
+			// pins an explicit instance type it must be a known x86 NVIDIA
+			// GPU family — otherwise reject at compose time rather than
+			// silently forcing a GPU AMI onto incompatible hardware. When no
+			// instance type is set, supply the default GPU type. We do NOT
+			// emit ami_type here: the preset's family auto-derive
+			// (aws/eks_nodegroup/main.tf `_gpu_x86_families` →
+			// AL2023_x86_64_NVIDIA) is the single source of truth for the AMI
+			// and already produces the right AMI for GPU families. The
+			// in-cluster NVIDIA device plugin (advertises nvidia.com/gpu) is
+			// app-layer and out of preset scope.
 			if cfg.AWSEKS.GPUEnabled != nil && *cfg.AWSEKS.GPUEnabled {
-				if _, ok := vals["instance_types"]; !ok {
-					vals["instance_types"] = []any{"g5.xlarge"}
+				if cfg.AWSEKS.InstanceType != "" {
+					if !isGPUX86Family(cfg.AWSEKS.InstanceType) {
+						return nil, NewValidationError(fmt.Sprintf(
+							"AWSEKS.GPUEnabled=true with InstanceType=%q: not a known x86 NVIDIA GPU family "+
+								"(expected one of g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/p5e/p5en). "+
+								"GPU AMIs are x86_64-only; clear the instance type to default to %s, "+
+								"or pick a supported GPU family.",
+							cfg.AWSEKS.InstanceType, defaultGPUInstanceType,
+						))
+					}
+				} else {
+					vals["instance_types"] = []any{defaultGPUInstanceType}
 				}
-				vals["ami_type"] = "AL2023_x86_64_NVIDIA"
 			}
 		}
 
@@ -353,12 +366,27 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSEC2.EnableInstanceConnect != nil && *cfg.AWSEC2.EnableInstanceConnect {
 				vals["enable_instance_connect"] = true
 			}
-			// GPU instance (#759): select the NVIDIA GPU AMI and force
-			// arch=x86_64 (AWS GPU AMIs are x86_64-only, so a GPU pick
-			// overrides any ARM component hint above). Pair with a GPU
-			// InstanceType (g4dn/g5/g6/p4d/p5). g/p families are
-			// quota-gated — surfaced to operators at deploy time.
+			// GPU instance (#759): VALIDATE, don't mask. AWS GPU AMIs are
+			// x86_64-only, so a GPU instance type must belong to a known x86
+			// NVIDIA GPU family. When the caller pins an explicit instance
+			// type, reject a non-GPU/ARM family at compose time instead of
+			// silently forcing arch=x86_64 onto an incompatible pick (which
+			// would mask the preset's own gpu_enabled/arch guard). When no
+			// instance type is set, the default GPU type is supplied below.
+			// Setting arch=x86_64 is then consistent-by-construction: every
+			// path that reaches here has (or will get) an x86 GPU family.
+			// g/p families are quota-gated — surfaced to operators at deploy
+			// time.
 			if cfg.AWSEC2.GPUEnabled != nil && *cfg.AWSEC2.GPUEnabled {
+				if cfg.AWSEC2.InstanceType != "" && !isGPUX86Family(cfg.AWSEC2.InstanceType) {
+					return nil, NewValidationError(fmt.Sprintf(
+						"AWSEC2.GPUEnabled=true with InstanceType=%q: not a known x86 NVIDIA GPU family "+
+							"(expected one of g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/p5e/p5en). "+
+							"GPU AMIs are x86_64-only; clear the instance type to default to %s, "+
+							"or pick a supported GPU family.",
+						cfg.AWSEC2.InstanceType, defaultGPUInstanceType,
+					))
+				}
 				vals["gpu_enabled"] = true
 				vals["arch"] = "x86_64"
 			}
@@ -378,9 +406,10 @@ func (m DefaultMapper) BuildModuleValues(
 			switch {
 			case vals["gpu_enabled"] == true:
 				// GPU AMI on the preset default t3.medium would waste the
-				// image; default to g5.xlarge (cheapest single-A10G NVIDIA
-				// family) to match the EKS GPU node-group default (#759).
-				vals["instance_type"] = "g5.xlarge"
+				// image; default to the shared GPU instance type (cheapest
+				// single-A10G NVIDIA family) to match the EKS GPU node-group
+				// default (#759).
+				vals["instance_type"] = defaultGPUInstanceType
 			case vals["arch"] == "arm64":
 				vals["instance_type"] = "t4g.medium"
 			}

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -279,6 +279,19 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSEKS.InstanceType != "" {
 				vals["instance_types"] = []any{cfg.AWSEKS.InstanceType}
 			}
+			// GPU node group (#759): default to a g5.xlarge (cheapest
+			// single-A10G NVIDIA family) when the caller didn't pick an
+			// explicit GPU instance type, and pin ami_type to the NVIDIA
+			// managed AMI so the node comes up GPU-capable regardless of
+			// what the preset's instance-family auto-derive would infer.
+			// The in-cluster NVIDIA device plugin (advertises
+			// nvidia.com/gpu) is app-layer and out of preset scope.
+			if cfg.AWSEKS.GPUEnabled != nil && *cfg.AWSEKS.GPUEnabled {
+				if _, ok := vals["instance_types"]; !ok {
+					vals["instance_types"] = []any{"g5.xlarge"}
+				}
+				vals["ami_type"] = "AL2023_x86_64_NVIDIA"
+			}
 		}
 
 		if _, ok := vals["desired_size"]; !ok {
@@ -340,6 +353,15 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSEC2.EnableInstanceConnect != nil && *cfg.AWSEC2.EnableInstanceConnect {
 				vals["enable_instance_connect"] = true
 			}
+			// GPU instance (#759): select the NVIDIA GPU AMI and force
+			// arch=x86_64 (AWS GPU AMIs are x86_64-only, so a GPU pick
+			// overrides any ARM component hint above). Pair with a GPU
+			// InstanceType (g4dn/g5/g6/p4d/p5). g/p families are
+			// quota-gated — surfaced to operators at deploy time.
+			if cfg.AWSEC2.GPUEnabled != nil && *cfg.AWSEC2.GPUEnabled {
+				vals["gpu_enabled"] = true
+				vals["arch"] = "x86_64"
+			}
 			if cfg.AWSEC2.DiskSizePerServer != "" {
 				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSEC2.DiskSizePerServer))
 				if err != nil {
@@ -353,10 +375,16 @@ func (m DefaultMapper) BuildModuleValues(
 		}
 		// Default instance type based on architecture if not explicitly configured
 		if _, ok := vals["instance_type"]; !ok {
-			if vals["arch"] == "arm64" {
+			switch {
+			case vals["gpu_enabled"] == true:
+				// GPU AMI on the preset default t3.medium would waste the
+				// image; default to g5.xlarge (cheapest single-A10G NVIDIA
+				// family) to match the EKS GPU node-group default (#759).
+				vals["instance_type"] = "g5.xlarge"
+			case vals["arch"] == "arm64":
 				vals["instance_type"] = "t4g.medium"
 			}
-			// Intel defaults handled by preset (t3.medium)
+			// Intel non-GPU defaults handled by preset (t3.medium)
 		}
 
 	case KeyAWSALB:

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -389,6 +389,15 @@ func (m DefaultMapper) BuildModuleValues(
 				}
 				vals["gpu_enabled"] = true
 				vals["arch"] = "x86_64"
+				// The aws/ec2 preset's os_type defaults to "ubuntu", but the
+				// GPU AMI is Amazon Linux 2023 — so a GPU instance left on the
+				// default os_type trips the module's gpu+ubuntu precondition at
+				// plan (the GPU AMI ignores os_type, and the preset rejects the
+				// silent override). The IR has no os_type field, so pin
+				// amazon-linux here to keep every composer-generated GPU stack
+				// plan-clean. A caller needing an Ubuntu GPU image supplies an
+				// explicit ami_id, which the precondition exempts.
+				vals["os_type"] = "amazon-linux"
 			}
 			if cfg.AWSEC2.DiskSizePerServer != "" {
 				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSEC2.DiskSizePerServer))

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -55,7 +55,11 @@ func kitchenSinkConfig() *Config {
 		EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
 		GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 	}{
-		InstanceType:          "t3.medium",
+		// GPUEnabled pairs with a real GPU family (g5.xlarge) so the config is
+		// internally consistent: the #759 mapper validation rejects GPUEnabled
+		// with a non-GPU instance type like t3.medium, which would fail this
+		// kitchen-sink mapper invocation outright.
+		InstanceType:          "g5.xlarge",
 		DiskSizePerServer:     "100",
 		UserData:              "#!/bin/bash\necho hello",
 		CustomIngressPorts:    []int{8080},
@@ -79,9 +83,14 @@ func kitchenSinkConfig() *Config {
 		DesiredSize:            "2",
 		MinSize:                "1",
 		MaxSize:                "3",
-		InstanceType:           "t3.medium",
-		// GPUEnabled exercises the #759 ami_type tfvar emission so the
-		// keys-subset gate confirms it is a declared module variable.
+		// GPUEnabled pairs with a real GPU family (g5.xlarge) so the config is
+		// internally consistent: the #759 mapper validation rejects GPUEnabled
+		// with a non-GPU instance type like t3.medium.
+		InstanceType: "g5.xlarge",
+		// GPUEnabled exercises the #759 instance-type default path. The mapper
+		// deliberately never emits ami_type — the preset's family auto-derive
+		// (_gpu_x86_families → AL2023_x86_64_NVIDIA) owns AMI selection — so
+		// this only confirms gpu-related emitted keys are declared variables.
 		GPUEnabled: &t,
 	}
 	cfg.AWSECS = &struct {

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -53,6 +53,7 @@ func kitchenSinkConfig() *Config {
 		CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 		SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 		EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+		GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 	}{
 		InstanceType:          "t3.medium",
 		DiskSizePerServer:     "100",
@@ -60,6 +61,9 @@ func kitchenSinkConfig() *Config {
 		CustomIngressPorts:    []int{8080},
 		SSHPublicKey:          "ssh-rsa AAAA...",
 		EnableInstanceConnect: &t,
+		// GPUEnabled exercises the #759 gpu_enabled tfvar emission so the
+		// keys-subset gate confirms it is a declared module variable.
+		GPUEnabled: &t,
 	}
 	cfg.AWSEKS = &struct {
 		HaControlPlane         *bool  `json:"haControlPlane,omitempty"`
@@ -68,6 +72,7 @@ func kitchenSinkConfig() *Config {
 		MaxSize                string `json:"maxSize,omitempty"`
 		MinSize                string `json:"minSize,omitempty"`
 		InstanceType           string `json:"instanceType,omitempty"`
+		GPUEnabled             *bool  `json:"gpuEnabled,omitempty"`
 	}{
 		HaControlPlane:         &t,
 		ControlPlaneVisibility: "private",
@@ -75,6 +80,9 @@ func kitchenSinkConfig() *Config {
 		MinSize:                "1",
 		MaxSize:                "3",
 		InstanceType:           "t3.medium",
+		// GPUEnabled exercises the #759 ami_type tfvar emission so the
+		// keys-subset gate confirms it is a declared module variable.
+		GPUEnabled: &t,
 	}
 	cfg.AWSECS = &struct {
 		EnableContainerInsights *bool    `json:"enableContainerInsights,omitempty"`

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -1073,3 +1073,104 @@ func TestBuildModuleValues_AWSCognito_MFAFactor(t *testing.T) {
 		assert.ErrorContains(t, err, `expected "totp"`)
 	})
 }
+
+// TestBuildModuleValues_AWSEKS_GPU pins the GPU node-group mapping (#759):
+// Config.AWSEKS.GPUEnabled=true must emit the NVIDIA managed AMI type and a
+// GPU instance-type default, while an explicit GPU InstanceType is preserved.
+func TestBuildModuleValues_AWSEKS_GPU(t *testing.T) {
+	m := DefaultMapper{}
+	trueVal := true
+	falseVal := false
+
+	t.Run("GPUEnabled defaults to NVIDIA ami_type + g5.xlarge", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal})
+		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.NoError(t, err)
+		assert.Equal(t, "AL2023_x86_64_NVIDIA", vals["ami_type"],
+			"GPUEnabled must pin the NVIDIA managed AMI type")
+		assert.Equal(t, []any{"g5.xlarge"}, vals["instance_types"],
+			"GPUEnabled with no explicit instance type must default to g5.xlarge")
+	})
+
+	t.Run("explicit GPU instance type preserved, ami_type still NVIDIA", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal, InstanceType: "p4d.24xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.NoError(t, err)
+		assert.Equal(t, []any{"p4d.24xlarge"}, vals["instance_types"],
+			"explicit GPU instance type must override the g5.xlarge default")
+		assert.Equal(t, "AL2023_x86_64_NVIDIA", vals["ami_type"])
+	})
+
+	t.Run("GPUEnabled=false leaves ami_type unset (preset auto-derive)", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &falseVal})
+		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.NoError(t, err)
+		_, hasAMI := vals["ami_type"]
+		assert.False(t, hasAMI, "GPUEnabled=false must not pin ami_type; preset auto-derives")
+		// Non-GPU default instance type still applies.
+		assert.Equal(t, []any{"c7i.large"}, vals["instance_types"])
+	})
+
+	t.Run("nil GPUEnabled leaves ami_type unset", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{})
+		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.NoError(t, err)
+		_, hasAMI := vals["ami_type"]
+		assert.False(t, hasAMI, "nil GPUEnabled must not pin ami_type")
+	})
+}
+
+// TestBuildModuleValues_AWSEC2_GPU pins the GPU instance mapping (#759):
+// Config.AWSEC2.GPUEnabled=true must set gpu_enabled, force arch=x86_64
+// (GPU AMIs are x86_64-only), and default to a GPU instance type.
+func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
+	m := DefaultMapper{}
+	trueVal := true
+	falseVal := false
+
+	t.Run("GPUEnabled sets gpu_enabled + x86_64 + g5.xlarge default", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["gpu_enabled"])
+		assert.Equal(t, "x86_64", vals["arch"], "GPU AMIs are x86_64-only")
+		assert.Equal(t, "g5.xlarge", vals["instance_type"],
+			"GPUEnabled with no explicit instance type must default to g5.xlarge")
+	})
+
+	t.Run("GPU overrides ARM component hint (x86_64-only AMI)", func(t *testing.T) {
+		// An ARM component hint would otherwise set arch=arm64; the GPU path
+		// must win because the NVIDIA AMI is x86_64-only.
+		comps := &Components{AWSEC2: "ARM"}
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "x86_64", vals["arch"], "GPU must override the ARM hint")
+		assert.Equal(t, "g5.xlarge", vals["instance_type"])
+	})
+
+	t.Run("explicit GPU instance type preserved", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "g6.2xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "g6.2xlarge", vals["instance_type"],
+			"explicit GPU instance type must override the g5.xlarge default")
+		assert.Equal(t, true, vals["gpu_enabled"])
+	})
+
+	t.Run("GPUEnabled=false does not set gpu_enabled", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &falseVal})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasKey := vals["gpu_enabled"]
+		assert.False(t, hasKey, "explicit false must not set gpu_enabled")
+	})
+
+	t.Run("nil GPUEnabled does not set gpu_enabled", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasKey := vals["gpu_enabled"]
+		assert.False(t, hasKey, "nil GPUEnabled must not set gpu_enabled")
+	})
+}

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -1075,30 +1075,49 @@ func TestBuildModuleValues_AWSCognito_MFAFactor(t *testing.T) {
 }
 
 // TestBuildModuleValues_AWSEKS_GPU pins the GPU node-group mapping (#759):
-// Config.AWSEKS.GPUEnabled=true must emit the NVIDIA managed AMI type and a
-// GPU instance-type default, while an explicit GPU InstanceType is preserved.
+// Config.AWSEKS.GPUEnabled=true defaults the instance type when unset and
+// validates (not masks) an explicit type. The mapper NEVER emits ami_type —
+// the preset's family auto-derive (`_gpu_x86_families` in main.tf) is the
+// single source of truth for the AMI.
 func TestBuildModuleValues_AWSEKS_GPU(t *testing.T) {
 	m := DefaultMapper{}
 	trueVal := true
 	falseVal := false
 
-	t.Run("GPUEnabled defaults to NVIDIA ami_type + g5.xlarge", func(t *testing.T) {
+	t.Run("GPUEnabled defaults to g5.xlarge, ami_type never emitted", func(t *testing.T) {
 		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal})
 		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
 		require.NoError(t, err)
-		assert.Equal(t, "AL2023_x86_64_NVIDIA", vals["ami_type"],
-			"GPUEnabled must pin the NVIDIA managed AMI type")
+		_, hasAMI := vals["ami_type"]
+		assert.False(t, hasAMI, "mapper must NOT emit ami_type; the preset auto-derives it from the GPU family")
 		assert.Equal(t, []any{"g5.xlarge"}, vals["instance_types"],
 			"GPUEnabled with no explicit instance type must default to g5.xlarge")
 	})
 
-	t.Run("explicit GPU instance type preserved, ami_type still NVIDIA", func(t *testing.T) {
+	t.Run("explicit GPU instance type preserved, ami_type never emitted", func(t *testing.T) {
 		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal, InstanceType: "p4d.24xlarge"})
 		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
 		require.NoError(t, err)
 		assert.Equal(t, []any{"p4d.24xlarge"}, vals["instance_types"],
 			"explicit GPU instance type must override the g5.xlarge default")
-		assert.Equal(t, "AL2023_x86_64_NVIDIA", vals["ami_type"])
+		_, hasAMI := vals["ami_type"]
+		assert.False(t, hasAMI, "mapper must NOT emit ami_type even for an explicit GPU family")
+	})
+
+	t.Run("explicit non-GPU instance type with GPUEnabled is rejected (validate, not mask)", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal, InstanceType: "c7i.large"})
+		_, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.Error(t, err, "a non-GPU instance type with GPUEnabled must be rejected, not silently forced")
+		assert.Contains(t, err.Error(), "not a known x86 NVIDIA GPU family")
+	})
+
+	t.Run("explicit ARM GPU instance type (g5g) is rejected", func(t *testing.T) {
+		// g5g is Graviton+NVIDIA but has no x86 NVIDIA AMI; it is not in the
+		// x86 GPU allow-list, so GPUEnabled must reject it.
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal, InstanceType: "g5g.xlarge"})
+		_, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a known x86 NVIDIA GPU family")
 	})
 
 	t.Run("GPUEnabled=false leaves ami_type unset (preset auto-derive)", func(t *testing.T) {
@@ -1156,6 +1175,22 @@ func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
 		assert.Equal(t, "g6.2xlarge", vals["instance_type"],
 			"explicit GPU instance type must override the g5.xlarge default")
 		assert.Equal(t, true, vals["gpu_enabled"])
+	})
+
+	t.Run("explicit non-GPU instance type with GPUEnabled is rejected (validate, not mask)", func(t *testing.T) {
+		// Previously the mapper would silently force arch=x86_64 onto a
+		// non-GPU pick; now it rejects the mismatch at compose time.
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "t3.medium"})
+		_, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.Error(t, err, "a non-GPU instance type with GPUEnabled must be rejected, not masked")
+		assert.Contains(t, err.Error(), "not a known x86 NVIDIA GPU family")
+	})
+
+	t.Run("explicit ARM instance type with GPUEnabled is rejected", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "c7g.large"})
+		_, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a known x86 NVIDIA GPU family")
 	})
 
 	t.Run("GPUEnabled=false does not set gpu_enabled", func(t *testing.T) {

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -1155,6 +1155,28 @@ func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
 		assert.Equal(t, "x86_64", vals["arch"], "GPU AMIs are x86_64-only")
 		assert.Equal(t, "g5.xlarge", vals["instance_type"],
 			"GPUEnabled with no explicit instance type must default to g5.xlarge")
+		// The preset's os_type defaults to "ubuntu", and the GPU AMI is
+		// Amazon Linux 2023 — leaving the default would trip the module's
+		// gpu+ubuntu precondition. The mapper must pin amazon-linux so a
+		// composer-generated GPU stack plans cleanly (#759 HIGH-3).
+		assert.Equal(t, "amazon-linux", vals["os_type"],
+			"GPU path must emit os_type=amazon-linux so the gpu+ubuntu precondition does not trip")
+	})
+
+	t.Run("explicit GPU instance type also pins os_type=amazon-linux", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "g6.2xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "amazon-linux", vals["os_type"],
+			"os_type must be pinned on every GPU path, not just the default-instance-type path")
+	})
+
+	t.Run("non-GPU EC2 leaves os_type unset (preset default applies)", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &falseVal})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasOSType := vals["os_type"]
+		assert.False(t, hasOSType, "non-GPU EC2 must not pin os_type; the preset default (ubuntu) applies")
 	})
 
 	t.Run("GPU overrides ARM component hint (x86_64-only AMI)", func(t *testing.T) {
@@ -1174,6 +1196,24 @@ func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "g6.2xlarge", vals["instance_type"],
 			"explicit GPU instance type must override the g5.xlarge default")
+		assert.Equal(t, true, vals["gpu_enabled"])
+	})
+
+	t.Run("gr6 GPU family is accepted", func(t *testing.T) {
+		// gr6 is a real x86 NVIDIA family in the allow-list; it must validate.
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "gr6.4xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "gr6.4xlarge", vals["instance_type"])
+		assert.Equal(t, true, vals["gpu_enabled"])
+	})
+
+	t.Run("capitalised GPU instance type accepted via normalization", func(t *testing.T) {
+		// AWS types are canonically lower-case, but a caller passing "G5.xlarge"
+		// must still validate — instanceFamily lower-cases before matching.
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "G5.xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err, "a capitalised GPU family must validate via normalization")
 		assert.Equal(t, true, vals["gpu_enabled"])
 	})
 

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -113,6 +113,10 @@ type Config struct {
 		CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 		SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 		EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+		// GPUEnabled selects an NVIDIA-GPU AMI for the instance (#759). Pair
+		// with a GPU InstanceType (g4dn/g5/g6/p4d/p5, ...). GPU AMIs are
+		// x86_64-only; the preset rejects gpu_enabled with arm64.
+		GPUEnabled *bool `json:"gpuEnabled,omitempty"`
 	} `json:"aws_ec2,omitempty"`
 
 	AWSEKS *struct {
@@ -122,6 +126,12 @@ type Config struct {
 		MaxSize                string `json:"maxSize,omitempty"`
 		MinSize                string `json:"minSize,omitempty"`
 		InstanceType           string `json:"instanceType,omitempty"`
+		// GPUEnabled provisions a GPU node group (#759): when true and no
+		// explicit GPU InstanceType is given, the mapper defaults
+		// instance_types to g5.xlarge and sets ami_type to
+		// AL2023_x86_64_NVIDIA. The in-cluster NVIDIA device plugin is
+		// app-layer and out of preset scope.
+		GPUEnabled *bool `json:"gpuEnabled,omitempty"`
 	} `json:"aws_eks,omitempty"`
 
 	AWSECS *struct {

--- a/pkg/composer/types_test.go
+++ b/pkg/composer/types_test.go
@@ -158,6 +158,7 @@ func TestConfig_Normalize_ClearsAWSFieldsForGCP(t *testing.T) {
 			MaxSize                string `json:"maxSize,omitempty"`
 			MinSize                string `json:"minSize,omitempty"`
 			InstanceType           string `json:"instanceType,omitempty"`
+			GPUEnabled             *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			DesiredSize: "3",
 		},

--- a/pkg/composer/union_test.go
+++ b/pkg/composer/union_test.go
@@ -171,6 +171,7 @@ func TestUnionConfig_NonNilEmptySliceOverridesPopulated(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{CustomIngressPorts: []int{22, 80, 443}},
 		},
 		{
@@ -184,6 +185,7 @@ func TestUnionConfig_NonNilEmptySliceOverridesPopulated(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{CustomIngressPorts: []int{}}, // non-nil empty — IS zero-distinct
 		},
 	}
@@ -214,6 +216,7 @@ func TestUnionConfig_NilSlice_NoOverride(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{
 				CustomIngressPorts: []int{22, 80, 443},
 			},
@@ -229,6 +232,7 @@ func TestUnionConfig_NilSlice_NoOverride(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{
 				InstanceType: "t3.large", // populated leaf
 				// CustomIngressPorts left nil — must not override


### PR DESCRIPTION
Closes #759. Part of #755 (AWS AI stack, L5 GPU compute).

## What
- `aws/eks_nodegroup`: `ami_type` enum extended with `AL2023_x86_64_NVIDIA` + `BOTTLEROCKET_x86_64_NVIDIA`; auto-derive now resolves a GPU AMI type from GPU instance families (g4dn/g5/g6/p4d/p5)
- `aws/ec2`: GPU AMI selection path; `gpu_enabled` + arm64 instance types rejected (GPU AMIs are x86_64-only)
- Composer: `Config.AWSEKS.GPUEnabled` and `Config.AWSEC2.GPUEnabled`; when set with no explicit instance type the mapper defaults to `g5.xlarge` (the preset auto-derives the NVIDIA AMI)

## Out of scope (by design)
- NVIDIA k8s device plugin: app-layer (no first-party EKS managed addon; helm excluded by repo policy)
- GPU quota (g/p families) is a deploy-time operator concern

## Testing
- New tftest runs in `aws/eks_nodegroup/tests/` (GPU node group shape, arch-mismatch `expect_failures`) and mapper partial-config Go tests
- Project-tag lint + gofmt clean locally; full suite runs in CI per repo convention


## Behavior change

- **EKS node-group AMI replacement (one-time).** The mapper no longer emits `ami_type`; the preset's family auto-derive (`_gpu_x86_families` → `AL2023_x86_64_NVIDIA`) is the single source of truth. Pre-existing module consumers that run a GPU instance family with the auto-derived `ami_type` will see a **one-time node-group replacement (STANDARD → NVIDIA AMI)** on the next apply. This is intentional: the STANDARD AMI on GPU nodes lacks the NVIDIA drivers, so `/dev/nvidia*` is absent and GPU pods sit Pending. To opt out, pin `var.ami_type` explicitly.
- **New compose-time validation.** `GPUEnabled=true` with an explicit non-GPU or ARM instance type is now **rejected at compose time** (`NewValidationError`) instead of silently forcing `arch=x86_64` / a GPU AMI onto incompatible hardware. Clear the instance type to default to `g5.xlarge`, or pick a supported x86 NVIDIA family (g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/p5e/p5en).
- **New plan-time precondition.** `aws/ec2` with `gpu_enabled=true` + `os_type="ubuntu"` (and no explicit `ami_id`) is now **rejected at plan** via a resource precondition. Previously the Ubuntu request was silently ignored and the AL2023 GPU AMI booted anyway. Drop `os_type` (accept the AL2023 GPU AMI) or supply an explicit Ubuntu GPU `ami_id`.
- **Pricing.** GPU stacks with no explicit instance type now resolve to `g5.xlarge` in the pricing-facing Config (was the non-GPU HCL default `t3.medium` / `c7i.large`), so GPU compute is no longer under-priced.
