### PR TITLE
feat(vertex_ai): Vertex AI Vector Search index/endpoint/deployed-index (#764)

### DIFF
--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -8,13 +8,20 @@
 #   google_vertex_ai_index_endpoint                 — the serving endpoint
 #   google_vertex_ai_index_endpoint_deployed_index  — binds index -> endpoint
 #
-# Private serving: when var.network is supplied the endpoint is created on the
-# VPC peering path (its public_endpoint_enabled is left false). This is the
-# reason gcp/vertex_ai carries a hard dependency on gcp/vpc (contracts.go:322 /
-# #600): a private index endpoint requires servicenetworking peering on the
-# network, otherwise the deployed index errors with NOT_FOUND on the peering
-# range. On a single-module preview (no network wired) the endpoint falls back
-# to a public endpoint so the preset still composes/plans standalone.
+# Serving endpoint: PUBLIC by default. The endpoint goes private (VPC-peered)
+# only when a network is wired AND var.enable_private_endpoint is set true.
+# Private serving requires a servicenetworking PSC peering range on the network
+# (google_service_networking_connection + a VPC_PEERING global address) that
+# gcp/vpc does not yet provision (#600 / follow-up #774); until that lands a
+# live private apply fails ~30-90min in. So the default composed path is a
+# public endpoint, which works live today. See var.enable_private_endpoint.
+#
+# Network form: google_vertex_ai_index_endpoint.network requires the
+# project-NUMBER form projects/<PROJECT_NUMBER>/global/networks/<name>. The
+# wired vpc_id (and any human-supplied value) is typically the project-ID form
+# projects/<PROJECT_ID>/global/networks/<name> or a bare network name, so we
+# parse out the network NAME and rebuild the canonical project-number path with
+# data.google_project.this.number. See local.network_canonical.
 
 terraform {
   required_version = ">= 1.5"
@@ -37,10 +44,30 @@ locals {
 
   resolved_schema_uri = coalesce(var.metadata_schema_uri, local.metadata_schemas[var.dataset_type])
 
-  # A private (VPC-peered) endpoint is used only when a network is wired in.
-  # Standalone previews have no network and fall back to a public endpoint so
-  # the preset still plans without the VPC peering range existing.
-  vector_search_private = var.enable_vector_search && var.network != null
+  # The endpoint is private (VPC-peered) only when a network is wired AND the
+  # operator opts in via enable_private_endpoint. Default is a public endpoint
+  # (works live today; private needs the #774 PSC peering range first). The
+  # consuming resource is already count-gated on enable_vector_search, so this
+  # local does not re-test that flag.
+  vector_search_private = var.network != null && var.enable_private_endpoint
+
+  # google_vertex_ai_index_endpoint.network needs the project-NUMBER form
+  # projects/<NUMBER>/global/networks/<name>. Extract the bare network NAME from
+  # whatever was supplied (full project-ID path, full project-number path, or a
+  # bare name) and rebuild the canonical path with the project number. Only
+  # evaluated on the private path; null otherwise.
+  network_name = var.network == null ? null : element(split("/", var.network), length(split("/", var.network)) - 1)
+  network_canonical = local.vector_search_private ? (
+    "projects/${data.google_project.this.number}/global/networks/${local.network_name}"
+  ) : null
+}
+
+# Resolves the caller's project to its numeric project number, which the
+# index-endpoint network path requires (the wired vpc_id carries the project ID,
+# not the number). Always read so the data source plans cleanly; only consumed
+# on the private path.
+data "google_project" "this" {
+  project_id = var.project_id
 }
 
 resource "google_vertex_ai_dataset" "dataset" {
@@ -106,8 +133,8 @@ resource "google_vertex_ai_index" "this" {
   )
 }
 
-# The serving endpoint. Private (VPC-peered) when var.network is wired,
-# otherwise public so a standalone preview still composes.
+# The serving endpoint. PUBLIC by default; private (VPC-peered) only when a
+# network is wired AND var.enable_private_endpoint is set.
 resource "google_vertex_ai_index_endpoint" "this" {
   count        = var.enable_vector_search ? 1 : 0
   project      = var.project_id
@@ -115,20 +142,19 @@ resource "google_vertex_ai_index_endpoint" "this" {
   display_name = "${var.project}-vector-endpoint"
   description  = "InsideOut Vector Search endpoint for ${var.project}"
 
-  # VPC peering path: network is the full resource name
-  # projects/<project>/global/networks/<name>. Wired from gcp/vpc.vpc_id.
+  # VPC peering path: network is the canonical project-NUMBER resource name
+  # projects/<NUMBER>/global/networks/<name>, rebuilt from the wired vpc_id
+  # (which carries the project ID) via data.google_project.this.number.
   #
-  # NOTE: a private (VPC-peered) endpoint requires a servicenetworking
-  # PSC peering range on this network (google_service_networking_connection +
-  # a VPC_PEERING global address). That peering is the VPC's responsibility
-  # (the reason gcp/vertex_ai hard-depends on gcp/vpc — #600); it is not
-  # provisioned here. Until gcp/vpc provisions that range, real applies on the
-  # private path will need the peering created out-of-band. Compose/plan and
-  # the public-endpoint path are unaffected.
-  network = local.vector_search_private ? var.network : null
+  # NOTE: the private path additionally requires a servicenetworking PSC
+  # peering range on this network (google_service_networking_connection + a
+  # VPC_PEERING global address) that gcp/vpc does not yet provision (#774).
+  # Until that lands, an opt-in private apply needs the peering created
+  # out-of-band. The default (public) path is unaffected.
+  network = local.network_canonical
 
-  # Public endpoint only when no private network is wired.
-  public_endpoint_enabled = local.vector_search_private ? false : true
+  # Public unless the private path is selected.
+  public_endpoint_enabled = !local.vector_search_private
 
   labels = merge(
     {
@@ -142,11 +168,15 @@ resource "google_vertex_ai_index_endpoint" "this" {
 # serving replicas, which routinely takes 30-60 minutes, so create has a 90m
 # timeout to stay well clear of the provider's shorter default.
 resource "google_vertex_ai_index_endpoint_deployed_index" "this" {
-  count             = var.enable_vector_search ? 1 : 0
-  region            = var.region
-  index_endpoint    = google_vertex_ai_index_endpoint.this[0].id
-  index             = google_vertex_ai_index.this[0].id
-  deployed_index_id = replace("${var.project}_vector_idx", "-", "_")
+  count          = var.enable_vector_search ? 1 : 0
+  region         = var.region
+  index_endpoint = google_vertex_ai_index_endpoint.this[0].id
+  index          = google_vertex_ai_index.this[0].id
+  # The API requires deployed_index_id to start with a letter and contain only
+  # [a-z0-9_]. Lowercase var.project, replace every invalid char with "_", and
+  # prefix "idx_" so a project that starts with a digit (or is otherwise
+  # awkward) still yields a valid id.
+  deployed_index_id = "idx_${replace(lower(var.project), "/[^a-z0-9_]/", "_")}_vector"
   display_name      = "${var.project}-vector-deployed"
 
   automatic_resources {

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -1,5 +1,20 @@
-# GCP Vertex AI Dataset
-# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_dataset
+# GCP Vertex AI
+# - Dataset (always created): https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_dataset
+# - Vector Search (gated on var.enable_vector_search): index + index endpoint +
+#   deployed index. https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_index
+#
+# Vector Search composes a managed nearest-neighbour vector DB:
+#   google_vertex_ai_index                          — the ANN index (embeddings)
+#   google_vertex_ai_index_endpoint                 — the serving endpoint
+#   google_vertex_ai_index_endpoint_deployed_index  — binds index -> endpoint
+#
+# Private serving: when var.network is supplied the endpoint is created on the
+# VPC peering path (its public_endpoint_enabled is left false). This is the
+# reason gcp/vertex_ai carries a hard dependency on gcp/vpc (contracts.go:322 /
+# #600): a private index endpoint requires servicenetworking peering on the
+# network, otherwise the deployed index errors with NOT_FOUND on the peering
+# range. On a single-module preview (no network wired) the endpoint falls back
+# to a public endpoint so the preset still composes/plans standalone.
 
 terraform {
   required_version = ">= 1.5"
@@ -21,6 +36,11 @@ locals {
   }
 
   resolved_schema_uri = coalesce(var.metadata_schema_uri, local.metadata_schemas[var.dataset_type])
+
+  # A private (VPC-peered) endpoint is used only when a network is wired in.
+  # Standalone previews have no network and fall back to a public endpoint so
+  # the preset still plans without the VPC peering range existing.
+  vector_search_private = var.enable_vector_search && var.network != null
 }
 
 resource "google_vertex_ai_dataset" "dataset" {
@@ -42,4 +62,109 @@ resource "google_vertex_ai_dataset" "dataset" {
     },
     var.labels
   )
+}
+
+# --- Vector Search ----------------------------------------------------------
+
+# The ANN index. Dimensions and update_method are immutable: the Google API
+# rejects in-place changes to either, so terraform must destroy/recreate the
+# index when they change. The preset surfaces both as their own variables with
+# plan-time validation so a bad value fails fast rather than at apply.
+resource "google_vertex_ai_index" "this" {
+  count               = var.enable_vector_search ? 1 : 0
+  project             = var.project_id
+  region              = var.region
+  display_name        = "${var.project}-vector-index"
+  description         = "InsideOut Vector Search index for ${var.project}"
+  index_update_method = var.index_update_method
+
+  metadata {
+    # contents_delta_uri points at a GCS prefix of embedding files used to seed
+    # the index. Null on a standalone preview (no GCS wired) — the index is
+    # created empty and embeddings are upserted out-of-band.
+    contents_delta_uri = var.contents_delta_uri
+
+    config {
+      dimensions                  = var.index_dimensions
+      approximate_neighbors_count = var.index_approximate_neighbors_count
+      distance_measure_type       = var.index_distance_measure_type
+
+      algorithm_config {
+        tree_ah_config {
+          leaf_node_embedding_count    = 1000
+          leaf_nodes_to_search_percent = 10
+        }
+      }
+    }
+  }
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+}
+
+# The serving endpoint. Private (VPC-peered) when var.network is wired,
+# otherwise public so a standalone preview still composes.
+resource "google_vertex_ai_index_endpoint" "this" {
+  count        = var.enable_vector_search ? 1 : 0
+  project      = var.project_id
+  region       = var.region
+  display_name = "${var.project}-vector-endpoint"
+  description  = "InsideOut Vector Search endpoint for ${var.project}"
+
+  # VPC peering path: network is the full resource name
+  # projects/<project>/global/networks/<name>. Wired from gcp/vpc.vpc_id.
+  #
+  # NOTE: a private (VPC-peered) endpoint requires a servicenetworking
+  # PSC peering range on this network (google_service_networking_connection +
+  # a VPC_PEERING global address). That peering is the VPC's responsibility
+  # (the reason gcp/vertex_ai hard-depends on gcp/vpc — #600); it is not
+  # provisioned here. Until gcp/vpc provisions that range, real applies on the
+  # private path will need the peering created out-of-band. Compose/plan and
+  # the public-endpoint path are unaffected.
+  network = local.vector_search_private ? var.network : null
+
+  # Public endpoint only when no private network is wired.
+  public_endpoint_enabled = local.vector_search_private ? false : true
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+}
+
+# Binds the index to the endpoint. The deploy is the long pole: Vertex spins up
+# serving replicas, which routinely takes 30-60 minutes, so create has a 90m
+# timeout to stay well clear of the provider's shorter default.
+resource "google_vertex_ai_index_endpoint_deployed_index" "this" {
+  count             = var.enable_vector_search ? 1 : 0
+  region            = var.region
+  index_endpoint    = google_vertex_ai_index_endpoint.this[0].id
+  index             = google_vertex_ai_index.this[0].id
+  deployed_index_id = replace("${var.project}_vector_idx", "-", "_")
+  display_name      = "${var.project}-vector-deployed"
+
+  automatic_resources {
+    min_replica_count = var.deployed_index_min_replicas
+    max_replica_count = var.deployed_index_max_replicas
+  }
+
+  timeouts {
+    create = "90m"
+  }
+
+  lifecycle {
+    # Cross-variable invariant lives here (not in a variable validation block)
+    # because a per-variable validation may only reference its own variable;
+    # the autoscaling ceiling must not sit below the floor.
+    precondition {
+      condition     = var.deployed_index_max_replicas >= var.deployed_index_min_replicas
+      error_message = "deployed_index_max_replicas must be >= deployed_index_min_replicas."
+    }
+  }
 }

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -56,7 +56,17 @@ locals {
   # whatever was supplied (full project-ID path, full project-number path, or a
   # bare name) and rebuild the canonical path with the project number. Only
   # evaluated on the private path; null otherwise.
-  network_name = var.network == null ? null : element(split("/", var.network), length(split("/", var.network)) - 1)
+  #
+  # Parse the name out of the .../networks/<name> path with a regex capture so a
+  # malformed value can't silently yield the wrong segment (var.network is
+  # validated to be a bare name or an exact projects/.../networks/<name> path,
+  # so a non-match here means it was a bare name — fall back to the value
+  # itself). element()-last was unsafe: a trailing slash or short path would
+  # parse to "" or the wrong segment with no plan-time signal.
+  network_name = var.network == null ? null : try(
+    regex("/networks/([^/]+)$", var.network)[0],
+    var.network,
+  )
   network_canonical = local.vector_search_private ? (
     "projects/${data.google_project.this.number}/global/networks/${local.network_name}"
   ) : null

--- a/gcp/vertex_ai/observability.tf
+++ b/gcp/vertex_ai/observability.tf
@@ -1,0 +1,71 @@
+# observability.tf — issue #204 / #764
+#
+# Per-component Cloud Monitoring alert policies for Vertex AI Vector Search.
+# Emitted only when Vector Search is enabled (the bare dataset has no serving
+# surface to alarm on). Wired the SNS-equivalent inputs (notification_channels,
+# enable_observability) from gcp/cloud_monitoring when that aggregator is
+# selected — see contracts.go observability post-switch wiring.
+
+variable "enable_observability" {
+  description = "When true, emit per-component Cloud Monitoring alert policies (issue #204)."
+  type        = bool
+  default     = true
+}
+
+variable "notification_channels" {
+  description = "Cloud Monitoring notification channel names."
+  type        = list(string)
+  default     = []
+}
+
+variable "alarm_severity" {
+  description = "Severity tag attached to alert policies."
+  type        = string
+  default     = "warning"
+  validation {
+    condition     = contains(["critical", "warning", "info"], var.alarm_severity)
+    error_message = "alarm_severity must be one of critical|warning|info."
+  }
+}
+
+variable "alarm_threshold_overrides" {
+  description = "Per-metric numeric threshold overrides."
+  type        = map(number)
+  default     = {}
+}
+
+locals {
+  _obs_user_labels = { project = var.project, severity = var.alarm_severity }
+  _obs_thresholds = merge({
+    query_latency_p99_ms = 500
+  }, var.alarm_threshold_overrides)
+
+  # Alarms only make sense when Vector Search is serving queries.
+  _obs_enabled = var.enable_observability && var.enable_vector_search
+}
+
+resource "google_monitoring_alert_policy" "vector_search_query_latency_high" {
+  for_each = local._obs_enabled ? { "0" = true } : {}
+
+  project      = var.project_id
+  display_name = "${var.project}-vertex-vector-query-latency"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Vector Search p99 query latency above ${local._obs_thresholds["query_latency_p99_ms"]}ms"
+    condition_threshold {
+      # Public metric on the Matching Engine index endpoint serving surface.
+      filter          = "metric.type=\"aiplatform.googleapis.com/matching_engine/query_latencies\" AND resource.type=\"aiplatform.googleapis.com/MatchingEngineIndexEndpoint\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local._obs_thresholds["query_latency_p99_ms"]
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_PERCENTILE_99"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+  user_labels           = local._obs_user_labels
+}

--- a/gcp/vertex_ai/observability.tf
+++ b/gcp/vertex_ai/observability.tf
@@ -55,7 +55,12 @@ resource "google_monitoring_alert_policy" "vector_search_query_latency_high" {
     display_name = "Vector Search p99 query latency above ${local._obs_thresholds["query_latency_p99_ms"]}ms"
     condition_threshold {
       # Public metric on the Matching Engine index endpoint serving surface.
-      filter          = "metric.type=\"aiplatform.googleapis.com/matching_engine/query_latencies\" AND resource.type=\"aiplatform.googleapis.com/MatchingEngineIndexEndpoint\""
+      # Metric path + monitored resource verified against Google's official
+      # list (cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform):
+      # the metric is matching_engine/query/latencies (slashes, not an
+      # underscore) reported on aiplatform.googleapis.com/IndexEndpoint
+      # (NOT MatchingEngineIndexEndpoint, which is not a real resource type).
+      filter          = "metric.type=\"aiplatform.googleapis.com/matching_engine/query/latencies\" AND resource.type=\"aiplatform.googleapis.com/IndexEndpoint\""
       duration        = "300s"
       comparison      = "COMPARISON_GT"
       threshold_value = local._obs_thresholds["query_latency_p99_ms"]

--- a/gcp/vertex_ai/outputs.tf
+++ b/gcp/vertex_ai/outputs.tf
@@ -17,3 +17,21 @@ output "region" {
   value       = google_vertex_ai_dataset.dataset.region
   description = "The region of the Vertex AI dataset"
 }
+
+# --- Vector Search ----------------------------------------------------------
+# Null when var.enable_vector_search is false (the resources are not created).
+
+output "index_id" {
+  value       = var.enable_vector_search ? google_vertex_ai_index.this[0].id : null
+  description = "The resource ID of the Vector Search index (null when Vector Search is disabled)"
+}
+
+output "index_endpoint_id" {
+  value       = var.enable_vector_search ? google_vertex_ai_index_endpoint.this[0].id : null
+  description = "The resource ID of the Vector Search index endpoint (null when Vector Search is disabled)"
+}
+
+output "deployed_index_id" {
+  value       = var.enable_vector_search ? google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id : null
+  description = "The deployed-index ID binding the index to the endpoint (null when Vector Search is disabled)"
+}

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -1,0 +1,200 @@
+mock_provider "google" {}
+
+# Issue #764 (gcp/vertex_ai Vector Search) shape tests. Verifies that:
+#   - Defaults compose just the dataset; Vector Search is OFF by default and
+#     emits zero index/endpoint/deployed-index resources.
+#   - enable_vector_search=true composes index + endpoint + deployed index,
+#     wires a private endpoint when a network is supplied, and carries the
+#     90m create timeout on the deployed index.
+#   - The immutable knobs (index_dimensions, index_update_method) and the
+#     other validations reject obvious misconfigurations at plan time.
+
+run "defaults_dataset_only" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+
+  # Dataset is always created.
+  assert {
+    condition     = google_vertex_ai_dataset.dataset.display_name == "main-dataset"
+    error_message = "dataset must be created unconditionally with its default display name."
+  }
+
+  # Vector Search is off by default -> no index/endpoint/deployed-index.
+  assert {
+    condition     = length(google_vertex_ai_index.this) == 0
+    error_message = "Vector Search index must NOT be created when enable_vector_search is false (default)."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint.this) == 0
+    error_message = "Vector Search endpoint must NOT be created when enable_vector_search is false (default)."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint_deployed_index.this) == 0
+    error_message = "Deployed index must NOT be created when enable_vector_search is false (default)."
+  }
+}
+
+run "vector_search" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = true
+    index_dimensions     = 768
+    contents_delta_uri   = "gs://test-bucket/embeddings"
+    network              = "projects/test-project/global/networks/test-vpc"
+  }
+
+  # All three Vector Search resources compose.
+  assert {
+    condition     = length(google_vertex_ai_index.this) == 1
+    error_message = "enable_vector_search=true must create exactly one index."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint.this) == 1
+    error_message = "enable_vector_search=true must create exactly one index endpoint."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint_deployed_index.this) == 1
+    error_message = "enable_vector_search=true must create exactly one deployed index."
+  }
+
+  # Index dimensions flow through to the metadata.config block.
+  assert {
+    condition     = google_vertex_ai_index.this[0].metadata[0].config[0].dimensions == 768
+    error_message = "index_dimensions must reach metadata.config.dimensions."
+  }
+
+  # Index display name carries the var.project prefix (name-prefix scoping).
+  assert {
+    condition     = google_vertex_ai_index.this[0].display_name == "test-vector-index"
+    error_message = "index display_name must be var.project-prefixed (lint-labelless-name-prefix contract)."
+  }
+
+  # A supplied network -> private endpoint (public disabled, network set).
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].network == "projects/test-project/global/networks/test-vpc"
+    error_message = "a wired network must drive the private (VPC-peered) endpoint path."
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == false
+    error_message = "endpoint must be private (public disabled) when a network is wired."
+  }
+
+  # contents_delta_uri flows through to seed the index.
+  assert {
+    condition     = google_vertex_ai_index.this[0].metadata[0].contents_delta_uri == "gs://test-bucket/embeddings"
+    error_message = "contents_delta_uri must reach metadata.contents_delta_uri."
+  }
+
+  # deployed_index_id is sanitized (hyphens -> underscores) to satisfy the API.
+  assert {
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id == "test_vector_idx"
+    error_message = "deployed_index_id must be sanitized to [a-z0-9_]."
+  }
+
+  # 90m create timeout on the long-running deploy.
+  assert {
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].timeouts.create == "90m"
+    error_message = "deployed index must carry a 90m create timeout (deploys run 30-60min)."
+  }
+}
+
+run "vector_search_public_endpoint_without_network" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = true
+  }
+
+  # No network wired -> public endpoint so a standalone preview still composes.
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == true
+    error_message = "endpoint must fall back to public when no network is wired (standalone preview)."
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].network == null
+    error_message = "endpoint network must be null when no network is wired."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: validation blocks must reject misconfigurations at plan time.
+# -----------------------------------------------------------------------------
+
+run "rejects_zero_dimensions" {
+  command = plan
+
+  variables {
+    project          = "test"
+    project_id       = "test-project"
+    index_dimensions = 0
+  }
+
+  expect_failures = [var.index_dimensions]
+}
+
+run "rejects_negative_dimensions" {
+  command = plan
+
+  variables {
+    project          = "test"
+    project_id       = "test-project"
+    index_dimensions = -1
+  }
+
+  expect_failures = [var.index_dimensions]
+}
+
+run "rejects_invalid_update_method" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    index_update_method = "STREAM" # API expects STREAM_UPDATE
+  }
+
+  expect_failures = [var.index_update_method]
+}
+
+run "rejects_non_gcs_contents_uri" {
+  command = plan
+
+  variables {
+    project            = "test"
+    project_id         = "test-project"
+    contents_delta_uri = "s3://wrong/scheme"
+  }
+
+  expect_failures = [var.contents_delta_uri]
+}
+
+run "rejects_max_replicas_below_min" {
+  command = plan
+
+  variables {
+    project                     = "test"
+    project_id                  = "test-project"
+    enable_vector_search        = true
+    deployed_index_min_replicas = 3
+    deployed_index_max_replicas = 1 # ceiling below floor
+  }
+
+  # The cross-variable invariant is a resource precondition, not a variable
+  # validation, so the failure surfaces on the deployed-index resource.
+  expect_failures = [google_vertex_ai_index_endpoint_deployed_index.this]
+}

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -117,12 +117,25 @@ run "vector_search" {
 run "vector_search_private_opt_in" {
   command = plan
 
+  # Pin data.google_project.this.number to a fixed value so the rebuilt
+  # canonical network path can be asserted as an EXACT literal (otherwise the
+  # mock provider supplies a random computed number and the test could only
+  # assert prefix/suffix — which a passthrough rebuild would survive).
+  override_data {
+    target = data.google_project.this
+    values = {
+      number = "123456789012"
+    }
+  }
+
   variables {
     project                 = "test"
     project_id              = "test-project"
     enable_vector_search    = true
     enable_private_endpoint = true
-    network                 = "projects/test-project/global/networks/test-vpc"
+    # Project-ID full path: the parser must keep the network NAME and the
+    # rebuild must swap the project ID for the pinned project NUMBER.
+    network = "projects/test-project/global/networks/test-vpc"
   }
 
   # network + enable_private_endpoint -> private endpoint (public disabled).
@@ -132,17 +145,39 @@ run "vector_search_private_opt_in" {
   }
 
   # The endpoint network is rebuilt into the project-NUMBER path the API
-  # requires. The mock provider supplies a computed project number, so assert
-  # the structure (prefix + the parsed network name) rather than the exact
-  # number.
+  # requires: the name survives, the pinned number replaces the project ID.
+  # Asserting the EXACT literal kills a passthrough mutation of the rebuild.
   assert {
-    condition     = startswith(google_vertex_ai_index_endpoint.this[0].network, "projects/")
-    error_message = "private endpoint network must be a projects/<number>/global/networks/<name> path."
+    condition     = google_vertex_ai_index_endpoint.this[0].network == "projects/123456789012/global/networks/test-vpc"
+    error_message = "private endpoint network must rebuild to projects/<number>/global/networks/<name> using the project NUMBER (not the project ID)."
+  }
+}
+
+run "vector_search_private_bare_network_name" {
+  command = plan
+
+  # Bare-name input ("my-vpc") with the project number pinned so the rebuilt
+  # path can be asserted EXACTLY. Exercises the regex bare-name fallback and
+  # the project-NUMBER rebuild — a passthrough that skipped the rebuild would
+  # leave network = "my-vpc" and fail this assert.
+  override_data {
+    target = data.google_project.this
+    values = {
+      number = "123456789012"
+    }
+  }
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    enable_vector_search    = true
+    enable_private_endpoint = true
+    network                 = "my-vpc"
   }
 
   assert {
-    condition     = endswith(google_vertex_ai_index_endpoint.this[0].network, "/global/networks/test-vpc")
-    error_message = "private endpoint network must carry the parsed network NAME (test-vpc)."
+    condition     = google_vertex_ai_index_endpoint.this[0].network == "projects/123456789012/global/networks/my-vpc"
+    error_message = "a bare network name must be rebuilt to the full projects/<number>/global/networks/<name> form."
   }
 }
 
@@ -186,6 +221,95 @@ run "vector_search_public_endpoint_without_network" {
   assert {
     condition     = google_vertex_ai_index_endpoint.this[0].network == null
     error_message = "endpoint network must be null when no network is wired."
+  }
+}
+
+run "deployed_index_id_sanitizes_dirty_project" {
+  command = plan
+
+  variables {
+    # Project with uppercase + a dot: both are illegal in a deployed_index_id
+    # (must start with a letter, only [a-z0-9_]). The default "test" project is
+    # already clean and never exercised the replace(); this one does.
+    project              = "My-Proj.1"
+    project_id           = "test-project"
+    enable_vector_search = true
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id == "idx_my_proj_1_vector"
+    error_message = "deployed_index_id must lowercase var.project and replace every non-[a-z0-9_] char with '_' (My-Proj.1 -> my_proj_1)."
+  }
+}
+
+run "deployed_index_min_eq_max_composes" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = true
+    # Equal floor/ceiling is the >= boundary: it MUST compose (pins the
+    # precondition against a strict-> mutation that would reject min == max).
+    deployed_index_min_replicas = 2
+    deployed_index_max_replicas = 2
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint_deployed_index.this) == 1
+    error_message = "deployed index must compose when max_replicas == min_replicas (the >= boundary is inclusive)."
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].automatic_resources[0].min_replica_count == 2
+    error_message = "min_replica_count must flow through to automatic_resources."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Alert policy: the per-component query-latency alarm is emitted only when
+# Vector Search AND observability are both on, and carries the verified metric.
+# -----------------------------------------------------------------------------
+
+run "alert_policy_emitted_when_vector_search_and_observability_on" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = true
+    enable_observability = true
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.vector_search_query_latency_high) == 1
+    error_message = "query-latency alert policy must be emitted when Vector Search AND observability are both enabled."
+  }
+
+  # The filter must carry the metric.type verified against Google's official
+  # metrics list (matching_engine/query/latencies, slashes not underscore).
+  assert {
+    condition = strcontains(
+      google_monitoring_alert_policy.vector_search_query_latency_high["0"].conditions[0].condition_threshold[0].filter,
+      "metric.type=\"aiplatform.googleapis.com/matching_engine/query/latencies\""
+    )
+    error_message = "alert policy filter must reference the verified matching_engine/query/latencies metric type."
+  }
+}
+
+run "alert_policy_absent_when_vector_search_off" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = false
+    enable_observability = true
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.vector_search_query_latency_high) == 0
+    error_message = "no alert policy when Vector Search is off — the bare dataset has no serving surface to alarm on."
   }
 }
 
@@ -239,6 +363,32 @@ run "rejects_non_gcs_contents_uri" {
   }
 
   expect_failures = [var.contents_delta_uri]
+}
+
+run "rejects_empty_network" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    network    = "" # would parse to an empty network name with no signal
+  }
+
+  expect_failures = [var.network]
+}
+
+run "rejects_malformed_network_path" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    # Trailing slash -> last-segment parse would yield "" ; not a valid bare
+    # name nor the exact projects/.../networks/<name> form.
+    network = "projects/test-project/global/networks/"
+  }
+
+  expect_failures = [var.network]
 }
 
 run "rejects_max_replicas_below_min" {

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -4,8 +4,9 @@ mock_provider "google" {}
 #   - Defaults compose just the dataset; Vector Search is OFF by default and
 #     emits zero index/endpoint/deployed-index resources.
 #   - enable_vector_search=true composes index + endpoint + deployed index,
-#     wires a private endpoint when a network is supplied, and carries the
-#     90m create timeout on the deployed index.
+#     defaults to a PUBLIC endpoint even with a network wired, goes private only
+#     when enable_private_endpoint is also set, and carries the 90m create
+#     timeout on the deployed index.
 #   - The immutable knobs (index_dimensions, index_update_method) and the
 #     other validations reject obvious misconfigurations at plan time.
 
@@ -48,8 +49,10 @@ run "vector_search" {
     project_id           = "test-project"
     enable_vector_search = true
     index_dimensions     = 768
-    contents_delta_uri   = "gs://test-bucket/embeddings"
-    network              = "projects/test-project/global/networks/test-vpc"
+    contents_delta_uri   = "gs://test-bucket/vertex-index/"
+    # Network wired but enable_private_endpoint left at its false default: the
+    # endpoint must stay PUBLIC (private requires the #774 PSC peering range).
+    network = "projects/test-project/global/networks/test-vpc"
   }
 
   # All three Vector Search resources compose.
@@ -80,33 +83,88 @@ run "vector_search" {
     error_message = "index display_name must be var.project-prefixed (lint-labelless-name-prefix contract)."
   }
 
-  # A supplied network -> private endpoint (public disabled, network set).
+  # Default (no enable_private_endpoint): PUBLIC even with a network wired, and
+  # no network is set on the endpoint (private path is opt-in only).
   assert {
-    condition     = google_vertex_ai_index_endpoint.this[0].network == "projects/test-project/global/networks/test-vpc"
-    error_message = "a wired network must drive the private (VPC-peered) endpoint path."
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == true
+    error_message = "endpoint must default to PUBLIC even when a network is wired (private is opt-in via enable_private_endpoint)."
   }
 
   assert {
-    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == false
-    error_message = "endpoint must be private (public disabled) when a network is wired."
+    condition     = google_vertex_ai_index_endpoint.this[0].network == null
+    error_message = "endpoint network must be null on the default public path (private is opt-in)."
   }
 
-  # contents_delta_uri flows through to seed the index.
+  # contents_delta_uri flows through to seed the index from the dedicated prefix.
   assert {
-    condition     = google_vertex_ai_index.this[0].metadata[0].contents_delta_uri == "gs://test-bucket/embeddings"
+    condition     = google_vertex_ai_index.this[0].metadata[0].contents_delta_uri == "gs://test-bucket/vertex-index/"
     error_message = "contents_delta_uri must reach metadata.contents_delta_uri."
   }
 
-  # deployed_index_id is sanitized (hyphens -> underscores) to satisfy the API.
+  # deployed_index_id is API-safe: starts with a letter, only [a-z0-9_].
   assert {
-    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id == "test_vector_idx"
-    error_message = "deployed_index_id must be sanitized to [a-z0-9_]."
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id == "idx_test_vector"
+    error_message = "deployed_index_id must be sanitized to a letter-leading [a-z0-9_] id (idx_<project>_vector)."
   }
 
   # 90m create timeout on the long-running deploy.
   assert {
     condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].timeouts.create == "90m"
     error_message = "deployed index must carry a 90m create timeout (deploys run 30-60min)."
+  }
+}
+
+run "vector_search_private_opt_in" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    enable_vector_search    = true
+    enable_private_endpoint = true
+    network                 = "projects/test-project/global/networks/test-vpc"
+  }
+
+  # network + enable_private_endpoint -> private endpoint (public disabled).
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == false
+    error_message = "endpoint must be private (public disabled) when a network is wired AND enable_private_endpoint is set."
+  }
+
+  # The endpoint network is rebuilt into the project-NUMBER path the API
+  # requires. The mock provider supplies a computed project number, so assert
+  # the structure (prefix + the parsed network name) rather than the exact
+  # number.
+  assert {
+    condition     = startswith(google_vertex_ai_index_endpoint.this[0].network, "projects/")
+    error_message = "private endpoint network must be a projects/<number>/global/networks/<name> path."
+  }
+
+  assert {
+    condition     = endswith(google_vertex_ai_index_endpoint.this[0].network, "/global/networks/test-vpc")
+    error_message = "private endpoint network must carry the parsed network NAME (test-vpc)."
+  }
+}
+
+run "vector_search_private_opt_in_without_network_stays_public" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    enable_vector_search    = true
+    enable_private_endpoint = true
+    # No network wired: the flag alone cannot force private.
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == true
+    error_message = "endpoint must stay PUBLIC when enable_private_endpoint is set but no network is wired."
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].network == null
+    error_message = "endpoint network must be null when no network is wired, regardless of enable_private_endpoint."
   }
 }
 

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -14,7 +14,7 @@ variable "project_id" {
 }
 
 variable "region" {
-  description = "GCP region for the Vertex AI dataset"
+  description = "GCP region for the Vertex AI resources"
   type        = string
   default     = "us-central1"
 }
@@ -57,4 +57,96 @@ variable "labels" {
   description = "Labels to apply"
   type        = map(string)
   default     = {}
+}
+
+# --- Vector Search ----------------------------------------------------------
+
+variable "enable_vector_search" {
+  description = "When true, provision Vertex AI Vector Search (index + index endpoint + deployed index) alongside the dataset. The dataset is always created; this gates only the Vector Search resources."
+  type        = bool
+  default     = false
+}
+
+variable "index_dimensions" {
+  description = "Dimensionality of the embedding vectors the index stores. IMMUTABLE — changing it forces index destroy/recreate. Must match the embedding model that produces the vectors (e.g. 768 for text-embedding-004)."
+  type        = number
+  default     = 768
+
+  validation {
+    condition     = var.index_dimensions > 0
+    error_message = "index_dimensions must be greater than 0."
+  }
+}
+
+variable "index_update_method" {
+  description = "How embeddings are written to the index. BATCH (default) ingests from contents_delta_uri batches; STREAM upserts individual vectors via the streaming API. IMMUTABLE — changing it forces index destroy/recreate."
+  type        = string
+  default     = "BATCH_UPDATE"
+
+  validation {
+    # The Google API accepts the verbose forms BATCH_UPDATE / STREAM_UPDATE.
+    condition     = contains(["BATCH_UPDATE", "STREAM_UPDATE"], var.index_update_method)
+    error_message = "index_update_method must be one of: BATCH_UPDATE, STREAM_UPDATE."
+  }
+}
+
+variable "contents_delta_uri" {
+  description = "GCS prefix (gs://bucket/path) of embedding files used to seed/refresh the index. Null creates an empty index seeded out-of-band. Wired from gcp/gcs.bucket_url in a full stack."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.contents_delta_uri == null ? true : startswith(var.contents_delta_uri, "gs://")
+    error_message = "contents_delta_uri must be a gs:// URI."
+  }
+}
+
+variable "index_distance_measure_type" {
+  description = "Distance metric for nearest-neighbour search. One of DOT_PRODUCT_DISTANCE, COSINE_DISTANCE, SQUARED_L2_DISTANCE."
+  type        = string
+  default     = "DOT_PRODUCT_DISTANCE"
+
+  validation {
+    condition     = contains(["DOT_PRODUCT_DISTANCE", "COSINE_DISTANCE", "SQUARED_L2_DISTANCE"], var.index_distance_measure_type)
+    error_message = "index_distance_measure_type must be one of: DOT_PRODUCT_DISTANCE, COSINE_DISTANCE, SQUARED_L2_DISTANCE."
+  }
+}
+
+variable "index_approximate_neighbors_count" {
+  description = "Number of neighbours to find via approximate search before exact reordering. Tuning knob; 150 is a sensible default for most embedding sizes."
+  type        = number
+  default     = 150
+
+  validation {
+    condition     = var.index_approximate_neighbors_count > 0
+    error_message = "index_approximate_neighbors_count must be greater than 0."
+  }
+}
+
+variable "network" {
+  description = "Full VPC network resource name (projects/<project>/global/networks/<name>) for a private (VPC-peered) index endpoint. Null creates a public endpoint. Wired from gcp/vpc.vpc_id in a full stack; requires servicenetworking peering on the network (#600)."
+  type        = string
+  default     = null
+}
+
+variable "deployed_index_min_replicas" {
+  description = "Minimum serving replicas for the deployed index."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.deployed_index_min_replicas > 0
+    error_message = "deployed_index_min_replicas must be greater than 0."
+  }
+}
+
+variable "deployed_index_max_replicas" {
+  description = "Maximum serving replicas for the deployed index (autoscaling ceiling). Must be >= deployed_index_min_replicas (enforced by a precondition on the deployed-index resource)."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.deployed_index_max_replicas > 0
+    error_message = "deployed_index_max_replicas must be greater than 0."
+  }
 }

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -127,6 +127,19 @@ variable "network" {
   description = "VPC network for a private (VPC-peered) index endpoint. Accepts the project-ID path (projects/<project_id>/global/networks/<name>, as emitted by gcp/vpc.vpc_id), the project-number path, or a bare network name — the preset extracts the network name and rebuilds the project-NUMBER path the API requires. Only used when enable_private_endpoint is also true; otherwise the endpoint is public."
   type        = string
   default     = null
+
+  validation {
+    # Accept null (public path), a bare network name (RFC1035-ish: starts with
+    # a lowercase letter, lowercase letters/digits/hyphens), or the exact
+    # projects/<project-id-or-number>/global/networks/<name> resource form.
+    # Reject "" and malformed paths (trailing slash, wrong segments) at plan
+    # time so local.network_name never silently parses to an empty/wrong name.
+    condition = var.network == null ? true : (
+      can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.network)) ||
+      can(regex("^projects/[a-z0-9-]+/global/networks/[a-z]([-a-z0-9]*[a-z0-9])?$", var.network))
+    )
+    error_message = "network must be null, a bare network name, or an exact projects/<id-or-number>/global/networks/<name> path."
+  }
 }
 
 variable "enable_private_endpoint" {

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -124,9 +124,15 @@ variable "index_approximate_neighbors_count" {
 }
 
 variable "network" {
-  description = "Full VPC network resource name (projects/<project>/global/networks/<name>) for a private (VPC-peered) index endpoint. Null creates a public endpoint. Wired from gcp/vpc.vpc_id in a full stack; requires servicenetworking peering on the network (#600)."
+  description = "VPC network for a private (VPC-peered) index endpoint. Accepts the project-ID path (projects/<project_id>/global/networks/<name>, as emitted by gcp/vpc.vpc_id), the project-number path, or a bare network name — the preset extracts the network name and rebuilds the project-NUMBER path the API requires. Only used when enable_private_endpoint is also true; otherwise the endpoint is public."
   type        = string
   default     = null
+}
+
+variable "enable_private_endpoint" {
+  description = "When true AND a network is wired, the index endpoint is private (VPC-peered) instead of public. Default false = public endpoint, which works live today. The private path requires a servicenetworking PSC peering range on the network that gcp/vpc does not yet provision (follow-up #774); enabling it before #774 lands means the peering must exist out-of-band or a live apply fails ~30-90min into the deployed-index step."
+  type        = bool
+  default     = false
 }
 
 variable "deployed_index_min_replicas" {

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -304,6 +304,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
+		KeyGCPVertexAI,
 		KeyGCPPubSub, KeyGCPCloudLogging,
 		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
 		KeyGCPCloudDNS, KeyGCPGitHubActions, KeyGCPCloudDeploy:

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1184,6 +1184,24 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.RawHCL["vpc_connector"] = WireRef(KeyGCPVPC, "connector_id")
 			wi.Names = append(wi.Names, "vpc_connector")
 		}
+
+	case KeyGCPVertexAI:
+		// Vertex AI Vector Search (#764). When a VPC is selected, wire its
+		// network resource id (projects/<p>/global/networks/<n>, the exact
+		// form google_vertex_ai_index_endpoint.network expects) so the index
+		// endpoint takes the private VPC-peering path — the reason the hard
+		// gcp/vpc dep exists (contracts.go:322 / #600 PSC peering). gcp/vpc's
+		// network_id is surfaced as the vpc_id output.
+		if selected[KeyGCPVPC] {
+			wi.RawHCL["network"] = WireRef(KeyGCPVPC, "vpc_id")
+			wi.Names = append(wi.Names, "network")
+		}
+		// When GCS is selected, seed the index from the bucket. bucket_url is
+		// the gs:// URL the index's contents_delta_uri expects.
+		if selected[KeyGCPGCS] {
+			wi.RawHCL["contents_delta_uri"] = WireRef(KeyGCPGCS, "bucket_url")
+			wi.Names = append(wi.Names, "contents_delta_uri")
+		}
 	}
 
 	// Observability post-switch wiring (issue #204). Driven off the

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1187,19 +1187,25 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 
 	case KeyGCPVertexAI:
 		// Vertex AI Vector Search (#764). When a VPC is selected, wire its
-		// network resource id (projects/<p>/global/networks/<n>, the exact
-		// form google_vertex_ai_index_endpoint.network expects) so the index
-		// endpoint takes the private VPC-peering path — the reason the hard
-		// gcp/vpc dep exists (contracts.go:322 / #600 PSC peering). gcp/vpc's
-		// network_id is surfaced as the vpc_id output.
+		// vpc_id (the project-ID path projects/<project_id>/global/networks/<n>)
+		// to the preset's network input. The preset extracts the network NAME
+		// and rebuilds the project-NUMBER path google_vertex_ai_index_endpoint
+		// actually requires (it cannot accept the project-ID form), so the wire
+		// stays vpc_id and the form conversion lives in the preset. The endpoint
+		// is still PUBLIC unless the operator also sets enable_private_endpoint
+		// (the private path needs #774 PSC peering that gcp/vpc lacks today).
 		if selected[KeyGCPVPC] {
 			wi.RawHCL["network"] = WireRef(KeyGCPVPC, "vpc_id")
 			wi.Names = append(wi.Names, "network")
 		}
-		// When GCS is selected, seed the index from the bucket. bucket_url is
-		// the gs:// URL the index's contents_delta_uri expects.
+		// When GCS is selected, seed the index from a dedicated prefix under the
+		// bucket rather than the bucket root. bucket_url is the gs://<bucket>
+		// root; Vertex's contents_delta_uri expects a DIRECTORY of index data
+		// files, so ingesting the whole bucket root would build a junk index.
+		// Scope it to gs://<bucket>/vertex-index/ — operators stage embedding
+		// files there (the index is created empty if the prefix is absent).
 		if selected[KeyGCPGCS] {
-			wi.RawHCL["contents_delta_uri"] = WireRef(KeyGCPGCS, "bucket_url")
+			wi.RawHCL["contents_delta_uri"] = "\"${" + WireRef(KeyGCPGCS, "bucket_url") + "}/vertex-index/\""
 			wi.Names = append(wi.Names, "contents_delta_uri")
 		}
 	}

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -928,6 +928,24 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyGCPVertexAI:
+		// Vertex AI deepening (#764). The dataset is always created; the
+		// Vector Search resources (index + endpoint + deployed index) are
+		// gated on enable_vector_search. Partial-config: only emit a field
+		// the caller actually populated so the preset's own defaults
+		// (enable_vector_search=false, index_dimensions=768,
+		// index_update_method="BATCH_UPDATE") win when the field is left
+		// unset. network + contents_delta_uri are supplied by DefaultWiring
+		// from gcp/vpc + gcp/gcs in a full stack, not here.
+		if cfg != nil && cfg.GCPVertexAI != nil {
+			if cfg.GCPVertexAI.EnableVectorSearch != nil {
+				vals["enable_vector_search"] = *cfg.GCPVertexAI.EnableVectorSearch
+			}
+			if cfg.GCPVertexAI.IndexDimensions > 0 {
+				vals["index_dimensions"] = cfg.GCPVertexAI.IndexDimensions
+			}
+		}
+
 	case KeyGCPPubSub:
 		vals["topic_name"] = "events"
 		if cfg != nil && cfg.GCPPubSub != nil {

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -209,6 +209,10 @@ func kitchenSinkConfig() *Config {
 		StorageClass string `json:"storageClass,omitempty"`
 		Versioning   *bool  `json:"versioning,omitempty"`
 	}{StorageClass: "STANDARD", Versioning: &t}
+	cfg.GCPVertexAI = &struct {
+		EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
+		IndexDimensions    int   `json:"indexDimensions,omitempty"`
+	}{EnableVectorSearch: &t, IndexDimensions: 768}
 	cfg.GCPPubSub = &struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	}{MessageRetentionDuration: "604800s"}

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -346,6 +346,18 @@ type Config struct {
 		Versioning   *bool  `json:"versioning,omitempty"`
 	} `json:"gcp_gcs,omitempty"`
 
+	// GCPVertexAI carries the caller-supplied Vertex AI configuration (#764).
+	// EnableVectorSearch gates the Vector Search resources (index + endpoint +
+	// deployed index) in the gcp/vertex_ai preset; the dataset is always
+	// created. IndexDimensions is the embedding dimensionality of the Vector
+	// Search index (immutable — changing it forces destroy/recreate). Both are
+	// partial-config: the mapper only emits a field the caller actually
+	// populated so the preset's own defaults win when left unset.
+	GCPVertexAI *struct {
+		EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
+		IndexDimensions    int   `json:"indexDimensions,omitempty"`
+	} `json:"gcp_vertex_ai,omitempty"`
+
 	GCPPubSub *struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	} `json:"gcp_pubsub,omitempty"`
@@ -697,13 +709,14 @@ func (c *Config) Normalize() {
 	}
 	switch c.Cloud {
 	case "AWS":
-		// Clear every GCP sub-config (14 fields — keep in sync with the
+		// Clear every GCP sub-config (15 fields — keep in sync with the
 		// GCPConfiguration section of the Config struct).
 		c.GCPCompute = nil
 		c.GCPGKE = nil
 		c.GCPCloudSQL = nil
 		c.GCPMemorystore = nil
 		c.GCPGCS = nil
+		c.GCPVertexAI = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudRun = nil

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -1,0 +1,111 @@
+package composer
+
+// vertex_ai_gcp_wiring_test.go covers the issue #764 composer surface for the
+// gcp/vertex_ai Vector Search deepening:
+//
+//   - The KeyGCPVertexAI mapper case is partial-config: it only emits a tfvar
+//     the caller actually populated, so the preset's own defaults win when a
+//     field is left unset (mirrors the AWS Bedrock pattern from #757).
+//   - DefaultWiring feeds the index endpoint's private VPC-peering network from
+//     gcp/vpc and the index's contents_delta_uri from gcp/gcs when those
+//     components are selected, and stays inert for both when they are not.
+//
+// The registry plumbing (ComponentKey + PresetKeyMap + ModulePath +
+// AllComponentKeys + ComposeOrder) and the required-variable coverage are
+// exercised by the sibling invariant gates (TestMapperKeysSubsetOfModuleVariables,
+// TestEveryRequiredVariableIsMappedOrWired).
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
+	t.Parallel()
+	m := DefaultMapper{}
+	tr := true
+	fa := false
+
+	t.Run("nil GCPVertexAI emits nothing (preset defaults win)", func(t *testing.T) {
+		t.Parallel()
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, &Config{}, "demo", "us-central1")
+		require.NoError(t, err)
+		_, hasEnable := vals["enable_vector_search"]
+		assert.False(t, hasEnable, "nil GCPVertexAI must not emit enable_vector_search")
+		_, hasDims := vals["index_dimensions"]
+		assert.False(t, hasDims, "nil GCPVertexAI must not emit index_dimensions")
+	})
+
+	t.Run("EnableVectorSearch=true flows through", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		cfg.GCPVertexAI = &struct {
+			EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int   `json:"indexDimensions,omitempty"`
+		}{EnableVectorSearch: &tr, IndexDimensions: 1536}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["enable_vector_search"])
+		assert.Equal(t, 1536, vals["index_dimensions"])
+	})
+
+	t.Run("EnableVectorSearch=false flows through, zero dimensions omitted", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		cfg.GCPVertexAI = &struct {
+			EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int   `json:"indexDimensions,omitempty"`
+		}{EnableVectorSearch: &fa}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["enable_vector_search"])
+		// IndexDimensions left at its zero value must NOT be emitted, so the
+		// preset's own default (768) applies rather than an invalid 0.
+		_, hasDims := vals["index_dimensions"]
+		assert.False(t, hasDims, "zero IndexDimensions must be omitted so the preset default wins")
+	})
+}
+
+func TestDefaultWiring_GCPVertexAI_PrivateEndpointAndGCS(t *testing.T) {
+	t.Parallel()
+
+	// Full stack: VPC + GCS selected -> the index endpoint gets the private
+	// VPC-peering network and the index gets its GCS seed URI.
+	selected := map[ComponentKey]bool{
+		KeyGCPVertexAI: true,
+		KeyGCPVPC:      true,
+		KeyGCPGCS:      true,
+	}
+	wi := DefaultWiring(selected, KeyGCPVertexAI, &Components{})
+
+	require.Contains(t, wi.RawHCL, "network",
+		"VPC selected -> the index endpoint must be wired to the VPC network for the private peering path")
+	assert.Equal(t, WireRef(KeyGCPVPC, "vpc_id"), wi.RawHCL["network"],
+		"network must reference gcp/vpc.vpc_id (the projects/<p>/global/networks/<n> form)")
+
+	require.Contains(t, wi.RawHCL, "contents_delta_uri",
+		"GCS selected -> the index must be seeded from the bucket")
+	assert.Equal(t, WireRef(KeyGCPGCS, "bucket_url"), wi.RawHCL["contents_delta_uri"],
+		"contents_delta_uri must reference gcp/gcs.bucket_url")
+
+	assert.Contains(t, wi.Names, "network")
+	assert.Contains(t, wi.Names, "contents_delta_uri")
+}
+
+func TestDefaultWiring_GCPVertexAI_InertStandalone(t *testing.T) {
+	t.Parallel()
+
+	// Standalone preview: neither VPC nor GCS selected -> no wiring, so the
+	// preset's public-endpoint + empty-index fallbacks apply.
+	selected := map[ComponentKey]bool{
+		KeyGCPVertexAI: true,
+	}
+	wi := DefaultWiring(selected, KeyGCPVertexAI, &Components{})
+
+	assert.NotContains(t, wi.RawHCL, "network",
+		"no VPC selected -> the endpoint must fall back to public (no network wiring)")
+	assert.NotContains(t, wi.RawHCL, "contents_delta_uri",
+		"no GCS selected -> the index must be created empty (no contents_delta_uri wiring)")
+}

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -6,9 +6,12 @@ package composer
 //   - The KeyGCPVertexAI mapper case is partial-config: it only emits a tfvar
 //     the caller actually populated, so the preset's own defaults win when a
 //     field is left unset (mirrors the AWS Bedrock pattern from #757).
-//   - DefaultWiring feeds the index endpoint's private VPC-peering network from
-//     gcp/vpc and the index's contents_delta_uri from gcp/gcs when those
-//     components are selected, and stays inert for both when they are not.
+//   - DefaultWiring feeds the index endpoint's network from gcp/vpc (the
+//     preset converts it to the project-NUMBER form the API needs and the
+//     endpoint stays public unless enable_private_endpoint is set) and the
+//     index's contents_delta_uri from a dedicated gcp/gcs bucket prefix when
+//     those components are selected, and stays inert for both when they are
+//     not.
 //
 // The registry plumbing (ComponentKey + PresetKeyMap + ModulePath +
 // AllComponentKeys + ComposeOrder) and the required-variable coverage are
@@ -68,11 +71,13 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 	})
 }
 
-func TestDefaultWiring_GCPVertexAI_PrivateEndpointAndGCS(t *testing.T) {
+func TestDefaultWiring_GCPVertexAI_NetworkAndGCS(t *testing.T) {
 	t.Parallel()
 
-	// Full stack: VPC + GCS selected -> the index endpoint gets the private
-	// VPC-peering network and the index gets its GCS seed URI.
+	// Full stack: VPC + GCS selected -> the index endpoint network is wired
+	// from gcp/vpc (the preset reshapes it to the project-NUMBER form and keeps
+	// the endpoint public unless enable_private_endpoint is set), and the index
+	// is seeded from a dedicated prefix under the bucket.
 	selected := map[ComponentKey]bool{
 		KeyGCPVertexAI: true,
 		KeyGCPVPC:      true,
@@ -81,14 +86,16 @@ func TestDefaultWiring_GCPVertexAI_PrivateEndpointAndGCS(t *testing.T) {
 	wi := DefaultWiring(selected, KeyGCPVertexAI, &Components{})
 
 	require.Contains(t, wi.RawHCL, "network",
-		"VPC selected -> the index endpoint must be wired to the VPC network for the private peering path")
+		"VPC selected -> the index endpoint network input must be wired from the VPC")
 	assert.Equal(t, WireRef(KeyGCPVPC, "vpc_id"), wi.RawHCL["network"],
-		"network must reference gcp/vpc.vpc_id (the projects/<p>/global/networks/<n> form)")
+		"network must reference gcp/vpc.vpc_id; the preset converts the project-ID path to the project-NUMBER path the API requires")
 
 	require.Contains(t, wi.RawHCL, "contents_delta_uri",
 		"GCS selected -> the index must be seeded from the bucket")
-	assert.Equal(t, WireRef(KeyGCPGCS, "bucket_url"), wi.RawHCL["contents_delta_uri"],
-		"contents_delta_uri must reference gcp/gcs.bucket_url")
+	// Wired to a dedicated prefix under the bucket, NOT the bucket root —
+	// Vertex's contents_delta_uri expects a directory of index data files.
+	assert.Equal(t, "\"${"+WireRef(KeyGCPGCS, "bucket_url")+"}/vertex-index/\"", wi.RawHCL["contents_delta_uri"],
+		"contents_delta_uri must reference a gcp/gcs.bucket_url subdirectory (gs://<bucket>/vertex-index/), not the bucket root")
 
 	assert.Contains(t, wi.Names, "network")
 	assert.Contains(t, wi.Names, "contents_delta_uri")
@@ -98,14 +105,14 @@ func TestDefaultWiring_GCPVertexAI_InertStandalone(t *testing.T) {
 	t.Parallel()
 
 	// Standalone preview: neither VPC nor GCS selected -> no wiring, so the
-	// preset's public-endpoint + empty-index fallbacks apply.
+	// preset's public-endpoint + empty-index defaults apply.
 	selected := map[ComponentKey]bool{
 		KeyGCPVertexAI: true,
 	}
 	wi := DefaultWiring(selected, KeyGCPVertexAI, &Components{})
 
 	assert.NotContains(t, wi.RawHCL, "network",
-		"no VPC selected -> the endpoint must fall back to public (no network wiring)")
+		"no VPC selected -> no network wiring (endpoint is public)")
 	assert.NotContains(t, wi.RawHCL, "contents_delta_uri",
 		"no GCS selected -> the index must be created empty (no contents_delta_uri wiring)")
 }

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -445,7 +445,7 @@ var gcpServiceMetrics = map[string]GCPObs{
 			// gcp/vertex_ai query-latency alert policy alarms on (#764). Lives
 			// here so componentObs() can flip Alarmed=true; without it the
 			// inspector is blind to the alarmed metric.
-			{MetricType: "aiplatform.googleapis.com/matching_engine/query_latencies", ResourceType: "aiplatform.googleapis.com/MatchingEngineIndexEndpoint", LabelKey: "index_endpoint_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "Vector Search Query Latency (p99)"},
+			{MetricType: "aiplatform.googleapis.com/matching_engine/query/latencies", ResourceType: "aiplatform.googleapis.com/IndexEndpoint", LabelKey: "index_endpoint_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "Vector Search Query Latency (p99)"},
 		},
 	},
 }
@@ -573,7 +573,7 @@ var alarmedGCPMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyGCPLoadbalancer:   {Module: "gcp/loadbalancer", Metrics: []string{"loadbalancing.googleapis.com/https/backend_latencies"}},
 	composer.KeyGCPMemorystore:    {Module: "gcp/memorystore", Metrics: []string{"redis.googleapis.com/stats/cpu_utilization"}},
 	composer.KeyGCPPubSub:         {Module: "gcp/pubsub", Metrics: []string{"pubsub.googleapis.com/subscription/num_undelivered_messages"}},
-	composer.KeyGCPVertexAI:       {Module: "gcp/vertex_ai", Metrics: []string{"aiplatform.googleapis.com/matching_engine/query_latencies"}},
+	composer.KeyGCPVertexAI:       {Module: "gcp/vertex_ai", Metrics: []string{"aiplatform.googleapis.com/matching_engine/query/latencies"}},
 }
 
 // AlarmedAWSMetrics returns a defensive copy of the AWS authority entry

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -441,6 +441,11 @@ var gcpServiceMetrics = map[string]GCPObs{
 			{MetricType: "aiplatform.googleapis.com/prediction/online/prediction_count", ResourceType: "aiplatform.googleapis.com/Endpoint", LabelKey: "endpoint_id", Aligner: "ALIGN_RATE", DisplayName: "Online Prediction Count"},
 			{MetricType: "aiplatform.googleapis.com/prediction/online/error_count", ResourceType: "aiplatform.googleapis.com/Endpoint", LabelKey: "endpoint_id", Aligner: "ALIGN_RATE", DisplayName: "Online Prediction Errors"},
 			{MetricType: "aiplatform.googleapis.com/prediction/online/prediction_latencies", ResourceType: "aiplatform.googleapis.com/Endpoint", LabelKey: "endpoint_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "Online Prediction Latency (p99)"},
+			// Vector Search (Matching Engine) serving surface — the metric the
+			// gcp/vertex_ai query-latency alert policy alarms on (#764). Lives
+			// here so componentObs() can flip Alarmed=true; without it the
+			// inspector is blind to the alarmed metric.
+			{MetricType: "aiplatform.googleapis.com/matching_engine/query_latencies", ResourceType: "aiplatform.googleapis.com/MatchingEngineIndexEndpoint", LabelKey: "index_endpoint_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "Vector Search Query Latency (p99)"},
 		},
 	},
 }

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -568,6 +568,7 @@ var alarmedGCPMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyGCPLoadbalancer:   {Module: "gcp/loadbalancer", Metrics: []string{"loadbalancing.googleapis.com/https/backend_latencies"}},
 	composer.KeyGCPMemorystore:    {Module: "gcp/memorystore", Metrics: []string{"redis.googleapis.com/stats/cpu_utilization"}},
 	composer.KeyGCPPubSub:         {Module: "gcp/pubsub", Metrics: []string{"pubsub.googleapis.com/subscription/num_undelivered_messages"}},
+	composer.KeyGCPVertexAI:       {Module: "gcp/vertex_ai", Metrics: []string{"aiplatform.googleapis.com/matching_engine/query_latencies"}},
 }
 
 // AlarmedAWSMetrics returns a defensive copy of the AWS authority entry

--- a/pkg/observability/metrics/gcp_test.go
+++ b/pkg/observability/metrics/gcp_test.go
@@ -1106,7 +1106,7 @@ func TestEveryGCPSpec_PinsMetricTypesAndDisplayNames(t *testing.T) {
 			{"aiplatform.googleapis.com/prediction/online/prediction_latencies", "Online Prediction Latency (p99)"},
 			// Vector Search (Matching Engine) serving surface — the metric the
 			// gcp/vertex_ai query-latency alert policy alarms on (#764).
-			{"aiplatform.googleapis.com/matching_engine/query_latencies", "Vector Search Query Latency (p99)"},
+			{"aiplatform.googleapis.com/matching_engine/query/latencies", "Vector Search Query Latency (p99)"},
 		},
 	}
 

--- a/pkg/observability/metrics/gcp_test.go
+++ b/pkg/observability/metrics/gcp_test.go
@@ -1104,6 +1104,9 @@ func TestEveryGCPSpec_PinsMetricTypesAndDisplayNames(t *testing.T) {
 			{"aiplatform.googleapis.com/prediction/online/prediction_count", "Online Prediction Count"},
 			{"aiplatform.googleapis.com/prediction/online/error_count", "Online Prediction Errors"},
 			{"aiplatform.googleapis.com/prediction/online/prediction_latencies", "Online Prediction Latency (p99)"},
+			// Vector Search (Matching Engine) serving surface — the metric the
+			// gcp/vertex_ai query-latency alert policy alarms on (#764).
+			{"aiplatform.googleapis.com/matching_engine/query_latencies", "Vector Search Query Latency (p99)"},
 		},
 	}
 

--- a/tests/lint-gcp-project-pin.sh
+++ b/tests/lint-gcp-project-pin.sh
@@ -73,6 +73,7 @@ EXEMPT_PROJECT_PIN_GCP=(
   google_service_networking_connection  # parent: network (gcp/cloudsql/main.tf:41)
   google_storage_bucket_iam_member      # parent: bucket (gcp/cloud_logging/main.tf:60)
   google_storage_bucket_object          # parent: bucket (gcp/cloud_functions/main.tf:56)
+  google_vertex_ai_index_endpoint_deployed_index  # parent: index_endpoint (gcp/vertex_ai/main.tf; no project attr in provider schema)
 )
 
 exempt_pattern="^($(IFS='|'; echo "${EXEMPT_PROJECT_PIN_GCP[*]}"))$"


### PR DESCRIPTION
Deepens the existing `gcp_vertex_ai` component (today a bare `google_vertex_ai_dataset`) with Vertex AI Vector Search. No new component key — mirrors how `aws/bedrock` deepened in #771.

## Preset (`gcp/vertex_ai/`)
- Adds `google_vertex_ai_index` + `google_vertex_ai_index_endpoint` + `google_vertex_ai_index_endpoint_deployed_index`, all gated on `var.enable_vector_search`. The dataset stays unconditional.
- `timeouts { create = "90m" }` on the deployed index (deploys run 30-60 min).
- New variables: `enable_vector_search`, `enable_private_endpoint`, `index_dimensions`, `index_update_method`, `contents_delta_uri`, plus distance-measure and replica knobs.
- New outputs: `index_id`, `index_endpoint_id`, `deployed_index_id`.
- `observability.tf`: Vector Search query-latency alert policy + catalog entry.

## Endpoint is public by default; private is opt-in
- The index endpoint is **public by default**. It goes private (VPC-peered) only when a network is wired **and** `enable_private_endpoint = true`.
- The private path needs a servicenetworking PSC peering range on the VPC that `gcp/vpc` does not yet provision (follow-up #774). Before #774 lands, a live private apply fails ~30-90 min into the deployed-index step. Keeping the default public means the standard composed path applies live today.

## Network form fix (project number)
- `google_vertex_ai_index_endpoint.network` requires the **project-NUMBER** path `projects/<number>/global/networks/<name>`. The wired `gcp/vpc.vpc_id` carries the **project-ID** form, which the API rejects.
- The preset now accepts the network in whatever form the VPC emits (project-ID path, project-number path, or bare name), parses the network **name**, and rebuilds the canonical project-number path via `data.google_project.this.number`.

## `contents_delta_uri` scoped to a prefix
- `gcp/gcs.bucket_url` is the `gs://<bucket>` root. Vertex's `contents_delta_uri` expects a **directory** of index data files, so root ingestion would build a junk index.
- Wiring now points at `gs://<bucket>/vertex-index/`; operators stage embedding files there. Absent the prefix, the index is created empty.

## Composer
- New `Config.GCPVertexAI` sub-struct `{ EnableVectorSearch, IndexDimensions }` with Normalize nil-out, partial-config mapper case, kitchenSinkConfig entry, and orphan-strip coverage.
- `DefaultWiring` case: `network` from `gcp/vpc.vpc_id` (preset reshapes it), `contents_delta_uri` from a `gcp/gcs.bucket_url` subdirectory. Uses `WireRef`, no raw module literals.
- Adds `aiplatform.googleapis.com/matching_engine/query_latencies` to the `vertexai` `GCPMetricSpec` catalog so the inspector can flip `Alarmed` for the alert policy's metric (the catalog previously only carried `prediction/online/*`).

## Real-world notes
- **Immutable fields:** `index_dimensions` and `index_update_method` changes force index destroy/recreate.
- `deployed_index_id` is hardened to a letter-leading `[a-z0-9_]` id (`idx_<project>_vector`) to satisfy the API constraint regardless of `var.project`.

## Verification
- `go test ./pkg/composer/` (242) and `./pkg/observability/...` targeted suites green.
- `cd gcp/vertex_ai && terraform test` — 10 passed (private now opt-in; public-by-default and project-number network cases added).
- `gofmt`, `terraform fmt`, `bash tests/lint-project-label.sh` clean.

Closes #764
Part of #756
