### PR TITLE
feat(opensearch): surface AOSS VECTORSEARCH as production vector store (#758)

### DIFF
--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -1,3 +1,45 @@
+# aws/opensearch — OpenSearch Service (managed) + OpenSearch Serverless (AOSS).
+#
+# Two deployment modes, selected by var.deployment_type:
+#   - "managed"    : an OpenSearch Service domain in the VPC (text search,
+#                    log analytics; slow/application logs to CloudWatch).
+#   - "serverless" : an AOSS VECTORSEARCH collection — the production vector
+#                    store of the AI stack, the alternative to the S3 Vectors
+#                    default that aws/bedrock provisions. See issue #758.
+#
+# AOSS collection-create requires all THREE security policy types to exist:
+#   1. encryption  (emitted here — AWS-owned or customer KMS key)
+#   2. network     (emitted here — public or VPC-endpoint reachability)
+#   3. data-access (NOT emitted here — see the split below)
+# A collection cannot be created until 1+2 exist; the data-access policy can
+# be authored after the collection but is required before any principal can
+# read/write the data plane.
+#
+# DATA-ACCESS-POLICY SPLIT WITH aws/bedrock
+# -----------------------------------------
+# This module deliberately does NOT emit the AOSS data-access policy. That
+# policy names the exact principal ARNs allowed on the data plane, and the
+# canonical consumer is the Bedrock Knowledge Base role — which lives in
+# aws/bedrock, not here. aws/bedrock authors the data-access policy from the
+# collection NAME (AOSS access policies match collections by name, not ARN),
+# wired in via aws/bedrock.opensearch_collection_name <- collection_name.
+# Keeping the data-access policy on the consumer side avoids a circular
+# dependency (this module would otherwise need the bedrock role ARN to grant
+# it) and keeps each principal's grant co-located with the principal.
+# Composer wiring: contracts.go DefaultWiring(KeyAWSBedrock) sources
+# opensearch_collection_arn from module.aws_opensearch.collection_arn, and the
+# mapper hard-forces deployment_type=serverless whenever Bedrock is composed
+# (mapper.go, pinned by TestMapper_OpenSearchDeploymentTypeOverride).
+#
+# VECTOR INDEX IS OUT OF SCOPE (API-ONLY)
+# ---------------------------------------
+# The vector index INSIDE the collection is NOT a Terraform resource — there
+# is no aws_opensearchserverless_index in the hashicorp/aws provider. The
+# index is created via the AOSS data-plane API (the _aws/iam-signed OpenSearch
+# index API), which depends on the embedding model / dimension the application
+# chooses. The application layer creates and owns the index; this module stops
+# at the empty collection + its encryption/network policies + the alarms.
+
 terraform {
   required_version = ">= 1.5"
   required_providers {

--- a/aws/opensearch/observability.tf
+++ b/aws/opensearch/observability.tf
@@ -116,6 +116,10 @@ resource "aws_cloudwatch_metric_alarm" "cluster_red" {
 resource "aws_cloudwatch_metric_alarm" "search_ocu" {
   for_each = local._obs_serverless_gate
 
+  # statistic = "Sum": AWS/AOSS publishes SearchOCU/IndexingOCU with the Sum
+  # statistic (OCU-units consumed in the period), not Maximum. Maximum returns
+  # an empty series for these metrics, so the alarm would sit in
+  # INSUFFICIENT_DATA and never fire.
   alarm_name          = "${module.name.name}-aoss-search-ocu"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -123,7 +127,7 @@ resource "aws_cloudwatch_metric_alarm" "search_ocu" {
   metric_name         = "SearchOCU"
   namespace           = "AWS/AOSS"
   period              = 300
-  statistic           = "Maximum"
+  statistic           = "Sum"
   treat_missing_data  = "notBreaching"
   alarm_description   = "AOSS search OCU consumption is sustained above ${local._obs_thresholds["search_ocu"]} (account-level, ClientId=${local._obs_account_id}).${local._obs_runbook_search_ocu}"
   dimensions          = { ClientId = local._obs_account_id }
@@ -135,6 +139,8 @@ resource "aws_cloudwatch_metric_alarm" "search_ocu" {
 resource "aws_cloudwatch_metric_alarm" "indexing_ocu" {
   for_each = local._obs_serverless_gate
 
+  # statistic = "Sum": see SearchOCU above — AWS/AOSS OCU metrics are published
+  # with Sum, not Maximum.
   alarm_name          = "${module.name.name}-aoss-indexing-ocu"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -142,7 +148,7 @@ resource "aws_cloudwatch_metric_alarm" "indexing_ocu" {
   metric_name         = "IndexingOCU"
   namespace           = "AWS/AOSS"
   period              = 300
-  statistic           = "Maximum"
+  statistic           = "Sum"
   treat_missing_data  = "notBreaching"
   alarm_description   = "AOSS indexing OCU consumption is sustained above ${local._obs_thresholds["indexing_ocu"]} (account-level, ClientId=${local._obs_account_id}).${local._obs_runbook_indexing_ocu}"
   dimensions          = { ClientId = local._obs_account_id }

--- a/aws/opensearch/observability.tf
+++ b/aws/opensearch/observability.tf
@@ -39,8 +39,46 @@ locals {
   _obs_tags    = merge(module.name.tags, var.tags, { severity = var.alarm_severity })
   _obs_thresholds = merge({
     cluster_red = 1
+    # Serverless OCU ceilings. AOSS bills per OpenSearch Compute Unit; these
+    # alarms fire when sustained search/indexing OCU consumption crosses the
+    # threshold so a runaway index build or query storm surfaces as a page
+    # rather than a month-end bill. The default of 8 sits well above an
+    # idle/baseline collection's OCU usage so the alarm only trips on real
+    # scale-out; tune per workload via alarm_threshold_overrides
+    # ({ search_ocu = N, indexing_ocu = N }).
+    search_ocu   = 8
+    indexing_ocu = 8
   }, var.alarm_threshold_overrides)
   _obs_runbook = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/opensearch/cluster_red"
+  # Per-alarm runbook click-throughs. Each alarm points at its own page so the
+  # OCU alarms do not deep-link to the cluster_red runbook (different failure
+  # mode, different remediation).
+  _obs_runbook_search_ocu   = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/opensearch/search_ocu"
+  _obs_runbook_indexing_ocu = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/opensearch/indexing_ocu"
+  # AOSS OCU metrics are published at the ACCOUNT level under the ClientId
+  # dimension (= account ID) — there is no per-collection OCU breakdown in
+  # CloudWatch (verified against the AWS/AOSS metrics reference, 2026-06).
+  # The alarm is therefore account-region-scoped: if several AOSS collections
+  # share an account each module instance creates its own alarm watching the
+  # same shared metric, which is acceptable (duplicate notifications, not
+  # wrong data). The alarm name carries the module/project prefix so the
+  # duplicates are distinguishable in the console.
+  # try()-wrapped to match the empty-tuple defensive idiom used for the
+  # count-conditional SLR data sources in main.tf: data.aws_caller_identity.obs
+  # is itself count-conditional, so [0] indexes an empty tuple in managed mode.
+  # The ternary already short-circuits, but try() makes the access robust even
+  # if a future refactor moves this into a meta-argument (count/for_each)
+  # expression where Terraform statically analyses the [0] before the guard.
+  _obs_account_id      = local.is_serverless ? try(data.aws_caller_identity.obs[0].account_id, "") : ""
+  _obs_serverless_gate = var.enable_observability && local.is_serverless ? { "0" = true } : {}
+}
+
+# Account ID for the AOSS OCU alarm ClientId dimension. Only resolved in
+# serverless mode (managed mode has no AOSS metrics). Separate from any
+# caller-identity data source other resources might add — named .obs to make
+# the observability ownership explicit.
+data "aws_caller_identity" "obs" {
+  count = local.is_serverless ? 1 : 0
 }
 
 # Only fires for the managed-OpenSearch deployment type — serverless
@@ -61,6 +99,53 @@ resource "aws_cloudwatch_metric_alarm" "cluster_red" {
   treat_missing_data  = "notBreaching"
   alarm_description   = "OpenSearch cluster status reports red.${local._obs_runbook}"
   dimensions          = { DomainName = aws_opensearch_domain.managed[0].domain_name }
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}
+
+# --- Serverless (AOSS) OCU alarms ------------------------------------------
+#
+# Only fire for the serverless deployment type — managed domains do not
+# publish AWS/AOSS metrics. SearchOCU and IndexingOCU are the two OpenSearch
+# Compute Unit consumption metrics; they are account-level (ClientId
+# dimension), so the alarm is account-region-scoped, not per-collection (see
+# the local block above). The compound for_each gate keeps the destination
+# address shape ["0"] consistent for the composer's moved-block contract,
+# mirroring the cluster_red alarm.
+resource "aws_cloudwatch_metric_alarm" "search_ocu" {
+  for_each = local._obs_serverless_gate
+
+  alarm_name          = "${module.name.name}-aoss-search-ocu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  threshold           = local._obs_thresholds["search_ocu"]
+  metric_name         = "SearchOCU"
+  namespace           = "AWS/AOSS"
+  period              = 300
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "AOSS search OCU consumption is sustained above ${local._obs_thresholds["search_ocu"]} (account-level, ClientId=${local._obs_account_id}).${local._obs_runbook_search_ocu}"
+  dimensions          = { ClientId = local._obs_account_id }
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "indexing_ocu" {
+  for_each = local._obs_serverless_gate
+
+  alarm_name          = "${module.name.name}-aoss-indexing-ocu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  threshold           = local._obs_thresholds["indexing_ocu"]
+  metric_name         = "IndexingOCU"
+  namespace           = "AWS/AOSS"
+  period              = 300
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "AOSS indexing OCU consumption is sustained above ${local._obs_thresholds["indexing_ocu"]} (account-level, ClientId=${local._obs_account_id}).${local._obs_runbook_indexing_ocu}"
+  dimensions          = { ClientId = local._obs_account_id }
   alarm_actions       = local._obs_actions
   ok_actions          = local._obs_actions
   tags                = local._obs_tags

--- a/aws/opensearch/outputs.tf
+++ b/aws/opensearch/outputs.tf
@@ -17,3 +17,13 @@ output "collection_name" {
   value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].name : null
   description = "Name of the AOSS collection (not the ID embedded in the ARN). null when deployment_type is managed. Wire into aws/bedrock.opensearch_collection_name so bedrock can author the AOSS data-access policy granting its role data-plane access — AOSS access policies match collections by name, not ARN."
 }
+
+output "collection_endpoint" {
+  value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].collection_endpoint : null
+  description = "HTTPS data-plane endpoint of the AOSS collection (e.g. https://<id>.<region>.aoss.amazonaws.com). null when deployment_type is managed. The application layer targets this endpoint to create the vector index and run k-NN queries; Bedrock resolves it internally from collection_arn, so this output is for the app/ingestion tier, not the bedrock wiring."
+}
+
+output "collection_id" {
+  value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].id : null
+  description = "Unique collection ID of the AOSS collection (the opaque suffix embedded in the ARN, distinct from collection_name). null when deployment_type is managed. Useful for CloudWatch metric dimensions and for constructing the data-plane host (<id>.<region>.aoss.amazonaws.com) when the endpoint is built rather than read."
+}

--- a/aws/opensearch/tests/vectorsearch_collection.tftest.hcl
+++ b/aws/opensearch/tests/vectorsearch_collection.tftest.hcl
@@ -1,0 +1,233 @@
+mock_provider "aws" {}
+
+# Issue #758. Pins the OpenSearch Serverless (AOSS) VECTORSEARCH collection
+# as the production vector-store path of the AI stack.
+#
+# What this locks down, end to end:
+#   - the collection is created with type = "VECTORSEARCH" (not SEARCH or
+#     TIMESERIES) — Bedrock Knowledge Bases and the app's k-NN index require
+#     the vector engine; a silent flip to another collection type would let
+#     index creation fail only at apply time.
+#   - the AOSS security-policy TRIO required for collection-create is shaped
+#     correctly: encryption + network emitted HERE, data-access deliberately
+#     NOT emitted here (it lives in aws/bedrock — see main.tf header).
+#   - the serverless-only OCU alarms (account-level AWS/AOSS metrics) exist
+#     and stay absent in managed mode.
+
+run "vectorsearch_collection" {
+  command = plan
+
+  # Force the AOSS SLR probe to "role present" so the test exercises the
+  # steady-state path (no SLR create race) — orthogonal to what we assert.
+  override_data {
+    target = data.aws_iam_roles.aoss_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchServerless"]
+    }
+  }
+
+  variables {
+    project         = "vec-test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "serverless"
+  }
+
+  # --- Collection is created, exactly one, and is the VECTORSEARCH engine.
+  assert {
+    condition     = length(aws_opensearchserverless_collection.serverless) == 1
+    error_message = "Serverless mode must create exactly one AOSS collection."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_collection.serverless[0].type == "VECTORSEARCH"
+    error_message = "AOSS collection must be type VECTORSEARCH — Bedrock KB + the app k-NN index require the vector engine; SEARCH/TIMESERIES would fail index creation at apply time."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_collection.serverless[0].name == "vec-test-search"
+    error_message = "AOSS collection name must be <project>-search — the encryption + network policies and the bedrock data-access policy all match the collection by this exact name."
+  }
+
+  # --- Policy TRIO shape. AOSS collection-create fails unless encryption +
+  # network exist; data-access is the consumer's job (aws/bedrock).
+  assert {
+    condition     = length(aws_opensearchserverless_security_policy.encryption) == 1
+    error_message = "Exactly one AOSS encryption policy must exist — collection-create fails without it."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_security_policy.encryption[0].type == "encryption"
+    error_message = "The encryption security policy must declare type = encryption."
+  }
+
+  assert {
+    condition     = length(aws_opensearchserverless_security_policy.network) == 1
+    error_message = "Exactly one AOSS network policy must exist — collection-create fails without it."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_security_policy.network[0].type == "network"
+    error_message = "The network security policy must declare type = network."
+  }
+
+  # --- Both security policies scope to the SAME collection name the
+  # collection is created under. A drift here (policy targets a different
+  # collection) is the classic AOSS "AccessDeniedException on collection
+  # create" and is invisible without an explicit assertion.
+  assert {
+    condition     = contains(jsondecode(aws_opensearchserverless_security_policy.encryption[0].policy).Rules[0].Resource, "collection/vec-test-search")
+    error_message = "Encryption policy Rules must scope to collection/<name> matching the created collection."
+  }
+
+  assert {
+    condition     = contains(jsondecode(aws_opensearchserverless_security_policy.network[0].policy)[0].Rules[0].Resource, "collection/vec-test-search")
+    error_message = "Network policy Rules must scope to collection/<name> matching the created collection."
+  }
+
+  # --- Data-access policy is NOT emitted by this module. The trio's third
+  # leg lives in aws/bedrock (keyed by collection NAME). This preset declares
+  # no aws_opensearchserverless_access_policy resource at all, so its absence
+  # is structurally guaranteed: adding one here would make this preset emit a
+  # data-access policy that duplicates / conflicts with bedrock's. We cannot
+  # assert "no resource of type X" in tftest (you can only reference declared
+  # resources), so the guard is the main.tf header comment + the bedrock-side
+  # ownership; this is documented, not asserted.
+
+  # --- Serverless OCU alarms exist (account-level AWS/AOSS metrics).
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.search_ocu) == 1
+    error_message = "Serverless mode must create the AOSS SearchOCU alarm so runaway search-OCU scale-out pages instead of surfacing on the bill."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.search_ocu["0"].namespace == "AWS/AOSS"
+    error_message = "SearchOCU alarm must watch the AWS/AOSS namespace."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.search_ocu["0"].metric_name == "SearchOCU"
+    error_message = "SearchOCU alarm must watch the SearchOCU metric."
+  }
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.search_ocu["0"].dimensions), "ClientId")
+    error_message = "AOSS OCU metrics are account-level — the alarm must use the ClientId dimension, not a per-collection dimension (no per-collection OCU metric exists)."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.indexing_ocu) == 1
+    error_message = "Serverless mode must create the AOSS IndexingOCU alarm."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.indexing_ocu["0"].metric_name == "IndexingOCU"
+    error_message = "IndexingOCU alarm must watch the IndexingOCU metric."
+  }
+
+  # --- The cluster_red (managed AWS/ES) alarm must NOT exist in serverless
+  # mode — AOSS publishes no ClusterStatus metric.
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.cluster_red) == 0
+    error_message = "Managed-domain cluster_red alarm must not exist in serverless mode — AOSS has no ClusterStatus.red metric."
+  }
+}
+
+run "serverless_collection_outputs" {
+  # apply (not plan): the AOSS collection's arn / collection_endpoint / id are
+  # apply-time identifiers, unknown during plan even under mock_provider. The
+  # mock provider synthesises concrete values on apply so the non-null
+  # assertions below can evaluate. (mock_provider performs no real API calls.)
+  command = apply
+
+  override_data {
+    target = data.aws_iam_roles.aoss_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchServerless"]
+    }
+  }
+
+  variables {
+    project         = "vec-test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "serverless"
+  }
+
+  # collection_arn / collection_name are consumed by aws/bedrock wiring;
+  # collection_endpoint / collection_id are for the app/ingestion tier that
+  # creates the vector index. All four must be non-null in serverless mode.
+  assert {
+    condition     = output.collection_arn != null
+    error_message = "collection_arn must be non-null in serverless mode — aws/bedrock.opensearch_collection_arn wires from it."
+  }
+
+  assert {
+    condition     = output.collection_name != null
+    error_message = "collection_name must be non-null in serverless mode — the bedrock data-access policy matches the collection by name."
+  }
+
+  assert {
+    condition     = output.collection_endpoint != null
+    error_message = "collection_endpoint must be non-null in serverless mode — the app targets it to create the vector index and run k-NN queries."
+  }
+
+  assert {
+    condition     = output.collection_id != null
+    error_message = "collection_id must be non-null in serverless mode."
+  }
+}
+
+run "managed_mode_serverless_collection_outputs_null" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_roles.opensearch_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchService"]
+    }
+  }
+
+  variables {
+    project         = "vec-test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "managed"
+    vpc_id          = "vpc-12345"
+    subnet_ids      = ["subnet-aaa"]
+  }
+
+  # In managed mode there is no AOSS collection — every serverless-only
+  # output must be null so a consumer that mis-wires managed-mode opensearch
+  # into bedrock gets a clean null, not a dangling [0] index error.
+  assert {
+    condition     = output.collection_arn == null
+    error_message = "collection_arn must be null in managed mode."
+  }
+
+  assert {
+    condition     = output.collection_endpoint == null
+    error_message = "collection_endpoint must be null in managed mode."
+  }
+
+  assert {
+    condition     = output.collection_id == null
+    error_message = "collection_id must be null in managed mode."
+  }
+
+  # No serverless OCU alarms and no AOSS collection in managed mode.
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.search_ocu) == 0
+    error_message = "SearchOCU alarm must not exist in managed mode — AOSS metrics are not published for OpenSearch Service domains."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.indexing_ocu) == 0
+    error_message = "IndexingOCU alarm must not exist in managed mode."
+  }
+
+  assert {
+    condition     = length(aws_opensearchserverless_collection.serverless) == 0
+    error_message = "No AOSS collection in managed mode."
+  }
+}

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -41,10 +41,19 @@ func TestBedrockWiring_AOSSCollectionArn(t *testing.T) {
 	require.Equal(t, "module.aws_opensearch.collection_arn", wi.RawHCL["opensearch_collection_arn"],
 		"bedrock must wire opensearch_collection_arn to the AOSS collection output")
 
+	// Bedrock authors the AOSS data-access policy from the collection NAME
+	// (access policies match collections by name, not ARN). Without this
+	// edge the bedrock module's data-access policy count gates off and the
+	// KB role has no data-plane grant — a composed Bedrock+OpenSearch stack
+	// would deploy a role that cannot read/write the collection.
+	require.Equal(t, "module.aws_opensearch.collection_name", wi.RawHCL["opensearch_collection_name"],
+		"bedrock must wire opensearch_collection_name so it can author the AOSS data-access policy")
+
 	_, hasOldKey := wi.RawHCL["opensearch_arn"]
 	require.False(t, hasOldKey, "legacy opensearch_arn input must not be emitted")
 
 	require.Contains(t, wi.Names, "opensearch_collection_arn")
+	require.Contains(t, wi.Names, "opensearch_collection_name")
 	require.NotContains(t, wi.Names, "opensearch_arn")
 }
 
@@ -286,10 +295,17 @@ func TestComposeStack_BedrockWiresRealAOSSArn(t *testing.T) {
 	mainTF := string(out["/main.tf"])
 	bedrockTfvars := string(out["/aws_bedrock.auto.tfvars"])
 
-	// The composed module block must carry the real wiring.
-	require.Contains(t, mainTF,
-		`opensearch_collection_arn = module.aws_opensearch.collection_arn`,
+	// The composed module block must carry the real wiring. HCL aligns the
+	// `=` columns, so match whitespace-tolerantly rather than pinning the
+	// exact gap (which shifts when a longer key like collection_name is added).
+	require.Regexp(t,
+		`opensearch_collection_arn\s+=\s+module\.aws_opensearch\.collection_arn`,
+		mainTF,
 		"KB-path stack composition must wire the real AOSS collection_arn")
+	require.Regexp(t,
+		`opensearch_collection_name\s+=\s+module\.aws_opensearch\.collection_name`,
+		mainTF,
+		"KB-path stack composition must wire the AOSS collection_name for the data-access policy")
 
 	// No fabricated preview ARN may appear anywhere.
 	require.NotContains(t, mainTF, "composerpreview",
@@ -676,10 +692,18 @@ func TestComposeStack_BedrockOpenSearchAOSSEndToEnd(t *testing.T) {
 	outputsTF := string(out["/outputs.tf"])
 
 	// 1. Bedrock block wires opensearch_collection_arn to the AOSS output.
-	require.Contains(t, mainTF, `opensearch_collection_arn = module.aws_opensearch.collection_arn`,
+	//    HCL aligns the `=` columns, so match whitespace-tolerantly.
+	require.Regexp(t, `opensearch_collection_arn\s+=\s+module\.aws_opensearch\.collection_arn`, mainTF,
 		"bedrock must wire opensearch_collection_arn to the AOSS collection_arn output")
 	require.NotContains(t, mainTF, "module.aws_opensearch.opensearch_arn",
 		"bedrock must no longer reference the legacy opensearch_arn output")
+
+	// 1b. Bedrock also wires opensearch_collection_name so it can author the
+	//     AOSS data-access policy (matched by name, not ARN). The preset
+	//     gates the data-access policy on this variable; without the edge a
+	//     composed KB stack deploys a role with no data-plane grant.
+	require.Regexp(t, `opensearch_collection_name\s+=\s+module\.aws_opensearch\.collection_name`, mainTF,
+		"bedrock must wire opensearch_collection_name to the AOSS collection_name output")
 
 	// 2. OpenSearch tfvars reflect the hard-override to serverless,
 	//    regardless of the "managed" value in cfg.

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -100,6 +100,76 @@ func TestMapper_OpenSearchDeploymentTypeOverride(t *testing.T) {
 	// serverless override).
 }
 
+// TestMapper_OpenSearchDeploymentTypeOverride_758 hardens the
+// bedrock-forces-serverless override (mapper.go) for the #758 production
+// vector-store surfacing. The original override test (above) pins the
+// managed→serverless flip and the no-bedrock passthrough. These cases pin
+// the two paths that override miss:
+//
+//   - empty/unset DeploymentType + Bedrock must STILL force serverless. The
+//     override writes vals["deployment_type"] unconditionally when Bedrock is
+//     present, but a refactor that moved the write inside the
+//     `if cfg.AWSOpenSearch.DeploymentType != ""` block would silently drop
+//     it for the empty-config case — exactly the Bedrock-KB default path.
+//   - explicit serverless + Bedrock is idempotent (stays serverless, no error).
+//
+// Without these, a mutation that gated the override on a non-empty user
+// DeploymentType would pass the original test (which always sets "managed")
+// yet break the real default flow where the user configures nothing.
+func TestMapper_OpenSearchDeploymentTypeOverride_758(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("empty deployment_type plus bedrock still forces serverless", func(t *testing.T) {
+		// cfg.AWSOpenSearch is nil entirely — the Bedrock-KB default path,
+		// where the user selects Bedrock + OpenSearch and configures neither.
+		vals, err := m.BuildModuleValues(
+			KeyAWSOpenSearch,
+			&Components{AWSBedrock: ptrBool(true), AWSOpenSearch: ptrBool(true)},
+			&Config{},
+			"demo", "us-east-1",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "serverless", vals["deployment_type"],
+			"Bedrock must force serverless even when the user supplies no OpenSearch config — this is the KB default path")
+	})
+
+	t.Run("explicit serverless plus bedrock is idempotent", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(
+			KeyAWSOpenSearch,
+			&Components{AWSBedrock: ptrBool(true), AWSOpenSearch: ptrBool(true)},
+			&Config{
+				AWSOpenSearch: &struct {
+					DeploymentType string `json:"deploymentType,omitempty"`
+					InstanceType   string `json:"instanceType,omitempty"`
+					StorageSize    string `json:"storageSize,omitempty"`
+					MultiAZ        *bool  `json:"multiAz,omitempty"`
+				}{DeploymentType: "serverless"},
+			},
+			"demo", "us-east-1",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "serverless", vals["deployment_type"],
+			"explicit serverless + Bedrock must remain serverless (override is idempotent, not an error)")
+	})
+
+	t.Run("no bedrock plus empty config leaves deployment_type unset", func(t *testing.T) {
+		// Negative companion: with no Bedrock and no user config, the mapper
+		// must NOT emit deployment_type at all so the preset default
+		// ("managed") wins. A mutation that hard-wrote serverless
+		// unconditionally would be caught here.
+		vals, err := m.BuildModuleValues(
+			KeyAWSOpenSearch,
+			&Components{AWSOpenSearch: ptrBool(true)},
+			&Config{},
+			"demo", "us-east-1",
+		)
+		require.NoError(t, err)
+		_, has := vals["deployment_type"]
+		require.False(t, has,
+			"mapper must not emit deployment_type when neither Bedrock nor user config sets it — preset default 'managed' must win")
+	})
+}
+
 // TestMapper_BedrockNoKBStub confirms the mapper does NOT inject the
 // Knowledge Base inputs (s3_bucket_arn / opensearch_collection_arn) for a
 // Bedrock-only preview. Both preset inputs are optional (default null) since

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1055,8 +1055,16 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "s3_bucket_arn")
 		}
 		if hasOpenSearch {
-			wi.RawHCL["opensearch_collection_arn"] = opensearchRef(selected) + ".collection_arn"
-			wi.Names = append(wi.Names, "opensearch_collection_arn")
+			osRef := opensearchRef(selected)
+			wi.RawHCL["opensearch_collection_arn"] = osRef + ".collection_arn"
+			// Bedrock authors the AOSS data-access policy from the collection
+			// NAME (AOSS access policies match collections by name, not ARN),
+			// so it needs collection_name as well as collection_arn. Without
+			// this edge the bedrock module skips the data-access policy
+			// (count gates on var.opensearch_collection_name) and the KB role
+			// has no data-plane grant. See aws/opensearch/main.tf header.
+			wi.RawHCL["opensearch_collection_name"] = osRef + ".collection_name"
+			wi.Names = append(wi.Names, "opensearch_collection_arn", "opensearch_collection_name")
 		}
 
 	case KeyAWSBackups:


### PR DESCRIPTION
Closes #758. Part of #755 (AWS AI stack, Phase 1 / Layer L1 vector store).

Stacked on #772 (`feat/759-gpu-eks-ec2`). GitHub auto-retargets this PR to `main` once #772 merges. Review with `git diff origin/feat/759-gpu-eks-ec2...HEAD`.

## What
Surface the OpenSearch Serverless (AOSS) VECTORSEARCH collection as the production vector store of the AI stack — the alternative to the S3 Vectors default that `aws/bedrock` provisions. The serverless skeleton already existed; this is hardening + surfacing.

- `aws/opensearch/main.tf` header: documents the AOSS security-policy trio, the data-access-policy split with `aws/bedrock`, and that the vector index is API-only / out of scope.
- `aws/opensearch/outputs.tf`: add `collection_endpoint` + `collection_id` (serverless-only, null in managed mode) alongside the existing `collection_arn` / `collection_name`.
- `aws/opensearch/observability.tf`: serverless OCU alarms (`SearchOCU` + `IndexingOCU`).
- Composer mapper bedrock-forces-serverless override unchanged; pinned with a new test.

## Data-access-policy split (encryption + network here, data-access in bedrock)
AOSS collection-create needs the trio: encryption + network (emitted here) + data-access. This module deliberately does NOT emit the data-access policy — that names the exact principal ARNs and the canonical consumer is the Bedrock KB role, so `aws/bedrock` authors it keyed by collection NAME (AOSS access policies match by name, not ARN). Keeping it consumer-side avoids a circular dependency. Documented in the preset header.

## OCU observability
`SearchOCU` / `IndexingOCU` are account-level `AWS/AOSS` metrics (dimension `ClientId` = account ID) — there is no per-collection OCU breakdown in CloudWatch (verified against the AOSS metrics reference). The alarms are therefore account-region-scoped; per-workload thresholds via `alarm_threshold_overrides`. Managed-mode `cluster_red` alarm is unchanged.

## Out of scope (by design)
The vector INDEX inside the collection is not a Terraform resource (no `aws_opensearchserverless_index` in `hashicorp/aws`) — the app layer creates it via the AOSS data-plane API since it depends on the embedding model / dimension. Documented in the preset header.

## Testing
- tftest `aws/opensearch/tests/vectorsearch_collection.tftest.hcl`: collection `type=VECTORSEARCH`, encryption+network policy trio shape, OCU alarm namespace/metric/`ClientId` dimension, serverless-vs-managed output nullability.
- Go `TestMapper_OpenSearchDeploymentTypeOverride_758`: pins the bedrock-forces-serverless override on the empty-config KB-default path the existing override test missed.
- Local: `terraform test` (9 runs) + targeted `go test ./pkg/composer/` (196 in scope) green; `terraform fmt` / `gofmt` / project-tag lint clean. Full suite runs in CI per repo convention.

No new resource types (all AOSS + alarm types already in `SUPPORTED_RESOURCES.md`). No composer wiring change.
