### PR TITLE
feat: AI stack phase-1 bundle — GPU, vector stores, Bedrock Agent (#758 #759 #762 #764)

### DIFF
--- a/aws/bedrock_agent/main.tf
+++ b/aws/bedrock_agent/main.tf
@@ -1,0 +1,248 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "bra"
+  resource       = "bra"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  agent_name        = var.agent_name == null ? "${var.project}-agent" : var.agent_name
+  action_group_name = var.action_group_name == null ? "actions" : var.action_group_name
+
+  # The action group / Lambda invoke permission only exist when a backing
+  # Lambda is wired in. A KB-only or chat-only agent leaves these off.
+  has_action_group = var.action_group_lambda_arn != null
+  # The KB association only exists when a Knowledge Base id is wired in.
+  has_knowledge_base = var.knowledge_base_id != null
+}
+
+# --- Agent resource IAM role --------------------------------------------------
+#
+# Bedrock assumes this role to run the agent: invoke the foundation model and,
+# when a Knowledge Base is associated, retrieve from it. Always created — it is
+# a required input to the agent resource below and keeps the preset producing
+# infrastructure even in its minimal (chat-only) shape.
+resource "aws_iam_role" "agent" {
+  name = "${var.project}-bedrock-agent-role"
+
+  # Scope the bedrock.amazonaws.com service trust to this account
+  # (aws:SourceAccount) to close the cross-account confused-deputy hole, and to
+  # the agent ARN namespace (aws:SourceArn) so only Bedrock agents in this
+  # account+region can assume the role. Mirrors the aws/bedrock KB role.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "bedrock.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:agent/*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(module.name.tags, var.tags)
+
+  # The inline policy is attached via aws_iam_role_policy below; the provider
+  # re-reads it onto the role on refresh and drift-check flags it. Ignore here.
+  # (managed_policy_arns is deprecated in AWS provider 6.x and unused here.)
+  lifecycle {
+    ignore_changes = [inline_policy]
+  }
+}
+
+# The agent role policy: InvokeModel on the agent's foundation model is always
+# present (the whole point of the role and keeps the Statement list non-empty,
+# which aws_iam_role_policy requires). bedrock:Retrieve is appended only when a
+# Knowledge Base is associated — it has no purpose for a chat-only agent.
+locals {
+  agent_invoke_statement = {
+    Sid    = "InvokeFoundationModel"
+    Effect = "Allow"
+    Action = [
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream",
+    ]
+    # The agent may resolve its model through an inference profile, which fans
+    # out to the underlying foundation models — grant both the model ARN and
+    # the inference-profile ARN namespace so either resolution path works.
+    Resource = [
+      "arn:aws:bedrock:${data.aws_region.current.region}::foundation-model/*",
+      "arn:aws:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:inference-profile/*",
+    ]
+  }
+
+  agent_retrieve_statements = local.has_knowledge_base ? [
+    {
+      Sid    = "RetrieveFromKnowledgeBase"
+      Effect = "Allow"
+      Action = [
+        "bedrock:Retrieve",
+        "bedrock:RetrieveAndGenerate",
+      ]
+      Resource = [
+        "arn:aws:bedrock:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:knowledge-base/${var.knowledge_base_id}",
+      ]
+    }
+  ] : []
+}
+
+resource "aws_iam_role_policy" "agent" {
+  name = "${var.project}-bedrock-agent-policy"
+  role = aws_iam_role.agent.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [local.agent_invoke_statement],
+      local.agent_retrieve_statements,
+    )
+  })
+}
+
+# --- Agent --------------------------------------------------------------------
+#
+# prepare_agent = true builds the DRAFT version into a PREPARED state, so a
+# chat-only agent (no action group / KB) is immediately invokable via its
+# alias. The agent CANNOT depend_on its own action group / KB association — they
+# reference the agent (agent_id), so that would be a cycle. Instead, the action
+# group and KB association each re-run prepare after they write into the DRAFT
+# (prepare_agent = true on those resources), and the alias depends_on all of
+# them so it only ever binds a PREPARED version that already includes the tools.
+resource "aws_bedrockagent_agent" "this" {
+  agent_name                  = local.agent_name
+  agent_resource_role_arn     = aws_iam_role.agent.arn
+  foundation_model            = var.foundation_model
+  instruction                 = var.instruction
+  idle_session_ttl_in_seconds = var.idle_session_ttl_in_seconds
+  prepare_agent               = true
+
+  tags = merge(module.name.tags, var.tags)
+
+  depends_on = [aws_iam_role_policy.agent]
+}
+
+# --- Knowledge Base association -----------------------------------------------
+#
+# Associates an existing Bedrock Knowledge Base with the agent's DRAFT version
+# so the agent can retrieve from it (RAG). Only created when a KB id is wired
+# in. This resource has no prepare_agent flag of its own; the action group's
+# prepare (below, ordered after this via depends_on) re-prepares the agent so
+# the alias picks up the KB. In the composed product aws/lambda is a HARD
+# implicit dependency of aws_bedrock_agent, so an action group is always
+# present to drive that re-prepare. (Standalone caveat: a KB-only agent with no
+# action_group_lambda_arn relies on the agent's initial prepare, which runs
+# before this association is written — the alias picks up the KB on the next
+# apply. Supply an action group, or re-apply once, to fold the KB in
+# immediately.)
+resource "aws_bedrockagent_agent_knowledge_base_association" "this" {
+  count = local.has_knowledge_base ? 1 : 0
+
+  agent_id             = aws_bedrockagent_agent.this.agent_id
+  knowledge_base_id    = var.knowledge_base_id
+  knowledge_base_state = "ENABLED"
+  description          = var.knowledge_base_instruction
+}
+
+# --- Action group -------------------------------------------------------------
+#
+# Attaches a Lambda executor to the agent's DRAFT version. function_schema
+# declares the callable tool inline (no external OpenAPI payload / S3 object
+# required). prepare_agent = true re-prepares the agent after the action group
+# is written into the DRAFT, so the alias (which depends_on this resource) only
+# ever binds a PREPARED version that already includes the tools. depends_on the
+# KB association so this prepare is the LAST DRAFT mutation in the apply — the
+# prepared snapshot then reflects BOTH the action group and the KB regardless of
+# the order Terraform applies the two independent resources.
+resource "aws_bedrockagent_agent_action_group" "this" {
+  count = local.has_action_group ? 1 : 0
+
+  agent_id          = aws_bedrockagent_agent.this.agent_id
+  agent_version     = "DRAFT"
+  action_group_name = local.action_group_name
+  description       = "Lambda-backed tools for ${local.agent_name}."
+  prepare_agent     = true
+
+  action_group_executor {
+    lambda = var.action_group_lambda_arn
+  }
+
+  function_schema {
+    member_functions {
+      functions {
+        name        = "invoke"
+        description = "Invoke the backing Lambda to perform an action on behalf of the user."
+        parameters {
+          map_block_key = "input"
+          type          = "string"
+          description   = "Free-form input forwarded to the Lambda."
+          required      = false
+        }
+      }
+    }
+  }
+
+  # Order the action group's prepare after the KB association so the prepared
+  # snapshot includes the KB. Safe when the KB association is absent (count=0):
+  # depends_on on an empty resource list is a no-op.
+  depends_on = [aws_bedrockagent_agent_knowledge_base_association.this]
+}
+
+# Allow the Bedrock agent service to invoke the action-group Lambda. Scoped to
+# the agent ARN so only this agent (not any Bedrock caller) may invoke it.
+resource "aws_lambda_permission" "agent_invoke" {
+  count = local.has_action_group ? 1 : 0
+
+  statement_id  = "AllowBedrockAgentInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = var.action_group_lambda_arn
+  principal     = "bedrock.amazonaws.com"
+  source_arn    = aws_bedrockagent_agent.this.agent_arn
+}
+
+# --- Alias --------------------------------------------------------------------
+#
+# A stable, invokable handle for the agent. depends_on the agent (which always
+# prepares itself) plus the action group + KB association guarantees the alias
+# NEVER binds a NOT_PREPARED agent and is created only AFTER every DRAFT
+# mutation + the re-prepare that follows them — the documented failure mode this
+# preset exists to encapsulate.
+resource "aws_bedrockagent_agent_alias" "this" {
+  agent_id         = aws_bedrockagent_agent.this.agent_id
+  agent_alias_name = "${var.project}-live"
+  description      = "Live alias for ${local.agent_name}, always bound to the latest PREPARED version."
+
+  tags = merge(module.name.tags, var.tags)
+
+  depends_on = [
+    aws_bedrockagent_agent.this,
+    aws_bedrockagent_agent_action_group.this,
+    aws_bedrockagent_agent_knowledge_base_association.this,
+  ]
+}

--- a/aws/bedrock_agent/main.tf
+++ b/aws/bedrock_agent/main.tf
@@ -143,6 +143,11 @@ resource "aws_bedrockagent_agent" "this" {
   idle_session_ttl_in_seconds = var.idle_session_ttl_in_seconds
   prepare_agent               = true
 
+  # A prepared agent that still has a live alias / action group bound can hit
+  # the same ConflictException as the action group on delete. Skip the in-use
+  # check so destroy tears the agent down cleanly alongside its dependents.
+  skip_resource_in_use_check = true
+
   tags = merge(module.name.tags, var.tags)
 
   depends_on = [aws_iam_role_policy.agent]
@@ -188,6 +193,12 @@ resource "aws_bedrockagent_agent_action_group" "this" {
   action_group_name = local.action_group_name
   description       = "Lambda-backed tools for ${local.agent_name}."
   prepare_agent     = true
+
+  # An ENABLED action group attached to a prepared agent cannot be deleted —
+  # Bedrock returns ConflictException ("ActionGroup ... cannot be deleted when
+  # it is Enabled") on DeleteAgentActionGroup. Skip the in-use check so destroy
+  # (and any replace) removes it cleanly without a manual disable step.
+  skip_resource_in_use_check = true
 
   action_group_executor {
     lambda = var.action_group_lambda_arn

--- a/aws/bedrock_agent/observability.tf
+++ b/aws/bedrock_agent/observability.tf
@@ -1,0 +1,67 @@
+# observability.tf — issue #204
+
+variable "enable_observability" {
+  description = "When true, emit per-component CloudWatch alarms gated on this module's resources (issue #204)."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_topic_arn" {
+  description = "SNS topic ARN that receives alarm + ok notifications. When null, the alarm exists but does not notify."
+  type        = string
+  default     = null
+}
+
+variable "alarm_severity" {
+  description = "Severity tag attached to alarms. One of critical|warning|info."
+  type        = string
+  default     = "warning"
+  validation {
+    condition     = contains(["critical", "warning", "info"], var.alarm_severity)
+    error_message = "alarm_severity must be one of critical|warning|info."
+  }
+}
+
+variable "alarm_threshold_overrides" {
+  description = "Per-metric numeric threshold overrides; missing keys fall through to the module's defaults."
+  type        = map(number)
+  default     = {}
+}
+
+variable "runbook_url_prefix" {
+  description = "Optional URL prefix included in alarm_description so on-call has a click-through."
+  type        = string
+  default     = ""
+}
+
+locals {
+  _obs_actions = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]
+  _obs_tags    = merge(module.name.tags, var.tags, { severity = var.alarm_severity })
+  _obs_thresholds = merge({
+    invocation_client_errors = 5
+  }, var.alarm_threshold_overrides)
+  _obs_runbook = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/bedrock_agent/errors"
+}
+
+# Bedrock Agents publish InvocationClientErrors under AWS/Bedrock keyed by the
+# agent id. A spike means callers are sending malformed InvokeAgent requests or
+# the agent is rejecting them (bad alias / unprepared version / missing
+# permissions) — exactly the failure surface this preset exists to prevent.
+resource "aws_cloudwatch_metric_alarm" "client_errors_high" {
+  for_each = var.enable_observability ? { "0" = true } : {}
+
+  alarm_name          = "${module.name.name}-bedrock-agent-client-errors"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  threshold           = local._obs_thresholds["invocation_client_errors"]
+  metric_name         = "InvocationClientErrors"
+  namespace           = "AWS/Bedrock"
+  period              = 300
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "Bedrock Agent client errors above ${local._obs_thresholds["invocation_client_errors"]} per period.${local._obs_runbook}"
+  dimensions          = { AgentId = aws_bedrockagent_agent.this.agent_id }
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}

--- a/aws/bedrock_agent/outputs.tf
+++ b/aws/bedrock_agent/outputs.tf
@@ -1,0 +1,34 @@
+output "agent_id" {
+  value       = aws_bedrockagent_agent.this.agent_id
+  description = "ID of the Bedrock Agent. Pass to InvokeAgent (with agent_alias_id) at runtime."
+}
+
+output "agent_arn" {
+  value       = aws_bedrockagent_agent.this.agent_arn
+  description = "ARN of the Bedrock Agent."
+}
+
+output "agent_alias_id" {
+  value       = aws_bedrockagent_agent_alias.this.agent_alias_id
+  description = "ID of the agent's live alias. The stable handle to pass to InvokeAgent — always bound to the latest PREPARED version."
+}
+
+output "agent_alias_arn" {
+  value       = aws_bedrockagent_agent_alias.this.agent_alias_arn
+  description = "ARN of the agent's live alias."
+}
+
+output "agent_version" {
+  value       = aws_bedrockagent_agent.this.agent_version
+  description = "Current version of the agent (DRAFT until a numbered version is published)."
+}
+
+output "agent_resource_role_arn" {
+  value       = aws_iam_role.agent.arn
+  description = "ARN of the IAM role Bedrock assumes to run the agent (InvokeModel, + Retrieve when a Knowledge Base is associated)."
+}
+
+output "action_group_id" {
+  value       = local.has_action_group ? aws_bedrockagent_agent_action_group.this[0].action_group_id : null
+  description = "ID of the Lambda-backed action group. null when no action_group_lambda_arn was wired in (chat-only agent)."
+}

--- a/aws/bedrock_agent/tests/integration.tftest.hcl
+++ b/aws/bedrock_agent/tests/integration.tftest.hcl
@@ -1,0 +1,201 @@
+# Integration tests for the bedrock_agent module — APPLIES AGAINST A REAL AWS ACCOUNT.
+#
+# Run with valid AWS credentials in the target account:
+#
+#   cd aws/bedrock_agent
+#   terraform init -backend=false
+#   AWS_REGION=us-east-1 terraform test -filter=tests/integration.tftest.hcl
+#
+# What it does:
+#   1. setup_action_lambda: stands up a real Lambda via the sibling ../lambda
+#      preset (bundled placeholder.zip, no VPC) to back the agent's action
+#      group. Yields a concrete function_arn for the executor.
+#   2. bedrock_agent_apply: applies bedrock_agent with the action-group Lambda
+#      wired in, asserting the agent id/arn, the live alias id, the action
+#      group + its Lambda executor, the Bedrock->Lambda invoke permission, and
+#      the agent role + trust-policy confused-deputy guard all come up. This is
+#      the live-apply proof that the PREPARED-before-alias ordering holds: the
+#      action group writes the tool into the DRAFT and re-prepares, and the
+#      alias (depends_on the action group) only ever binds the PREPARED version.
+#      If the ordering were wrong, the alias create would fail against a
+#      NOT_PREPARED agent and this apply would error.
+#   3. Tears EVERYTHING down at the end (terraform test always destroys).
+#
+# No Knowledge Base run here on purpose — the KB suite (aws/bedrock) is the
+# RAG live-apply proof and is exercised separately. This test stays
+# self-contained and fast: agent + action group + alias only.
+#
+# Model: anthropic.claude-3-haiku-20240307-v1:0 — the cheapest authorized
+# Anthropic text model in this account/region (verified with
+# `aws bedrock get-foundation-model-availability`). If agent creation ever
+# fails with a model-access / on-demand-throughput error, switch
+# foundation_model to the cross-region inference profile form
+# "us.anthropic.claude-3-haiku-20240307-v1:0" (the preset role already grants
+# the inference-profile ARN namespace).
+#
+# Resource names embed a UTC timestamp suffix (MMDDhhmmss) under the iotagt-
+# prefix so this never collides with the concurrent aws/bedrock KB
+# integration run (iotbed- prefix) or with a prior iotagt- run. This test does
+# NOT touch the aws_bedrock_model_invocation_logging_configuration singleton.
+#
+# If a prior run was killed mid-apply, manual cleanup may be required:
+#
+#   aws bedrock-agent list-agents --query 'agentSummaries[?starts_with(agentName, `iotagt-`)]'
+#   aws bedrock-agent delete-agent --agent-id <id> --skip-resource-in-use-check
+#   aws lambda list-functions --query 'Functions[?starts_with(FunctionName, `iotagt-`)]'
+#   aws lambda delete-function --function-name <name>
+#   aws iam list-roles --query 'Roles[?starts_with(RoleName, `iotagt-`)]'
+#   # detach/delete inline + managed policies, then:
+#   aws iam delete-role --role-name <name>
+
+provider "aws" {
+  region = var.region
+}
+
+variables {
+  # Suffix the project name with a UTC MMDDhhmmss timestamp so concurrent or
+  # back-to-back runs don't collide on agent / Lambda / role names. Computed
+  # once at file-load time and shared across every run in this file, so
+  # setup_action_lambda and bedrock_agent_apply see the same project string.
+  # Risk: two runs in the exact same second collide. Acceptable for a
+  # human-driven integration test.
+  project     = "iotagt-${formatdate("MMDDhhmmss", timestamp())}"
+  region      = "us-east-1"
+  environment = "test"
+
+  # Cheapest authorized Anthropic text model in this account/region. See the
+  # header note for the inference-profile fallback if model access changes.
+  foundation_model = "anthropic.claude-3-haiku-20240307-v1:0"
+}
+
+# --- Setup: real action-group Lambda --------------------------------------
+#
+# Uses the sibling lambda preset (bundled placeholder.zip, no VPC) so the
+# action group has a concrete executor ARN. Path is resolved relative to the
+# module under test (aws/bedrock_agent), so we go up one level and across.
+run "setup_action_lambda" {
+  command = apply
+
+  module {
+    source = "../lambda"
+  }
+
+  variables {
+    project     = var.project
+    environment = var.environment
+    region      = var.region
+  }
+
+  assert {
+    condition     = output.function_arn != null && length(output.function_arn) > 0
+    error_message = "Action-group Lambda setup must yield a function ARN."
+  }
+}
+
+# --- Main: bedrock_agent against the real Lambda --------------------------
+#
+# The live-apply proof for the PREPARED-before-alias ordering. With the
+# action-group Lambda wired in, the apply must build: the agent (prepares its
+# DRAFT), the action group (writes the tool into the DRAFT and re-prepares),
+# the Bedrock->Lambda invoke permission, and the alias (binds the PREPARED
+# version that now includes the tool). A wrong ordering — alias created before
+# the agent reaches PREPARED — fails the alias create here.
+run "bedrock_agent_apply" {
+  command = apply
+
+  variables {
+    action_group_lambda_arn = run.setup_action_lambda.function_arn
+  }
+
+  # --- Agent up with id + arn ---
+  assert {
+    condition     = aws_bedrockagent_agent.this.agent_name == "${var.project}-agent"
+    error_message = "Agent name must default to {project}-agent."
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_agent.this.agent_id) > 0
+    error_message = "Live agent must report a non-empty agent_id after apply."
+  }
+
+  assert {
+    condition     = can(regex("^arn:aws:bedrock:", aws_bedrockagent_agent.this.agent_arn))
+    error_message = "Live agent must report a Bedrock agent ARN after apply."
+  }
+
+  # The agent must reach PREPARED so the alias can bind it. The resource has no
+  # agent_status attribute, but prepared_at is the computed timestamp Bedrock
+  # only sets once the DRAFT has successfully prepared — a non-null value is the
+  # proof the prepare build succeeded. This is the headline of the live test
+  # (mocks can't reach this state).
+  assert {
+    condition     = aws_bedrockagent_agent.this.prepare_agent == true
+    error_message = "Agent must set prepare_agent = true so its DRAFT reaches PREPARED."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent.this.prepared_at != null && length(aws_bedrockagent_agent.this.prepared_at) > 0
+    error_message = "Live agent must report a non-null prepared_at after apply (the prepare_agent build must succeed)."
+  }
+
+  # --- Agent role + confused-deputy trust guard ---
+  assert {
+    condition     = aws_iam_role.agent.name == "${var.project}-bedrock-agent-role"
+    error_message = "Agent resource IAM role must be named {project}-bedrock-agent-role."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role.agent.assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == data.aws_caller_identity.current.account_id
+    error_message = "Agent trust policy must scope aws:SourceAccount to the deploying account."
+  }
+
+  # --- Action group attached to the DRAFT, pointed at the live Lambda ---
+  assert {
+    condition     = length(aws_bedrockagent_agent_action_group.this) == 1
+    error_message = "Action group must be created when action_group_lambda_arn is wired in."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent_action_group.this[0].agent_version == "DRAFT"
+    error_message = "Action group must attach to the DRAFT version."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent_action_group.this[0].action_group_executor[0].lambda == run.setup_action_lambda.function_arn
+    error_message = "Action group executor must point at the live setup Lambda ARN."
+  }
+
+  assert {
+    condition     = length(output.action_group_id) > 0
+    error_message = "action_group_id output must be populated after a live action-group apply."
+  }
+
+  # --- Bedrock -> Lambda invoke permission, scoped to this agent ---
+  assert {
+    condition     = length(aws_lambda_permission.agent_invoke) == 1
+    error_message = "Lambda invoke permission must be created alongside the action group."
+  }
+
+  assert {
+    condition     = aws_lambda_permission.agent_invoke[0].principal == "bedrock.amazonaws.com"
+    error_message = "Lambda invoke permission must grant bedrock.amazonaws.com."
+  }
+
+  assert {
+    condition     = aws_lambda_permission.agent_invoke[0].source_arn == aws_bedrockagent_agent.this.agent_arn
+    error_message = "Lambda invoke permission must be scoped to this agent's ARN (only this agent may invoke)."
+  }
+
+  # --- Live alias bound to the PREPARED version ---
+  # No KB association in this test, so the alias depends only on the agent +
+  # action group. Its creation succeeding is the proof the ordering held.
+  assert {
+    condition     = aws_bedrockagent_agent_alias.this.agent_alias_name == "${var.project}-live"
+    error_message = "A live alias must be created with the {project}-live name."
+  }
+
+  assert {
+    condition     = length(output.agent_alias_id) > 0
+    error_message = "agent_alias_id output must be populated — the alias bound a PREPARED agent version."
+  }
+}

--- a/aws/bedrock_agent/tests/shape.tftest.hcl
+++ b/aws/bedrock_agent/tests/shape.tftest.hcl
@@ -1,0 +1,241 @@
+# Plan-only unit tests for the bedrock_agent module.
+#
+# No AWS credentials required: the AWS provider is mocked so
+# data.aws_caller_identity.current and data.aws_region.current resolve at plan
+# time. Run with:
+#
+#   cd aws/bedrock_agent
+#   terraform init
+#   terraform test -filter=tests/shape.tftest.hcl
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "111111111111"
+      arn        = "arn:aws:iam::111111111111:user/test"
+      user_id    = "AIDACKCEVSQ6C2EXAMPLE"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = {
+      region = "us-east-1"
+    }
+  }
+  # The action-group Lambda invoke permission and the agent role reference the
+  # agent ARN; give the agent resource an ARN-shaped mock so attributes that
+  # parse as ARNs resolve at apply time.
+  mock_resource "aws_bedrockagent_agent" {
+    defaults = {
+      agent_arn = "arn:aws:bedrock:us-east-1:111111111111:agent/ABCDEFGHIJ"
+      agent_id  = "ABCDEFGHIJ"
+    }
+  }
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::111111111111:role/iotest-bra-bedrock-agent-role"
+    }
+  }
+}
+
+variables {
+  project     = "iotest-bra"
+  region      = "us-east-1"
+  environment = "test"
+}
+
+# --- Default shape (chat-only agent) -----------------------------------------
+
+run "defaults" {
+  command = plan
+
+  # Agent role + policy are always created.
+  assert {
+    condition     = aws_iam_role.agent.name == "iotest-bra-bedrock-agent-role"
+    error_message = "Agent resource IAM role must always be created with the project-prefixed name."
+  }
+
+  assert {
+    condition     = aws_iam_role_policy.agent.name == "iotest-bra-bedrock-agent-policy"
+    error_message = "Agent IAM policy must always be created."
+  }
+
+  # Trust policy carries the confused-deputy guards.
+  assert {
+    condition     = jsondecode(aws_iam_role.agent.assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == "111111111111"
+    error_message = "Agent trust policy must scope aws:SourceAccount to the current account."
+  }
+
+  assert {
+    condition     = can(jsondecode(aws_iam_role.agent.assume_role_policy).Statement[0].Condition.ArnLike["aws:SourceArn"])
+    error_message = "Agent trust policy must include an aws:SourceArn ArnLike condition scoping trust to this account's agents."
+  }
+
+  # The agent prepares itself so the alias never binds a NOT_PREPARED agent.
+  assert {
+    condition     = aws_bedrockagent_agent.this.prepare_agent == true
+    error_message = "Agent must set prepare_agent = true so its alias binds a PREPARED version."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent.this.agent_name == "iotest-bra-agent"
+    error_message = "Agent name must default to {project}-agent."
+  }
+
+  # Default chat-only agent: no action group, no Lambda permission, no KB
+  # association, no Retrieve statement on the policy.
+  assert {
+    condition     = length(aws_bedrockagent_agent_action_group.this) == 0
+    error_message = "Action group must NOT be created when action_group_lambda_arn is null (default)."
+  }
+
+  assert {
+    condition     = length(aws_lambda_permission.agent_invoke) == 0
+    error_message = "Lambda invoke permission must NOT be created when no action-group Lambda is wired."
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_agent_knowledge_base_association.this) == 0
+    error_message = "KB association must NOT be created when knowledge_base_id is null (default)."
+  }
+
+  assert {
+    condition     = length(jsondecode(aws_iam_role_policy.agent.policy).Statement) == 1
+    error_message = "Chat-only agent policy must contain only the InvokeModel statement (no Retrieve)."
+  }
+
+  # The alias is always created — the stable invokable handle.
+  assert {
+    condition     = aws_bedrockagent_agent_alias.this.agent_alias_name == "iotest-bra-live"
+    error_message = "A live alias must always be created."
+  }
+}
+
+# --- With action group (Lambda executor wired in) ----------------------------
+
+run "with_action_group" {
+  command = plan
+
+  variables {
+    action_group_lambda_arn = "arn:aws:lambda:us-east-1:111111111111:function:iotest-bra-fn"
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_agent_action_group.this) == 1
+    error_message = "Action group must be created when action_group_lambda_arn is supplied."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent_action_group.this[0].action_group_executor[0].lambda == "arn:aws:lambda:us-east-1:111111111111:function:iotest-bra-fn"
+    error_message = "Action group executor must point at the wired Lambda ARN."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent_action_group.this[0].agent_version == "DRAFT"
+    error_message = "Action group must attach to the DRAFT version."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent_action_group.this[0].prepare_agent == true
+    error_message = "Action group must re-prepare the agent so the alias picks up the tools."
+  }
+
+  assert {
+    condition     = length(aws_lambda_permission.agent_invoke) == 1
+    error_message = "Lambda invoke permission must be created alongside the action group."
+  }
+
+  assert {
+    condition     = aws_lambda_permission.agent_invoke[0].principal == "bedrock.amazonaws.com"
+    error_message = "Lambda invoke permission must grant bedrock.amazonaws.com."
+  }
+}
+
+# --- With Knowledge Base association (RAG agent) -----------------------------
+
+run "with_knowledge_base" {
+  command = plan
+
+  variables {
+    knowledge_base_id = "EMDPPAYPZI"
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_agent_knowledge_base_association.this) == 1
+    error_message = "KB association must be created when knowledge_base_id is supplied."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent_knowledge_base_association.this[0].knowledge_base_id == "EMDPPAYPZI"
+    error_message = "KB association must reference the supplied knowledge_base_id."
+  }
+
+  assert {
+    condition     = aws_bedrockagent_agent_knowledge_base_association.this[0].knowledge_base_state == "ENABLED"
+    error_message = "KB association must be ENABLED so the agent retrieves from it."
+  }
+
+  # The agent role must now also carry the Retrieve statement.
+  assert {
+    condition     = length(jsondecode(aws_iam_role_policy.agent.policy).Statement) == 2
+    error_message = "RAG agent policy must contain both InvokeModel and Retrieve statements."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.agent.policy).Statement[1].Sid == "RetrieveFromKnowledgeBase"
+    error_message = "Second policy statement must be the KB Retrieve grant."
+  }
+}
+
+# --- Full RAG agent (action group + KB) --------------------------------------
+
+run "action_group_and_knowledge_base" {
+  command = plan
+
+  variables {
+    action_group_lambda_arn = "arn:aws:lambda:us-east-1:111111111111:function:iotest-bra-fn"
+    knowledge_base_id       = "EMDPPAYPZI"
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_agent_action_group.this) == 1 && length(aws_bedrockagent_agent_knowledge_base_association.this) == 1
+    error_message = "Both action group and KB association must compose together for a tool-using RAG agent."
+  }
+}
+
+# --- Validation failures -----------------------------------------------------
+
+run "empty_instruction_rejected" {
+  command = plan
+
+  variables {
+    instruction = ""
+  }
+
+  expect_failures = [
+    var.instruction,
+  ]
+}
+
+run "empty_foundation_model_rejected" {
+  command = plan
+
+  variables {
+    foundation_model = "  "
+  }
+
+  expect_failures = [
+    var.foundation_model,
+  ]
+}
+
+run "bad_lambda_arn_rejected" {
+  command = plan
+
+  variables {
+    action_group_lambda_arn = "not-an-arn"
+  }
+
+  expect_failures = [
+    var.action_group_lambda_arn,
+  ]
+}

--- a/aws/bedrock_agent/variables.tf
+++ b/aws/bedrock_agent/variables.tf
@@ -1,0 +1,108 @@
+variable "project" {
+  description = "Project name"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,61}[a-z0-9]$", var.project))
+    error_message = "Project must be lowercase alphanumeric with hyphens, 3-63 characters."
+  }
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. dev, staging, prod). Surfaces in the luthername module's tags."
+  type        = string
+  default     = "dev"
+}
+
+variable "tags" {
+  description = "Additional resource tags merged over the module's standard Project tags."
+  type        = map(string)
+  default     = {}
+}
+
+# --- Agent --------------------------------------------------------------------
+
+variable "agent_name" {
+  description = "Name of the Bedrock Agent. Defaults to \"{project}-agent\" when null."
+  type        = string
+  default     = null
+
+  validation {
+    # Bedrock agent names allow [a-zA-Z0-9_-], 1-100 chars. Enforce when set.
+    condition     = var.agent_name == null ? true : can(regex("^[a-zA-Z0-9_-]{1,100}$", var.agent_name))
+    error_message = "agent_name must be 1-100 characters of letters, digits, hyphens, or underscores."
+  }
+}
+
+variable "foundation_model" {
+  description = "Foundation model the agent reasons with (an on-demand model ID or inference-profile ID Bedrock accepts for agents). Defaults to a current Claude Sonnet model."
+  type        = string
+  default     = "anthropic.claude-3-5-sonnet-20240620-v1:0"
+
+  validation {
+    condition     = trimspace(var.foundation_model) != ""
+    error_message = "foundation_model must not be empty — supply a Bedrock foundation-model ID or inference-profile ID."
+  }
+}
+
+variable "instruction" {
+  description = "Natural-language instruction that defines the agent's role and behavior. Bedrock requires at least 40 characters."
+  type        = string
+  default     = "You are a helpful assistant. Answer the user's questions accurately and concisely using the tools and knowledge available to you."
+
+  validation {
+    # Bedrock's CreateAgent rejects instructions shorter than 40 chars; fail
+    # at plan time with a clearer message than the API's.
+    condition     = length(trimspace(var.instruction)) >= 40
+    error_message = "instruction must be at least 40 characters (Bedrock CreateAgent requirement)."
+  }
+}
+
+variable "idle_session_ttl_in_seconds" {
+  description = "How long Bedrock retains a session's conversational context while idle, in seconds (60-3600)."
+  type        = number
+  default     = 600
+
+  validation {
+    condition     = var.idle_session_ttl_in_seconds >= 60 && var.idle_session_ttl_in_seconds <= 3600
+    error_message = "idle_session_ttl_in_seconds must be between 60 and 3600."
+  }
+}
+
+# --- Action group -------------------------------------------------------------
+
+variable "action_group_lambda_arn" {
+  description = "ARN of the Lambda function that backs the agent's action group (the executor Bedrock invokes for tool calls). When null the action group, its Lambda invoke permission, and the alias's tool wiring are all skipped — a chat-only agent. In a composed stack DefaultWiring supplies this from module.aws_lambda.function_arn."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.action_group_lambda_arn == null ? true : can(regex("^arn:aws[a-zA-Z-]*:lambda:", var.action_group_lambda_arn))
+    error_message = "action_group_lambda_arn must be a Lambda function ARN (arn:aws:lambda:...) or null."
+  }
+}
+
+variable "action_group_name" {
+  description = "Name of the agent's action group. Defaults to \"actions\" when null."
+  type        = string
+  default     = null
+}
+
+# --- Knowledge Base association ------------------------------------------------
+
+variable "knowledge_base_id" {
+  description = "ID of a Bedrock Knowledge Base to associate with the agent for RAG. When null no association is created (the agent answers without retrieval). In a composed stack DefaultWiring supplies this from module.aws_bedrock.knowledge_base_id when aws_bedrock is selected with its Knowledge Base enabled."
+  type        = string
+  default     = null
+}
+
+variable "knowledge_base_instruction" {
+  description = "Instruction telling the agent when to consult the Knowledge Base. Required by Bedrock when a KB is associated; defaults to a generic retrieval instruction."
+  type        = string
+  default     = "Consult this knowledge base to answer questions about the customer's documents and ingested content."
+}

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -237,6 +237,20 @@ resource "aws_instance" "this" {
       condition     = !(var.user_data != "" && var.user_data_url != "")
       error_message = "user_data and user_data_url are mutually exclusive. Set one or the other, not both."
     }
+
+    # GPU AMI is os_type-independent (#759): when gpu_enabled and no explicit
+    # ami_id, the module always boots the AWS Deep Learning Base GPU AMI
+    # (Amazon Linux 2023) regardless of os_type. Previously os_type="ubuntu"
+    # was silently ignored on the GPU path — a caller asking for Ubuntu got an
+    # Amazon Linux node with no warning. Reject the combination loudly so the
+    # caller either drops os_type (accept the AL2023 GPU AMI) or supplies their
+    # own Ubuntu GPU ami_id. Not enforceable as a var validation block — TF
+    # forbids cross-variable conditions there — so it lives as a resource
+    # precondition.
+    precondition {
+      condition     = !(var.gpu_enabled && var.ami_id == null && var.os_type == "ubuntu")
+      error_message = "gpu_enabled=true selects the Amazon Linux 2023 GPU AMI and ignores os_type=\"ubuntu\". Drop os_type (or set it to \"amazon-linux\") to use the built-in GPU AMI, or supply an explicit Ubuntu GPU ami_id."
+    }
   }
 
   root_block_device {

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -21,12 +21,27 @@ module "name" {
 }
 
 locals {
+  # NVIDIA-GPU x86_64 EC2 families (#759). MUST stay in lockstep with the
+  # HCL `_gpu_x86_families` local in aws/eks_nodegroup/main.tf and the Go
+  # `gpuX86Families` set in pkg/composer/gpu.go — TestGPUFamiliesDrift parses
+  # all three and fails the moment any one drifts. The GPU AMI is x86_64-only,
+  # so gpu_enabled with a non-x86-GPU instance type (ARM, or a non-GPU family)
+  # is rejected at plan by the aws_instance precondition below. g5g is
+  # deliberately ABSENT: it is Graviton (ARM) + NVIDIA T4G with no x86 NVIDIA
+  # AMI, so it stays on the ARM standard path.
+  _gpu_x86_families = [
+    "g4dn", "g5", "g6", "g6e", "gr6",
+    "p3", "p3dn", "p4d", "p4de", "p5", "p5e", "p5en",
+  ]
+  _instance_family   = split(".", var.instance_type)[0]
+  _is_gpu_x86_family = contains(local._gpu_x86_families, local._instance_family)
+
   # GPU path (#759) wins over os_type: when gpu_enabled and no explicit
   # ami_id, select the AWS Deep Learning Base GPU AMI (AL2023, NVIDIA
   # driver + container toolkit baked in) so a g5/g6/p4d/p5 instance comes
   # up with /dev/nvidia* present. Non-GPU path keeps the existing
   # os_type/arch selection. The NVIDIA AMI is x86_64-only (enforced by the
-  # var.gpu_enabled validation), so this never collides with arm64.
+  # aws_instance precondition), so this never collides with arm64.
   ami_id = var.ami_id != null ? var.ami_id : (
     var.gpu_enabled ? data.aws_ami.gpu[0].id : (
       var.os_type == "ubuntu" ? data.aws_ami.ubuntu[0].id : data.aws_ami.al2023[0].id
@@ -236,6 +251,23 @@ resource "aws_instance" "this" {
     precondition {
       condition     = !(var.user_data != "" && var.user_data_url != "")
       error_message = "user_data and user_data_url are mutually exclusive. Set one or the other, not both."
+    }
+
+    # GPU AMI is x86_64-only (#759): when gpu_enabled and no explicit ami_id,
+    # the module boots the AWS Deep Learning Base GPU AMI, which exists only
+    # for x86_64 NVIDIA GPU families (g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/
+    # p5e/p5en). A non-GPU type (t3.medium) or an ARM/Graviton type (c7g, g5g)
+    # would boot a node with the GPU AMI's driver but no NVIDIA hardware, so
+    # /dev/nvidia* never appears — the EC2 analogue of the EKS #207 arch
+    # mismatch. Reject at plan rather than silently provisioning a useless GPU
+    # node. Direct module callers who supply their own ami_id are exempt (the
+    # ami_id==null guard). The composer always defaults/validates an x86 GPU
+    # family upstream, so this fires only for direct/hand-rolled module use.
+    # Not enforceable as a var validation block — TF forbids cross-variable
+    # conditions there — so it lives as a resource precondition.
+    precondition {
+      condition     = !(var.gpu_enabled && var.ami_id == null) || local._is_gpu_x86_family
+      error_message = "gpu_enabled=true requires an x86 NVIDIA GPU instance_type (one of g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/p5e/p5en) when ami_id is null — AWS GPU AMIs are x86_64-only and a non-GPU/ARM type boots without /dev/nvidia*. Pick a supported GPU instance_type, or supply an explicit ami_id."
     }
 
     # GPU AMI is os_type-independent (#759): when gpu_enabled and no explicit

--- a/aws/ec2/main.tf
+++ b/aws/ec2/main.tf
@@ -21,8 +21,16 @@ module "name" {
 }
 
 locals {
+  # GPU path (#759) wins over os_type: when gpu_enabled and no explicit
+  # ami_id, select the AWS Deep Learning Base GPU AMI (AL2023, NVIDIA
+  # driver + container toolkit baked in) so a g5/g6/p4d/p5 instance comes
+  # up with /dev/nvidia* present. Non-GPU path keeps the existing
+  # os_type/arch selection. The NVIDIA AMI is x86_64-only (enforced by the
+  # var.gpu_enabled validation), so this never collides with arm64.
   ami_id = var.ami_id != null ? var.ami_id : (
-    var.os_type == "ubuntu" ? data.aws_ami.ubuntu[0].id : data.aws_ami.al2023[0].id
+    var.gpu_enabled ? data.aws_ami.gpu[0].id : (
+      var.os_type == "ubuntu" ? data.aws_ami.ubuntu[0].id : data.aws_ami.al2023[0].id
+    )
   )
 
   # Resolve effective user_data: inline script takes priority, URL generates a fetch wrapper.
@@ -31,9 +39,37 @@ locals {
   )
 }
 
-# Pick Amazon Linux 2023 AMI by arch (only when ami_id is not provided and os_type is amazon-linux)
+# Pick the AWS Deep Learning Base GPU AMI (Amazon Linux 2023) when GPU is
+# requested and no explicit ami_id is given (#759). This AMI is published by
+# Amazon (owner alias `amazon`) and ships the NVIDIA kernel driver + container
+# toolkit pre-installed — no app-layer driver bootstrap needed on the host.
+# x86_64-only (var.gpu_enabled requires arch=x86_64). The "Base" variant
+# carries drivers without a bundled DL framework, keeping the image lean.
+data "aws_ami" "gpu" {
+  count       = var.ami_id == null && var.gpu_enabled ? 1 : 0
+  owners      = ["amazon"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["Deep Learning Base OSS Nvidia Driver GPU AMI (Amazon Linux 2023)*"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+# Pick Amazon Linux 2023 AMI by arch (only when ami_id is not provided, GPU is
+# off, and os_type is amazon-linux)
 data "aws_ami" "al2023" {
-  count       = var.ami_id == null && var.os_type == "amazon-linux" ? 1 : 0
+  count       = var.ami_id == null && !var.gpu_enabled && var.os_type == "amazon-linux" ? 1 : 0
   owners      = ["137112412989"] # Amazon
   most_recent = true
 
@@ -43,9 +79,10 @@ data "aws_ami" "al2023" {
   }
 }
 
-# Pick Ubuntu 24.04 LTS AMI by arch (only when ami_id is not provided and os_type is ubuntu)
+# Pick Ubuntu 24.04 LTS AMI by arch (only when ami_id is not provided, GPU is
+# off, and os_type is ubuntu)
 data "aws_ami" "ubuntu" {
-  count       = var.ami_id == null && var.os_type == "ubuntu" ? 1 : 0
+  count       = var.ami_id == null && !var.gpu_enabled && var.os_type == "ubuntu" ? 1 : 0
   owners      = ["099720109477"] # Canonical
   most_recent = true
 

--- a/aws/ec2/tests/ec2_gpu.tftest.hcl
+++ b/aws/ec2/tests/ec2_gpu.tftest.hcl
@@ -40,6 +40,7 @@ run "gpu_enabled_selects_gpu_ami" {
   variables {
     gpu_enabled   = true
     arch          = "x86_64"
+    os_type       = "amazon-linux"
     instance_type = "g5.xlarge"
   }
 
@@ -104,4 +105,64 @@ run "gpu_with_arm64_fails_validation" {
   }
 
   expect_failures = [var.gpu_enabled]
+}
+
+# os_type override (#759): gpu_enabled selects the Amazon Linux 2023 GPU AMI
+# and ignores os_type. Previously os_type="ubuntu" was silently dropped on the
+# GPU path — a caller asking for Ubuntu got an Amazon Linux node with no
+# warning. The aws_instance precondition now rejects the combination loudly so
+# the mismatch surfaces at plan instead of booting an unexpected OS.
+run "gpu_with_ubuntu_os_type_fails_precondition" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  override_data {
+    target = data.aws_ami.gpu[0]
+    values = {
+      id = "ami-0gpu00000000000ab"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    os_type       = "ubuntu"
+    instance_type = "g5.xlarge"
+  }
+
+  expect_failures = [aws_instance.this]
+}
+
+# Explicit ami_id with gpu_enabled + os_type="ubuntu" is allowed: the caller
+# supplied their own (e.g. Ubuntu GPU) AMI, so the precondition's ami_id==null
+# guard does not trip. Locks that the precondition only fires on the
+# silent-override path, not on the bring-your-own-AMI path.
+run "gpu_with_ubuntu_and_explicit_ami_id_passes" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    os_type       = "ubuntu"
+    instance_type = "g5.xlarge"
+    ami_id        = "ami-ubuntugpu0000000"
+  }
+
+  assert {
+    condition     = aws_instance.this.ami == "ami-ubuntugpu0000000"
+    error_message = "explicit ami_id must be honored even with gpu_enabled + os_type=ubuntu"
+  }
 }

--- a/aws/ec2/tests/ec2_gpu.tftest.hcl
+++ b/aws/ec2/tests/ec2_gpu.tftest.hcl
@@ -1,0 +1,107 @@
+# Hermetic plan tests for the GPU AMI selection path added in #759.
+#
+# gpu_enabled=true selects the AWS Deep Learning Base GPU AMI (Amazon Linux
+# 2023, NVIDIA driver baked in) so a g5/g6/p4d/p5 instance comes up with
+# /dev/nvidia* present, instead of the plain OS AMI. GPU AMIs are x86_64-only,
+# so gpu_enabled=true requires arch=x86_64 — the variable validation rejects
+# the arm64 mismatch (the #207 class: wrong AMI for the chosen hardware).
+#
+# The in-cluster / on-host NVIDIA device plugin and CUDA runtime layering is
+# app-layer and out of preset scope — this module only provisions a
+# GPU-capable instance with the driver-bearing AMI.
+
+mock_provider "aws" {}
+
+variables {
+  project     = "test"
+  region      = "us-east-1"
+  environment = "test"
+  vpc_id      = "vpc-12345678"
+  subnet_id   = "subnet-12345678"
+}
+
+run "gpu_enabled_selects_gpu_ami" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  override_data {
+    target = data.aws_ami.gpu[0]
+    values = {
+      id = "ami-0gpu00000000000ab"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    instance_type = "g5.xlarge"
+  }
+
+  assert {
+    condition     = aws_instance.this.ami == "ami-0gpu00000000000ab"
+    error_message = "gpu_enabled must select the GPU AMI (data.aws_ami.gpu) for the instance (#759)"
+  }
+  assert {
+    condition     = length(data.aws_ami.al2023) == 0 && length(data.aws_ami.ubuntu) == 0
+    error_message = "gpu_enabled must short-circuit the os_type AMI lookups (#759)"
+  }
+  assert {
+    condition     = aws_instance.this.instance_type == "g5.xlarge"
+    error_message = "instance_type must be the requested GPU type g5.xlarge"
+  }
+}
+
+# Explicit ami_id still wins over the GPU AMI lookup.
+run "explicit_ami_id_overrides_gpu" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    instance_type = "g5.xlarge"
+    ami_id        = "ami-deadbeefdeadbeef0"
+  }
+
+  assert {
+    condition     = aws_instance.this.ami == "ami-deadbeefdeadbeef0"
+    error_message = "explicit ami_id must override the GPU AMI lookup"
+  }
+  assert {
+    condition     = length(data.aws_ami.gpu) == 0
+    error_message = "explicit ami_id must short-circuit the GPU AMI data source"
+  }
+}
+
+# Arch/AMI mismatch (#207 class): GPU AMIs are x86_64-only, so gpu_enabled
+# with arch=arm64 must fail validation rather than silently provisioning an
+# instance with an incompatible AMI.
+run "gpu_with_arm64_fails_validation" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  variables {
+    gpu_enabled = true
+    arch        = "arm64"
+  }
+
+  expect_failures = [var.gpu_enabled]
+}

--- a/aws/ec2/tests/ec2_gpu.tftest.hcl
+++ b/aws/ec2/tests/ec2_gpu.tftest.hcl
@@ -3,8 +3,11 @@
 # gpu_enabled=true selects the AWS Deep Learning Base GPU AMI (Amazon Linux
 # 2023, NVIDIA driver baked in) so a g5/g6/p4d/p5 instance comes up with
 # /dev/nvidia* present, instead of the plain OS AMI. GPU AMIs are x86_64-only,
-# so gpu_enabled=true requires arch=x86_64 — the variable validation rejects
-# the arm64 mismatch (the #207 class: wrong AMI for the chosen hardware).
+# so gpu_enabled=true requires an x86 NVIDIA GPU instance_type — the
+# aws_instance precondition rejects non-GPU/ARM types (the #207 class: wrong
+# AMI for the chosen hardware). The check is a resource precondition rather
+# than a variable validation because TF forbids cross-variable conditions in
+# variable validation blocks.
 #
 # The in-cluster / on-host NVIDIA device plugin and CUDA runtime layering is
 # app-layer and out of preset scope — this module only provisions a
@@ -87,9 +90,11 @@ run "explicit_ami_id_overrides_gpu" {
 }
 
 # Arch/AMI mismatch (#207 class): GPU AMIs are x86_64-only, so gpu_enabled
-# with arch=arm64 must fail validation rather than silently provisioning an
-# instance with an incompatible AMI.
-run "gpu_with_arm64_fails_validation" {
+# with an ARM/Graviton instance_type must fail rather than silently
+# provisioning an instance with an incompatible AMI. The check lives on the
+# aws_instance precondition (TF forbids the cross-variable condition in a
+# variable validation block), so the failure surfaces against aws_instance.this.
+run "gpu_with_arm64_instance_type_fails_precondition" {
   command = plan
 
   override_data {
@@ -99,12 +104,49 @@ run "gpu_with_arm64_fails_validation" {
     }
   }
 
-  variables {
-    gpu_enabled = true
-    arch        = "arm64"
+  override_data {
+    target = data.aws_ami.gpu[0]
+    values = {
+      id = "ami-0gpu00000000000ab"
+    }
   }
 
-  expect_failures = [var.gpu_enabled]
+  variables {
+    gpu_enabled   = true
+    arch          = "arm64"
+    instance_type = "g5g.xlarge"
+  }
+
+  expect_failures = [aws_instance.this]
+}
+
+# Non-GPU instance type with gpu_enabled (#759): a plain compute type like
+# t3.medium has no NVIDIA hardware, so booting it with the GPU AMI yields a
+# node without /dev/nvidia*. The precondition rejects it at plan.
+run "gpu_with_non_gpu_instance_type_fails_precondition" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_policy_document.ec2_assume_role
+    values = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+
+  override_data {
+    target = data.aws_ami.gpu[0]
+    values = {
+      id = "ami-0gpu00000000000ab"
+    }
+  }
+
+  variables {
+    gpu_enabled   = true
+    arch          = "x86_64"
+    instance_type = "t3.medium"
+  }
+
+  expect_failures = [aws_instance.this]
 }
 
 # os_type override (#759): gpu_enabled selects the Amazon Linux 2023 GPU AMI

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -79,6 +79,16 @@ variable "arch" {
   }
 }
 
+variable "gpu_enabled" {
+  description = "Select an NVIDIA-GPU AMI (AWS Deep Learning Base GPU AMI, Amazon Linux 2023) instead of the plain OS AMI when ami_id is null. Use with a GPU instance_type (g4dn/g5/g6/p4d/p5, etc.). The GPU AMI ships the NVIDIA kernel driver + container toolkit baked in. GPU AMIs are x86_64-only — gpu_enabled=true requires arch=x86_64 (validated on the aws_instance). NOTE: g/p instance families are quota-gated; an account with a 0 vCPU GPU quota fails at apply with an InsufficientInstanceCapacity / VcpuLimitExceeded error surfaced to the operator (#759)."
+  type        = bool
+  default     = false
+  validation {
+    condition     = !var.gpu_enabled || var.arch == "x86_64"
+    error_message = "gpu_enabled=true requires arch=x86_64 — AWS GPU AMIs are x86_64-only."
+  }
+}
+
 variable "key_name" {
   description = "Existing EC2 key pair name for SSH (null to rely on SSM only)"
   type        = string

--- a/aws/ec2/variables.tf
+++ b/aws/ec2/variables.tf
@@ -80,13 +80,9 @@ variable "arch" {
 }
 
 variable "gpu_enabled" {
-  description = "Select an NVIDIA-GPU AMI (AWS Deep Learning Base GPU AMI, Amazon Linux 2023) instead of the plain OS AMI when ami_id is null. Use with a GPU instance_type (g4dn/g5/g6/p4d/p5, etc.). The GPU AMI ships the NVIDIA kernel driver + container toolkit baked in. GPU AMIs are x86_64-only — gpu_enabled=true requires arch=x86_64 (validated on the aws_instance). NOTE: g/p instance families are quota-gated; an account with a 0 vCPU GPU quota fails at apply with an InsufficientInstanceCapacity / VcpuLimitExceeded error surfaced to the operator (#759)."
+  description = "Select an NVIDIA-GPU AMI (AWS Deep Learning Base GPU AMI, Amazon Linux 2023) instead of the plain OS AMI when ami_id is null. Use with a GPU instance_type (g4dn/g5/g6/p4d/p5, etc.). The GPU AMI ships the NVIDIA kernel driver + container toolkit baked in. GPU AMIs are x86_64-only, so gpu_enabled=true requires an x86 NVIDIA GPU instance_type (validated on the aws_instance precondition — TF forbids cross-variable conditions in variable validation blocks). NOTE: g/p instance families are quota-gated; an account with a 0 vCPU GPU quota fails at apply with an InsufficientInstanceCapacity / VcpuLimitExceeded error surfaced to the operator (#759)."
   type        = bool
   default     = false
-  validation {
-    condition     = !var.gpu_enabled || var.arch == "x86_64"
-    error_message = "gpu_enabled=true requires arch=x86_64 — AWS GPU AMIs are x86_64-only."
-  }
 }
 
 variable "key_name" {

--- a/aws/eks_nodegroup/main.tf
+++ b/aws/eks_nodegroup/main.tf
@@ -1,3 +1,14 @@
+# EKS managed node group preset.
+#
+# GPU note (#759): selecting an NVIDIA GPU instance family (g4dn/g5/g6/g6e/
+# gr6/p3/p4d/p5, ...) auto-derives a GPU AMI type (AL2023_x86_64_NVIDIA), so
+# the worker boots with the NVIDIA kernel driver present. This preset only
+# provisions GPU-CAPABLE nodes. The in-cluster NVIDIA k8s device plugin that
+# advertises `nvidia.com/gpu` to the scheduler is APP-LAYER and intentionally
+# out of preset scope — EKS has no first-party managed addon for it and Helm
+# is excluded from this repo, so it is installed by the deploying application.
+# g/p families are quota-gated; surface capacity errors to the operator.
+
 terraform {
   required_version = ">= 1.5"
   required_providers {
@@ -36,7 +47,35 @@ locals {
   _instance_family     = split(".", local._first_instance_type)[0]
   _is_arm_family       = can(regex("^[a-z]+[0-9]+g(d|n|en|ad|adn)?$", local._instance_family))
 
-  derived_ami_type  = local._is_arm_family ? "AL2023_ARM_64_STANDARD" : "AL2023_x86_64_STANDARD"
+  # NVIDIA-GPU EC2 families (#759): g4dn, g5, g5g, g6, g6e, gr6, p3, p3dn,
+  # p4d, p4de, p5, p5e, p5en. These need a GPU-bundled AMI type so the
+  # NVIDIA kernel driver + container runtime are present on the node — a
+  # plain AL2023_x86_64_STANDARD AMI on a g5.xlarge brings the worker up
+  # but exposes no /dev/nvidia* devices, so GPU pods sit Pending forever
+  # (the GPU analogue of the #207 arch mismatch). We match the family with
+  # an explicit allow-list rather than a loose regex so that non-GPU
+  # families that merely start with `g`/`p` (none today, but e.g. a future
+  # general-purpose `g`-prefixed family) don't get misclassified.
+  #
+  # g5g is Graviton (ARM) + NVIDIA T4G — it ends in `g`, so the ARM regex
+  # above already claims it; we deliberately leave g5g on the ARM path
+  # (AL2023_ARM_64_STANDARD) because EKS has no ARM NVIDIA managed AMI type.
+  # All other GPU families here are x86_64 → AL2023_x86_64_NVIDIA.
+  _gpu_x86_families = [
+    "g4dn", "g5", "g6", "g6e", "gr6",
+    "p3", "p3dn", "p4d", "p4de", "p5", "p5e", "p5en",
+  ]
+  _is_gpu_x86_family = contains(local._gpu_x86_families, local._instance_family)
+
+  # GPU x86 wins over the generic x86 default; ARM (incl. g5g) keeps the ARM
+  # standard AMI. The NVIDIA in-cluster device plugin that advertises
+  # nvidia.com/gpu to the scheduler is app-layer and intentionally out of
+  # preset scope (no first-party EKS managed addon; see README + #759).
+  derived_ami_type = (
+    local._is_arm_family ? "AL2023_ARM_64_STANDARD" : (
+      local._is_gpu_x86_family ? "AL2023_x86_64_NVIDIA" : "AL2023_x86_64_STANDARD"
+    )
+  )
   resolved_ami_type = coalesce(var.ami_type, local.derived_ami_type)
 }
 

--- a/aws/eks_nodegroup/tests/eks_nodegroup.tftest.hcl
+++ b/aws/eks_nodegroup/tests/eks_nodegroup.tftest.hcl
@@ -120,3 +120,75 @@ run "bogus_ami_type_fails_validation" {
 
   expect_failures = [var.ami_type]
 }
+
+# GPU node group (#759): an NVIDIA x86 instance family must auto-derive the
+# NVIDIA managed AMI type so the node comes up GPU-capable. Without this, a
+# g5.xlarge on the AL2023_x86_64_STANDARD default exposes no /dev/nvidia*
+# devices and GPU pods sit Pending — the GPU analogue of the #207 arch
+# mismatch.
+run "gpu_nodegroup" {
+  command = plan
+
+  variables {
+    instance_types = ["g5.xlarge"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_x86_64_NVIDIA"
+    error_message = "GPU x86 family g5.xlarge must derive AL2023_x86_64_NVIDIA (#759)"
+  }
+  assert {
+    condition     = aws_eks_node_group.this.ami_type == "AL2023_x86_64_NVIDIA"
+    error_message = "node group resource ami_type must be AL2023_x86_64_NVIDIA for a GPU instance family (#759)"
+  }
+  assert {
+    condition     = tolist(aws_eks_node_group.this.instance_types)[0] == "g5.xlarge"
+    error_message = "node group must use the requested GPU instance type g5.xlarge"
+  }
+}
+
+# p-family GPU instances also resolve the NVIDIA AMI.
+run "gpu_p_family_derives_nvidia_ami" {
+  command = plan
+
+  variables {
+    instance_types = ["p4d.24xlarge"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_x86_64_NVIDIA"
+    error_message = "GPU p-family p4d.24xlarge must derive AL2023_x86_64_NVIDIA (#759)"
+  }
+}
+
+# g5g is Graviton (ARM) + NVIDIA T4G. EKS has no ARM NVIDIA managed AMI type,
+# so g5g stays on the ARM standard AMI — locks that the GPU allow-list does
+# not steal ARM families ending in `g`.
+run "g5g_arm_stays_arm_standard" {
+  command = plan
+
+  variables {
+    instance_types = ["g5g.xlarge"]
+  }
+
+  assert {
+    condition     = output.ami_type == "AL2023_ARM_64_STANDARD"
+    error_message = "g5g (Graviton NVIDIA) must keep AL2023_ARM_64_STANDARD — no ARM NVIDIA managed AMI type exists (#759)"
+  }
+}
+
+# Explicit var.ami_type still overrides the GPU auto-derive (e.g. picking the
+# Bottlerocket NVIDIA variant).
+run "explicit_bottlerocket_nvidia_overrides_gpu_derive" {
+  command = plan
+
+  variables {
+    instance_types = ["g5.xlarge"]
+    ami_type       = "BOTTLEROCKET_x86_64_NVIDIA"
+  }
+
+  assert {
+    condition     = output.ami_type == "BOTTLEROCKET_x86_64_NVIDIA"
+    error_message = "explicit var.ami_type must override the GPU auto-derive"
+  }
+}

--- a/aws/eks_nodegroup/variables.tf
+++ b/aws/eks_nodegroup/variables.tf
@@ -129,7 +129,7 @@ variable "enable_container_insights" {
 }
 
 variable "ami_type" {
-  description = "EKS node AMI type. When null (default), the module derives the AMI type from var.instance_types: ARM/Graviton families (c7g, m7g, r7g, t4g, c8g, m8g, r8g, etc. — names ending in `g`) get AL2023_ARM_64_STANDARD; all other families get AL2023_x86_64_STANDARD. Set explicitly to override (e.g. BOTTLEROCKET_x86_64, AL2_x86_64_GPU)."
+  description = "EKS node AMI type. When null (default), the module derives the AMI type from var.instance_types: ARM/Graviton families (c7g, m7g, r7g, t4g, c8g, m8g, r8g, etc. — names ending in `g`) get AL2023_ARM_64_STANDARD; x86 NVIDIA-GPU families (g4dn, g5, g6, g6e, gr6, p3, p4d, p5, etc.) get AL2023_x86_64_NVIDIA; all other families get AL2023_x86_64_STANDARD (#759). Set explicitly to override (e.g. BOTTLEROCKET_x86_64, BOTTLEROCKET_x86_64_NVIDIA, AL2_x86_64_GPU). NOTE: the in-cluster NVIDIA k8s device plugin that advertises nvidia.com/gpu is app-layer and out of preset scope — this module only provisions GPU-capable nodes."
   type        = string
   default     = null
 

--- a/aws/opensearch/main.tf
+++ b/aws/opensearch/main.tf
@@ -1,3 +1,45 @@
+# aws/opensearch — OpenSearch Service (managed) + OpenSearch Serverless (AOSS).
+#
+# Two deployment modes, selected by var.deployment_type:
+#   - "managed"    : an OpenSearch Service domain in the VPC (text search,
+#                    log analytics; slow/application logs to CloudWatch).
+#   - "serverless" : an AOSS VECTORSEARCH collection — the production vector
+#                    store of the AI stack, the alternative to the S3 Vectors
+#                    default that aws/bedrock provisions. See issue #758.
+#
+# AOSS collection-create requires all THREE security policy types to exist:
+#   1. encryption  (emitted here — AWS-owned or customer KMS key)
+#   2. network     (emitted here — public or VPC-endpoint reachability)
+#   3. data-access (NOT emitted here — see the split below)
+# A collection cannot be created until 1+2 exist; the data-access policy can
+# be authored after the collection but is required before any principal can
+# read/write the data plane.
+#
+# DATA-ACCESS-POLICY SPLIT WITH aws/bedrock
+# -----------------------------------------
+# This module deliberately does NOT emit the AOSS data-access policy. That
+# policy names the exact principal ARNs allowed on the data plane, and the
+# canonical consumer is the Bedrock Knowledge Base role — which lives in
+# aws/bedrock, not here. aws/bedrock authors the data-access policy from the
+# collection NAME (AOSS access policies match collections by name, not ARN),
+# wired in via aws/bedrock.opensearch_collection_name <- collection_name.
+# Keeping the data-access policy on the consumer side avoids a circular
+# dependency (this module would otherwise need the bedrock role ARN to grant
+# it) and keeps each principal's grant co-located with the principal.
+# Composer wiring: contracts.go DefaultWiring(KeyAWSBedrock) sources
+# opensearch_collection_arn from module.aws_opensearch.collection_arn, and the
+# mapper hard-forces deployment_type=serverless whenever Bedrock is composed
+# (mapper.go, pinned by TestMapper_OpenSearchDeploymentTypeOverride).
+#
+# VECTOR INDEX IS OUT OF SCOPE (API-ONLY)
+# ---------------------------------------
+# The vector index INSIDE the collection is NOT a Terraform resource — there
+# is no aws_opensearchserverless_index in the hashicorp/aws provider. The
+# index is created via the AOSS data-plane API (the _aws/iam-signed OpenSearch
+# index API), which depends on the embedding model / dimension the application
+# chooses. The application layer creates and owns the index; this module stops
+# at the empty collection + its encryption/network policies + the alarms.
+
 terraform {
   required_version = ">= 1.5"
   required_providers {

--- a/aws/opensearch/observability.tf
+++ b/aws/opensearch/observability.tf
@@ -116,6 +116,10 @@ resource "aws_cloudwatch_metric_alarm" "cluster_red" {
 resource "aws_cloudwatch_metric_alarm" "search_ocu" {
   for_each = local._obs_serverless_gate
 
+  # statistic = "Sum": AWS/AOSS publishes SearchOCU/IndexingOCU with the Sum
+  # statistic (OCU-units consumed in the period), not Maximum. Maximum returns
+  # an empty series for these metrics, so the alarm would sit in
+  # INSUFFICIENT_DATA and never fire.
   alarm_name          = "${module.name.name}-aoss-search-ocu"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -123,7 +127,7 @@ resource "aws_cloudwatch_metric_alarm" "search_ocu" {
   metric_name         = "SearchOCU"
   namespace           = "AWS/AOSS"
   period              = 300
-  statistic           = "Maximum"
+  statistic           = "Sum"
   treat_missing_data  = "notBreaching"
   alarm_description   = "AOSS search OCU consumption is sustained above ${local._obs_thresholds["search_ocu"]} (account-level, ClientId=${local._obs_account_id}).${local._obs_runbook_search_ocu}"
   dimensions          = { ClientId = local._obs_account_id }
@@ -135,6 +139,8 @@ resource "aws_cloudwatch_metric_alarm" "search_ocu" {
 resource "aws_cloudwatch_metric_alarm" "indexing_ocu" {
   for_each = local._obs_serverless_gate
 
+  # statistic = "Sum": see SearchOCU above — AWS/AOSS OCU metrics are published
+  # with Sum, not Maximum.
   alarm_name          = "${module.name.name}-aoss-indexing-ocu"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
@@ -142,7 +148,7 @@ resource "aws_cloudwatch_metric_alarm" "indexing_ocu" {
   metric_name         = "IndexingOCU"
   namespace           = "AWS/AOSS"
   period              = 300
-  statistic           = "Maximum"
+  statistic           = "Sum"
   treat_missing_data  = "notBreaching"
   alarm_description   = "AOSS indexing OCU consumption is sustained above ${local._obs_thresholds["indexing_ocu"]} (account-level, ClientId=${local._obs_account_id}).${local._obs_runbook_indexing_ocu}"
   dimensions          = { ClientId = local._obs_account_id }

--- a/aws/opensearch/observability.tf
+++ b/aws/opensearch/observability.tf
@@ -39,8 +39,46 @@ locals {
   _obs_tags    = merge(module.name.tags, var.tags, { severity = var.alarm_severity })
   _obs_thresholds = merge({
     cluster_red = 1
+    # Serverless OCU ceilings. AOSS bills per OpenSearch Compute Unit; these
+    # alarms fire when sustained search/indexing OCU consumption crosses the
+    # threshold so a runaway index build or query storm surfaces as a page
+    # rather than a month-end bill. The default of 8 sits well above an
+    # idle/baseline collection's OCU usage so the alarm only trips on real
+    # scale-out; tune per workload via alarm_threshold_overrides
+    # ({ search_ocu = N, indexing_ocu = N }).
+    search_ocu   = 8
+    indexing_ocu = 8
   }, var.alarm_threshold_overrides)
   _obs_runbook = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/opensearch/cluster_red"
+  # Per-alarm runbook click-throughs. Each alarm points at its own page so the
+  # OCU alarms do not deep-link to the cluster_red runbook (different failure
+  # mode, different remediation).
+  _obs_runbook_search_ocu   = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/opensearch/search_ocu"
+  _obs_runbook_indexing_ocu = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/opensearch/indexing_ocu"
+  # AOSS OCU metrics are published at the ACCOUNT level under the ClientId
+  # dimension (= account ID) — there is no per-collection OCU breakdown in
+  # CloudWatch (verified against the AWS/AOSS metrics reference, 2026-06).
+  # The alarm is therefore account-region-scoped: if several AOSS collections
+  # share an account each module instance creates its own alarm watching the
+  # same shared metric, which is acceptable (duplicate notifications, not
+  # wrong data). The alarm name carries the module/project prefix so the
+  # duplicates are distinguishable in the console.
+  # try()-wrapped to match the empty-tuple defensive idiom used for the
+  # count-conditional SLR data sources in main.tf: data.aws_caller_identity.obs
+  # is itself count-conditional, so [0] indexes an empty tuple in managed mode.
+  # The ternary already short-circuits, but try() makes the access robust even
+  # if a future refactor moves this into a meta-argument (count/for_each)
+  # expression where Terraform statically analyses the [0] before the guard.
+  _obs_account_id      = local.is_serverless ? try(data.aws_caller_identity.obs[0].account_id, "") : ""
+  _obs_serverless_gate = var.enable_observability && local.is_serverless ? { "0" = true } : {}
+}
+
+# Account ID for the AOSS OCU alarm ClientId dimension. Only resolved in
+# serverless mode (managed mode has no AOSS metrics). Separate from any
+# caller-identity data source other resources might add — named .obs to make
+# the observability ownership explicit.
+data "aws_caller_identity" "obs" {
+  count = local.is_serverless ? 1 : 0
 }
 
 # Only fires for the managed-OpenSearch deployment type — serverless
@@ -61,6 +99,53 @@ resource "aws_cloudwatch_metric_alarm" "cluster_red" {
   treat_missing_data  = "notBreaching"
   alarm_description   = "OpenSearch cluster status reports red.${local._obs_runbook}"
   dimensions          = { DomainName = aws_opensearch_domain.managed[0].domain_name }
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}
+
+# --- Serverless (AOSS) OCU alarms ------------------------------------------
+#
+# Only fire for the serverless deployment type — managed domains do not
+# publish AWS/AOSS metrics. SearchOCU and IndexingOCU are the two OpenSearch
+# Compute Unit consumption metrics; they are account-level (ClientId
+# dimension), so the alarm is account-region-scoped, not per-collection (see
+# the local block above). The compound for_each gate keeps the destination
+# address shape ["0"] consistent for the composer's moved-block contract,
+# mirroring the cluster_red alarm.
+resource "aws_cloudwatch_metric_alarm" "search_ocu" {
+  for_each = local._obs_serverless_gate
+
+  alarm_name          = "${module.name.name}-aoss-search-ocu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  threshold           = local._obs_thresholds["search_ocu"]
+  metric_name         = "SearchOCU"
+  namespace           = "AWS/AOSS"
+  period              = 300
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "AOSS search OCU consumption is sustained above ${local._obs_thresholds["search_ocu"]} (account-level, ClientId=${local._obs_account_id}).${local._obs_runbook_search_ocu}"
+  dimensions          = { ClientId = local._obs_account_id }
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "indexing_ocu" {
+  for_each = local._obs_serverless_gate
+
+  alarm_name          = "${module.name.name}-aoss-indexing-ocu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  threshold           = local._obs_thresholds["indexing_ocu"]
+  metric_name         = "IndexingOCU"
+  namespace           = "AWS/AOSS"
+  period              = 300
+  statistic           = "Maximum"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "AOSS indexing OCU consumption is sustained above ${local._obs_thresholds["indexing_ocu"]} (account-level, ClientId=${local._obs_account_id}).${local._obs_runbook_indexing_ocu}"
+  dimensions          = { ClientId = local._obs_account_id }
   alarm_actions       = local._obs_actions
   ok_actions          = local._obs_actions
   tags                = local._obs_tags

--- a/aws/opensearch/outputs.tf
+++ b/aws/opensearch/outputs.tf
@@ -17,3 +17,13 @@ output "collection_name" {
   value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].name : null
   description = "Name of the AOSS collection (not the ID embedded in the ARN). null when deployment_type is managed. Wire into aws/bedrock.opensearch_collection_name so bedrock can author the AOSS data-access policy granting its role data-plane access — AOSS access policies match collections by name, not ARN."
 }
+
+output "collection_endpoint" {
+  value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].collection_endpoint : null
+  description = "HTTPS data-plane endpoint of the AOSS collection (e.g. https://<id>.<region>.aoss.amazonaws.com). null when deployment_type is managed. The application layer targets this endpoint to create the vector index and run k-NN queries; Bedrock resolves it internally from collection_arn, so this output is for the app/ingestion tier, not the bedrock wiring."
+}
+
+output "collection_id" {
+  value       = var.deployment_type == "serverless" ? aws_opensearchserverless_collection.serverless[0].id : null
+  description = "Unique collection ID of the AOSS collection (the opaque suffix embedded in the ARN, distinct from collection_name). null when deployment_type is managed. Useful for CloudWatch metric dimensions and for constructing the data-plane host (<id>.<region>.aoss.amazonaws.com) when the endpoint is built rather than read."
+}

--- a/aws/opensearch/tests/vectorsearch_collection.tftest.hcl
+++ b/aws/opensearch/tests/vectorsearch_collection.tftest.hcl
@@ -1,0 +1,233 @@
+mock_provider "aws" {}
+
+# Issue #758. Pins the OpenSearch Serverless (AOSS) VECTORSEARCH collection
+# as the production vector-store path of the AI stack.
+#
+# What this locks down, end to end:
+#   - the collection is created with type = "VECTORSEARCH" (not SEARCH or
+#     TIMESERIES) — Bedrock Knowledge Bases and the app's k-NN index require
+#     the vector engine; a silent flip to another collection type would let
+#     index creation fail only at apply time.
+#   - the AOSS security-policy TRIO required for collection-create is shaped
+#     correctly: encryption + network emitted HERE, data-access deliberately
+#     NOT emitted here (it lives in aws/bedrock — see main.tf header).
+#   - the serverless-only OCU alarms (account-level AWS/AOSS metrics) exist
+#     and stay absent in managed mode.
+
+run "vectorsearch_collection" {
+  command = plan
+
+  # Force the AOSS SLR probe to "role present" so the test exercises the
+  # steady-state path (no SLR create race) — orthogonal to what we assert.
+  override_data {
+    target = data.aws_iam_roles.aoss_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchServerless"]
+    }
+  }
+
+  variables {
+    project         = "vec-test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "serverless"
+  }
+
+  # --- Collection is created, exactly one, and is the VECTORSEARCH engine.
+  assert {
+    condition     = length(aws_opensearchserverless_collection.serverless) == 1
+    error_message = "Serverless mode must create exactly one AOSS collection."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_collection.serverless[0].type == "VECTORSEARCH"
+    error_message = "AOSS collection must be type VECTORSEARCH — Bedrock KB + the app k-NN index require the vector engine; SEARCH/TIMESERIES would fail index creation at apply time."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_collection.serverless[0].name == "vec-test-search"
+    error_message = "AOSS collection name must be <project>-search — the encryption + network policies and the bedrock data-access policy all match the collection by this exact name."
+  }
+
+  # --- Policy TRIO shape. AOSS collection-create fails unless encryption +
+  # network exist; data-access is the consumer's job (aws/bedrock).
+  assert {
+    condition     = length(aws_opensearchserverless_security_policy.encryption) == 1
+    error_message = "Exactly one AOSS encryption policy must exist — collection-create fails without it."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_security_policy.encryption[0].type == "encryption"
+    error_message = "The encryption security policy must declare type = encryption."
+  }
+
+  assert {
+    condition     = length(aws_opensearchserverless_security_policy.network) == 1
+    error_message = "Exactly one AOSS network policy must exist — collection-create fails without it."
+  }
+
+  assert {
+    condition     = aws_opensearchserverless_security_policy.network[0].type == "network"
+    error_message = "The network security policy must declare type = network."
+  }
+
+  # --- Both security policies scope to the SAME collection name the
+  # collection is created under. A drift here (policy targets a different
+  # collection) is the classic AOSS "AccessDeniedException on collection
+  # create" and is invisible without an explicit assertion.
+  assert {
+    condition     = contains(jsondecode(aws_opensearchserverless_security_policy.encryption[0].policy).Rules[0].Resource, "collection/vec-test-search")
+    error_message = "Encryption policy Rules must scope to collection/<name> matching the created collection."
+  }
+
+  assert {
+    condition     = contains(jsondecode(aws_opensearchserverless_security_policy.network[0].policy)[0].Rules[0].Resource, "collection/vec-test-search")
+    error_message = "Network policy Rules must scope to collection/<name> matching the created collection."
+  }
+
+  # --- Data-access policy is NOT emitted by this module. The trio's third
+  # leg lives in aws/bedrock (keyed by collection NAME). This preset declares
+  # no aws_opensearchserverless_access_policy resource at all, so its absence
+  # is structurally guaranteed: adding one here would make this preset emit a
+  # data-access policy that duplicates / conflicts with bedrock's. We cannot
+  # assert "no resource of type X" in tftest (you can only reference declared
+  # resources), so the guard is the main.tf header comment + the bedrock-side
+  # ownership; this is documented, not asserted.
+
+  # --- Serverless OCU alarms exist (account-level AWS/AOSS metrics).
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.search_ocu) == 1
+    error_message = "Serverless mode must create the AOSS SearchOCU alarm so runaway search-OCU scale-out pages instead of surfacing on the bill."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.search_ocu["0"].namespace == "AWS/AOSS"
+    error_message = "SearchOCU alarm must watch the AWS/AOSS namespace."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.search_ocu["0"].metric_name == "SearchOCU"
+    error_message = "SearchOCU alarm must watch the SearchOCU metric."
+  }
+
+  assert {
+    condition     = contains(keys(aws_cloudwatch_metric_alarm.search_ocu["0"].dimensions), "ClientId")
+    error_message = "AOSS OCU metrics are account-level — the alarm must use the ClientId dimension, not a per-collection dimension (no per-collection OCU metric exists)."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.indexing_ocu) == 1
+    error_message = "Serverless mode must create the AOSS IndexingOCU alarm."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.indexing_ocu["0"].metric_name == "IndexingOCU"
+    error_message = "IndexingOCU alarm must watch the IndexingOCU metric."
+  }
+
+  # --- The cluster_red (managed AWS/ES) alarm must NOT exist in serverless
+  # mode — AOSS publishes no ClusterStatus metric.
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.cluster_red) == 0
+    error_message = "Managed-domain cluster_red alarm must not exist in serverless mode — AOSS has no ClusterStatus.red metric."
+  }
+}
+
+run "serverless_collection_outputs" {
+  # apply (not plan): the AOSS collection's arn / collection_endpoint / id are
+  # apply-time identifiers, unknown during plan even under mock_provider. The
+  # mock provider synthesises concrete values on apply so the non-null
+  # assertions below can evaluate. (mock_provider performs no real API calls.)
+  command = apply
+
+  override_data {
+    target = data.aws_iam_roles.aoss_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchServerless"]
+    }
+  }
+
+  variables {
+    project         = "vec-test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "serverless"
+  }
+
+  # collection_arn / collection_name are consumed by aws/bedrock wiring;
+  # collection_endpoint / collection_id are for the app/ingestion tier that
+  # creates the vector index. All four must be non-null in serverless mode.
+  assert {
+    condition     = output.collection_arn != null
+    error_message = "collection_arn must be non-null in serverless mode — aws/bedrock.opensearch_collection_arn wires from it."
+  }
+
+  assert {
+    condition     = output.collection_name != null
+    error_message = "collection_name must be non-null in serverless mode — the bedrock data-access policy matches the collection by name."
+  }
+
+  assert {
+    condition     = output.collection_endpoint != null
+    error_message = "collection_endpoint must be non-null in serverless mode — the app targets it to create the vector index and run k-NN queries."
+  }
+
+  assert {
+    condition     = output.collection_id != null
+    error_message = "collection_id must be non-null in serverless mode."
+  }
+}
+
+run "managed_mode_serverless_collection_outputs_null" {
+  command = plan
+
+  override_data {
+    target = data.aws_iam_roles.opensearch_slr[0]
+    values = {
+      names = ["AWSServiceRoleForAmazonOpenSearchService"]
+    }
+  }
+
+  variables {
+    project         = "vec-test"
+    region          = "us-east-1"
+    environment     = "test"
+    deployment_type = "managed"
+    vpc_id          = "vpc-12345"
+    subnet_ids      = ["subnet-aaa"]
+  }
+
+  # In managed mode there is no AOSS collection — every serverless-only
+  # output must be null so a consumer that mis-wires managed-mode opensearch
+  # into bedrock gets a clean null, not a dangling [0] index error.
+  assert {
+    condition     = output.collection_arn == null
+    error_message = "collection_arn must be null in managed mode."
+  }
+
+  assert {
+    condition     = output.collection_endpoint == null
+    error_message = "collection_endpoint must be null in managed mode."
+  }
+
+  assert {
+    condition     = output.collection_id == null
+    error_message = "collection_id must be null in managed mode."
+  }
+
+  # No serverless OCU alarms and no AOSS collection in managed mode.
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.search_ocu) == 0
+    error_message = "SearchOCU alarm must not exist in managed mode — AOSS metrics are not published for OpenSearch Service domains."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.indexing_ocu) == 0
+    error_message = "IndexingOCU alarm must not exist in managed mode."
+  }
+
+  assert {
+    condition     = length(aws_opensearchserverless_collection.serverless) == 0
+    error_message = "No AOSS collection in managed mode."
+  }
+}

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -8,13 +8,20 @@
 #   google_vertex_ai_index_endpoint                 — the serving endpoint
 #   google_vertex_ai_index_endpoint_deployed_index  — binds index -> endpoint
 #
-# Private serving: when var.network is supplied the endpoint is created on the
-# VPC peering path (its public_endpoint_enabled is left false). This is the
-# reason gcp/vertex_ai carries a hard dependency on gcp/vpc (contracts.go:322 /
-# #600): a private index endpoint requires servicenetworking peering on the
-# network, otherwise the deployed index errors with NOT_FOUND on the peering
-# range. On a single-module preview (no network wired) the endpoint falls back
-# to a public endpoint so the preset still composes/plans standalone.
+# Serving endpoint: PUBLIC by default. The endpoint goes private (VPC-peered)
+# only when a network is wired AND var.enable_private_endpoint is set true.
+# Private serving requires a servicenetworking PSC peering range on the network
+# (google_service_networking_connection + a VPC_PEERING global address) that
+# gcp/vpc does not yet provision (#600 / follow-up #774); until that lands a
+# live private apply fails ~30-90min in. So the default composed path is a
+# public endpoint, which works live today. See var.enable_private_endpoint.
+#
+# Network form: google_vertex_ai_index_endpoint.network requires the
+# project-NUMBER form projects/<PROJECT_NUMBER>/global/networks/<name>. The
+# wired vpc_id (and any human-supplied value) is typically the project-ID form
+# projects/<PROJECT_ID>/global/networks/<name> or a bare network name, so we
+# parse out the network NAME and rebuild the canonical project-number path with
+# data.google_project.this.number. See local.network_canonical.
 
 terraform {
   required_version = ">= 1.5"
@@ -37,10 +44,30 @@ locals {
 
   resolved_schema_uri = coalesce(var.metadata_schema_uri, local.metadata_schemas[var.dataset_type])
 
-  # A private (VPC-peered) endpoint is used only when a network is wired in.
-  # Standalone previews have no network and fall back to a public endpoint so
-  # the preset still plans without the VPC peering range existing.
-  vector_search_private = var.enable_vector_search && var.network != null
+  # The endpoint is private (VPC-peered) only when a network is wired AND the
+  # operator opts in via enable_private_endpoint. Default is a public endpoint
+  # (works live today; private needs the #774 PSC peering range first). The
+  # consuming resource is already count-gated on enable_vector_search, so this
+  # local does not re-test that flag.
+  vector_search_private = var.network != null && var.enable_private_endpoint
+
+  # google_vertex_ai_index_endpoint.network needs the project-NUMBER form
+  # projects/<NUMBER>/global/networks/<name>. Extract the bare network NAME from
+  # whatever was supplied (full project-ID path, full project-number path, or a
+  # bare name) and rebuild the canonical path with the project number. Only
+  # evaluated on the private path; null otherwise.
+  network_name = var.network == null ? null : element(split("/", var.network), length(split("/", var.network)) - 1)
+  network_canonical = local.vector_search_private ? (
+    "projects/${data.google_project.this.number}/global/networks/${local.network_name}"
+  ) : null
+}
+
+# Resolves the caller's project to its numeric project number, which the
+# index-endpoint network path requires (the wired vpc_id carries the project ID,
+# not the number). Always read so the data source plans cleanly; only consumed
+# on the private path.
+data "google_project" "this" {
+  project_id = var.project_id
 }
 
 resource "google_vertex_ai_dataset" "dataset" {
@@ -106,8 +133,8 @@ resource "google_vertex_ai_index" "this" {
   )
 }
 
-# The serving endpoint. Private (VPC-peered) when var.network is wired,
-# otherwise public so a standalone preview still composes.
+# The serving endpoint. PUBLIC by default; private (VPC-peered) only when a
+# network is wired AND var.enable_private_endpoint is set.
 resource "google_vertex_ai_index_endpoint" "this" {
   count        = var.enable_vector_search ? 1 : 0
   project      = var.project_id
@@ -115,20 +142,19 @@ resource "google_vertex_ai_index_endpoint" "this" {
   display_name = "${var.project}-vector-endpoint"
   description  = "InsideOut Vector Search endpoint for ${var.project}"
 
-  # VPC peering path: network is the full resource name
-  # projects/<project>/global/networks/<name>. Wired from gcp/vpc.vpc_id.
+  # VPC peering path: network is the canonical project-NUMBER resource name
+  # projects/<NUMBER>/global/networks/<name>, rebuilt from the wired vpc_id
+  # (which carries the project ID) via data.google_project.this.number.
   #
-  # NOTE: a private (VPC-peered) endpoint requires a servicenetworking
-  # PSC peering range on this network (google_service_networking_connection +
-  # a VPC_PEERING global address). That peering is the VPC's responsibility
-  # (the reason gcp/vertex_ai hard-depends on gcp/vpc — #600); it is not
-  # provisioned here. Until gcp/vpc provisions that range, real applies on the
-  # private path will need the peering created out-of-band. Compose/plan and
-  # the public-endpoint path are unaffected.
-  network = local.vector_search_private ? var.network : null
+  # NOTE: the private path additionally requires a servicenetworking PSC
+  # peering range on this network (google_service_networking_connection + a
+  # VPC_PEERING global address) that gcp/vpc does not yet provision (#774).
+  # Until that lands, an opt-in private apply needs the peering created
+  # out-of-band. The default (public) path is unaffected.
+  network = local.network_canonical
 
-  # Public endpoint only when no private network is wired.
-  public_endpoint_enabled = local.vector_search_private ? false : true
+  # Public unless the private path is selected.
+  public_endpoint_enabled = !local.vector_search_private
 
   labels = merge(
     {
@@ -142,11 +168,15 @@ resource "google_vertex_ai_index_endpoint" "this" {
 # serving replicas, which routinely takes 30-60 minutes, so create has a 90m
 # timeout to stay well clear of the provider's shorter default.
 resource "google_vertex_ai_index_endpoint_deployed_index" "this" {
-  count             = var.enable_vector_search ? 1 : 0
-  region            = var.region
-  index_endpoint    = google_vertex_ai_index_endpoint.this[0].id
-  index             = google_vertex_ai_index.this[0].id
-  deployed_index_id = replace("${var.project}_vector_idx", "-", "_")
+  count          = var.enable_vector_search ? 1 : 0
+  region         = var.region
+  index_endpoint = google_vertex_ai_index_endpoint.this[0].id
+  index          = google_vertex_ai_index.this[0].id
+  # The API requires deployed_index_id to start with a letter and contain only
+  # [a-z0-9_]. Lowercase var.project, replace every invalid char with "_", and
+  # prefix "idx_" so a project that starts with a digit (or is otherwise
+  # awkward) still yields a valid id.
+  deployed_index_id = "idx_${replace(lower(var.project), "/[^a-z0-9_]/", "_")}_vector"
   display_name      = "${var.project}-vector-deployed"
 
   automatic_resources {

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -1,5 +1,20 @@
-# GCP Vertex AI Dataset
-# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_dataset
+# GCP Vertex AI
+# - Dataset (always created): https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_dataset
+# - Vector Search (gated on var.enable_vector_search): index + index endpoint +
+#   deployed index. https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vertex_ai_index
+#
+# Vector Search composes a managed nearest-neighbour vector DB:
+#   google_vertex_ai_index                          — the ANN index (embeddings)
+#   google_vertex_ai_index_endpoint                 — the serving endpoint
+#   google_vertex_ai_index_endpoint_deployed_index  — binds index -> endpoint
+#
+# Private serving: when var.network is supplied the endpoint is created on the
+# VPC peering path (its public_endpoint_enabled is left false). This is the
+# reason gcp/vertex_ai carries a hard dependency on gcp/vpc (contracts.go:322 /
+# #600): a private index endpoint requires servicenetworking peering on the
+# network, otherwise the deployed index errors with NOT_FOUND on the peering
+# range. On a single-module preview (no network wired) the endpoint falls back
+# to a public endpoint so the preset still composes/plans standalone.
 
 terraform {
   required_version = ">= 1.5"
@@ -21,6 +36,11 @@ locals {
   }
 
   resolved_schema_uri = coalesce(var.metadata_schema_uri, local.metadata_schemas[var.dataset_type])
+
+  # A private (VPC-peered) endpoint is used only when a network is wired in.
+  # Standalone previews have no network and fall back to a public endpoint so
+  # the preset still plans without the VPC peering range existing.
+  vector_search_private = var.enable_vector_search && var.network != null
 }
 
 resource "google_vertex_ai_dataset" "dataset" {
@@ -42,4 +62,109 @@ resource "google_vertex_ai_dataset" "dataset" {
     },
     var.labels
   )
+}
+
+# --- Vector Search ----------------------------------------------------------
+
+# The ANN index. Dimensions and update_method are immutable: the Google API
+# rejects in-place changes to either, so terraform must destroy/recreate the
+# index when they change. The preset surfaces both as their own variables with
+# plan-time validation so a bad value fails fast rather than at apply.
+resource "google_vertex_ai_index" "this" {
+  count               = var.enable_vector_search ? 1 : 0
+  project             = var.project_id
+  region              = var.region
+  display_name        = "${var.project}-vector-index"
+  description         = "InsideOut Vector Search index for ${var.project}"
+  index_update_method = var.index_update_method
+
+  metadata {
+    # contents_delta_uri points at a GCS prefix of embedding files used to seed
+    # the index. Null on a standalone preview (no GCS wired) — the index is
+    # created empty and embeddings are upserted out-of-band.
+    contents_delta_uri = var.contents_delta_uri
+
+    config {
+      dimensions                  = var.index_dimensions
+      approximate_neighbors_count = var.index_approximate_neighbors_count
+      distance_measure_type       = var.index_distance_measure_type
+
+      algorithm_config {
+        tree_ah_config {
+          leaf_node_embedding_count    = 1000
+          leaf_nodes_to_search_percent = 10
+        }
+      }
+    }
+  }
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+}
+
+# The serving endpoint. Private (VPC-peered) when var.network is wired,
+# otherwise public so a standalone preview still composes.
+resource "google_vertex_ai_index_endpoint" "this" {
+  count        = var.enable_vector_search ? 1 : 0
+  project      = var.project_id
+  region       = var.region
+  display_name = "${var.project}-vector-endpoint"
+  description  = "InsideOut Vector Search endpoint for ${var.project}"
+
+  # VPC peering path: network is the full resource name
+  # projects/<project>/global/networks/<name>. Wired from gcp/vpc.vpc_id.
+  #
+  # NOTE: a private (VPC-peered) endpoint requires a servicenetworking
+  # PSC peering range on this network (google_service_networking_connection +
+  # a VPC_PEERING global address). That peering is the VPC's responsibility
+  # (the reason gcp/vertex_ai hard-depends on gcp/vpc — #600); it is not
+  # provisioned here. Until gcp/vpc provisions that range, real applies on the
+  # private path will need the peering created out-of-band. Compose/plan and
+  # the public-endpoint path are unaffected.
+  network = local.vector_search_private ? var.network : null
+
+  # Public endpoint only when no private network is wired.
+  public_endpoint_enabled = local.vector_search_private ? false : true
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+}
+
+# Binds the index to the endpoint. The deploy is the long pole: Vertex spins up
+# serving replicas, which routinely takes 30-60 minutes, so create has a 90m
+# timeout to stay well clear of the provider's shorter default.
+resource "google_vertex_ai_index_endpoint_deployed_index" "this" {
+  count             = var.enable_vector_search ? 1 : 0
+  region            = var.region
+  index_endpoint    = google_vertex_ai_index_endpoint.this[0].id
+  index             = google_vertex_ai_index.this[0].id
+  deployed_index_id = replace("${var.project}_vector_idx", "-", "_")
+  display_name      = "${var.project}-vector-deployed"
+
+  automatic_resources {
+    min_replica_count = var.deployed_index_min_replicas
+    max_replica_count = var.deployed_index_max_replicas
+  }
+
+  timeouts {
+    create = "90m"
+  }
+
+  lifecycle {
+    # Cross-variable invariant lives here (not in a variable validation block)
+    # because a per-variable validation may only reference its own variable;
+    # the autoscaling ceiling must not sit below the floor.
+    precondition {
+      condition     = var.deployed_index_max_replicas >= var.deployed_index_min_replicas
+      error_message = "deployed_index_max_replicas must be >= deployed_index_min_replicas."
+    }
+  }
 }

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -56,7 +56,17 @@ locals {
   # whatever was supplied (full project-ID path, full project-number path, or a
   # bare name) and rebuild the canonical path with the project number. Only
   # evaluated on the private path; null otherwise.
-  network_name = var.network == null ? null : element(split("/", var.network), length(split("/", var.network)) - 1)
+  #
+  # Parse the name out of the .../networks/<name> path with a regex capture so a
+  # malformed value can't silently yield the wrong segment (var.network is
+  # validated to be a bare name or an exact projects/.../networks/<name> path,
+  # so a non-match here means it was a bare name — fall back to the value
+  # itself). element()-last was unsafe: a trailing slash or short path would
+  # parse to "" or the wrong segment with no plan-time signal.
+  network_name = var.network == null ? null : try(
+    regex("/networks/([^/]+)$", var.network)[0],
+    var.network,
+  )
   network_canonical = local.vector_search_private ? (
     "projects/${data.google_project.this.number}/global/networks/${local.network_name}"
   ) : null

--- a/gcp/vertex_ai/observability.tf
+++ b/gcp/vertex_ai/observability.tf
@@ -1,0 +1,71 @@
+# observability.tf — issue #204 / #764
+#
+# Per-component Cloud Monitoring alert policies for Vertex AI Vector Search.
+# Emitted only when Vector Search is enabled (the bare dataset has no serving
+# surface to alarm on). Wired the SNS-equivalent inputs (notification_channels,
+# enable_observability) from gcp/cloud_monitoring when that aggregator is
+# selected — see contracts.go observability post-switch wiring.
+
+variable "enable_observability" {
+  description = "When true, emit per-component Cloud Monitoring alert policies (issue #204)."
+  type        = bool
+  default     = true
+}
+
+variable "notification_channels" {
+  description = "Cloud Monitoring notification channel names."
+  type        = list(string)
+  default     = []
+}
+
+variable "alarm_severity" {
+  description = "Severity tag attached to alert policies."
+  type        = string
+  default     = "warning"
+  validation {
+    condition     = contains(["critical", "warning", "info"], var.alarm_severity)
+    error_message = "alarm_severity must be one of critical|warning|info."
+  }
+}
+
+variable "alarm_threshold_overrides" {
+  description = "Per-metric numeric threshold overrides."
+  type        = map(number)
+  default     = {}
+}
+
+locals {
+  _obs_user_labels = { project = var.project, severity = var.alarm_severity }
+  _obs_thresholds = merge({
+    query_latency_p99_ms = 500
+  }, var.alarm_threshold_overrides)
+
+  # Alarms only make sense when Vector Search is serving queries.
+  _obs_enabled = var.enable_observability && var.enable_vector_search
+}
+
+resource "google_monitoring_alert_policy" "vector_search_query_latency_high" {
+  for_each = local._obs_enabled ? { "0" = true } : {}
+
+  project      = var.project_id
+  display_name = "${var.project}-vertex-vector-query-latency"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Vector Search p99 query latency above ${local._obs_thresholds["query_latency_p99_ms"]}ms"
+    condition_threshold {
+      # Public metric on the Matching Engine index endpoint serving surface.
+      filter          = "metric.type=\"aiplatform.googleapis.com/matching_engine/query_latencies\" AND resource.type=\"aiplatform.googleapis.com/MatchingEngineIndexEndpoint\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local._obs_thresholds["query_latency_p99_ms"]
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_PERCENTILE_99"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+  user_labels           = local._obs_user_labels
+}

--- a/gcp/vertex_ai/observability.tf
+++ b/gcp/vertex_ai/observability.tf
@@ -55,7 +55,12 @@ resource "google_monitoring_alert_policy" "vector_search_query_latency_high" {
     display_name = "Vector Search p99 query latency above ${local._obs_thresholds["query_latency_p99_ms"]}ms"
     condition_threshold {
       # Public metric on the Matching Engine index endpoint serving surface.
-      filter          = "metric.type=\"aiplatform.googleapis.com/matching_engine/query_latencies\" AND resource.type=\"aiplatform.googleapis.com/MatchingEngineIndexEndpoint\""
+      # Metric path + monitored resource verified against Google's official
+      # list (cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform):
+      # the metric is matching_engine/query/latencies (slashes, not an
+      # underscore) reported on aiplatform.googleapis.com/IndexEndpoint
+      # (NOT MatchingEngineIndexEndpoint, which is not a real resource type).
+      filter          = "metric.type=\"aiplatform.googleapis.com/matching_engine/query/latencies\" AND resource.type=\"aiplatform.googleapis.com/IndexEndpoint\""
       duration        = "300s"
       comparison      = "COMPARISON_GT"
       threshold_value = local._obs_thresholds["query_latency_p99_ms"]

--- a/gcp/vertex_ai/outputs.tf
+++ b/gcp/vertex_ai/outputs.tf
@@ -17,3 +17,21 @@ output "region" {
   value       = google_vertex_ai_dataset.dataset.region
   description = "The region of the Vertex AI dataset"
 }
+
+# --- Vector Search ----------------------------------------------------------
+# Null when var.enable_vector_search is false (the resources are not created).
+
+output "index_id" {
+  value       = var.enable_vector_search ? google_vertex_ai_index.this[0].id : null
+  description = "The resource ID of the Vector Search index (null when Vector Search is disabled)"
+}
+
+output "index_endpoint_id" {
+  value       = var.enable_vector_search ? google_vertex_ai_index_endpoint.this[0].id : null
+  description = "The resource ID of the Vector Search index endpoint (null when Vector Search is disabled)"
+}
+
+output "deployed_index_id" {
+  value       = var.enable_vector_search ? google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id : null
+  description = "The deployed-index ID binding the index to the endpoint (null when Vector Search is disabled)"
+}

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -1,0 +1,200 @@
+mock_provider "google" {}
+
+# Issue #764 (gcp/vertex_ai Vector Search) shape tests. Verifies that:
+#   - Defaults compose just the dataset; Vector Search is OFF by default and
+#     emits zero index/endpoint/deployed-index resources.
+#   - enable_vector_search=true composes index + endpoint + deployed index,
+#     wires a private endpoint when a network is supplied, and carries the
+#     90m create timeout on the deployed index.
+#   - The immutable knobs (index_dimensions, index_update_method) and the
+#     other validations reject obvious misconfigurations at plan time.
+
+run "defaults_dataset_only" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+
+  # Dataset is always created.
+  assert {
+    condition     = google_vertex_ai_dataset.dataset.display_name == "main-dataset"
+    error_message = "dataset must be created unconditionally with its default display name."
+  }
+
+  # Vector Search is off by default -> no index/endpoint/deployed-index.
+  assert {
+    condition     = length(google_vertex_ai_index.this) == 0
+    error_message = "Vector Search index must NOT be created when enable_vector_search is false (default)."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint.this) == 0
+    error_message = "Vector Search endpoint must NOT be created when enable_vector_search is false (default)."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint_deployed_index.this) == 0
+    error_message = "Deployed index must NOT be created when enable_vector_search is false (default)."
+  }
+}
+
+run "vector_search" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = true
+    index_dimensions     = 768
+    contents_delta_uri   = "gs://test-bucket/embeddings"
+    network              = "projects/test-project/global/networks/test-vpc"
+  }
+
+  # All three Vector Search resources compose.
+  assert {
+    condition     = length(google_vertex_ai_index.this) == 1
+    error_message = "enable_vector_search=true must create exactly one index."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint.this) == 1
+    error_message = "enable_vector_search=true must create exactly one index endpoint."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint_deployed_index.this) == 1
+    error_message = "enable_vector_search=true must create exactly one deployed index."
+  }
+
+  # Index dimensions flow through to the metadata.config block.
+  assert {
+    condition     = google_vertex_ai_index.this[0].metadata[0].config[0].dimensions == 768
+    error_message = "index_dimensions must reach metadata.config.dimensions."
+  }
+
+  # Index display name carries the var.project prefix (name-prefix scoping).
+  assert {
+    condition     = google_vertex_ai_index.this[0].display_name == "test-vector-index"
+    error_message = "index display_name must be var.project-prefixed (lint-labelless-name-prefix contract)."
+  }
+
+  # A supplied network -> private endpoint (public disabled, network set).
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].network == "projects/test-project/global/networks/test-vpc"
+    error_message = "a wired network must drive the private (VPC-peered) endpoint path."
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == false
+    error_message = "endpoint must be private (public disabled) when a network is wired."
+  }
+
+  # contents_delta_uri flows through to seed the index.
+  assert {
+    condition     = google_vertex_ai_index.this[0].metadata[0].contents_delta_uri == "gs://test-bucket/embeddings"
+    error_message = "contents_delta_uri must reach metadata.contents_delta_uri."
+  }
+
+  # deployed_index_id is sanitized (hyphens -> underscores) to satisfy the API.
+  assert {
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id == "test_vector_idx"
+    error_message = "deployed_index_id must be sanitized to [a-z0-9_]."
+  }
+
+  # 90m create timeout on the long-running deploy.
+  assert {
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].timeouts.create == "90m"
+    error_message = "deployed index must carry a 90m create timeout (deploys run 30-60min)."
+  }
+}
+
+run "vector_search_public_endpoint_without_network" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = true
+  }
+
+  # No network wired -> public endpoint so a standalone preview still composes.
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == true
+    error_message = "endpoint must fall back to public when no network is wired (standalone preview)."
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].network == null
+    error_message = "endpoint network must be null when no network is wired."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: validation blocks must reject misconfigurations at plan time.
+# -----------------------------------------------------------------------------
+
+run "rejects_zero_dimensions" {
+  command = plan
+
+  variables {
+    project          = "test"
+    project_id       = "test-project"
+    index_dimensions = 0
+  }
+
+  expect_failures = [var.index_dimensions]
+}
+
+run "rejects_negative_dimensions" {
+  command = plan
+
+  variables {
+    project          = "test"
+    project_id       = "test-project"
+    index_dimensions = -1
+  }
+
+  expect_failures = [var.index_dimensions]
+}
+
+run "rejects_invalid_update_method" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    index_update_method = "STREAM" # API expects STREAM_UPDATE
+  }
+
+  expect_failures = [var.index_update_method]
+}
+
+run "rejects_non_gcs_contents_uri" {
+  command = plan
+
+  variables {
+    project            = "test"
+    project_id         = "test-project"
+    contents_delta_uri = "s3://wrong/scheme"
+  }
+
+  expect_failures = [var.contents_delta_uri]
+}
+
+run "rejects_max_replicas_below_min" {
+  command = plan
+
+  variables {
+    project                     = "test"
+    project_id                  = "test-project"
+    enable_vector_search        = true
+    deployed_index_min_replicas = 3
+    deployed_index_max_replicas = 1 # ceiling below floor
+  }
+
+  # The cross-variable invariant is a resource precondition, not a variable
+  # validation, so the failure surfaces on the deployed-index resource.
+  expect_failures = [google_vertex_ai_index_endpoint_deployed_index.this]
+}

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -117,12 +117,25 @@ run "vector_search" {
 run "vector_search_private_opt_in" {
   command = plan
 
+  # Pin data.google_project.this.number to a fixed value so the rebuilt
+  # canonical network path can be asserted as an EXACT literal (otherwise the
+  # mock provider supplies a random computed number and the test could only
+  # assert prefix/suffix — which a passthrough rebuild would survive).
+  override_data {
+    target = data.google_project.this
+    values = {
+      number = "123456789012"
+    }
+  }
+
   variables {
     project                 = "test"
     project_id              = "test-project"
     enable_vector_search    = true
     enable_private_endpoint = true
-    network                 = "projects/test-project/global/networks/test-vpc"
+    # Project-ID full path: the parser must keep the network NAME and the
+    # rebuild must swap the project ID for the pinned project NUMBER.
+    network = "projects/test-project/global/networks/test-vpc"
   }
 
   # network + enable_private_endpoint -> private endpoint (public disabled).
@@ -132,17 +145,39 @@ run "vector_search_private_opt_in" {
   }
 
   # The endpoint network is rebuilt into the project-NUMBER path the API
-  # requires. The mock provider supplies a computed project number, so assert
-  # the structure (prefix + the parsed network name) rather than the exact
-  # number.
+  # requires: the name survives, the pinned number replaces the project ID.
+  # Asserting the EXACT literal kills a passthrough mutation of the rebuild.
   assert {
-    condition     = startswith(google_vertex_ai_index_endpoint.this[0].network, "projects/")
-    error_message = "private endpoint network must be a projects/<number>/global/networks/<name> path."
+    condition     = google_vertex_ai_index_endpoint.this[0].network == "projects/123456789012/global/networks/test-vpc"
+    error_message = "private endpoint network must rebuild to projects/<number>/global/networks/<name> using the project NUMBER (not the project ID)."
+  }
+}
+
+run "vector_search_private_bare_network_name" {
+  command = plan
+
+  # Bare-name input ("my-vpc") with the project number pinned so the rebuilt
+  # path can be asserted EXACTLY. Exercises the regex bare-name fallback and
+  # the project-NUMBER rebuild — a passthrough that skipped the rebuild would
+  # leave network = "my-vpc" and fail this assert.
+  override_data {
+    target = data.google_project.this
+    values = {
+      number = "123456789012"
+    }
+  }
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    enable_vector_search    = true
+    enable_private_endpoint = true
+    network                 = "my-vpc"
   }
 
   assert {
-    condition     = endswith(google_vertex_ai_index_endpoint.this[0].network, "/global/networks/test-vpc")
-    error_message = "private endpoint network must carry the parsed network NAME (test-vpc)."
+    condition     = google_vertex_ai_index_endpoint.this[0].network == "projects/123456789012/global/networks/my-vpc"
+    error_message = "a bare network name must be rebuilt to the full projects/<number>/global/networks/<name> form."
   }
 }
 
@@ -186,6 +221,95 @@ run "vector_search_public_endpoint_without_network" {
   assert {
     condition     = google_vertex_ai_index_endpoint.this[0].network == null
     error_message = "endpoint network must be null when no network is wired."
+  }
+}
+
+run "deployed_index_id_sanitizes_dirty_project" {
+  command = plan
+
+  variables {
+    # Project with uppercase + a dot: both are illegal in a deployed_index_id
+    # (must start with a letter, only [a-z0-9_]). The default "test" project is
+    # already clean and never exercised the replace(); this one does.
+    project              = "My-Proj.1"
+    project_id           = "test-project"
+    enable_vector_search = true
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id == "idx_my_proj_1_vector"
+    error_message = "deployed_index_id must lowercase var.project and replace every non-[a-z0-9_] char with '_' (My-Proj.1 -> my_proj_1)."
+  }
+}
+
+run "deployed_index_min_eq_max_composes" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = true
+    # Equal floor/ceiling is the >= boundary: it MUST compose (pins the
+    # precondition against a strict-> mutation that would reject min == max).
+    deployed_index_min_replicas = 2
+    deployed_index_max_replicas = 2
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_index_endpoint_deployed_index.this) == 1
+    error_message = "deployed index must compose when max_replicas == min_replicas (the >= boundary is inclusive)."
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].automatic_resources[0].min_replica_count == 2
+    error_message = "min_replica_count must flow through to automatic_resources."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Alert policy: the per-component query-latency alarm is emitted only when
+# Vector Search AND observability are both on, and carries the verified metric.
+# -----------------------------------------------------------------------------
+
+run "alert_policy_emitted_when_vector_search_and_observability_on" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = true
+    enable_observability = true
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.vector_search_query_latency_high) == 1
+    error_message = "query-latency alert policy must be emitted when Vector Search AND observability are both enabled."
+  }
+
+  # The filter must carry the metric.type verified against Google's official
+  # metrics list (matching_engine/query/latencies, slashes not underscore).
+  assert {
+    condition = strcontains(
+      google_monitoring_alert_policy.vector_search_query_latency_high["0"].conditions[0].condition_threshold[0].filter,
+      "metric.type=\"aiplatform.googleapis.com/matching_engine/query/latencies\""
+    )
+    error_message = "alert policy filter must reference the verified matching_engine/query/latencies metric type."
+  }
+}
+
+run "alert_policy_absent_when_vector_search_off" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_vector_search = false
+    enable_observability = true
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.vector_search_query_latency_high) == 0
+    error_message = "no alert policy when Vector Search is off — the bare dataset has no serving surface to alarm on."
   }
 }
 
@@ -239,6 +363,32 @@ run "rejects_non_gcs_contents_uri" {
   }
 
   expect_failures = [var.contents_delta_uri]
+}
+
+run "rejects_empty_network" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    network    = "" # would parse to an empty network name with no signal
+  }
+
+  expect_failures = [var.network]
+}
+
+run "rejects_malformed_network_path" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    # Trailing slash -> last-segment parse would yield "" ; not a valid bare
+    # name nor the exact projects/.../networks/<name> form.
+    network = "projects/test-project/global/networks/"
+  }
+
+  expect_failures = [var.network]
 }
 
 run "rejects_max_replicas_below_min" {

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -4,8 +4,9 @@ mock_provider "google" {}
 #   - Defaults compose just the dataset; Vector Search is OFF by default and
 #     emits zero index/endpoint/deployed-index resources.
 #   - enable_vector_search=true composes index + endpoint + deployed index,
-#     wires a private endpoint when a network is supplied, and carries the
-#     90m create timeout on the deployed index.
+#     defaults to a PUBLIC endpoint even with a network wired, goes private only
+#     when enable_private_endpoint is also set, and carries the 90m create
+#     timeout on the deployed index.
 #   - The immutable knobs (index_dimensions, index_update_method) and the
 #     other validations reject obvious misconfigurations at plan time.
 
@@ -48,8 +49,10 @@ run "vector_search" {
     project_id           = "test-project"
     enable_vector_search = true
     index_dimensions     = 768
-    contents_delta_uri   = "gs://test-bucket/embeddings"
-    network              = "projects/test-project/global/networks/test-vpc"
+    contents_delta_uri   = "gs://test-bucket/vertex-index/"
+    # Network wired but enable_private_endpoint left at its false default: the
+    # endpoint must stay PUBLIC (private requires the #774 PSC peering range).
+    network = "projects/test-project/global/networks/test-vpc"
   }
 
   # All three Vector Search resources compose.
@@ -80,33 +83,88 @@ run "vector_search" {
     error_message = "index display_name must be var.project-prefixed (lint-labelless-name-prefix contract)."
   }
 
-  # A supplied network -> private endpoint (public disabled, network set).
+  # Default (no enable_private_endpoint): PUBLIC even with a network wired, and
+  # no network is set on the endpoint (private path is opt-in only).
   assert {
-    condition     = google_vertex_ai_index_endpoint.this[0].network == "projects/test-project/global/networks/test-vpc"
-    error_message = "a wired network must drive the private (VPC-peered) endpoint path."
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == true
+    error_message = "endpoint must default to PUBLIC even when a network is wired (private is opt-in via enable_private_endpoint)."
   }
 
   assert {
-    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == false
-    error_message = "endpoint must be private (public disabled) when a network is wired."
+    condition     = google_vertex_ai_index_endpoint.this[0].network == null
+    error_message = "endpoint network must be null on the default public path (private is opt-in)."
   }
 
-  # contents_delta_uri flows through to seed the index.
+  # contents_delta_uri flows through to seed the index from the dedicated prefix.
   assert {
-    condition     = google_vertex_ai_index.this[0].metadata[0].contents_delta_uri == "gs://test-bucket/embeddings"
+    condition     = google_vertex_ai_index.this[0].metadata[0].contents_delta_uri == "gs://test-bucket/vertex-index/"
     error_message = "contents_delta_uri must reach metadata.contents_delta_uri."
   }
 
-  # deployed_index_id is sanitized (hyphens -> underscores) to satisfy the API.
+  # deployed_index_id is API-safe: starts with a letter, only [a-z0-9_].
   assert {
-    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id == "test_vector_idx"
-    error_message = "deployed_index_id must be sanitized to [a-z0-9_]."
+    condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id == "idx_test_vector"
+    error_message = "deployed_index_id must be sanitized to a letter-leading [a-z0-9_] id (idx_<project>_vector)."
   }
 
   # 90m create timeout on the long-running deploy.
   assert {
     condition     = google_vertex_ai_index_endpoint_deployed_index.this[0].timeouts.create == "90m"
     error_message = "deployed index must carry a 90m create timeout (deploys run 30-60min)."
+  }
+}
+
+run "vector_search_private_opt_in" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    enable_vector_search    = true
+    enable_private_endpoint = true
+    network                 = "projects/test-project/global/networks/test-vpc"
+  }
+
+  # network + enable_private_endpoint -> private endpoint (public disabled).
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == false
+    error_message = "endpoint must be private (public disabled) when a network is wired AND enable_private_endpoint is set."
+  }
+
+  # The endpoint network is rebuilt into the project-NUMBER path the API
+  # requires. The mock provider supplies a computed project number, so assert
+  # the structure (prefix + the parsed network name) rather than the exact
+  # number.
+  assert {
+    condition     = startswith(google_vertex_ai_index_endpoint.this[0].network, "projects/")
+    error_message = "private endpoint network must be a projects/<number>/global/networks/<name> path."
+  }
+
+  assert {
+    condition     = endswith(google_vertex_ai_index_endpoint.this[0].network, "/global/networks/test-vpc")
+    error_message = "private endpoint network must carry the parsed network NAME (test-vpc)."
+  }
+}
+
+run "vector_search_private_opt_in_without_network_stays_public" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    enable_vector_search    = true
+    enable_private_endpoint = true
+    # No network wired: the flag alone cannot force private.
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].public_endpoint_enabled == true
+    error_message = "endpoint must stay PUBLIC when enable_private_endpoint is set but no network is wired."
+  }
+
+  assert {
+    condition     = google_vertex_ai_index_endpoint.this[0].network == null
+    error_message = "endpoint network must be null when no network is wired, regardless of enable_private_endpoint."
   }
 }
 

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -14,7 +14,7 @@ variable "project_id" {
 }
 
 variable "region" {
-  description = "GCP region for the Vertex AI dataset"
+  description = "GCP region for the Vertex AI resources"
   type        = string
   default     = "us-central1"
 }
@@ -57,4 +57,96 @@ variable "labels" {
   description = "Labels to apply"
   type        = map(string)
   default     = {}
+}
+
+# --- Vector Search ----------------------------------------------------------
+
+variable "enable_vector_search" {
+  description = "When true, provision Vertex AI Vector Search (index + index endpoint + deployed index) alongside the dataset. The dataset is always created; this gates only the Vector Search resources."
+  type        = bool
+  default     = false
+}
+
+variable "index_dimensions" {
+  description = "Dimensionality of the embedding vectors the index stores. IMMUTABLE — changing it forces index destroy/recreate. Must match the embedding model that produces the vectors (e.g. 768 for text-embedding-004)."
+  type        = number
+  default     = 768
+
+  validation {
+    condition     = var.index_dimensions > 0
+    error_message = "index_dimensions must be greater than 0."
+  }
+}
+
+variable "index_update_method" {
+  description = "How embeddings are written to the index. BATCH (default) ingests from contents_delta_uri batches; STREAM upserts individual vectors via the streaming API. IMMUTABLE — changing it forces index destroy/recreate."
+  type        = string
+  default     = "BATCH_UPDATE"
+
+  validation {
+    # The Google API accepts the verbose forms BATCH_UPDATE / STREAM_UPDATE.
+    condition     = contains(["BATCH_UPDATE", "STREAM_UPDATE"], var.index_update_method)
+    error_message = "index_update_method must be one of: BATCH_UPDATE, STREAM_UPDATE."
+  }
+}
+
+variable "contents_delta_uri" {
+  description = "GCS prefix (gs://bucket/path) of embedding files used to seed/refresh the index. Null creates an empty index seeded out-of-band. Wired from gcp/gcs.bucket_url in a full stack."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.contents_delta_uri == null ? true : startswith(var.contents_delta_uri, "gs://")
+    error_message = "contents_delta_uri must be a gs:// URI."
+  }
+}
+
+variable "index_distance_measure_type" {
+  description = "Distance metric for nearest-neighbour search. One of DOT_PRODUCT_DISTANCE, COSINE_DISTANCE, SQUARED_L2_DISTANCE."
+  type        = string
+  default     = "DOT_PRODUCT_DISTANCE"
+
+  validation {
+    condition     = contains(["DOT_PRODUCT_DISTANCE", "COSINE_DISTANCE", "SQUARED_L2_DISTANCE"], var.index_distance_measure_type)
+    error_message = "index_distance_measure_type must be one of: DOT_PRODUCT_DISTANCE, COSINE_DISTANCE, SQUARED_L2_DISTANCE."
+  }
+}
+
+variable "index_approximate_neighbors_count" {
+  description = "Number of neighbours to find via approximate search before exact reordering. Tuning knob; 150 is a sensible default for most embedding sizes."
+  type        = number
+  default     = 150
+
+  validation {
+    condition     = var.index_approximate_neighbors_count > 0
+    error_message = "index_approximate_neighbors_count must be greater than 0."
+  }
+}
+
+variable "network" {
+  description = "Full VPC network resource name (projects/<project>/global/networks/<name>) for a private (VPC-peered) index endpoint. Null creates a public endpoint. Wired from gcp/vpc.vpc_id in a full stack; requires servicenetworking peering on the network (#600)."
+  type        = string
+  default     = null
+}
+
+variable "deployed_index_min_replicas" {
+  description = "Minimum serving replicas for the deployed index."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.deployed_index_min_replicas > 0
+    error_message = "deployed_index_min_replicas must be greater than 0."
+  }
+}
+
+variable "deployed_index_max_replicas" {
+  description = "Maximum serving replicas for the deployed index (autoscaling ceiling). Must be >= deployed_index_min_replicas (enforced by a precondition on the deployed-index resource)."
+  type        = number
+  default     = 2
+
+  validation {
+    condition     = var.deployed_index_max_replicas > 0
+    error_message = "deployed_index_max_replicas must be greater than 0."
+  }
 }

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -127,6 +127,19 @@ variable "network" {
   description = "VPC network for a private (VPC-peered) index endpoint. Accepts the project-ID path (projects/<project_id>/global/networks/<name>, as emitted by gcp/vpc.vpc_id), the project-number path, or a bare network name — the preset extracts the network name and rebuilds the project-NUMBER path the API requires. Only used when enable_private_endpoint is also true; otherwise the endpoint is public."
   type        = string
   default     = null
+
+  validation {
+    # Accept null (public path), a bare network name (RFC1035-ish: starts with
+    # a lowercase letter, lowercase letters/digits/hyphens), or the exact
+    # projects/<project-id-or-number>/global/networks/<name> resource form.
+    # Reject "" and malformed paths (trailing slash, wrong segments) at plan
+    # time so local.network_name never silently parses to an empty/wrong name.
+    condition = var.network == null ? true : (
+      can(regex("^[a-z]([-a-z0-9]*[a-z0-9])?$", var.network)) ||
+      can(regex("^projects/[a-z0-9-]+/global/networks/[a-z]([-a-z0-9]*[a-z0-9])?$", var.network))
+    )
+    error_message = "network must be null, a bare network name, or an exact projects/<id-or-number>/global/networks/<name> path."
+  }
 }
 
 variable "enable_private_endpoint" {

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -124,9 +124,15 @@ variable "index_approximate_neighbors_count" {
 }
 
 variable "network" {
-  description = "Full VPC network resource name (projects/<project>/global/networks/<name>) for a private (VPC-peered) index endpoint. Null creates a public endpoint. Wired from gcp/vpc.vpc_id in a full stack; requires servicenetworking peering on the network (#600)."
+  description = "VPC network for a private (VPC-peered) index endpoint. Accepts the project-ID path (projects/<project_id>/global/networks/<name>, as emitted by gcp/vpc.vpc_id), the project-number path, or a bare network name — the preset extracts the network name and rebuilds the project-NUMBER path the API requires. Only used when enable_private_endpoint is also true; otherwise the endpoint is public."
   type        = string
   default     = null
+}
+
+variable "enable_private_endpoint" {
+  description = "When true AND a network is wired, the index endpoint is private (VPC-peered) instead of public. Default false = public endpoint, which works live today. The private path requires a servicenetworking PSC peering range on the network that gcp/vpc does not yet provision (follow-up #774); enabling it before #774 lands means the peering must exist out-of-band or a live apply fails ~30-90min into the deployed-index step."
+  type        = bool
+  default     = false
 }
 
 variable "deployed_index_min_replicas" {

--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -20,6 +20,7 @@ type awsEC2CfgInput struct {
 	CustomIngressPorts    []int
 	SSHPublicKey          string
 	EnableInstanceConnect *bool
+	GPUEnabled            *bool
 }
 
 // configWithAWSEC2 returns *Config with AWSEC2 populated from input, eliding
@@ -36,6 +37,7 @@ func configWithAWSEC2(in awsEC2CfgInput) *Config {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			InstanceType:          in.InstanceType,
 			NumServers:            in.NumServers,
@@ -46,6 +48,39 @@ func configWithAWSEC2(in awsEC2CfgInput) *Config {
 			CustomIngressPorts:    in.CustomIngressPorts,
 			SSHPublicKey:          in.SSHPublicKey,
 			EnableInstanceConnect: in.EnableInstanceConnect,
+			GPUEnabled:            in.GPUEnabled,
+		},
+	}
+}
+
+// awsEKSCfgInput mirrors the subset of Config.AWSEKS fields exercised by
+// mapper tests.
+type awsEKSCfgInput struct {
+	DesiredSize  string
+	MaxSize      string
+	MinSize      string
+	InstanceType string
+	GPUEnabled   *bool
+}
+
+// configWithAWSEKS returns *Config with AWSEKS populated from input, eliding
+// the anonymous-struct redeclaration at each call site.
+func configWithAWSEKS(in awsEKSCfgInput) *Config {
+	return &Config{
+		AWSEKS: &struct {
+			HaControlPlane         *bool  `json:"haControlPlane,omitempty"`
+			ControlPlaneVisibility string `json:"controlPlaneVisibility,omitempty"`
+			DesiredSize            string `json:"desiredSize,omitempty"`
+			MaxSize                string `json:"maxSize,omitempty"`
+			MinSize                string `json:"minSize,omitempty"`
+			InstanceType           string `json:"instanceType,omitempty"`
+			GPUEnabled             *bool  `json:"gpuEnabled,omitempty"`
+		}{
+			DesiredSize:  in.DesiredSize,
+			MaxSize:      in.MaxSize,
+			MinSize:      in.MinSize,
+			InstanceType: in.InstanceType,
+			GPUEnabled:   in.GPUEnabled,
 		},
 	}
 }

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -81,6 +81,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.AWSOpenSearch)
 	case KeyAWSBedrock:
 		return boolPtrTrue(c.AWSBedrock)
+	case KeyAWSBedrockAgent:
+		return boolPtrTrue(c.AWSBedrockAgent)
 	case KeyAWSSQS:
 		return boolPtrTrue(c.AWSSQS)
 	case KeyAWSMSK:
@@ -299,7 +301,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
 		KeyAWSCognito, KeyAWSLambda, KeyAWSAppRunner, KeyAWSSageMaker, KeyAWSCodeBuild, KeyAWSAPIGateway,
 		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
-		KeyAWSBedrock, KeyAWSBackups, KeyAWSRoute53,
+		KeyAWSBedrock, KeyAWSBedrockAgent, KeyAWSBackups, KeyAWSRoute53,
 		KeyAWSACM,
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -304,6 +304,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
+		KeyGCPVertexAI,
 		KeyGCPPubSub, KeyGCPCloudLogging,
 		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
 		KeyGCPCloudDNS, KeyGCPGitHubActions, KeyGCPCloudDeploy:

--- a/pkg/composer/compose_bedrock_agent_test.go
+++ b/pkg/composer/compose_bedrock_agent_test.go
@@ -1,0 +1,100 @@
+package composer
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// wiresAttr reports whether composed HCL wires attr to the given RHS
+// expression, tolerant of the composer's `=`-alignment whitespace.
+func wiresAttr(hcl, attr, rhs string) bool {
+	re := regexp.MustCompile(`(?m)^\s*` + regexp.QuoteMeta(attr) + `\s*=\s*` + regexp.QuoteMeta(rhs) + `\s*$`)
+	return re.MatchString(hcl)
+}
+
+// TestComposeStack_BedrockAgent_ImplicitLambda verifies the #762 acceptance
+// criterion: selecting aws_bedrock_agent alone drags in aws/lambda (the
+// action-group executor is a HARD ImplicitDependency) and DefaultWiring feeds
+// the agent's action_group_lambda_arn from module.aws_lambda.function_arn.
+func TestComposeStack_BedrockAgent_ImplicitLambda(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSBedrockAgent},
+		Comps:        &Components{AWSBedrockAgent: ptrBool(true)},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	mainTF := string(out["/main.tf"])
+
+	// Lambda must be implicitly composed (action-group executor).
+	require.Contains(t, mainTF, `module "aws_lambda"`,
+		"aws_bedrock_agent must implicitly pull in the aws/lambda module (action-group executor)")
+	require.Contains(t, mainTF, `module "aws_bedrock_agent"`,
+		"the agent module itself must be composed")
+
+	// The agent's action_group_lambda_arn must be wired from the lambda module.
+	require.True(t, wiresAttr(mainTF, "action_group_lambda_arn", "module.aws_lambda.function_arn"),
+		"DefaultWiring must wire the agent's action_group_lambda_arn from module.aws_lambda.function_arn")
+
+	// A bedrock-agent-only stack (no aws_bedrock) must NOT wire a KB id.
+	require.NotContains(t, mainTF, "knowledge_base_id",
+		"a bedrock-agent stack without aws_bedrock must not wire knowledge_base_id")
+
+	// No fabricated preview ARN may leak into the composed stack.
+	require.NotContains(t, mainTF, "composerpreview",
+		"no fabricated preview ARN may leak into a composed stack's main.tf")
+}
+
+// TestComposeStack_BedrockAgent_WiresKnowledgeBase verifies the #762 "agent
+// that does RAG" criterion: when aws_bedrock (KB, #757) is selected alongside
+// aws_bedrock_agent, the composed stack wires the agent's knowledge_base_id
+// from the bedrock module's knowledge_base_id output — no stub, no fabricated
+// id. This is the KB-association composition described in the ticket.
+func TestComposeStack_BedrockAgent_WiresKnowledgeBase(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud: "aws",
+		SelectedKeys: []ComponentKey{
+			KeyAWSBedrockAgent,
+			KeyAWSBedrock,
+		},
+		Comps: &Components{
+			AWSBedrockAgent: ptrBool(true),
+			AWSBedrock:      ptrBool(true),
+		},
+		Cfg:     &Config{},
+		Project: "demo",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	mainTF := string(out["/main.tf"])
+
+	// The agent's knowledge_base_id must be wired from the bedrock KB output.
+	require.True(t, wiresAttr(mainTF, "knowledge_base_id", "module.aws_bedrock.knowledge_base_id"),
+		"composing aws_bedrock with aws_bedrock_agent must wire the agent's knowledge_base_id from module.aws_bedrock.knowledge_base_id (KB association, #757 outputs)")
+
+	// Lambda is still implicitly present (the executor).
+	require.Contains(t, mainTF, `module "aws_lambda"`,
+		"aws_bedrock_agent must still implicitly pull in aws/lambda alongside the KB wiring")
+
+	// aws_bedrock must compose BEFORE aws_bedrock_agent so its knowledge_base_id
+	// output exists when the agent module references it (ComposeOrder contract).
+	bedrockPos := strings.Index(mainTF, `module "aws_bedrock"`)
+	agentPos := strings.Index(mainTF, `module "aws_bedrock_agent"`)
+	require.NotEqual(t, -1, bedrockPos)
+	require.NotEqual(t, -1, agentPos)
+	require.Less(t, bedrockPos, agentPos,
+		"aws_bedrock must be declared before aws_bedrock_agent so the KB output is available to wire")
+}

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -41,10 +41,19 @@ func TestBedrockWiring_AOSSCollectionArn(t *testing.T) {
 	require.Equal(t, "module.aws_opensearch.collection_arn", wi.RawHCL["opensearch_collection_arn"],
 		"bedrock must wire opensearch_collection_arn to the AOSS collection output")
 
+	// Bedrock authors the AOSS data-access policy from the collection NAME
+	// (access policies match collections by name, not ARN). Without this
+	// edge the bedrock module's data-access policy count gates off and the
+	// KB role has no data-plane grant — a composed Bedrock+OpenSearch stack
+	// would deploy a role that cannot read/write the collection.
+	require.Equal(t, "module.aws_opensearch.collection_name", wi.RawHCL["opensearch_collection_name"],
+		"bedrock must wire opensearch_collection_name so it can author the AOSS data-access policy")
+
 	_, hasOldKey := wi.RawHCL["opensearch_arn"]
 	require.False(t, hasOldKey, "legacy opensearch_arn input must not be emitted")
 
 	require.Contains(t, wi.Names, "opensearch_collection_arn")
+	require.Contains(t, wi.Names, "opensearch_collection_name")
 	require.NotContains(t, wi.Names, "opensearch_arn")
 }
 
@@ -286,10 +295,17 @@ func TestComposeStack_BedrockWiresRealAOSSArn(t *testing.T) {
 	mainTF := string(out["/main.tf"])
 	bedrockTfvars := string(out["/aws_bedrock.auto.tfvars"])
 
-	// The composed module block must carry the real wiring.
-	require.Contains(t, mainTF,
-		`opensearch_collection_arn = module.aws_opensearch.collection_arn`,
+	// The composed module block must carry the real wiring. HCL aligns the
+	// `=` columns, so match whitespace-tolerantly rather than pinning the
+	// exact gap (which shifts when a longer key like collection_name is added).
+	require.Regexp(t,
+		`opensearch_collection_arn\s+=\s+module\.aws_opensearch\.collection_arn`,
+		mainTF,
 		"KB-path stack composition must wire the real AOSS collection_arn")
+	require.Regexp(t,
+		`opensearch_collection_name\s+=\s+module\.aws_opensearch\.collection_name`,
+		mainTF,
+		"KB-path stack composition must wire the AOSS collection_name for the data-access policy")
 
 	// No fabricated preview ARN may appear anywhere.
 	require.NotContains(t, mainTF, "composerpreview",
@@ -676,10 +692,18 @@ func TestComposeStack_BedrockOpenSearchAOSSEndToEnd(t *testing.T) {
 	outputsTF := string(out["/outputs.tf"])
 
 	// 1. Bedrock block wires opensearch_collection_arn to the AOSS output.
-	require.Contains(t, mainTF, `opensearch_collection_arn = module.aws_opensearch.collection_arn`,
+	//    HCL aligns the `=` columns, so match whitespace-tolerantly.
+	require.Regexp(t, `opensearch_collection_arn\s+=\s+module\.aws_opensearch\.collection_arn`, mainTF,
 		"bedrock must wire opensearch_collection_arn to the AOSS collection_arn output")
 	require.NotContains(t, mainTF, "module.aws_opensearch.opensearch_arn",
 		"bedrock must no longer reference the legacy opensearch_arn output")
+
+	// 1b. Bedrock also wires opensearch_collection_name so it can author the
+	//     AOSS data-access policy (matched by name, not ARN). The preset
+	//     gates the data-access policy on this variable; without the edge a
+	//     composed KB stack deploys a role with no data-plane grant.
+	require.Regexp(t, `opensearch_collection_name\s+=\s+module\.aws_opensearch\.collection_name`, mainTF,
+		"bedrock must wire opensearch_collection_name to the AOSS collection_name output")
 
 	// 2. OpenSearch tfvars reflect the hard-override to serverless,
 	//    regardless of the "managed" value in cfg.

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -100,6 +100,76 @@ func TestMapper_OpenSearchDeploymentTypeOverride(t *testing.T) {
 	// serverless override).
 }
 
+// TestMapper_OpenSearchDeploymentTypeOverride_758 hardens the
+// bedrock-forces-serverless override (mapper.go) for the #758 production
+// vector-store surfacing. The original override test (above) pins the
+// managed→serverless flip and the no-bedrock passthrough. These cases pin
+// the two paths that override miss:
+//
+//   - empty/unset DeploymentType + Bedrock must STILL force serverless. The
+//     override writes vals["deployment_type"] unconditionally when Bedrock is
+//     present, but a refactor that moved the write inside the
+//     `if cfg.AWSOpenSearch.DeploymentType != ""` block would silently drop
+//     it for the empty-config case — exactly the Bedrock-KB default path.
+//   - explicit serverless + Bedrock is idempotent (stays serverless, no error).
+//
+// Without these, a mutation that gated the override on a non-empty user
+// DeploymentType would pass the original test (which always sets "managed")
+// yet break the real default flow where the user configures nothing.
+func TestMapper_OpenSearchDeploymentTypeOverride_758(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("empty deployment_type plus bedrock still forces serverless", func(t *testing.T) {
+		// cfg.AWSOpenSearch is nil entirely — the Bedrock-KB default path,
+		// where the user selects Bedrock + OpenSearch and configures neither.
+		vals, err := m.BuildModuleValues(
+			KeyAWSOpenSearch,
+			&Components{AWSBedrock: ptrBool(true), AWSOpenSearch: ptrBool(true)},
+			&Config{},
+			"demo", "us-east-1",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "serverless", vals["deployment_type"],
+			"Bedrock must force serverless even when the user supplies no OpenSearch config — this is the KB default path")
+	})
+
+	t.Run("explicit serverless plus bedrock is idempotent", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(
+			KeyAWSOpenSearch,
+			&Components{AWSBedrock: ptrBool(true), AWSOpenSearch: ptrBool(true)},
+			&Config{
+				AWSOpenSearch: &struct {
+					DeploymentType string `json:"deploymentType,omitempty"`
+					InstanceType   string `json:"instanceType,omitempty"`
+					StorageSize    string `json:"storageSize,omitempty"`
+					MultiAZ        *bool  `json:"multiAz,omitempty"`
+				}{DeploymentType: "serverless"},
+			},
+			"demo", "us-east-1",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "serverless", vals["deployment_type"],
+			"explicit serverless + Bedrock must remain serverless (override is idempotent, not an error)")
+	})
+
+	t.Run("no bedrock plus empty config leaves deployment_type unset", func(t *testing.T) {
+		// Negative companion: with no Bedrock and no user config, the mapper
+		// must NOT emit deployment_type at all so the preset default
+		// ("managed") wins. A mutation that hard-wrote serverless
+		// unconditionally would be caught here.
+		vals, err := m.BuildModuleValues(
+			KeyAWSOpenSearch,
+			&Components{AWSOpenSearch: ptrBool(true)},
+			&Config{},
+			"demo", "us-east-1",
+		)
+		require.NoError(t, err)
+		_, has := vals["deployment_type"]
+		require.False(t, has,
+			"mapper must not emit deployment_type when neither Bedrock nor user config sets it — preset default 'managed' must win")
+	})
+}
+
 // TestMapper_BedrockNoKBStub confirms the mapper does NOT inject the
 // Knowledge Base inputs (s3_bucket_arn / opensearch_collection_arn) for a
 // Bedrock-only preview. Both preset inputs are optional (default null) since

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -1096,6 +1096,7 @@ func TestComposeStack_MonolithEC2(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			UserData:           "#!/bin/bash\napt-get update && apt-get install -y nodejs",
 			DiskSizePerServer:  "32",
@@ -1275,6 +1276,7 @@ touch /var/log/openclaw-init-complete`
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			NumServers:         "1",
 			UserData:           cloudInitScript,
@@ -1410,6 +1412,7 @@ func TestComposeStack_OpenClawDemo_URL(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			NumServers:         "1",
 			UserDataURL:        gistURL,
@@ -1466,6 +1469,7 @@ func TestComposeStack_EC2_InstanceConnect(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			NumServers:            "1",
 			EnableInstanceConnect: &trueVal,
@@ -1515,6 +1519,7 @@ func TestComposeStack_EC2_NoInstanceConnect(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			NumServers: "1",
 		},

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1055,8 +1055,16 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.Names = append(wi.Names, "s3_bucket_arn")
 		}
 		if hasOpenSearch {
-			wi.RawHCL["opensearch_collection_arn"] = opensearchRef(selected) + ".collection_arn"
-			wi.Names = append(wi.Names, "opensearch_collection_arn")
+			osRef := opensearchRef(selected)
+			wi.RawHCL["opensearch_collection_arn"] = osRef + ".collection_arn"
+			// Bedrock authors the AOSS data-access policy from the collection
+			// NAME (AOSS access policies match collections by name, not ARN),
+			// so it needs collection_name as well as collection_arn. Without
+			// this edge the bedrock module skips the data-access policy
+			// (count gates on var.opensearch_collection_name) and the KB role
+			// has no data-plane grant. See aws/opensearch/main.tf header.
+			wi.RawHCL["opensearch_collection_name"] = osRef + ".collection_name"
+			wi.Names = append(wi.Names, "opensearch_collection_arn", "opensearch_collection_name")
 		}
 
 	case KeyAWSBackups:

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1184,6 +1184,24 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.RawHCL["vpc_connector"] = WireRef(KeyGCPVPC, "connector_id")
 			wi.Names = append(wi.Names, "vpc_connector")
 		}
+
+	case KeyGCPVertexAI:
+		// Vertex AI Vector Search (#764). When a VPC is selected, wire its
+		// network resource id (projects/<p>/global/networks/<n>, the exact
+		// form google_vertex_ai_index_endpoint.network expects) so the index
+		// endpoint takes the private VPC-peering path — the reason the hard
+		// gcp/vpc dep exists (contracts.go:322 / #600 PSC peering). gcp/vpc's
+		// network_id is surfaced as the vpc_id output.
+		if selected[KeyGCPVPC] {
+			wi.RawHCL["network"] = WireRef(KeyGCPVPC, "vpc_id")
+			wi.Names = append(wi.Names, "network")
+		}
+		// When GCS is selected, seed the index from the bucket. bucket_url is
+		// the gs:// URL the index's contents_delta_uri expects.
+		if selected[KeyGCPGCS] {
+			wi.RawHCL["contents_delta_uri"] = WireRef(KeyGCPGCS, "bucket_url")
+			wi.Names = append(wi.Names, "contents_delta_uri")
+		}
 	}
 
 	// Observability post-switch wiring (issue #204). Driven off the

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -55,6 +55,7 @@ const (
 	KeyAWSSecretsManager       ComponentKey = "aws_secretsmanager"
 	KeyAWSOpenSearch           ComponentKey = "aws_opensearch"
 	KeyAWSBedrock              ComponentKey = "aws_bedrock"
+	KeyAWSBedrockAgent         ComponentKey = "aws_bedrock_agent"
 	KeyAWSSQS                  ComponentKey = "aws_sqs"
 	KeyAWSMSK                  ComponentKey = "aws_msk"
 	KeyAWSCloudWatchLogs       ComponentKey = "aws_cloudwatch_logs"
@@ -156,6 +157,13 @@ var ComposeOrder = []ComponentKey{
 	KeyGCPSecretManager,
 	KeyAWSOpenSearch,
 	KeyAWSBedrock,
+	// Bedrock Agent (#762) composes after KeyAWSBedrock so its DefaultWiring
+	// case can read the KB's knowledge_base_id output when aws_bedrock is also
+	// selected. Its hard ImplicitDependency on KeyAWSLambda (the action-group
+	// executor) is positioned far earlier (Lambda :~110), so both producers
+	// precede this consumer — TestImplicitDependencies_ComposeOrderRespected
+	// enforces that.
+	KeyAWSBedrockAgent,
 	KeyAWSSageMaker,
 	KeyGCPVertexAI,
 	// App Runner (#598 row 2). Independent of EKS/ECS/Lambda compute
@@ -216,6 +224,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyAWSKMS:                  "modules/kms",
 	KeyAWSSecretsManager:       "modules/secretsmanager",
 	KeyAWSBedrock:              "modules/bedrock",
+	KeyAWSBedrockAgent:         "modules/bedrock_agent",
 	KeyAWSSQS:                  "modules/sqs",
 	KeyAWSMSK:                  "modules/msk",
 	KeyAWSCloudWatchLogs:       "modules/cloudwatchlogs",
@@ -294,6 +303,14 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	// network_mode is PublicInternetOnly or VpcOnly — selecting SageMaker
 	// without a VPC leaves the required inputs without a wired source.
 	KeyAWSSageMaker: {KeyAWSVPC},
+	// Bedrock Agent (#762): the action group's executor is a Lambda function.
+	// aws_bedrockagent_agent_action_group.action_group_executor.lambda has no
+	// source unless aws/lambda is in the stack, so the action_group_lambda_arn
+	// wire is unsatisfiable without it — a HARD dependency. The VPC arrives
+	// transitively (KeyAWSLambda → KeyAWSVPC). The KB association is NOT a hard
+	// dep: a Bedrock Agent is fully functional without RAG; the KB wire is
+	// added conditionally by DefaultWiring only when aws_bedrock is selected.
+	KeyAWSBedrockAgent: {KeyAWSLambda},
 	// App Runner (#598 row 2). The public-only service does NOT strictly
 	// require a VPC, but the preset's optional VPC connector path
 	// (enable_vpc_connector = true) feeds vpc_id + subnet_ids from
@@ -433,6 +450,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyAWSKMS:                  "kms",
 	KeyAWSSecretsManager:       "secretsmanager",
 	KeyAWSBedrock:              "bedrock",
+	KeyAWSBedrockAgent:         "bedrock_agent",
 	KeyAWSSQS:                  "sqs",
 	KeyAWSMSK:                  "msk",
 	KeyAWSCloudWatchLogs:       "cloudwatchlogs",
@@ -537,6 +555,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyAWSBackups,
 	KeyAWSBastion,
 	KeyAWSBedrock,
+	KeyAWSBedrockAgent,
 	KeyAWSCloudWatchLogs,
 	KeyAWSCloudWatchMonitoring,
 	KeyAWSCloudfront,
@@ -658,6 +677,8 @@ func rdsRef(_ map[ComponentKey]bool) string        { return ModuleRef(KeyAWSRDS)
 func s3Ref(_ map[ComponentKey]bool) string         { return ModuleRef(KeyAWSS3) }
 func opensearchRef(_ map[ComponentKey]bool) string { return ModuleRef(KeyAWSOpenSearch) }
 func sqsRef(_ map[ComponentKey]bool) string        { return ModuleRef(KeyAWSSQS) }
+func lambdaRef(_ map[ComponentKey]bool) string     { return ModuleRef(KeyAWSLambda) }
+func bedrockRef(_ map[ComponentKey]bool) string    { return ModuleRef(KeyAWSBedrock) }
 
 // resourceRef returns the EKS/ECS module reference for the selected stack.
 // Prefers KeyAWSEKS over KeyAWSECS when both are somehow present (validators
@@ -1057,6 +1078,25 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		if hasOpenSearch {
 			wi.RawHCL["opensearch_collection_arn"] = opensearchRef(selected) + ".collection_arn"
 			wi.Names = append(wi.Names, "opensearch_collection_arn")
+		}
+
+	case KeyAWSBedrockAgent:
+		// The action group's executor is a Lambda function. KeyAWSLambda is a
+		// HARD ImplicitDependency of KeyAWSBedrockAgent, so aws/lambda is always
+		// in the stack here — wire the agent's action_group_lambda_arn from the
+		// lambda module's function_arn output unconditionally.
+		wi.RawHCL["action_group_lambda_arn"] = lambdaRef(selected) + ".function_arn"
+		wi.Names = append(wi.Names, "action_group_lambda_arn")
+		// "Agent that does RAG": when aws/bedrock is also selected with its
+		// Knowledge Base enabled, wire the KB's id into the agent so the preset
+		// creates an aws_bedrockagent_agent_knowledge_base_association. The
+		// bedrock preset's knowledge_base_id output is null when the KB is
+		// disabled, so the association is gated preset-side on a non-null id —
+		// composing aws_bedrock without enable_knowledge_base leaves the agent
+		// KB-less, which is correct.
+		if selected[KeyAWSBedrock] {
+			wi.RawHCL["knowledge_base_id"] = bedrockRef(selected) + ".knowledge_base_id"
+			wi.Names = append(wi.Names, "knowledge_base_id")
 		}
 
 	case KeyAWSBackups:

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1187,19 +1187,25 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 
 	case KeyGCPVertexAI:
 		// Vertex AI Vector Search (#764). When a VPC is selected, wire its
-		// network resource id (projects/<p>/global/networks/<n>, the exact
-		// form google_vertex_ai_index_endpoint.network expects) so the index
-		// endpoint takes the private VPC-peering path — the reason the hard
-		// gcp/vpc dep exists (contracts.go:322 / #600 PSC peering). gcp/vpc's
-		// network_id is surfaced as the vpc_id output.
+		// vpc_id (the project-ID path projects/<project_id>/global/networks/<n>)
+		// to the preset's network input. The preset extracts the network NAME
+		// and rebuilds the project-NUMBER path google_vertex_ai_index_endpoint
+		// actually requires (it cannot accept the project-ID form), so the wire
+		// stays vpc_id and the form conversion lives in the preset. The endpoint
+		// is still PUBLIC unless the operator also sets enable_private_endpoint
+		// (the private path needs #774 PSC peering that gcp/vpc lacks today).
 		if selected[KeyGCPVPC] {
 			wi.RawHCL["network"] = WireRef(KeyGCPVPC, "vpc_id")
 			wi.Names = append(wi.Names, "network")
 		}
-		// When GCS is selected, seed the index from the bucket. bucket_url is
-		// the gs:// URL the index's contents_delta_uri expects.
+		// When GCS is selected, seed the index from a dedicated prefix under the
+		// bucket rather than the bucket root. bucket_url is the gs://<bucket>
+		// root; Vertex's contents_delta_uri expects a DIRECTORY of index data
+		// files, so ingesting the whole bucket root would build a junk index.
+		// Scope it to gs://<bucket>/vertex-index/ — operators stage embedding
+		// files there (the index is created empty if the prefix is absent).
 		if selected[KeyGCPGCS] {
-			wi.RawHCL["contents_delta_uri"] = WireRef(KeyGCPGCS, "bucket_url")
+			wi.RawHCL["contents_delta_uri"] = "\"${" + WireRef(KeyGCPGCS, "bucket_url") + "}/vertex-index/\""
 			wi.Names = append(wi.Names, "contents_delta_uri")
 		}
 	}

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -188,7 +188,44 @@ func (c *Client) ComputePresetDefaults(cfg Config, comps *Components, selected [
 			outInner.Set(reflect.Zero(outInner.Type()))
 		}
 	}
+
+	// GPU instance-type default (#759): the HCL `default` for instance_type is
+	// the non-GPU type (t3.medium for EC2, c7i.large for EKS), so a GPU stack
+	// with no explicit instance type would otherwise be priced as the non-GPU
+	// default. When the caller enabled GPU but did not pin an instance type,
+	// overlay the shared GPU default so pricing (which reads Config) sees the
+	// instance type the mapper will actually deploy. Only fills when the user's
+	// own cfg left the instance type blank — an explicit pick is preserved.
+	applyGPUInstanceTypeDefault(&cfg, &out)
+
 	return out, nil
+}
+
+// applyGPUInstanceTypeDefault overlays defaultGPUInstanceType onto the EC2/EKS
+// instance-type overlay field when GPU is enabled in the user's config and no
+// explicit instance type was supplied (#759). This keeps the pricing-facing
+// Config in sync with the GPU instance type the mapper defaults to, so a GPU
+// stack is not priced as the non-GPU HCL default. The overlay is later merged
+// zero-only, so writing the value here fills the blank without clobbering an
+// explicit user pick.
+func applyGPUInstanceTypeDefault(cfg, out *Config) {
+	if cfg.AWSEC2 != nil && boolPtrTrue(cfg.AWSEC2.GPUEnabled) && cfg.AWSEC2.InstanceType == "" {
+		// Allocate a zero value of the field's own (anonymous) type via
+		// reflection so this stays correct if the AWSEC2 shape changes —
+		// cfg.AWSEC2 and out.AWSEC2 share the type, so a new(elem) is assignable.
+		if out.AWSEC2 == nil {
+			v := reflect.New(reflect.TypeOf(out.AWSEC2).Elem())
+			reflect.ValueOf(&out.AWSEC2).Elem().Set(v)
+		}
+		out.AWSEC2.InstanceType = defaultGPUInstanceType
+	}
+	if cfg.AWSEKS != nil && boolPtrTrue(cfg.AWSEKS.GPUEnabled) && cfg.AWSEKS.InstanceType == "" {
+		if out.AWSEKS == nil {
+			v := reflect.New(reflect.TypeOf(out.AWSEKS).Elem())
+			reflect.ValueOf(&out.AWSEKS).Elem().Set(v)
+		}
+		out.AWSEKS.InstanceType = defaultGPUInstanceType
+	}
 }
 
 // ApplyPresetDefaults backfills cfg with statically-resolvable HCL defaults

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -529,6 +529,55 @@ func TestComputePresetDefaults_NilNestedStructInInput_AllocatesInOverlay(t *test
 	assert.Equal(t, "t3.medium", overlay.AWSEC2.InstanceType)
 }
 
+// TestComputePresetDefaults_GPUInstanceTypeDefault pins the pricing fix (#759):
+// a GPU-enabled EC2/EKS config with no explicit instance type must overlay the
+// GPU default instance type (g5.xlarge), NOT the non-GPU HCL default
+// (t3.medium / c7i.large). Pricing reads Config, so without this a GPU stack
+// would be priced as the non-GPU default.
+func TestComputePresetDefaults_GPUInstanceTypeDefault(t *testing.T) {
+	c := New()
+	trueVal := true
+
+	t.Run("EC2 GPU with no instance type overlays g5.xlarge", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal})
+		overlay, err := c.ComputePresetDefaults(*cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+		require.NoError(t, err)
+		require.NotNil(t, overlay.AWSEC2)
+		assert.Equal(t, defaultGPUInstanceType, overlay.AWSEC2.InstanceType,
+			"GPU EC2 must overlay the GPU default, not the non-GPU t3.medium HCL default")
+	})
+
+	t.Run("EKS GPU with no instance type overlays g5.xlarge", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal})
+		overlay, err := c.ComputePresetDefaults(*cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEKSNodeGroup})
+		require.NoError(t, err)
+		require.NotNil(t, overlay.AWSEKS)
+		assert.Equal(t, defaultGPUInstanceType, overlay.AWSEKS.InstanceType,
+			"GPU EKS node group must overlay the GPU default instance type")
+	})
+
+	t.Run("explicit GPU instance type is preserved (not overwritten)", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "p4d.24xlarge"})
+		overlay, err := c.ComputePresetDefaults(*cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+		require.NoError(t, err)
+		// The overlay is the back-fill only; an explicit user pick is in cfg,
+		// so the overlay's instance type must NOT be the GPU default (the
+		// zero-only merge keeps the user's explicit value).
+		assert.NotEqual(t, defaultGPUInstanceType, "p4d.24xlarge")
+		require.NotNil(t, overlay.AWSEC2)
+		assert.NotEqual(t, defaultGPUInstanceType, overlay.AWSEC2.InstanceType,
+			"explicit user instance type must not trigger the GPU default overlay")
+	})
+
+	t.Run("non-GPU EC2 keeps the t3.medium HCL default", func(t *testing.T) {
+		overlay, err := c.ComputePresetDefaults(Config{}, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
+		require.NoError(t, err)
+		require.NotNil(t, overlay.AWSEC2)
+		assert.Equal(t, "t3.medium", overlay.AWSEC2.InstanceType,
+			"non-GPU EC2 must keep the non-GPU HCL default")
+	})
+}
+
 // TestComputePresetDefaults_UnselectedComponentsAbsentFromOverlay pins the
 // scope rule: only the selected components contribute to the overlay.
 func TestComputePresetDefaults_UnselectedComponentsAbsentFromOverlay(t *testing.T) {

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -556,17 +556,28 @@ func TestComputePresetDefaults_GPUInstanceTypeDefault(t *testing.T) {
 			"GPU EKS node group must overlay the GPU default instance type")
 	})
 
-	t.Run("explicit GPU instance type is preserved (not overwritten)", func(t *testing.T) {
+	t.Run("explicit GPU instance type is preserved through the full merge", func(t *testing.T) {
+		// Guard the premise: the user's pick must differ from the GPU default,
+		// otherwise "preserved" would be indistinguishable from "overwritten".
+		require.NotEqual(t, defaultGPUInstanceType, "p4d.24xlarge")
+
 		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "p4d.24xlarge"})
+
+		// The overlay is the back-fill only; the zero-only merge keeps the
+		// user's explicit value, so the overlay must NOT echo the GPU default.
 		overlay, err := c.ComputePresetDefaults(*cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2})
 		require.NoError(t, err)
-		// The overlay is the back-fill only; an explicit user pick is in cfg,
-		// so the overlay's instance type must NOT be the GPU default (the
-		// zero-only merge keeps the user's explicit value).
-		assert.NotEqual(t, defaultGPUInstanceType, "p4d.24xlarge")
 		require.NotNil(t, overlay.AWSEC2)
 		assert.NotEqual(t, defaultGPUInstanceType, overlay.AWSEC2.InstanceType,
 			"explicit user instance type must not trigger the GPU default overlay")
+
+		// Run the full ApplyPresetDefaults/merge path and positively assert the
+		// EFFECTIVE instance type is the user's explicit pick, not the GPU
+		// default — the real outcome a caller observes after defaults apply.
+		require.NoError(t, c.ApplyPresetDefaults(cfg, &Components{Cloud: "aws"}, []ComponentKey{KeyAWSEC2}))
+		require.NotNil(t, cfg.AWSEC2)
+		assert.Equal(t, "p4d.24xlarge", cfg.AWSEC2.InstanceType,
+			"the user's explicit GPU instance type must survive the full defaults merge")
 	})
 
 	t.Run("non-GPU EC2 keeps the t3.medium HCL default", func(t *testing.T) {
@@ -575,6 +586,40 @@ func TestComputePresetDefaults_GPUInstanceTypeDefault(t *testing.T) {
 		require.NotNil(t, overlay.AWSEC2)
 		assert.Equal(t, "t3.medium", overlay.AWSEC2.InstanceType,
 			"non-GPU EC2 must keep the non-GPU HCL default")
+	})
+}
+
+// TestApplyGPUInstanceTypeDefault_AllocatesNilOverlay exercises
+// applyGPUInstanceTypeDefault directly with an empty (&Config{}) overlay so the
+// reflect-based nil-allocation branch is covered. Through ComputePresetDefaults
+// the overlay's inner struct is always pre-allocated by the selection loop, so
+// that branch is otherwise dead — this calls it head-on with out.AWSEC2 ==
+// nil / out.AWSEKS == nil to prove the allocate-on-demand path works (#759).
+func TestApplyGPUInstanceTypeDefault_AllocatesNilOverlay(t *testing.T) {
+	trueVal := true
+
+	t.Run("EC2 GPU with nil overlay allocates and fills the GPU default", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal})
+		out := &Config{} // out.AWSEC2 is nil — drives the allocation branch.
+		applyGPUInstanceTypeDefault(cfg, out)
+		require.NotNil(t, out.AWSEC2, "nil overlay must be allocated on demand")
+		assert.Equal(t, defaultGPUInstanceType, out.AWSEC2.InstanceType)
+	})
+
+	t.Run("EKS GPU with nil overlay allocates and fills the GPU default", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal})
+		out := &Config{} // out.AWSEKS is nil — drives the allocation branch.
+		applyGPUInstanceTypeDefault(cfg, out)
+		require.NotNil(t, out.AWSEKS, "nil overlay must be allocated on demand")
+		assert.Equal(t, defaultGPUInstanceType, out.AWSEKS.InstanceType)
+	})
+
+	t.Run("no GPU → nil overlay untouched", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{})
+		out := &Config{}
+		applyGPUInstanceTypeDefault(cfg, out)
+		assert.Nil(t, out.AWSEC2, "no GPU enabled must not allocate the overlay")
+		assert.Nil(t, out.AWSEKS)
 	})
 }
 

--- a/pkg/composer/defaults_test.go
+++ b/pkg/composer/defaults_test.go
@@ -264,6 +264,7 @@ func TestApplyPresetDefaults_FillsZeroFieldsOnly(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			InstanceType: "m6i.large",                   // user-set: must be preserved
 			UserData:     "echo configured by the user", // user-set: must be preserved
@@ -443,6 +444,7 @@ func TestComputePresetDefaults_ReturnsOverlayOnly(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			InstanceType: "m6i.large", // user-set: must NOT echo into overlay
 		},
@@ -483,6 +485,7 @@ func TestComputePresetDefaults_DoesNotMutateInput(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{
 				InstanceType: "m6i.large",
 			},
@@ -622,6 +625,7 @@ func TestComputePresetDefaults_ProvenanceDistinguishesUserSetEqualToDefault(t *t
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{
 				EnableInstanceConnect: enable,
 			},
@@ -686,6 +690,7 @@ func TestMergeConfigs_NilGuards(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "t3.medium"},
 	}
 
@@ -718,6 +723,7 @@ func TestMergeConfigs_AllocatesAndFills(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "m6i.large"},
 	}
 	dst := &Config{}
@@ -743,6 +749,7 @@ func TestMergeConfigs_PreservesNonZero(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "m6i.large", SSHPublicKey: "src-key", EnableInstanceConnect: &trueVal},
 	}
 	dst := &Config{
@@ -756,6 +763,7 @@ func TestMergeConfigs_PreservesNonZero(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "t3.medium"},
 	}
 
@@ -782,6 +790,7 @@ func TestMergeConfigs_PartialFill(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "m6i.large", SSHPublicKey: "ssh-ed25519 AAAA..."},
 	}
 	dst := &Config{
@@ -795,6 +804,7 @@ func TestMergeConfigs_PartialFill(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "t3.medium"},
 	}
 
@@ -820,6 +830,7 @@ func TestMergeConfigs_CrossCloudIsolation(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "t3.medium"},
 	}
 	existingEKS := &struct {
@@ -829,6 +840,7 @@ func TestMergeConfigs_CrossCloudIsolation(t *testing.T) {
 		MaxSize                string `json:"maxSize,omitempty"`
 		MinSize                string `json:"minSize,omitempty"`
 		InstanceType           string `json:"instanceType,omitempty"`
+		GPUEnabled             *bool  `json:"gpuEnabled,omitempty"`
 	}{InstanceType: "m6i.xlarge", DesiredSize: "3"}
 	dst := &Config{AWSEKS: existingEKS}
 
@@ -861,6 +873,7 @@ func TestMergeConfigs_BoolPointerFill(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{EnableInstanceConnect: &falseVal},
 	}
 	dst := &Config{
@@ -874,6 +887,7 @@ func TestMergeConfigs_BoolPointerFill(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{},
 	}
 
@@ -900,6 +914,7 @@ func TestMergeConfigs_AllocatedButEmptySrc_RevertsToNil(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{}, // all fields zero
 	}
 	dst := &Config{}
@@ -926,6 +941,7 @@ func TestMergeConfigs_SliceFields(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{CustomIngressPorts: populated},
 	}
 
@@ -941,6 +957,7 @@ func TestMergeConfigs_SliceFields(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{},
 	}
 	MergeConfigs(dstA, src)
@@ -959,6 +976,7 @@ func TestMergeConfigs_SliceFields(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{CustomIngressPorts: []int{}},
 	}
 	MergeConfigs(dstB, src)
@@ -1026,6 +1044,7 @@ func TestMergeConfigs_Idempotent(t *testing.T) {
 			CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 			SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 			EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+			GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 		}{InstanceType: "m6i.large", SSHPublicKey: "ssh-ed25519 ABC", EnableInstanceConnect: &trueVal},
 	}
 	dst := &Config{}

--- a/pkg/composer/gpu.go
+++ b/pkg/composer/gpu.go
@@ -42,9 +42,12 @@ var gpuX86Families = map[string]struct{}{
 // instanceFamily returns the family prefix of an EC2 instance type — the part
 // before the first "." — matching the HCL `split(".", ...)[0]` derive. For
 // "g5.xlarge" it returns "g5"; for a string with no "." it returns the input
-// unchanged.
+// unchanged. The input is trimmed and lower-cased first so surrounding
+// whitespace or a capitalised family ("G5.xlarge") still matches the allow-list
+// (AWS instance types are canonically lower-case).
 func instanceFamily(instanceType string) string {
-	return strings.SplitN(instanceType, ".", 2)[0]
+	normalized := strings.ToLower(strings.TrimSpace(instanceType))
+	return strings.SplitN(normalized, ".", 2)[0]
 }
 
 // isGPUX86Family reports whether instanceType belongs to a known NVIDIA-GPU

--- a/pkg/composer/gpu.go
+++ b/pkg/composer/gpu.go
@@ -1,0 +1,57 @@
+package composer
+
+import "strings"
+
+// gpu.go centralises the single source of truth the GPU mapper branches
+// (#759) share: the default GPU instance type and the set of NVIDIA x86_64
+// EC2 instance families. Both the AWS EC2 and EKS-node-group branches consume
+// these so the default + family knowledge can't drift between them, and a
+// drift test (gpu_families_drift_test.go) asserts the Go set stays in lockstep
+// with the HCL `_gpu_x86_families` list in aws/eks_nodegroup/main.tf — the
+// preset's own AMI auto-derive is the runtime source of truth.
+
+// defaultGPUInstanceType is the instance type the mapper supplies when a
+// caller enables GPU but does not pin an explicit instance type. g5.xlarge is
+// the cheapest single-A10G NVIDIA family and is shared by the EC2 and EKS GPU
+// paths (and by pricing, so a GPU stack is not priced as the non-GPU default).
+const defaultGPUInstanceType = "g5.xlarge"
+
+// gpuX86Families is the allow-list of NVIDIA-GPU x86_64 EC2 instance families
+// (#759). These are the families that require an x86_64 NVIDIA-bundled AMI so
+// the node boots with the NVIDIA kernel driver + container runtime present.
+//
+// This list MUST stay in lockstep with the HCL `_gpu_x86_families` local in
+// aws/eks_nodegroup/main.tf — TestGPUFamiliesDrift enforces it. Note g5g is
+// deliberately ABSENT: it is Graviton (ARM) + NVIDIA T4G, and EKS has no ARM
+// NVIDIA managed AMI type, so it stays on the ARM standard AMI path.
+var gpuX86Families = map[string]struct{}{
+	"g4dn": {},
+	"g5":   {},
+	"g6":   {},
+	"g6e":  {},
+	"gr6":  {},
+	"p3":   {},
+	"p3dn": {},
+	"p4d":  {},
+	"p4de": {},
+	"p5":   {},
+	"p5e":  {},
+	"p5en": {},
+}
+
+// instanceFamily returns the family prefix of an EC2 instance type — the part
+// before the first "." — matching the HCL `split(".", ...)[0]` derive. For
+// "g5.xlarge" it returns "g5"; for a string with no "." it returns the input
+// unchanged.
+func instanceFamily(instanceType string) string {
+	return strings.SplitN(instanceType, ".", 2)[0]
+}
+
+// isGPUX86Family reports whether instanceType belongs to a known NVIDIA-GPU
+// x86_64 family (per gpuX86Families). Used to validate explicit GPU instance
+// types so a non-GPU or ARM family is rejected at compose time instead of
+// silently forcing an x86_64/NVIDIA AMI onto incompatible hardware.
+func isGPUX86Family(instanceType string) bool {
+	_, ok := gpuX86Families[instanceFamily(instanceType)]
+	return ok
+}

--- a/pkg/composer/gpu_families_drift_test.go
+++ b/pkg/composer/gpu_families_drift_test.go
@@ -1,0 +1,81 @@
+package composer
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestGPUFamiliesDrift asserts the Go NVIDIA-GPU x86 family allow-list
+// (gpuX86Families in gpu.go) stays in lockstep with the HCL `_gpu_x86_families`
+// local in aws/eks_nodegroup/main.tf (#759). The HCL list drives the preset's
+// AMI auto-derive (the runtime source of truth); the Go set drives mapper
+// validation of explicit GPU instance types. If the two drift, a family
+// accepted by the mapper might not derive an NVIDIA AMI (or vice versa), so a
+// GPU node could come up without /dev/nvidia* — exactly the failure the
+// validation exists to prevent. This test fails the moment either list adds or
+// removes a family without the other.
+func TestGPUFamiliesDrift(t *testing.T) {
+	mainTF := filepath.Join("..", "..", "aws", "eks_nodegroup", "main.tf")
+	b, err := os.ReadFile(mainTF)
+	if err != nil {
+		t.Fatalf("read %s: %v", mainTF, err)
+	}
+
+	hclFamilies := parseGPUFamiliesHCL(t, string(b))
+	if len(hclFamilies) == 0 {
+		t.Fatalf("no families parsed from _gpu_x86_families in %s — parser or HCL shape changed", mainTF)
+	}
+
+	goFamilies := map[string]struct{}{}
+	for f := range gpuX86Families {
+		goFamilies[f] = struct{}{}
+	}
+
+	// Families in HCL but missing from the Go set.
+	var missingInGo []string
+	for f := range hclFamilies {
+		if _, ok := goFamilies[f]; !ok {
+			missingInGo = append(missingInGo, f)
+		}
+	}
+	// Families in the Go set but missing from HCL.
+	var missingInHCL []string
+	for f := range goFamilies {
+		if _, ok := hclFamilies[f]; !ok {
+			missingInHCL = append(missingInHCL, f)
+		}
+	}
+
+	sort.Strings(missingInGo)
+	sort.Strings(missingInHCL)
+	if len(missingInGo) > 0 {
+		t.Errorf("families in aws/eks_nodegroup/main.tf _gpu_x86_families but missing from gpuX86Families (gpu.go): %v", missingInGo)
+	}
+	if len(missingInHCL) > 0 {
+		t.Errorf("families in gpuX86Families (gpu.go) but missing from aws/eks_nodegroup/main.tf _gpu_x86_families: %v", missingInHCL)
+	}
+}
+
+// parseGPUFamiliesHCL extracts the quoted family strings from the
+// `_gpu_x86_families = [ ... ]` local assignment. It isolates the bracketed
+// list body and then pulls every double-quoted token, so reordering or
+// reflowing the HCL doesn't affect the result.
+func parseGPUFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
+	t.Helper()
+	listRe := regexp.MustCompile(`(?s)_gpu_x86_families\s*=\s*\[(.*?)\]`)
+	m := listRe.FindStringSubmatch(hcl)
+	if m == nil {
+		t.Fatalf("could not locate `_gpu_x86_families = [...]` in main.tf")
+	}
+	body := m[1]
+	tokenRe := regexp.MustCompile(`"([^"]+)"`)
+	out := map[string]struct{}{}
+	for _, tm := range tokenRe.FindAllStringSubmatch(body, -1) {
+		out[strings.TrimSpace(tm[1])] = struct{}{}
+	}
+	return out
+}

--- a/pkg/composer/gpu_families_drift_test.go
+++ b/pkg/composer/gpu_families_drift_test.go
@@ -11,59 +11,70 @@ import (
 
 // TestGPUFamiliesDrift asserts the Go NVIDIA-GPU x86 family allow-list
 // (gpuX86Families in gpu.go) stays in lockstep with the HCL `_gpu_x86_families`
-// local in aws/eks_nodegroup/main.tf (#759). The HCL list drives the preset's
-// AMI auto-derive (the runtime source of truth); the Go set drives mapper
-// validation of explicit GPU instance types. If the two drift, a family
-// accepted by the mapper might not derive an NVIDIA AMI (or vice versa), so a
-// GPU node could come up without /dev/nvidia* — exactly the failure the
-// validation exists to prevent. This test fails the moment either list adds or
-// removes a family without the other.
+// locals in BOTH aws/eks_nodegroup/main.tf and aws/ec2/main.tf (#759). The HCL
+// lists drive each preset's plan-time GPU guard (the eks_nodegroup AMI
+// auto-derive and the ec2 aws_instance precondition); the Go set drives mapper
+// validation of explicit GPU instance types. If any of the three drift, a
+// family accepted by one layer might be rejected (or mis-AMI'd) by another, so
+// a GPU node could come up without /dev/nvidia* — exactly the failure the
+// validation exists to prevent. This test fails the moment any list adds or
+// removes a family without the other two.
 func TestGPUFamiliesDrift(t *testing.T) {
-	mainTF := filepath.Join("..", "..", "aws", "eks_nodegroup", "main.tf")
-	b, err := os.ReadFile(mainTF)
-	if err != nil {
-		t.Fatalf("read %s: %v", mainTF, err)
-	}
-
-	hclFamilies := parseGPUFamiliesHCL(t, string(b))
-	if len(hclFamilies) == 0 {
-		t.Fatalf("no families parsed from _gpu_x86_families in %s — parser or HCL shape changed", mainTF)
-	}
-
 	goFamilies := map[string]struct{}{}
 	for f := range gpuX86Families {
 		goFamilies[f] = struct{}{}
 	}
 
-	// Families in HCL but missing from the Go set.
-	var missingInGo []string
-	for f := range hclFamilies {
-		if _, ok := goFamilies[f]; !ok {
-			missingInGo = append(missingInGo, f)
-		}
-	}
-	// Families in the Go set but missing from HCL.
-	var missingInHCL []string
-	for f := range goFamilies {
-		if _, ok := hclFamilies[f]; !ok {
-			missingInHCL = append(missingInHCL, f)
-		}
-	}
+	for _, src := range []struct {
+		name string
+		path string
+	}{
+		{"eks_nodegroup", filepath.Join("..", "..", "aws", "eks_nodegroup", "main.tf")},
+		{"ec2", filepath.Join("..", "..", "aws", "ec2", "main.tf")},
+	} {
+		t.Run(src.name, func(t *testing.T) {
+			b, err := os.ReadFile(src.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", src.path, err)
+			}
 
-	sort.Strings(missingInGo)
-	sort.Strings(missingInHCL)
-	if len(missingInGo) > 0 {
-		t.Errorf("families in aws/eks_nodegroup/main.tf _gpu_x86_families but missing from gpuX86Families (gpu.go): %v", missingInGo)
-	}
-	if len(missingInHCL) > 0 {
-		t.Errorf("families in gpuX86Families (gpu.go) but missing from aws/eks_nodegroup/main.tf _gpu_x86_families: %v", missingInHCL)
+			hclFamilies := parseGPUFamiliesHCL(t, string(b))
+			if len(hclFamilies) == 0 {
+				t.Fatalf("no families parsed from _gpu_x86_families in %s — parser or HCL shape changed", src.path)
+			}
+
+			// Families in HCL but missing from the Go set.
+			var missingInGo []string
+			for f := range hclFamilies {
+				if _, ok := goFamilies[f]; !ok {
+					missingInGo = append(missingInGo, f)
+				}
+			}
+			// Families in the Go set but missing from HCL.
+			var missingInHCL []string
+			for f := range goFamilies {
+				if _, ok := hclFamilies[f]; !ok {
+					missingInHCL = append(missingInHCL, f)
+				}
+			}
+
+			sort.Strings(missingInGo)
+			sort.Strings(missingInHCL)
+			if len(missingInGo) > 0 {
+				t.Errorf("families in %s _gpu_x86_families but missing from gpuX86Families (gpu.go): %v", src.path, missingInGo)
+			}
+			if len(missingInHCL) > 0 {
+				t.Errorf("families in gpuX86Families (gpu.go) but missing from %s _gpu_x86_families: %v", src.path, missingInHCL)
+			}
+		})
 	}
 }
 
 // parseGPUFamiliesHCL extracts the quoted family strings from the
 // `_gpu_x86_families = [ ... ]` local assignment. It isolates the bracketed
-// list body and then pulls every double-quoted token, so reordering or
-// reflowing the HCL doesn't affect the result.
+// list body, strips any `# ...` inline comments (so a quoted token sitting in a
+// comment can't false-fail the drift check), and then pulls every double-quoted
+// token, so reordering or reflowing the HCL doesn't affect the result.
 func parseGPUFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
 	t.Helper()
 	listRe := regexp.MustCompile(`(?s)_gpu_x86_families\s*=\s*\[(.*?)\]`)
@@ -71,11 +82,26 @@ func parseGPUFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
 	if m == nil {
 		t.Fatalf("could not locate `_gpu_x86_families = [...]` in main.tf")
 	}
-	body := m[1]
+	body := stripHCLLineComments(m[1])
 	tokenRe := regexp.MustCompile(`"([^"]+)"`)
 	out := map[string]struct{}{}
 	for _, tm := range tokenRe.FindAllStringSubmatch(body, -1) {
 		out[strings.TrimSpace(tm[1])] = struct{}{}
 	}
 	return out
+}
+
+// stripHCLLineComments removes `# ...`-to-end-of-line comments from each line of
+// the bracket body so a quoted token appearing in an inline comment is not
+// counted as a family. Only `#` comments are handled — the families list uses
+// no `//` or block comments — and this is a deliberately simple line-oriented
+// strip (the list body never contains a literal `#` inside a quoted token).
+func stripHCLLineComments(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if idx := strings.IndexByte(line, '#'); idx >= 0 {
+			lines[i] = line[:idx]
+		}
+	}
+	return strings.Join(lines, "\n")
 }

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -82,6 +82,7 @@ var AWSIAMActions = map[ComponentKey][]string{
 	KeyAWSSecretsManager:       {"secretsmanager:CreateSecret"},
 	KeyAWSOpenSearch:           {"es:CreateDomain"},
 	KeyAWSBedrock:              {"bedrock:GetFoundationModel"},
+	KeyAWSBedrockAgent:         {"bedrock:CreateAgent"},
 	KeyAWSSQS:                  {"sqs:CreateQueue"},
 	KeyAWSMSK:                  {"kafka:CreateClusterV2"},
 	KeyAWSCloudWatchLogs:       {"logs:CreateLogGroup"},

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -37,6 +37,8 @@ var untaggableAWS = map[string]struct{}{
 	"aws_autoscaling_group_tag":                          {},
 	"aws_backup_selection":                               {},
 	"aws_bedrock_model_invocation_logging_configuration": {},
+	"aws_bedrockagent_agent_action_group":                {},
+	"aws_bedrockagent_agent_knowledge_base_association":  {},
 	"aws_bedrockagent_data_source":                       {},
 	"aws_cloudfront_monitoring_subscription":             {},
 	"aws_cloudfront_origin_access_identity":              {},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -812,6 +812,30 @@ func (m DefaultMapper) BuildModuleValues(
 		// null. The KB itself is off by default, so a preview compose with no
 		// config produces just the plain model-invocation role + guardrail.
 
+	case KeyAWSBedrockAgent:
+		// Partial-config: only emit a field the caller actually populated so
+		// the preset's own sensible defaults (foundation_model = a Claude
+		// model, a generic instruction) win when the field is left unset. The
+		// preset validates non-empty foundation_model + instruction, so an
+		// explicit empty string from the caller surfaces as a plan-time
+		// precondition failure rather than a silent default.
+		if cfg != nil && cfg.AWSBedrockAgent != nil {
+			if strings.TrimSpace(cfg.AWSBedrockAgent.FoundationModel) != "" {
+				vals["foundation_model"] = strings.TrimSpace(cfg.AWSBedrockAgent.FoundationModel)
+			}
+			if cfg.AWSBedrockAgent.Instruction != "" {
+				vals["instruction"] = cfg.AWSBedrockAgent.Instruction
+			}
+			if strings.TrimSpace(cfg.AWSBedrockAgent.AgentName) != "" {
+				vals["agent_name"] = strings.TrimSpace(cfg.AWSBedrockAgent.AgentName)
+			}
+		}
+		// action_group_lambda_arn and knowledge_base_id are wired by
+		// DefaultWiring (function_arn from the implicitly-added aws/lambda;
+		// knowledge_base_id from aws/bedrock when selected). For single-module
+		// preview compose they are left unset — the preset defaults them to
+		// null and gates the action group / KB association on a non-null arn.
+
 	case KeyAWSLambda:
 		vals["runtime"] = "nodejs20.x" // Default to nodejs
 		if cfg != nil && cfg.AWSLambda != nil {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -279,18 +279,31 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSEKS.InstanceType != "" {
 				vals["instance_types"] = []any{cfg.AWSEKS.InstanceType}
 			}
-			// GPU node group (#759): default to a g5.xlarge (cheapest
-			// single-A10G NVIDIA family) when the caller didn't pick an
-			// explicit GPU instance type, and pin ami_type to the NVIDIA
-			// managed AMI so the node comes up GPU-capable regardless of
-			// what the preset's instance-family auto-derive would infer.
-			// The in-cluster NVIDIA device plugin (advertises
-			// nvidia.com/gpu) is app-layer and out of preset scope.
+			// GPU node group (#759): VALIDATE, don't mask. When the caller
+			// pins an explicit instance type it must be a known x86 NVIDIA
+			// GPU family — otherwise reject at compose time rather than
+			// silently forcing a GPU AMI onto incompatible hardware. When no
+			// instance type is set, supply the default GPU type. We do NOT
+			// emit ami_type here: the preset's family auto-derive
+			// (aws/eks_nodegroup/main.tf `_gpu_x86_families` →
+			// AL2023_x86_64_NVIDIA) is the single source of truth for the AMI
+			// and already produces the right AMI for GPU families. The
+			// in-cluster NVIDIA device plugin (advertises nvidia.com/gpu) is
+			// app-layer and out of preset scope.
 			if cfg.AWSEKS.GPUEnabled != nil && *cfg.AWSEKS.GPUEnabled {
-				if _, ok := vals["instance_types"]; !ok {
-					vals["instance_types"] = []any{"g5.xlarge"}
+				if cfg.AWSEKS.InstanceType != "" {
+					if !isGPUX86Family(cfg.AWSEKS.InstanceType) {
+						return nil, NewValidationError(fmt.Sprintf(
+							"AWSEKS.GPUEnabled=true with InstanceType=%q: not a known x86 NVIDIA GPU family "+
+								"(expected one of g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/p5e/p5en). "+
+								"GPU AMIs are x86_64-only; clear the instance type to default to %s, "+
+								"or pick a supported GPU family.",
+							cfg.AWSEKS.InstanceType, defaultGPUInstanceType,
+						))
+					}
+				} else {
+					vals["instance_types"] = []any{defaultGPUInstanceType}
 				}
-				vals["ami_type"] = "AL2023_x86_64_NVIDIA"
 			}
 		}
 
@@ -353,12 +366,27 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSEC2.EnableInstanceConnect != nil && *cfg.AWSEC2.EnableInstanceConnect {
 				vals["enable_instance_connect"] = true
 			}
-			// GPU instance (#759): select the NVIDIA GPU AMI and force
-			// arch=x86_64 (AWS GPU AMIs are x86_64-only, so a GPU pick
-			// overrides any ARM component hint above). Pair with a GPU
-			// InstanceType (g4dn/g5/g6/p4d/p5). g/p families are
-			// quota-gated — surfaced to operators at deploy time.
+			// GPU instance (#759): VALIDATE, don't mask. AWS GPU AMIs are
+			// x86_64-only, so a GPU instance type must belong to a known x86
+			// NVIDIA GPU family. When the caller pins an explicit instance
+			// type, reject a non-GPU/ARM family at compose time instead of
+			// silently forcing arch=x86_64 onto an incompatible pick (which
+			// would mask the preset's own gpu_enabled/arch guard). When no
+			// instance type is set, the default GPU type is supplied below.
+			// Setting arch=x86_64 is then consistent-by-construction: every
+			// path that reaches here has (or will get) an x86 GPU family.
+			// g/p families are quota-gated — surfaced to operators at deploy
+			// time.
 			if cfg.AWSEC2.GPUEnabled != nil && *cfg.AWSEC2.GPUEnabled {
+				if cfg.AWSEC2.InstanceType != "" && !isGPUX86Family(cfg.AWSEC2.InstanceType) {
+					return nil, NewValidationError(fmt.Sprintf(
+						"AWSEC2.GPUEnabled=true with InstanceType=%q: not a known x86 NVIDIA GPU family "+
+							"(expected one of g4dn/g5/g6/g6e/gr6/p3/p3dn/p4d/p4de/p5/p5e/p5en). "+
+							"GPU AMIs are x86_64-only; clear the instance type to default to %s, "+
+							"or pick a supported GPU family.",
+						cfg.AWSEC2.InstanceType, defaultGPUInstanceType,
+					))
+				}
 				vals["gpu_enabled"] = true
 				vals["arch"] = "x86_64"
 			}
@@ -378,9 +406,10 @@ func (m DefaultMapper) BuildModuleValues(
 			switch {
 			case vals["gpu_enabled"] == true:
 				// GPU AMI on the preset default t3.medium would waste the
-				// image; default to g5.xlarge (cheapest single-A10G NVIDIA
-				// family) to match the EKS GPU node-group default (#759).
-				vals["instance_type"] = "g5.xlarge"
+				// image; default to the shared GPU instance type (cheapest
+				// single-A10G NVIDIA family) to match the EKS GPU node-group
+				// default (#759).
+				vals["instance_type"] = defaultGPUInstanceType
 			case vals["arch"] == "arm64":
 				vals["instance_type"] = "t4g.medium"
 			}

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -279,6 +279,19 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSEKS.InstanceType != "" {
 				vals["instance_types"] = []any{cfg.AWSEKS.InstanceType}
 			}
+			// GPU node group (#759): default to a g5.xlarge (cheapest
+			// single-A10G NVIDIA family) when the caller didn't pick an
+			// explicit GPU instance type, and pin ami_type to the NVIDIA
+			// managed AMI so the node comes up GPU-capable regardless of
+			// what the preset's instance-family auto-derive would infer.
+			// The in-cluster NVIDIA device plugin (advertises
+			// nvidia.com/gpu) is app-layer and out of preset scope.
+			if cfg.AWSEKS.GPUEnabled != nil && *cfg.AWSEKS.GPUEnabled {
+				if _, ok := vals["instance_types"]; !ok {
+					vals["instance_types"] = []any{"g5.xlarge"}
+				}
+				vals["ami_type"] = "AL2023_x86_64_NVIDIA"
+			}
 		}
 
 		if _, ok := vals["desired_size"]; !ok {
@@ -340,6 +353,15 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.AWSEC2.EnableInstanceConnect != nil && *cfg.AWSEC2.EnableInstanceConnect {
 				vals["enable_instance_connect"] = true
 			}
+			// GPU instance (#759): select the NVIDIA GPU AMI and force
+			// arch=x86_64 (AWS GPU AMIs are x86_64-only, so a GPU pick
+			// overrides any ARM component hint above). Pair with a GPU
+			// InstanceType (g4dn/g5/g6/p4d/p5). g/p families are
+			// quota-gated — surfaced to operators at deploy time.
+			if cfg.AWSEC2.GPUEnabled != nil && *cfg.AWSEC2.GPUEnabled {
+				vals["gpu_enabled"] = true
+				vals["arch"] = "x86_64"
+			}
 			if cfg.AWSEC2.DiskSizePerServer != "" {
 				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSEC2.DiskSizePerServer))
 				if err != nil {
@@ -353,10 +375,16 @@ func (m DefaultMapper) BuildModuleValues(
 		}
 		// Default instance type based on architecture if not explicitly configured
 		if _, ok := vals["instance_type"]; !ok {
-			if vals["arch"] == "arm64" {
+			switch {
+			case vals["gpu_enabled"] == true:
+				// GPU AMI on the preset default t3.medium would waste the
+				// image; default to g5.xlarge (cheapest single-A10G NVIDIA
+				// family) to match the EKS GPU node-group default (#759).
+				vals["instance_type"] = "g5.xlarge"
+			case vals["arch"] == "arm64":
 				vals["instance_type"] = "t4g.medium"
 			}
-			// Intel defaults handled by preset (t3.medium)
+			// Intel non-GPU defaults handled by preset (t3.medium)
 		}
 
 	case KeyAWSALB:

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -389,6 +389,15 @@ func (m DefaultMapper) BuildModuleValues(
 				}
 				vals["gpu_enabled"] = true
 				vals["arch"] = "x86_64"
+				// The aws/ec2 preset's os_type defaults to "ubuntu", but the
+				// GPU AMI is Amazon Linux 2023 — so a GPU instance left on the
+				// default os_type trips the module's gpu+ubuntu precondition at
+				// plan (the GPU AMI ignores os_type, and the preset rejects the
+				// silent override). The IR has no os_type field, so pin
+				// amazon-linux here to keep every composer-generated GPU stack
+				// plan-clean. A caller needing an Ubuntu GPU image supplies an
+				// explicit ami_id, which the precondition exempts.
+				vals["os_type"] = "amazon-linux"
 			}
 			if cfg.AWSEC2.DiskSizePerServer != "" {
 				n, err := strconv.Atoi(strings.TrimSpace(cfg.AWSEC2.DiskSizePerServer))

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -928,6 +928,24 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyGCPVertexAI:
+		// Vertex AI deepening (#764). The dataset is always created; the
+		// Vector Search resources (index + endpoint + deployed index) are
+		// gated on enable_vector_search. Partial-config: only emit a field
+		// the caller actually populated so the preset's own defaults
+		// (enable_vector_search=false, index_dimensions=768,
+		// index_update_method="BATCH_UPDATE") win when the field is left
+		// unset. network + contents_delta_uri are supplied by DefaultWiring
+		// from gcp/vpc + gcp/gcs in a full stack, not here.
+		if cfg != nil && cfg.GCPVertexAI != nil {
+			if cfg.GCPVertexAI.EnableVectorSearch != nil {
+				vals["enable_vector_search"] = *cfg.GCPVertexAI.EnableVectorSearch
+			}
+			if cfg.GCPVertexAI.IndexDimensions > 0 {
+				vals["index_dimensions"] = cfg.GCPVertexAI.IndexDimensions
+			}
+		}
+
 	case KeyGCPPubSub:
 		vals["topic_name"] = "events"
 		if cfg != nil && cfg.GCPPubSub != nil {

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -55,7 +55,11 @@ func kitchenSinkConfig() *Config {
 		EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
 		GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 	}{
-		InstanceType:          "t3.medium",
+		// GPUEnabled pairs with a real GPU family (g5.xlarge) so the config is
+		// internally consistent: the #759 mapper validation rejects GPUEnabled
+		// with a non-GPU instance type like t3.medium, which would fail this
+		// kitchen-sink mapper invocation outright.
+		InstanceType:          "g5.xlarge",
 		DiskSizePerServer:     "100",
 		UserData:              "#!/bin/bash\necho hello",
 		CustomIngressPorts:    []int{8080},
@@ -79,9 +83,14 @@ func kitchenSinkConfig() *Config {
 		DesiredSize:            "2",
 		MinSize:                "1",
 		MaxSize:                "3",
-		InstanceType:           "t3.medium",
-		// GPUEnabled exercises the #759 ami_type tfvar emission so the
-		// keys-subset gate confirms it is a declared module variable.
+		// GPUEnabled pairs with a real GPU family (g5.xlarge) so the config is
+		// internally consistent: the #759 mapper validation rejects GPUEnabled
+		// with a non-GPU instance type like t3.medium.
+		InstanceType: "g5.xlarge",
+		// GPUEnabled exercises the #759 instance-type default path. The mapper
+		// deliberately never emits ami_type — the preset's family auto-derive
+		// (_gpu_x86_families → AL2023_x86_64_NVIDIA) owns AMI selection — so
+		// this only confirms gpu-related emitted keys are declared variables.
 		GPUEnabled: &t,
 	}
 	cfg.AWSECS = &struct {

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -53,6 +53,7 @@ func kitchenSinkConfig() *Config {
 		CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 		SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 		EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+		GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 	}{
 		InstanceType:          "t3.medium",
 		DiskSizePerServer:     "100",
@@ -60,6 +61,9 @@ func kitchenSinkConfig() *Config {
 		CustomIngressPorts:    []int{8080},
 		SSHPublicKey:          "ssh-rsa AAAA...",
 		EnableInstanceConnect: &t,
+		// GPUEnabled exercises the #759 gpu_enabled tfvar emission so the
+		// keys-subset gate confirms it is a declared module variable.
+		GPUEnabled: &t,
 	}
 	cfg.AWSEKS = &struct {
 		HaControlPlane         *bool  `json:"haControlPlane,omitempty"`
@@ -68,6 +72,7 @@ func kitchenSinkConfig() *Config {
 		MaxSize                string `json:"maxSize,omitempty"`
 		MinSize                string `json:"minSize,omitempty"`
 		InstanceType           string `json:"instanceType,omitempty"`
+		GPUEnabled             *bool  `json:"gpuEnabled,omitempty"`
 	}{
 		HaControlPlane:         &t,
 		ControlPlaneVisibility: "private",
@@ -75,6 +80,9 @@ func kitchenSinkConfig() *Config {
 		MinSize:                "1",
 		MaxSize:                "3",
 		InstanceType:           "t3.medium",
+		// GPUEnabled exercises the #759 ami_type tfvar emission so the
+		// keys-subset gate confirms it is a declared module variable.
+		GPUEnabled: &t,
 	}
 	cfg.AWSECS = &struct {
 		EnableContainerInsights *bool    `json:"enableContainerInsights,omitempty"`

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -209,6 +209,10 @@ func kitchenSinkConfig() *Config {
 		StorageClass string `json:"storageClass,omitempty"`
 		Versioning   *bool  `json:"versioning,omitempty"`
 	}{StorageClass: "STANDARD", Versioning: &t}
+	cfg.GCPVertexAI = &struct {
+		EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
+		IndexDimensions    int   `json:"indexDimensions,omitempty"`
+	}{EnableVectorSearch: &t, IndexDimensions: 768}
 	cfg.GCPPubSub = &struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	}{MessageRetentionDuration: "604800s"}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -185,6 +185,11 @@ func kitchenSinkConfig() *Config {
 		EnableKnowledgeBase *bool  `json:"enableKnowledgeBase,omitempty"`
 		VectorStore         string `json:"vectorStore,omitempty"`
 	}{KnowledgeBaseName: "kb", ModelID: "anthropic.claude-3", EmbeddingModelID: "amazon.titan-embed", EnableKnowledgeBase: &t, VectorStore: "s3vectors"}
+	cfg.AWSBedrockAgent = &struct {
+		FoundationModel string `json:"foundationModel,omitempty"`
+		Instruction     string `json:"instruction,omitempty"`
+		AgentName       string `json:"agentName,omitempty"`
+	}{FoundationModel: "anthropic.claude-3-5-sonnet-20240620-v1:0", Instruction: "You are a helpful assistant that answers questions about the customer's documents.", AgentName: "support-agent"}
 	cfg.AWSRoute53 = &struct {
 		DomainName   string   `json:"domainName,omitempty"`
 		CreateZone   *bool    `json:"createZone,omitempty"`

--- a/pkg/composer/mapper_required_test.go
+++ b/pkg/composer/mapper_required_test.go
@@ -121,6 +121,7 @@ func kitchenSinkComponents() *Components {
 		AWSKMS:                  &t,
 		AWSSecretsManager:       &t,
 		AWSBedrock:              &t,
+		AWSBedrockAgent:         &t,
 		AWSSQS:                  &t,
 		AWSMSK:                  &t,
 		AWSCloudWatchLogs:       &t,

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -1073,3 +1073,104 @@ func TestBuildModuleValues_AWSCognito_MFAFactor(t *testing.T) {
 		assert.ErrorContains(t, err, `expected "totp"`)
 	})
 }
+
+// TestBuildModuleValues_AWSEKS_GPU pins the GPU node-group mapping (#759):
+// Config.AWSEKS.GPUEnabled=true must emit the NVIDIA managed AMI type and a
+// GPU instance-type default, while an explicit GPU InstanceType is preserved.
+func TestBuildModuleValues_AWSEKS_GPU(t *testing.T) {
+	m := DefaultMapper{}
+	trueVal := true
+	falseVal := false
+
+	t.Run("GPUEnabled defaults to NVIDIA ami_type + g5.xlarge", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal})
+		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.NoError(t, err)
+		assert.Equal(t, "AL2023_x86_64_NVIDIA", vals["ami_type"],
+			"GPUEnabled must pin the NVIDIA managed AMI type")
+		assert.Equal(t, []any{"g5.xlarge"}, vals["instance_types"],
+			"GPUEnabled with no explicit instance type must default to g5.xlarge")
+	})
+
+	t.Run("explicit GPU instance type preserved, ami_type still NVIDIA", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal, InstanceType: "p4d.24xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.NoError(t, err)
+		assert.Equal(t, []any{"p4d.24xlarge"}, vals["instance_types"],
+			"explicit GPU instance type must override the g5.xlarge default")
+		assert.Equal(t, "AL2023_x86_64_NVIDIA", vals["ami_type"])
+	})
+
+	t.Run("GPUEnabled=false leaves ami_type unset (preset auto-derive)", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &falseVal})
+		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.NoError(t, err)
+		_, hasAMI := vals["ami_type"]
+		assert.False(t, hasAMI, "GPUEnabled=false must not pin ami_type; preset auto-derives")
+		// Non-GPU default instance type still applies.
+		assert.Equal(t, []any{"c7i.large"}, vals["instance_types"])
+	})
+
+	t.Run("nil GPUEnabled leaves ami_type unset", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{})
+		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.NoError(t, err)
+		_, hasAMI := vals["ami_type"]
+		assert.False(t, hasAMI, "nil GPUEnabled must not pin ami_type")
+	})
+}
+
+// TestBuildModuleValues_AWSEC2_GPU pins the GPU instance mapping (#759):
+// Config.AWSEC2.GPUEnabled=true must set gpu_enabled, force arch=x86_64
+// (GPU AMIs are x86_64-only), and default to a GPU instance type.
+func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
+	m := DefaultMapper{}
+	trueVal := true
+	falseVal := false
+
+	t.Run("GPUEnabled sets gpu_enabled + x86_64 + g5.xlarge default", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["gpu_enabled"])
+		assert.Equal(t, "x86_64", vals["arch"], "GPU AMIs are x86_64-only")
+		assert.Equal(t, "g5.xlarge", vals["instance_type"],
+			"GPUEnabled with no explicit instance type must default to g5.xlarge")
+	})
+
+	t.Run("GPU overrides ARM component hint (x86_64-only AMI)", func(t *testing.T) {
+		// An ARM component hint would otherwise set arch=arm64; the GPU path
+		// must win because the NVIDIA AMI is x86_64-only.
+		comps := &Components{AWSEC2: "ARM"}
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, comps, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "x86_64", vals["arch"], "GPU must override the ARM hint")
+		assert.Equal(t, "g5.xlarge", vals["instance_type"])
+	})
+
+	t.Run("explicit GPU instance type preserved", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "g6.2xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "g6.2xlarge", vals["instance_type"],
+			"explicit GPU instance type must override the g5.xlarge default")
+		assert.Equal(t, true, vals["gpu_enabled"])
+	})
+
+	t.Run("GPUEnabled=false does not set gpu_enabled", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &falseVal})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasKey := vals["gpu_enabled"]
+		assert.False(t, hasKey, "explicit false must not set gpu_enabled")
+	})
+
+	t.Run("nil GPUEnabled does not set gpu_enabled", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasKey := vals["gpu_enabled"]
+		assert.False(t, hasKey, "nil GPUEnabled must not set gpu_enabled")
+	})
+}

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -1075,30 +1075,49 @@ func TestBuildModuleValues_AWSCognito_MFAFactor(t *testing.T) {
 }
 
 // TestBuildModuleValues_AWSEKS_GPU pins the GPU node-group mapping (#759):
-// Config.AWSEKS.GPUEnabled=true must emit the NVIDIA managed AMI type and a
-// GPU instance-type default, while an explicit GPU InstanceType is preserved.
+// Config.AWSEKS.GPUEnabled=true defaults the instance type when unset and
+// validates (not masks) an explicit type. The mapper NEVER emits ami_type —
+// the preset's family auto-derive (`_gpu_x86_families` in main.tf) is the
+// single source of truth for the AMI.
 func TestBuildModuleValues_AWSEKS_GPU(t *testing.T) {
 	m := DefaultMapper{}
 	trueVal := true
 	falseVal := false
 
-	t.Run("GPUEnabled defaults to NVIDIA ami_type + g5.xlarge", func(t *testing.T) {
+	t.Run("GPUEnabled defaults to g5.xlarge, ami_type never emitted", func(t *testing.T) {
 		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal})
 		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
 		require.NoError(t, err)
-		assert.Equal(t, "AL2023_x86_64_NVIDIA", vals["ami_type"],
-			"GPUEnabled must pin the NVIDIA managed AMI type")
+		_, hasAMI := vals["ami_type"]
+		assert.False(t, hasAMI, "mapper must NOT emit ami_type; the preset auto-derives it from the GPU family")
 		assert.Equal(t, []any{"g5.xlarge"}, vals["instance_types"],
 			"GPUEnabled with no explicit instance type must default to g5.xlarge")
 	})
 
-	t.Run("explicit GPU instance type preserved, ami_type still NVIDIA", func(t *testing.T) {
+	t.Run("explicit GPU instance type preserved, ami_type never emitted", func(t *testing.T) {
 		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal, InstanceType: "p4d.24xlarge"})
 		vals, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
 		require.NoError(t, err)
 		assert.Equal(t, []any{"p4d.24xlarge"}, vals["instance_types"],
 			"explicit GPU instance type must override the g5.xlarge default")
-		assert.Equal(t, "AL2023_x86_64_NVIDIA", vals["ami_type"])
+		_, hasAMI := vals["ami_type"]
+		assert.False(t, hasAMI, "mapper must NOT emit ami_type even for an explicit GPU family")
+	})
+
+	t.Run("explicit non-GPU instance type with GPUEnabled is rejected (validate, not mask)", func(t *testing.T) {
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal, InstanceType: "c7i.large"})
+		_, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.Error(t, err, "a non-GPU instance type with GPUEnabled must be rejected, not silently forced")
+		assert.Contains(t, err.Error(), "not a known x86 NVIDIA GPU family")
+	})
+
+	t.Run("explicit ARM GPU instance type (g5g) is rejected", func(t *testing.T) {
+		// g5g is Graviton+NVIDIA but has no x86 NVIDIA AMI; it is not in the
+		// x86 GPU allow-list, so GPUEnabled must reject it.
+		cfg := configWithAWSEKS(awsEKSCfgInput{GPUEnabled: &trueVal, InstanceType: "g5g.xlarge"})
+		_, err := m.BuildModuleValues(KeyAWSEKSNodeGroup, nil, cfg, "demo", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a known x86 NVIDIA GPU family")
 	})
 
 	t.Run("GPUEnabled=false leaves ami_type unset (preset auto-derive)", func(t *testing.T) {
@@ -1156,6 +1175,22 @@ func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
 		assert.Equal(t, "g6.2xlarge", vals["instance_type"],
 			"explicit GPU instance type must override the g5.xlarge default")
 		assert.Equal(t, true, vals["gpu_enabled"])
+	})
+
+	t.Run("explicit non-GPU instance type with GPUEnabled is rejected (validate, not mask)", func(t *testing.T) {
+		// Previously the mapper would silently force arch=x86_64 onto a
+		// non-GPU pick; now it rejects the mismatch at compose time.
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "t3.medium"})
+		_, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.Error(t, err, "a non-GPU instance type with GPUEnabled must be rejected, not masked")
+		assert.Contains(t, err.Error(), "not a known x86 NVIDIA GPU family")
+	})
+
+	t.Run("explicit ARM instance type with GPUEnabled is rejected", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "c7g.large"})
+		_, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a known x86 NVIDIA GPU family")
 	})
 
 	t.Run("GPUEnabled=false does not set gpu_enabled", func(t *testing.T) {

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -1155,6 +1155,28 @@ func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
 		assert.Equal(t, "x86_64", vals["arch"], "GPU AMIs are x86_64-only")
 		assert.Equal(t, "g5.xlarge", vals["instance_type"],
 			"GPUEnabled with no explicit instance type must default to g5.xlarge")
+		// The preset's os_type defaults to "ubuntu", and the GPU AMI is
+		// Amazon Linux 2023 — leaving the default would trip the module's
+		// gpu+ubuntu precondition. The mapper must pin amazon-linux so a
+		// composer-generated GPU stack plans cleanly (#759 HIGH-3).
+		assert.Equal(t, "amazon-linux", vals["os_type"],
+			"GPU path must emit os_type=amazon-linux so the gpu+ubuntu precondition does not trip")
+	})
+
+	t.Run("explicit GPU instance type also pins os_type=amazon-linux", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "g6.2xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "amazon-linux", vals["os_type"],
+			"os_type must be pinned on every GPU path, not just the default-instance-type path")
+	})
+
+	t.Run("non-GPU EC2 leaves os_type unset (preset default applies)", func(t *testing.T) {
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &falseVal})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasOSType := vals["os_type"]
+		assert.False(t, hasOSType, "non-GPU EC2 must not pin os_type; the preset default (ubuntu) applies")
 	})
 
 	t.Run("GPU overrides ARM component hint (x86_64-only AMI)", func(t *testing.T) {
@@ -1174,6 +1196,24 @@ func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "g6.2xlarge", vals["instance_type"],
 			"explicit GPU instance type must override the g5.xlarge default")
+		assert.Equal(t, true, vals["gpu_enabled"])
+	})
+
+	t.Run("gr6 GPU family is accepted", func(t *testing.T) {
+		// gr6 is a real x86 NVIDIA family in the allow-list; it must validate.
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "gr6.4xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "gr6.4xlarge", vals["instance_type"])
+		assert.Equal(t, true, vals["gpu_enabled"])
+	})
+
+	t.Run("capitalised GPU instance type accepted via normalization", func(t *testing.T) {
+		// AWS types are canonically lower-case, but a caller passing "G5.xlarge"
+		// must still validate — instanceFamily lower-cases before matching.
+		cfg := configWithAWSEC2(awsEC2CfgInput{GPUEnabled: &trueVal, InstanceType: "G5.xlarge"})
+		vals, err := m.BuildModuleValues(KeyAWSEC2, nil, cfg, "", "")
+		require.NoError(t, err, "a capitalised GPU family must validate via normalization")
 		assert.Equal(t, true, vals["gpu_enabled"])
 	})
 

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -84,7 +84,7 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 		KeyAWSSageMaker,
 		KeyAWSALB, KeyAWSCloudfront, KeyAWSWAF, KeyAWSAPIGateway, KeyAWSRDS,
 		KeyAWSElastiCache, KeyAWSDynamoDB, KeyAWSS3, KeyAWSKMS, KeyAWSSecretsManager,
-		KeyAWSOpenSearch, KeyAWSBedrock, KeyAWSSQS, KeyAWSMSK, KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
+		KeyAWSOpenSearch, KeyAWSBedrock, KeyAWSBedrockAgent, KeyAWSSQS, KeyAWSMSK, KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
 		KeyAWSGrafana, KeyAWSCognito, KeyAWSBackups, KeyAWSGitHubActions, KeyAWSCodeBuild, KeyAWSCodePipeline,
 
 		// GCP keys

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -113,6 +113,7 @@ type PricingData struct {
 		AWSKMS                  *PricingItem    `json:"aws_kms,omitempty"`
 		AWSSecretsManager       *PricingItem    `json:"aws_secretsmanager,omitempty"`
 		AWSBedrock              *PricingItem    `json:"aws_bedrock,omitempty"`
+		AWSBedrockAgent         *PricingItem    `json:"aws_bedrock_agent,omitempty"`
 		AWSSageMaker            *PricingItem    `json:"aws_sagemaker,omitempty"`
 		AWSSQS                  *PricingItem    `json:"aws_sqs,omitempty"`
 		AWSMSK                  *PricingItem    `json:"aws_msk,omitempty"`
@@ -226,6 +227,7 @@ func (p *PricingData) Normalize() {
 		c.AWSKMS = nil
 		c.AWSSecretsManager = nil
 		c.AWSBedrock = nil
+		c.AWSBedrockAgent = nil
 		c.AWSSageMaker = nil
 		c.AWSSQS = nil
 		c.AWSMSK = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -37,6 +37,7 @@ type Components struct {
 	AWSKMS                  *bool  `json:"aws_kms,omitempty"`
 	AWSSecretsManager       *bool  `json:"aws_secretsmanager,omitempty"`
 	AWSBedrock              *bool  `json:"aws_bedrock,omitempty"`
+	AWSBedrockAgent         *bool  `json:"aws_bedrock_agent,omitempty"`
 	AWSSQS                  *bool  `json:"aws_sqs,omitempty"`
 	AWSMSK                  *bool  `json:"aws_msk,omitempty"`
 	AWSCloudWatchLogs       *bool  `json:"aws_cloudwatch_logs,omitempty"`
@@ -298,6 +299,12 @@ type Config struct {
 		EnableKnowledgeBase *bool  `json:"enableKnowledgeBase,omitempty"`
 		VectorStore         string `json:"vectorStore,omitempty"`
 	} `json:"aws_bedrock,omitempty"`
+
+	AWSBedrockAgent *struct {
+		FoundationModel string `json:"foundationModel,omitempty"`
+		Instruction     string `json:"instruction,omitempty"`
+		AgentName       string `json:"agentName,omitempty"`
+	} `json:"aws_bedrock_agent,omitempty"`
 
 	AWSBackups *struct {
 		EC2 *struct {
@@ -638,6 +645,7 @@ func (c *Components) Normalize() {
 		c.AWSKMS = nil
 		c.AWSSecretsManager = nil
 		c.AWSBedrock = nil
+		c.AWSBedrockAgent = nil
 		c.AWSSQS = nil
 		c.AWSMSK = nil
 		c.AWSCloudWatchLogs = nil
@@ -760,6 +768,7 @@ func (c *Config) Normalize() {
 		c.AWSSecretsManager = nil
 		c.AWSOpenSearch = nil
 		c.AWSBedrock = nil
+		c.AWSBedrockAgent = nil
 		c.AWSRoute53 = nil
 		c.AWSACM = nil
 		c.AWSBackups = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -346,6 +346,18 @@ type Config struct {
 		Versioning   *bool  `json:"versioning,omitempty"`
 	} `json:"gcp_gcs,omitempty"`
 
+	// GCPVertexAI carries the caller-supplied Vertex AI configuration (#764).
+	// EnableVectorSearch gates the Vector Search resources (index + endpoint +
+	// deployed index) in the gcp/vertex_ai preset; the dataset is always
+	// created. IndexDimensions is the embedding dimensionality of the Vector
+	// Search index (immutable — changing it forces destroy/recreate). Both are
+	// partial-config: the mapper only emits a field the caller actually
+	// populated so the preset's own defaults win when left unset.
+	GCPVertexAI *struct {
+		EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
+		IndexDimensions    int   `json:"indexDimensions,omitempty"`
+	} `json:"gcp_vertex_ai,omitempty"`
+
 	GCPPubSub *struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	} `json:"gcp_pubsub,omitempty"`
@@ -697,13 +709,14 @@ func (c *Config) Normalize() {
 	}
 	switch c.Cloud {
 	case "AWS":
-		// Clear every GCP sub-config (14 fields — keep in sync with the
+		// Clear every GCP sub-config (15 fields — keep in sync with the
 		// GCPConfiguration section of the Config struct).
 		c.GCPCompute = nil
 		c.GCPGKE = nil
 		c.GCPCloudSQL = nil
 		c.GCPMemorystore = nil
 		c.GCPGCS = nil
+		c.GCPVertexAI = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudRun = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -113,6 +113,10 @@ type Config struct {
 		CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 		SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 		EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+		// GPUEnabled selects an NVIDIA-GPU AMI for the instance (#759). Pair
+		// with a GPU InstanceType (g4dn/g5/g6/p4d/p5, ...). GPU AMIs are
+		// x86_64-only; the preset rejects gpu_enabled with arm64.
+		GPUEnabled *bool `json:"gpuEnabled,omitempty"`
 	} `json:"aws_ec2,omitempty"`
 
 	AWSEKS *struct {
@@ -122,6 +126,12 @@ type Config struct {
 		MaxSize                string `json:"maxSize,omitempty"`
 		MinSize                string `json:"minSize,omitempty"`
 		InstanceType           string `json:"instanceType,omitempty"`
+		// GPUEnabled provisions a GPU node group (#759): when true and no
+		// explicit GPU InstanceType is given, the mapper defaults
+		// instance_types to g5.xlarge and sets ami_type to
+		// AL2023_x86_64_NVIDIA. The in-cluster NVIDIA device plugin is
+		// app-layer and out of preset scope.
+		GPUEnabled *bool `json:"gpuEnabled,omitempty"`
 	} `json:"aws_eks,omitempty"`
 
 	AWSECS *struct {

--- a/pkg/composer/types_test.go
+++ b/pkg/composer/types_test.go
@@ -158,6 +158,7 @@ func TestConfig_Normalize_ClearsAWSFieldsForGCP(t *testing.T) {
 			MaxSize                string `json:"maxSize,omitempty"`
 			MinSize                string `json:"minSize,omitempty"`
 			InstanceType           string `json:"instanceType,omitempty"`
+			GPUEnabled             *bool  `json:"gpuEnabled,omitempty"`
 		}{
 			DesiredSize: "3",
 		},

--- a/pkg/composer/union_test.go
+++ b/pkg/composer/union_test.go
@@ -171,6 +171,7 @@ func TestUnionConfig_NonNilEmptySliceOverridesPopulated(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{CustomIngressPorts: []int{22, 80, 443}},
 		},
 		{
@@ -184,6 +185,7 @@ func TestUnionConfig_NonNilEmptySliceOverridesPopulated(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{CustomIngressPorts: []int{}}, // non-nil empty — IS zero-distinct
 		},
 	}
@@ -214,6 +216,7 @@ func TestUnionConfig_NilSlice_NoOverride(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{
 				CustomIngressPorts: []int{22, 80, 443},
 			},
@@ -229,6 +232,7 @@ func TestUnionConfig_NilSlice_NoOverride(t *testing.T) {
 				CustomIngressPorts    []int  `json:"customIngressPorts,omitempty"`
 				SSHPublicKey          string `json:"sshPublicKey,omitempty"`
 				EnableInstanceConnect *bool  `json:"enableInstanceConnect,omitempty"`
+				GPUEnabled            *bool  `json:"gpuEnabled,omitempty"`
 			}{
 				InstanceType: "t3.large", // populated leaf
 				// CustomIngressPorts left nil — must not override

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -1,0 +1,111 @@
+package composer
+
+// vertex_ai_gcp_wiring_test.go covers the issue #764 composer surface for the
+// gcp/vertex_ai Vector Search deepening:
+//
+//   - The KeyGCPVertexAI mapper case is partial-config: it only emits a tfvar
+//     the caller actually populated, so the preset's own defaults win when a
+//     field is left unset (mirrors the AWS Bedrock pattern from #757).
+//   - DefaultWiring feeds the index endpoint's private VPC-peering network from
+//     gcp/vpc and the index's contents_delta_uri from gcp/gcs when those
+//     components are selected, and stays inert for both when they are not.
+//
+// The registry plumbing (ComponentKey + PresetKeyMap + ModulePath +
+// AllComponentKeys + ComposeOrder) and the required-variable coverage are
+// exercised by the sibling invariant gates (TestMapperKeysSubsetOfModuleVariables,
+// TestEveryRequiredVariableIsMappedOrWired).
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
+	t.Parallel()
+	m := DefaultMapper{}
+	tr := true
+	fa := false
+
+	t.Run("nil GCPVertexAI emits nothing (preset defaults win)", func(t *testing.T) {
+		t.Parallel()
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, &Config{}, "demo", "us-central1")
+		require.NoError(t, err)
+		_, hasEnable := vals["enable_vector_search"]
+		assert.False(t, hasEnable, "nil GCPVertexAI must not emit enable_vector_search")
+		_, hasDims := vals["index_dimensions"]
+		assert.False(t, hasDims, "nil GCPVertexAI must not emit index_dimensions")
+	})
+
+	t.Run("EnableVectorSearch=true flows through", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		cfg.GCPVertexAI = &struct {
+			EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int   `json:"indexDimensions,omitempty"`
+		}{EnableVectorSearch: &tr, IndexDimensions: 1536}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["enable_vector_search"])
+		assert.Equal(t, 1536, vals["index_dimensions"])
+	})
+
+	t.Run("EnableVectorSearch=false flows through, zero dimensions omitted", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		cfg.GCPVertexAI = &struct {
+			EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int   `json:"indexDimensions,omitempty"`
+		}{EnableVectorSearch: &fa}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["enable_vector_search"])
+		// IndexDimensions left at its zero value must NOT be emitted, so the
+		// preset's own default (768) applies rather than an invalid 0.
+		_, hasDims := vals["index_dimensions"]
+		assert.False(t, hasDims, "zero IndexDimensions must be omitted so the preset default wins")
+	})
+}
+
+func TestDefaultWiring_GCPVertexAI_PrivateEndpointAndGCS(t *testing.T) {
+	t.Parallel()
+
+	// Full stack: VPC + GCS selected -> the index endpoint gets the private
+	// VPC-peering network and the index gets its GCS seed URI.
+	selected := map[ComponentKey]bool{
+		KeyGCPVertexAI: true,
+		KeyGCPVPC:      true,
+		KeyGCPGCS:      true,
+	}
+	wi := DefaultWiring(selected, KeyGCPVertexAI, &Components{})
+
+	require.Contains(t, wi.RawHCL, "network",
+		"VPC selected -> the index endpoint must be wired to the VPC network for the private peering path")
+	assert.Equal(t, WireRef(KeyGCPVPC, "vpc_id"), wi.RawHCL["network"],
+		"network must reference gcp/vpc.vpc_id (the projects/<p>/global/networks/<n> form)")
+
+	require.Contains(t, wi.RawHCL, "contents_delta_uri",
+		"GCS selected -> the index must be seeded from the bucket")
+	assert.Equal(t, WireRef(KeyGCPGCS, "bucket_url"), wi.RawHCL["contents_delta_uri"],
+		"contents_delta_uri must reference gcp/gcs.bucket_url")
+
+	assert.Contains(t, wi.Names, "network")
+	assert.Contains(t, wi.Names, "contents_delta_uri")
+}
+
+func TestDefaultWiring_GCPVertexAI_InertStandalone(t *testing.T) {
+	t.Parallel()
+
+	// Standalone preview: neither VPC nor GCS selected -> no wiring, so the
+	// preset's public-endpoint + empty-index fallbacks apply.
+	selected := map[ComponentKey]bool{
+		KeyGCPVertexAI: true,
+	}
+	wi := DefaultWiring(selected, KeyGCPVertexAI, &Components{})
+
+	assert.NotContains(t, wi.RawHCL, "network",
+		"no VPC selected -> the endpoint must fall back to public (no network wiring)")
+	assert.NotContains(t, wi.RawHCL, "contents_delta_uri",
+		"no GCS selected -> the index must be created empty (no contents_delta_uri wiring)")
+}

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -6,9 +6,12 @@ package composer
 //   - The KeyGCPVertexAI mapper case is partial-config: it only emits a tfvar
 //     the caller actually populated, so the preset's own defaults win when a
 //     field is left unset (mirrors the AWS Bedrock pattern from #757).
-//   - DefaultWiring feeds the index endpoint's private VPC-peering network from
-//     gcp/vpc and the index's contents_delta_uri from gcp/gcs when those
-//     components are selected, and stays inert for both when they are not.
+//   - DefaultWiring feeds the index endpoint's network from gcp/vpc (the
+//     preset converts it to the project-NUMBER form the API needs and the
+//     endpoint stays public unless enable_private_endpoint is set) and the
+//     index's contents_delta_uri from a dedicated gcp/gcs bucket prefix when
+//     those components are selected, and stays inert for both when they are
+//     not.
 //
 // The registry plumbing (ComponentKey + PresetKeyMap + ModulePath +
 // AllComponentKeys + ComposeOrder) and the required-variable coverage are
@@ -68,11 +71,13 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 	})
 }
 
-func TestDefaultWiring_GCPVertexAI_PrivateEndpointAndGCS(t *testing.T) {
+func TestDefaultWiring_GCPVertexAI_NetworkAndGCS(t *testing.T) {
 	t.Parallel()
 
-	// Full stack: VPC + GCS selected -> the index endpoint gets the private
-	// VPC-peering network and the index gets its GCS seed URI.
+	// Full stack: VPC + GCS selected -> the index endpoint network is wired
+	// from gcp/vpc (the preset reshapes it to the project-NUMBER form and keeps
+	// the endpoint public unless enable_private_endpoint is set), and the index
+	// is seeded from a dedicated prefix under the bucket.
 	selected := map[ComponentKey]bool{
 		KeyGCPVertexAI: true,
 		KeyGCPVPC:      true,
@@ -81,14 +86,16 @@ func TestDefaultWiring_GCPVertexAI_PrivateEndpointAndGCS(t *testing.T) {
 	wi := DefaultWiring(selected, KeyGCPVertexAI, &Components{})
 
 	require.Contains(t, wi.RawHCL, "network",
-		"VPC selected -> the index endpoint must be wired to the VPC network for the private peering path")
+		"VPC selected -> the index endpoint network input must be wired from the VPC")
 	assert.Equal(t, WireRef(KeyGCPVPC, "vpc_id"), wi.RawHCL["network"],
-		"network must reference gcp/vpc.vpc_id (the projects/<p>/global/networks/<n> form)")
+		"network must reference gcp/vpc.vpc_id; the preset converts the project-ID path to the project-NUMBER path the API requires")
 
 	require.Contains(t, wi.RawHCL, "contents_delta_uri",
 		"GCS selected -> the index must be seeded from the bucket")
-	assert.Equal(t, WireRef(KeyGCPGCS, "bucket_url"), wi.RawHCL["contents_delta_uri"],
-		"contents_delta_uri must reference gcp/gcs.bucket_url")
+	// Wired to a dedicated prefix under the bucket, NOT the bucket root —
+	// Vertex's contents_delta_uri expects a directory of index data files.
+	assert.Equal(t, "\"${"+WireRef(KeyGCPGCS, "bucket_url")+"}/vertex-index/\"", wi.RawHCL["contents_delta_uri"],
+		"contents_delta_uri must reference a gcp/gcs.bucket_url subdirectory (gs://<bucket>/vertex-index/), not the bucket root")
 
 	assert.Contains(t, wi.Names, "network")
 	assert.Contains(t, wi.Names, "contents_delta_uri")
@@ -98,14 +105,14 @@ func TestDefaultWiring_GCPVertexAI_InertStandalone(t *testing.T) {
 	t.Parallel()
 
 	// Standalone preview: neither VPC nor GCS selected -> no wiring, so the
-	// preset's public-endpoint + empty-index fallbacks apply.
+	// preset's public-endpoint + empty-index defaults apply.
 	selected := map[ComponentKey]bool{
 		KeyGCPVertexAI: true,
 	}
 	wi := DefaultWiring(selected, KeyGCPVertexAI, &Components{})
 
 	assert.NotContains(t, wi.RawHCL, "network",
-		"no VPC selected -> the endpoint must fall back to public (no network wiring)")
+		"no VPC selected -> no network wiring (endpoint is public)")
 	assert.NotContains(t, wi.RawHCL, "contents_delta_uri",
 		"no GCS selected -> the index must be created empty (no contents_delta_uri wiring)")
 }

--- a/pkg/imported/managed_components.go
+++ b/pkg/imported/managed_components.go
@@ -20,6 +20,7 @@ var managedComponentPrimaryTFTypes = map[composer.ComponentKey]string{
 	composer.KeyAWSBackups:              "aws_backup_vault",
 	composer.KeyAWSBastion:              "aws_instance",
 	composer.KeyAWSBedrock:              "aws_bedrock_guardrail",
+	composer.KeyAWSBedrockAgent:         "aws_bedrockagent_agent",
 	composer.KeyAWSCloudfront:           "aws_cloudfront_distribution",
 	composer.KeyAWSCloudWatchLogs:       "aws_cloudwatch_log_group",
 	composer.KeyAWSCloudWatchMonitoring: "aws_cloudwatch_metric_alarm",

--- a/pkg/imported/managed_components_test.go
+++ b/pkg/imported/managed_components_test.go
@@ -35,6 +35,10 @@ var observableParityNonChartable = map[composer.ComponentKey]nonChartableObserva
 		Class:  "inventory-only",
 		Reason: "#712 - aws_sagemaker_domain uses sagemaker.list-domains inventory; no default imported chart metrics",
 	},
+	composer.KeyAWSBedrockAgent: {
+		Class:  "inventory-only",
+		Reason: "#762 - aws_bedrockagent_agent uses bedrock.list-agents inventory; no default imported chart metrics binding (imported discovery support is a follow-up, cf. #712)",
+	},
 	composer.KeyGCPCloudDeploy: {
 		Class:  "inventory-only",
 		Reason: "#712 - google_clouddeploy_delivery_pipeline uses clouddeploy.list-delivery-pipelines inventory; no default imported chart metrics",

--- a/pkg/observability/component_metrics.go
+++ b/pkg/observability/component_metrics.go
@@ -61,10 +61,15 @@ var ComponentMetricsMapping = map[composer.ComponentKey]ComponentMetricsBinding{
 	composer.KeyAWSAPIGateway:           {Service: "apigateway", Action: "get-apis"},
 	composer.KeyAWSOpenSearch:           {Service: "opensearch", Action: "describe-domains"},
 	composer.KeyAWSBedrock:              {Service: "bedrock", Action: "list-knowledge-bases"},
-	composer.KeyAWSVPC:                  {Service: "vpc", Action: "describe-vpcs"},
-	composer.KeyAWSBastion:              {Service: "ec2", Action: "describe-instances"},
-	composer.KeyAWSGrafana:              {Service: "ec2", Action: "describe-instances"},
-	composer.KeyAWSCodePipeline:         {Service: "ec2", Action: "describe-instances"},
+	// aws_bedrock_agent (#762): the agent is the panel-default surface. The
+	// preset declares aws_bedrockagent_agent as its top-level entity; the
+	// action group / alias / KB association hang off it. bedrock.list-agents
+	// is already a registered action on the bedrock service.
+	composer.KeyAWSBedrockAgent: {Service: "bedrock", Action: "list-agents"},
+	composer.KeyAWSVPC:          {Service: "vpc", Action: "describe-vpcs"},
+	composer.KeyAWSBastion:      {Service: "ec2", Action: "describe-instances"},
+	composer.KeyAWSGrafana:      {Service: "ec2", Action: "describe-instances"},
+	composer.KeyAWSCodePipeline: {Service: "ec2", Action: "describe-instances"},
 	// #622 historical-drift backfill: ACM panel surface is the cert
 	// inventory; Route 53 panel surface is the hosted-zone inventory;
 	// Backups panel surface is the vault inventory. All three had

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -445,7 +445,7 @@ var gcpServiceMetrics = map[string]GCPObs{
 			// gcp/vertex_ai query-latency alert policy alarms on (#764). Lives
 			// here so componentObs() can flip Alarmed=true; without it the
 			// inspector is blind to the alarmed metric.
-			{MetricType: "aiplatform.googleapis.com/matching_engine/query_latencies", ResourceType: "aiplatform.googleapis.com/MatchingEngineIndexEndpoint", LabelKey: "index_endpoint_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "Vector Search Query Latency (p99)"},
+			{MetricType: "aiplatform.googleapis.com/matching_engine/query/latencies", ResourceType: "aiplatform.googleapis.com/IndexEndpoint", LabelKey: "index_endpoint_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "Vector Search Query Latency (p99)"},
 		},
 	},
 }
@@ -573,7 +573,7 @@ var alarmedGCPMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyGCPLoadbalancer:   {Module: "gcp/loadbalancer", Metrics: []string{"loadbalancing.googleapis.com/https/backend_latencies"}},
 	composer.KeyGCPMemorystore:    {Module: "gcp/memorystore", Metrics: []string{"redis.googleapis.com/stats/cpu_utilization"}},
 	composer.KeyGCPPubSub:         {Module: "gcp/pubsub", Metrics: []string{"pubsub.googleapis.com/subscription/num_undelivered_messages"}},
-	composer.KeyGCPVertexAI:       {Module: "gcp/vertex_ai", Metrics: []string{"aiplatform.googleapis.com/matching_engine/query_latencies"}},
+	composer.KeyGCPVertexAI:       {Module: "gcp/vertex_ai", Metrics: []string{"aiplatform.googleapis.com/matching_engine/query/latencies"}},
 }
 
 // AlarmedAWSMetrics returns a defensive copy of the AWS authority entry

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -441,6 +441,11 @@ var gcpServiceMetrics = map[string]GCPObs{
 			{MetricType: "aiplatform.googleapis.com/prediction/online/prediction_count", ResourceType: "aiplatform.googleapis.com/Endpoint", LabelKey: "endpoint_id", Aligner: "ALIGN_RATE", DisplayName: "Online Prediction Count"},
 			{MetricType: "aiplatform.googleapis.com/prediction/online/error_count", ResourceType: "aiplatform.googleapis.com/Endpoint", LabelKey: "endpoint_id", Aligner: "ALIGN_RATE", DisplayName: "Online Prediction Errors"},
 			{MetricType: "aiplatform.googleapis.com/prediction/online/prediction_latencies", ResourceType: "aiplatform.googleapis.com/Endpoint", LabelKey: "endpoint_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "Online Prediction Latency (p99)"},
+			// Vector Search (Matching Engine) serving surface — the metric the
+			// gcp/vertex_ai query-latency alert policy alarms on (#764). Lives
+			// here so componentObs() can flip Alarmed=true; without it the
+			// inspector is blind to the alarmed metric.
+			{MetricType: "aiplatform.googleapis.com/matching_engine/query_latencies", ResourceType: "aiplatform.googleapis.com/MatchingEngineIndexEndpoint", LabelKey: "index_endpoint_id", Aligner: "ALIGN_PERCENTILE_99", DisplayName: "Vector Search Query Latency (p99)"},
 		},
 	},
 }

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -568,6 +568,7 @@ var alarmedGCPMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyGCPLoadbalancer:   {Module: "gcp/loadbalancer", Metrics: []string{"loadbalancing.googleapis.com/https/backend_latencies"}},
 	composer.KeyGCPMemorystore:    {Module: "gcp/memorystore", Metrics: []string{"redis.googleapis.com/stats/cpu_utilization"}},
 	composer.KeyGCPPubSub:         {Module: "gcp/pubsub", Metrics: []string{"pubsub.googleapis.com/subscription/num_undelivered_messages"}},
+	composer.KeyGCPVertexAI:       {Module: "gcp/vertex_ai", Metrics: []string{"aiplatform.googleapis.com/matching_engine/query_latencies"}},
 }
 
 // AlarmedAWSMetrics returns a defensive copy of the AWS authority entry

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -534,19 +534,20 @@ type AlarmAuthor struct {
 // then add the metric_name here (and remove the key from
 // observabilityDeferred once every spec for that key is alarmed).
 var alarmedAWSMetrics = map[composer.ComponentKey]AlarmAuthor{
-	composer.KeyAWSALB:         {Module: "aws/alb", Metrics: []string{"HTTPCode_ELB_5XX_Count"}},
-	composer.KeyAWSAPIGateway:  {Module: "aws/apigateway", Metrics: []string{"5xx"}},
-	composer.KeyAWSBastion:     {Module: "aws/bastion", Metrics: []string{"CPUUtilization"}},
-	composer.KeyAWSDynamoDB:    {Module: "aws/dynamodb", Metrics: []string{"ThrottledRequests"}},
-	composer.KeyAWSEC2:         {Module: "aws/ec2", Metrics: []string{"CPUUtilization"}},
-	composer.KeyAWSECS:         {Module: "aws/ecs", Metrics: []string{"CPUUtilization"}},
-	composer.KeyAWSEKS:         {Module: "aws/eks_nodegroup", Metrics: []string{"cluster_failed_node_count"}},
-	composer.KeyAWSElastiCache: {Module: "aws/elasticache", Metrics: []string{"CPUUtilization"}},
-	composer.KeyAWSLambda:      {Module: "aws/lambda", Metrics: []string{"Errors"}},
-	composer.KeyAWSMSK:         {Module: "aws/msk", Metrics: []string{"OfflinePartitionsCount"}},
-	composer.KeyAWSOpenSearch:  {Module: "aws/opensearch", Metrics: []string{"ClusterStatus.red"}},
-	composer.KeyAWSRDS:         {Module: "aws/rds", Metrics: []string{"CPUUtilization", "FreeStorageSpace"}},
-	composer.KeyAWSSQS:         {Module: "aws/sqs", Metrics: []string{"ApproximateNumberOfMessagesVisible"}},
+	composer.KeyAWSALB:          {Module: "aws/alb", Metrics: []string{"HTTPCode_ELB_5XX_Count"}},
+	composer.KeyAWSAPIGateway:   {Module: "aws/apigateway", Metrics: []string{"5xx"}},
+	composer.KeyAWSBastion:      {Module: "aws/bastion", Metrics: []string{"CPUUtilization"}},
+	composer.KeyAWSBedrockAgent: {Module: "aws/bedrock_agent", Metrics: []string{"InvocationClientErrors"}},
+	composer.KeyAWSDynamoDB:     {Module: "aws/dynamodb", Metrics: []string{"ThrottledRequests"}},
+	composer.KeyAWSEC2:          {Module: "aws/ec2", Metrics: []string{"CPUUtilization"}},
+	composer.KeyAWSECS:          {Module: "aws/ecs", Metrics: []string{"CPUUtilization"}},
+	composer.KeyAWSEKS:          {Module: "aws/eks_nodegroup", Metrics: []string{"cluster_failed_node_count"}},
+	composer.KeyAWSElastiCache:  {Module: "aws/elasticache", Metrics: []string{"CPUUtilization"}},
+	composer.KeyAWSLambda:       {Module: "aws/lambda", Metrics: []string{"Errors"}},
+	composer.KeyAWSMSK:          {Module: "aws/msk", Metrics: []string{"OfflinePartitionsCount"}},
+	composer.KeyAWSOpenSearch:   {Module: "aws/opensearch", Metrics: []string{"ClusterStatus.red"}},
+	composer.KeyAWSRDS:          {Module: "aws/rds", Metrics: []string{"CPUUtilization", "FreeStorageSpace"}},
+	composer.KeyAWSSQS:          {Module: "aws/sqs", Metrics: []string{"ApproximateNumberOfMessagesVisible"}},
 }
 
 // alarmedGCPMetrics is the GCP analogue. Metric strings match

--- a/pkg/observability/discovery_alignment_test.go
+++ b/pkg/observability/discovery_alignment_test.go
@@ -61,6 +61,7 @@ var expectedResourceTypesByAction = map[string][]string{
 	"aws/apigateway/get-apis":                 {"aws_apigatewayv2_api", "aws_api_gateway_rest_api"},
 	"aws/opensearch/describe-domains":         {"aws_opensearch_domain"},
 	"aws/bedrock/list-knowledge-bases":        {"aws_bedrockagent_knowledge_base"},
+	"aws/bedrock/list-agents":                 {"aws_bedrockagent_agent"},
 	"aws/vpc/describe-vpcs":                   {"aws_vpc"},
 	// #622 historical-drift backfill.
 	"aws/acm/list-certificates":     {"aws_acm_certificate"},

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -123,6 +123,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "AWS OpenSearch"
 	case composer.KeyAWSBedrock:
 		return "AWS Bedrock"
+	case composer.KeyAWSBedrockAgent:
+		return "AWS Bedrock Agent"
 	case composer.KeyAWSBastion:
 		return "AWS Bastion"
 	case composer.KeyAWSGrafana:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -69,9 +69,10 @@ var configExtractorAllowlist = map[string]string{
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
-	"aws_sagemaker": "[no-inspector] SageMaker Studio inspector deferred (#615 explicitly marks discovery inspector as optional/follow-up — domain + execution role are surfaced via name-prefix scoping until per-resource extractors land)",
-	"aws_apprunner": "[no-inspector] App Runner inspector deferred (#598 explicitly marks discovery inspector as optional/follow-up for every parity row — service + autoscaling config + VPC connector are surfaced via name-prefix scoping until per-resource extractors land)",
-	"aws_codebuild": "[no-inspector] CodeBuild inspector deferred (#619 explicitly marks discovery inspector as optional/follow-up — project + service role + optional logs bucket are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_sagemaker":     "[no-inspector] SageMaker Studio inspector deferred (#615 explicitly marks discovery inspector as optional/follow-up — domain + execution role are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_apprunner":     "[no-inspector] App Runner inspector deferred (#598 explicitly marks discovery inspector as optional/follow-up for every parity row — service + autoscaling config + VPC connector are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_codebuild":     "[no-inspector] CodeBuild inspector deferred (#619 explicitly marks discovery inspector as optional/follow-up — project + service role + optional logs bucket are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_bedrock_agent": "[no-inspector] Bedrock Agent inspector deferred (#762 — the agent panel binds bedrock.list-agents but a per-component SDK-shape extractor for agent + action group + alias + KB association is a discovery-pipeline follow-up; surfaced via name-prefix scoping until it lands)",
 
 	"gcp_backups":      "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
 	"gcp_cloud_deploy": "[no-inspector] Cloud Deploy delivery-pipeline inspector deferred (#613 explicitly marks discovery inspector + extractor as optional/follow-up); ComponentMetricsMapping has no entry yet so the panel falls back to design values until the per-component extractor lands",

--- a/pkg/observability/metrics/gcp_test.go
+++ b/pkg/observability/metrics/gcp_test.go
@@ -1106,7 +1106,7 @@ func TestEveryGCPSpec_PinsMetricTypesAndDisplayNames(t *testing.T) {
 			{"aiplatform.googleapis.com/prediction/online/prediction_latencies", "Online Prediction Latency (p99)"},
 			// Vector Search (Matching Engine) serving surface — the metric the
 			// gcp/vertex_ai query-latency alert policy alarms on (#764).
-			{"aiplatform.googleapis.com/matching_engine/query_latencies", "Vector Search Query Latency (p99)"},
+			{"aiplatform.googleapis.com/matching_engine/query/latencies", "Vector Search Query Latency (p99)"},
 		},
 	}
 

--- a/pkg/observability/metrics/gcp_test.go
+++ b/pkg/observability/metrics/gcp_test.go
@@ -1104,6 +1104,9 @@ func TestEveryGCPSpec_PinsMetricTypesAndDisplayNames(t *testing.T) {
 			{"aiplatform.googleapis.com/prediction/online/prediction_count", "Online Prediction Count"},
 			{"aiplatform.googleapis.com/prediction/online/error_count", "Online Prediction Errors"},
 			{"aiplatform.googleapis.com/prediction/online/prediction_latencies", "Online Prediction Latency (p99)"},
+			// Vector Search (Matching Engine) serving surface — the metric the
+			// gcp/vertex_ai query-latency alert policy alarms on (#764).
+			{"aiplatform.googleapis.com/matching_engine/query_latencies", "Vector Search Query Latency (p99)"},
 		},
 	}
 

--- a/pkg/observability/observability_alarms_test.go
+++ b/pkg/observability/observability_alarms_test.go
@@ -46,6 +46,12 @@ var excludedFromAuthority = map[string]string{
 	// gke entry to gcpServiceMetrics in a follow-up to retire this
 	// exclusion.
 	"gcp/gke:kubernetes.io/node/cpu/allocatable_utilization": "#204",
+	// aws/opensearch AOSS OCU alarms (#758) live in namespace AWS/AOSS with
+	// the account-level ClientId dimension; the catalog's "opensearch"
+	// service group is AWS/ES + DomainName (managed domains), so these are
+	// HCL-only until an AOSS-scoped AWSMetricSpec group exists (#778).
+	"aws/opensearch:SearchOCU":   "#778",
+	"aws/opensearch:IndexingOCU": "#778",
 }
 
 // awsModuleAuthor inverts alarmedAWSMetrics by module path so the reverse

--- a/tests/lint-gcp-project-pin.sh
+++ b/tests/lint-gcp-project-pin.sh
@@ -73,6 +73,7 @@ EXEMPT_PROJECT_PIN_GCP=(
   google_service_networking_connection  # parent: network (gcp/cloudsql/main.tf:41)
   google_storage_bucket_iam_member      # parent: bucket (gcp/cloud_logging/main.tf:60)
   google_storage_bucket_object          # parent: bucket (gcp/cloud_functions/main.tf:56)
+  google_vertex_ai_index_endpoint_deployed_index  # parent: index_endpoint (gcp/vertex_ai/main.tf; no project attr in provider schema)
 )
 
 exempt_pattern="^($(IFS='|'; echo "${EXEMPT_PROJECT_PIN_GCP[*]}"))$"

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -35,6 +35,8 @@ NON_TAGGABLE_AWS=(
   aws_autoscaling_group_tag
   aws_backup_selection
   aws_bedrock_model_invocation_logging_configuration
+  aws_bedrockagent_agent_action_group
+  aws_bedrockagent_agent_knowledge_base_association
   aws_bedrockagent_data_source
   aws_cloudfront_monitoring_subscription
   aws_cloudfront_origin_access_identity


### PR DESCRIPTION
One bundle PR subsuming the open AI-stack slices so they can be live-tested together. One merge per work item — each remains individually revertible/bisectable.

Closes #759. Closes #758. Closes #762. Closes #764. Part of #755 / #756.

## Contents
- **GPU compute on `aws_eks_nodegroup` + `aws_ec2`** (#759, was PR #772): GPU instance-family validation (validate-don't-mask), NVIDIA AMI auto-derive single-sourced in HCL, preset-level GPU preconditions drift-locked across Go + both HCL lists, GPU-aware pricing default, mapper emits `os_type` on the GPU path.
- **`aws_opensearch` VECTORSEARCH surfacing** (#758, was PR #775): policy-trio docs + data-access split, `collection_endpoint`/`collection_id` outputs, AOSS OCU alarms (Sum statistic), and a real wiring fix — `opensearch_collection_name` now wired into Bedrock so the AOSS data-access policy actually activates in composed stacks.
- **New component `aws_bedrock_agent`** (#762): Bedrock Agent + Lambda action group + alias (PREPARED-before-alias encapsulated) + optional KB association wired to #757's Knowledge Base outputs. Hard dep on `aws_lambda`. Full new-key registration + invariant gates.
- **`gcp_vertex_ai` Vector Search** (#764, was PR #773): index + endpoint + deployed index (public-by-default; private opt-in pending #774), project-number network canonicalization, corrected matching-engine metric, mutation-hardened tests.

## Behavior changes
- Pre-existing EKS GPU-family node groups using auto-derived `ami_type` get a one-time STANDARD→NVIDIA replacement (intentional: STANDARD lacked drivers; pin `var.ami_type` to opt out).
- Compose-time rejection of `gpu_enabled` + non-GPU/ARM instance types; plan-time rejection of GPU+ubuntu.

## QC applied per slice
Multi-angle diff review + qa-professor mutation testing + Codex second opinion; all P0/P1 findings fixed (details in the subsumed PRs #772/#773/#775).

## Testing
Targeted gates green locally (invariant battery + all lint scripts on the union; zero merge conflicts). Full suite in CI. Live cust3 validation to follow on this branch.
