### PR TITLE
feat(sagemaker): real-time inference endpoint — model serving (#761)

### DIFF
--- a/aws/sagemaker/main.tf
+++ b/aws/sagemaker/main.tf
@@ -102,6 +102,31 @@ locals {
   # for the grant from the s3://bucket/key URL.
   model_data_bucket = local.enable_inference && trimspace(var.model_data_url) != "" ? split("/", replace(var.model_data_url, "s3://", ""))[0] : ""
   model_data_arn    = local.model_data_bucket == "" ? "" : "arn:${data.aws_partition.current.partition}:s3:::${local.model_data_bucket}"
+
+  # ECR registry scoping (#761 review MED-3). var.model_image can be a
+  # cross-account image — AWS Deep Learning Containers live in AWS-owned
+  # registries (e.g. 763104351884.dkr.ecr.<region>.amazonaws.com/...), not the
+  # deploying account. Scoping the layer/image-read grant to the *deploying*
+  # account's repos would 403 the pull of any DLC. So we parse the registry
+  # account id out of the standard ECR image URI
+  # (<acct>.dkr.ecr.<region>.amazonaws.com/<repo>[:tag|@digest]) and scope the
+  # BatchGetImage / GetDownloadUrlForLayer / BatchCheckLayerAvailability grant
+  # to *that* registry's repos. If the URI isn't a parseable ECR registry host
+  # (e.g. a bare SageMaker built-in algorithm image or a public/non-ECR ref),
+  # the regex yields no match and we fall back to the deploying account — the
+  # safe default for an in-account image, and non-ECR images don't consult an
+  # ECR repo grant at all.
+  #
+  # ecr_registry_account: the 12-digit account id from the registry host, or
+  # "" when the image URI isn't an ECR registry reference.
+  _ecr_registry_matches = local.enable_inference ? regexall("^([0-9]{12})\\.dkr\\.ecr\\.[a-z0-9-]+\\.amazonaws\\.com/", trimspace(var.model_image)) : []
+  ecr_registry_account  = length(local._ecr_registry_matches) > 0 ? local._ecr_registry_matches[0][0] : data.aws_caller_identity.current.account_id
+
+  # ARN of the repo namespace the model image lives in, scoped to the parsed
+  # (possibly cross-account) registry. The pull grant targets this — not the
+  # deploying account's repos — so cross-account DLC pulls succeed under least
+  # privilege.
+  ecr_repo_arn = "arn:${data.aws_partition.current.partition}:ecr:${var.region}:${local.ecr_registry_account}:repository/*"
 }
 
 resource "random_id" "workspace_suffix" {
@@ -281,7 +306,10 @@ resource "aws_sagemaker_user_profile" "studio_user" {
 
 # ECR pull for the model image. ecr:GetAuthorizationToken is account-wide
 # (Resource "*" is required — the token isn't scopable to a repo); the image
-# layer/manifest reads are scoped to ECR repos in the deploying account.
+# layer/manifest reads are scoped to the registry the model image actually
+# lives in (local.ecr_repo_arn), which may be a *cross-account* AWS registry
+# for a Deep Learning Container (#761 review MED-3). Falls back to the
+# deploying account when the URI isn't a parseable ECR registry reference.
 resource "aws_iam_role_policy" "inference_ecr_pull" {
   count = local.enable_inference ? 1 : 0
 
@@ -303,7 +331,7 @@ resource "aws_iam_role_policy" "inference_ecr_pull" {
           "ecr:GetDownloadUrlForLayer",
           "ecr:BatchGetImage",
         ]
-        Resource = "arn:${data.aws_partition.current.partition}:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/*"
+        Resource = local.ecr_repo_arn
       },
     ]
   })
@@ -392,6 +420,28 @@ resource "aws_sagemaker_endpoint" "inference" {
 
   name                 = "${var.project}-endpoint"
   endpoint_config_name = aws_sagemaker_endpoint_configuration.inference[0].name
+
+  # IAM race guard (#761 review HIGH-1). The endpoint create is where AWS
+  # actually instantiates the container: it pulls the model image from ECR
+  # and (when set) reads model.tar.gz from S3 *as the execution role*. The
+  # aws_sagemaker_model resource above only registers metadata (image URI +
+  # role ARN) — no pull happens there — so the real consumer of these grants
+  # is the endpoint. terraform's implicit graph does NOT order the endpoint
+  # after the inline role policies (the endpoint references the model →
+  # config, not the policies), so without an explicit depends_on the endpoint
+  # create can start before the execution role can pull the image / read the
+  # artifact, intermittently failing the InService rollout. The managed-policy
+  # attachment is included for the same reason (AmazonSageMakerFullAccess
+  # carries the ECR/S3 permissions a scoped override might rely on).
+  #
+  # inference_model_data is count-gated (only present when model_data_url is
+  # set); depends_on tolerates a resource that resolves to zero instances, so
+  # listing it unconditionally is safe whether or not the artifact grant exists.
+  depends_on = [
+    aws_iam_role_policy.inference_ecr_pull,
+    aws_iam_role_policy.inference_model_data,
+    aws_iam_role_policy_attachment.studio_managed,
+  ]
 
   tags = merge(local.tags, { Name = "${var.project}-endpoint" })
 }

--- a/aws/sagemaker/main.tf
+++ b/aws/sagemaker/main.tf
@@ -89,6 +89,19 @@ locals {
   workspace_bucket_name = local.create_bucket ? aws_s3_bucket.workspace[0].id : var.workspace_bucket
   workspace_bucket_arn  = local.create_bucket ? aws_s3_bucket.workspace[0].arn : "arn:${data.aws_partition.current.partition}:s3:::${var.workspace_bucket}"
   default_bucket_name   = local.create_bucket ? "${var.project}-sagemaker-workspace-${random_id.workspace_suffix[0].hex}" : null
+
+  # Real-time inference slice (#761). When off, the preset stays Studio-only.
+  # The model / endpoint-config / endpoint resources below use
+  # `count = local.enable_inference ? 1 : 0` so they read cleanly as `[0]`
+  # while staying absent when disabled.
+  enable_inference = var.enable_inference
+
+  # model_data_url is optional: many LLM serving images bundle / pull their
+  # own weights. We only attach the s3:GetObject read grant for the artifact
+  # when a URL is actually supplied (least privilege). Derive the bucket ARN
+  # for the grant from the s3://bucket/key URL.
+  model_data_bucket = local.enable_inference && trimspace(var.model_data_url) != "" ? split("/", replace(var.model_data_url, "s3://", ""))[0] : ""
+  model_data_arn    = local.model_data_bucket == "" ? "" : "arn:${data.aws_partition.current.partition}:s3:::${local.model_data_bucket}"
 }
 
 resource "random_id" "workspace_suffix" {
@@ -250,4 +263,135 @@ resource "aws_sagemaker_user_profile" "studio_user" {
   user_profile_name = each.value
 
   tags = local.tags
+}
+
+# -----------------------------------------------------------------------------
+# Real-time inference endpoint (#761) — gated on var.enable_inference.
+#
+# Lifecycle: aws_sagemaker_model (defines the servable container + the
+# execution role it runs under) → aws_sagemaker_endpoint_configuration
+# (the production-variant hosting plan: which model, instance type, count)
+# → aws_sagemaker_endpoint (the live HTTPS endpoint InvokeEndpoint hits).
+#
+# The endpoint hosting container runs as the Studio execution role. To pull
+# the model image from ECR and read the model artifact from S3 it needs
+# explicit grants beyond Studio's bucket access — attached below, only when
+# inference is enabled so the Studio-only path keeps a tighter role.
+# -----------------------------------------------------------------------------
+
+# ECR pull for the model image. ecr:GetAuthorizationToken is account-wide
+# (Resource "*" is required — the token isn't scopable to a repo); the image
+# layer/manifest reads are scoped to ECR repos in the deploying account.
+resource "aws_iam_role_policy" "inference_ecr_pull" {
+  count = local.enable_inference ? 1 : 0
+
+  name = "${var.project}-sagemaker-inference-ecr-pull"
+  role = aws_iam_role.studio_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/*"
+      },
+    ]
+  })
+}
+
+# S3 read for the model artifact (model.tar.gz). Only attached when a
+# model_data_url is supplied — images that bundle their own weights need no
+# extra S3 grant. Scoped to the specific artifact bucket (get object + list).
+resource "aws_iam_role_policy" "inference_model_data" {
+  count = local.enable_inference && local.model_data_arn != "" ? 1 : 0
+
+  name = "${var.project}-sagemaker-inference-model-data"
+  role = aws_iam_role.studio_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "${local.model_data_arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = local.model_data_arn
+      },
+    ]
+  })
+}
+
+resource "aws_sagemaker_model" "inference" {
+  count = local.enable_inference ? 1 : 0
+
+  name               = "${var.project}-model"
+  execution_role_arn = aws_iam_role.studio_execution.arn
+
+  primary_container {
+    image = var.model_image
+    # model_data_url is optional — omit it (null) so the provider doesn't set
+    # an empty ModelDataUrl, which AWS rejects. Images that pull their own
+    # weights leave this unset.
+    model_data_url = trimspace(var.model_data_url) != "" ? var.model_data_url : null
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-model" })
+
+  lifecycle {
+    precondition {
+      # model_image must be non-empty when inference is on — SageMaker can't
+      # host a model without a servable container. Enforced here (not as a
+      # var validation) because the requirement is conditional on
+      # var.enable_inference, and TF forbids cross-variable conditions in a
+      # variable validation block.
+      condition     = trimspace(var.model_image) != ""
+      error_message = "model_image must be a non-empty ECR/SageMaker container image URI when enable_inference is true — SageMaker cannot host a model without a servable container."
+    }
+  }
+}
+
+resource "aws_sagemaker_endpoint_configuration" "inference" {
+  count = local.enable_inference ? 1 : 0
+
+  name = "${var.project}-endpoint-config"
+
+  production_variants {
+    variant_name           = "primary"
+    model_name             = aws_sagemaker_model.inference[0].name
+    initial_instance_count = 1
+    instance_type          = var.endpoint_instance_type
+    initial_variant_weight = 1.0
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-endpoint-config" })
+}
+
+# Endpoint create blocks until the production variant reaches InService —
+# pulling the image + (optionally) the model artifact and warming the container
+# can take several minutes, longer for large GPU LLM images. The aws provider
+# 6.x aws_sagemaker_endpoint resource does NOT expose a configurable `timeouts`
+# block (verified against `terraform providers schema -json`); it uses the
+# provider's built-in InService wait. A slow-but-healthy rollout is therefore
+# bounded by the provider default, not a knob we can set here.
+resource "aws_sagemaker_endpoint" "inference" {
+  count = local.enable_inference ? 1 : 0
+
+  name                 = "${var.project}-endpoint"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.inference[0].name
+
+  tags = merge(local.tags, { Name = "${var.project}-endpoint" })
 }

--- a/aws/sagemaker/observability.tf
+++ b/aws/sagemaker/observability.tf
@@ -1,0 +1,113 @@
+# observability.tf — issue #761 (real-time inference endpoint alarms).
+#
+# Alarms only exist when var.enable_inference is true: with no endpoint there
+# are no AWS/SageMaker invocation metrics to alarm on. Each alarm is keyed by
+# the EndpointName + VariantName dimensions the endpoint publishes under.
+#
+# Metric names verified against the AWS/SageMaker endpoint-invocation metric
+# table (Invocation5XXErrors, ModelLatency) — not memory (the #764 metric-name
+# regression). ModelLatency is reported in MICROSECONDS, which the latency
+# threshold default reflects.
+
+variable "enable_observability" {
+  description = "When true, emit per-component CloudWatch alarms gated on this module's inference endpoint (issue #761). Has no effect unless var.enable_inference is also true (no endpoint = no metrics to alarm on)."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_topic_arn" {
+  description = "SNS topic ARN that receives alarm + ok notifications. When null, the alarm exists but does not notify."
+  type        = string
+  default     = null
+}
+
+variable "alarm_severity" {
+  description = "Severity tag attached to alarms. One of critical|warning|info."
+  type        = string
+  default     = "warning"
+  validation {
+    condition     = contains(["critical", "warning", "info"], var.alarm_severity)
+    error_message = "alarm_severity must be one of critical|warning|info."
+  }
+}
+
+variable "alarm_threshold_overrides" {
+  description = "Per-metric numeric threshold overrides; missing keys fall through to the module's defaults. Keys: invocation_5xx_errors (count per period), model_latency_micros (microseconds)."
+  type        = map(number)
+  default     = {}
+}
+
+variable "runbook_url_prefix" {
+  description = "Optional URL prefix included in alarm_description so on-call has a click-through."
+  type        = string
+  default     = ""
+}
+
+locals {
+  # Alarms exist only when both the endpoint is provisioned AND observability
+  # is enabled. for_each over a 1/0-element map so the alarms read as a single
+  # resource that's present or absent.
+  _obs_enabled = local.enable_inference && var.enable_observability
+  _obs_actions = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]
+  _obs_tags    = merge(module.name.tags, var.tags, { severity = var.alarm_severity })
+  _obs_thresholds = merge({
+    invocation_5xx_errors = 1
+    # ModelLatency is published in MICROSECONDS. 5_000_000 µs = 5s — a
+    # conservative default for an LLM serving endpoint; tune per workload via
+    # alarm_threshold_overrides.
+    model_latency_micros = 5000000
+  }, var.alarm_threshold_overrides)
+  _obs_runbook = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/sagemaker/inference"
+
+  # Dimension shared by both alarms — the endpoint + its single "primary"
+  # production variant (the variant_name set in the endpoint configuration).
+  _obs_dimensions = local._obs_enabled ? {
+    EndpointName = aws_sagemaker_endpoint.inference[0].name
+    VariantName  = "primary"
+  } : {}
+}
+
+# A spike in Invocation5XXErrors means the hosted model container is returning
+# server errors (OOM, crashed worker, bad model artifact) — the inference
+# endpoint is up but failing requests. This is the headline failure surface the
+# inference slice exists to serve.
+resource "aws_cloudwatch_metric_alarm" "invocation_5xx_high" {
+  for_each = local._obs_enabled ? { "0" = true } : {}
+
+  alarm_name          = "${module.name.name}-sagemaker-invocation-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  threshold           = local._obs_thresholds["invocation_5xx_errors"]
+  metric_name         = "Invocation5XXErrors"
+  namespace           = "AWS/SageMaker"
+  period              = 300
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "SageMaker endpoint 5XX invocation errors above ${local._obs_thresholds["invocation_5xx_errors"]} per period — the hosted model is failing requests.${local._obs_runbook}"
+  dimensions          = local._obs_dimensions
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}
+
+# Rising ModelLatency means the container is taking longer to return inferences
+# (overloaded instance, cold model, GPU contention). Sustained high latency on
+# a real-time endpoint degrades every caller.
+resource "aws_cloudwatch_metric_alarm" "model_latency_high" {
+  for_each = local._obs_enabled ? { "0" = true } : {}
+
+  alarm_name          = "${module.name.name}-sagemaker-model-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  threshold           = local._obs_thresholds["model_latency_micros"]
+  metric_name         = "ModelLatency"
+  namespace           = "AWS/SageMaker"
+  period              = 300
+  statistic           = "Average"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "SageMaker endpoint ModelLatency (avg) above ${local._obs_thresholds["model_latency_micros"]}µs — the hosted model is responding slowly.${local._obs_runbook}"
+  dimensions          = local._obs_dimensions
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}

--- a/aws/sagemaker/outputs.tf
+++ b/aws/sagemaker/outputs.tf
@@ -45,3 +45,28 @@ output "tags" {
   description = "The Project-tagged map applied to every taggable resource in this preset. Other presets composing on top can `merge(module.aws_sagemaker.tags, ...)` to inherit the same Project attribution."
   value       = local.tags
 }
+
+# -----------------------------------------------------------------------------
+# Real-time inference endpoint outputs (#761). Null when enable_inference is
+# false so downstream wiring can detect the Studio-only configuration.
+# -----------------------------------------------------------------------------
+
+output "endpoint_name" {
+  description = "Name of the real-time inference endpoint (`<project>-endpoint`). Callers hit this via the SageMaker Runtime InvokeEndpoint API. Null when enable_inference is false."
+  value       = local.enable_inference ? aws_sagemaker_endpoint.inference[0].name : null
+}
+
+output "endpoint_arn" {
+  description = "Full ARN of the inference endpoint. Useful for IAM policy resource references (e.g. granting sagemaker:InvokeEndpoint to callers). Null when enable_inference is false."
+  value       = local.enable_inference ? aws_sagemaker_endpoint.inference[0].arn : null
+}
+
+output "model_name" {
+  description = "Name of the SageMaker model (`<project>-model`) hosting the servable container. Null when enable_inference is false."
+  value       = local.enable_inference ? aws_sagemaker_model.inference[0].name : null
+}
+
+output "endpoint_config_name" {
+  description = "Name of the endpoint configuration (`<project>-endpoint-config`) — the production-variant hosting plan the endpoint binds. Null when enable_inference is false."
+  value       = local.enable_inference ? aws_sagemaker_endpoint_configuration.inference[0].name : null
+}

--- a/aws/sagemaker/tests/integration.tftest.hcl
+++ b/aws/sagemaker/tests/integration.tftest.hcl
@@ -1,0 +1,166 @@
+# Integration tests for the aws/sagemaker inference slice (#761) —
+# APPLIES AGAINST A REAL AWS ACCOUNT. CI SKIPS this file by filename
+# convention (anything matching *integration*); it is opt-in and needs real
+# credentials + a real, servable container image.
+#
+# Run with valid AWS credentials in the target account:
+#
+#   cd aws/sagemaker
+#   terraform init -backend=false
+#   AWS_REGION=us-east-1 terraform test \
+#     -filter=tests/integration.tftest.hcl \
+#     -var 'model_image=<ECR_OR_SAGEMAKER_IMAGE_URI>' \
+#     -var 'model_data_url=s3://<bucket>/<key>/model.tar.gz'
+#
+# REQUIRED OPERATOR INPUT — model_image:
+#   SageMaker hosting needs a *servable* container that implements the
+#   /ping + /invocations contract (a SageMaker DLC, a HuggingFace TGI/LMI
+#   image, or your own). There is NO sensible default — a wrong/non-servable
+#   image makes the endpoint create hang then fail at InService, so the apply
+#   below will block for several minutes before erroring. Pass a known-good
+#   image URI for your account/region. model_data_url is optional (many LLM
+#   serving images bundle or hub-pull their weights); supply it only if your
+#   image expects a model.tar.gz from S3.
+#
+# QUOTA: real-time GPU hosting (ml.g5.*) needs the per-account
+# "ml.g5.xlarge for endpoint usage" service quota raised above 0, or the
+# endpoint create fails with a ResourceLimitExceeded. The default below uses
+# ml.m5.xlarge (CPU, generally available) so the test runs without a GPU
+# quota bump; override endpoint_instance_type for a GPU image.
+#
+# What it does:
+#   1. setup_vpc: stands up a real VPC via the sibling ../vpc preset so the
+#      Studio domain (required vpc_id + subnet_ids) and the endpoint ENIs have
+#      somewhere to land. Yields concrete vpc_id + private_subnet_ids.
+#   2. sagemaker_inference_apply: applies aws/sagemaker with
+#      enable_inference=true wired to the live VPC, asserting the model /
+#      endpoint-config / endpoint trio all reach a live state — the endpoint
+#      apply only returns once the production variant is InService, so a green
+#      apply here is the live proof the container is servable and the
+#      execution role's ECR-pull + S3 model-data grants are sufficient.
+#   3. Tears EVERYTHING down at the end (terraform test always destroys).
+#      Endpoint + config + model + VPC are destroyed in dependency order.
+#
+# Resource names embed a UTC timestamp suffix (MMDDhhmmss) under the iotsm-
+# prefix so this never collides with a prior iotsm- run.
+#
+# If a prior run was killed mid-apply, manual cleanup may be required:
+#
+#   aws sagemaker list-endpoints --query 'Endpoints[?starts_with(EndpointName, `iotsm-`)]'
+#   aws sagemaker delete-endpoint --endpoint-name <name>
+#   aws sagemaker list-endpoint-configs --query 'EndpointConfigs[?starts_with(EndpointConfigName, `iotsm-`)]'
+#   aws sagemaker delete-endpoint-config --endpoint-config-name <name>
+#   aws sagemaker list-models --query 'Models[?starts_with(ModelName, `iotsm-`)]'
+#   aws sagemaker delete-model --model-name <name>
+
+provider "aws" {
+  region = var.region
+}
+
+variables {
+  # Suffix the project name with a UTC MMDDhhmmss timestamp so back-to-back
+  # runs don't collide on model / endpoint / role names. Computed once at
+  # file-load time and shared across every run in this file, so setup_vpc and
+  # sagemaker_inference_apply see the same project string.
+  # Risk: two runs in the exact same second collide. Acceptable for a
+  # human-driven integration test.
+  project     = "iotsm-${formatdate("MMDDhhmmss", timestamp())}"
+  region      = "us-east-1"
+  environment = "test"
+
+  enable_inference = true
+
+  # CPU hosting instance — generally available without a GPU quota bump.
+  # Override for a GPU serving image (e.g. ml.g5.xlarge) once the endpoint-
+  # usage quota is raised.
+  endpoint_instance_type = "ml.m5.xlarge"
+
+  # model_image is intentionally undefaulted — the operator MUST pass a real,
+  # servable image URI via -var (see header). With no -var the apply fails the
+  # non-empty-image precondition immediately, which is the correct loud signal.
+}
+
+# --- Setup: real VPC for the Studio domain + endpoint ENIs -----------------
+#
+# Uses the sibling vpc preset. Path is resolved relative to the module under
+# test (aws/sagemaker), so we go up one level and across.
+run "setup_vpc" {
+  command = apply
+
+  module {
+    source = "../vpc"
+  }
+
+  variables {
+    project     = var.project
+    environment = var.environment
+    region      = var.region
+  }
+
+  assert {
+    condition     = length(output.private_subnet_ids) > 0
+    error_message = "VPC setup must yield at least one private subnet for the Studio domain + endpoint ENIs."
+  }
+}
+
+# --- Main: sagemaker inference against the real VPC ------------------------
+#
+# The live-apply proof for the #761 inference slice. The endpoint create
+# blocks until the production variant is InService; a green apply is the proof
+# the image is servable and the execution role can pull it (+ read the model
+# artifact when model_data_url is set).
+run "sagemaker_inference_apply" {
+  command = apply
+
+  variables {
+    vpc_id     = run.setup_vpc.vpc_id
+    subnet_ids = run.setup_vpc.private_subnet_ids
+  }
+
+  # --- Model up, hosting the operator's image as the execution role ---
+  assert {
+    condition     = aws_sagemaker_model.inference[0].name == "${var.project}-model"
+    error_message = "Model name must default to {project}-model."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].execution_role_arn == aws_iam_role.studio_execution.arn
+    error_message = "Live model must run as the Studio execution role."
+  }
+
+  # --- Endpoint configuration bound to the model ---
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].instance_type == var.endpoint_instance_type
+    error_message = "Endpoint config production variant must host on endpoint_instance_type."
+  }
+
+  # --- Live endpoint reached InService (the headline live proof) ---
+  # The apply only returns once the endpoint is InService; the resource exposes
+  # arn once created. A non-empty arn after apply is the proof the create
+  # succeeded end-to-end (image pulled, container warmed, variant InService).
+  assert {
+    condition     = aws_sagemaker_endpoint.inference[0].name == "${var.project}-endpoint"
+    error_message = "A live endpoint must be created with the {project}-endpoint name."
+  }
+
+  assert {
+    condition     = can(regex("^arn:aws:sagemaker:", aws_sagemaker_endpoint.inference[0].arn))
+    error_message = "Live endpoint must report a SageMaker endpoint ARN after apply (the InService rollout must succeed)."
+  }
+
+  # --- Outputs populated end-to-end ---
+  assert {
+    condition     = output.endpoint_name == "${var.project}-endpoint"
+    error_message = "endpoint_name output must be populated after a live inference apply."
+  }
+
+  assert {
+    condition     = output.model_name == "${var.project}-model"
+    error_message = "model_name output must be populated after a live inference apply."
+  }
+
+  assert {
+    condition     = output.endpoint_config_name == "${var.project}-endpoint-config"
+    error_message = "endpoint_config_name output must be populated after a live inference apply."
+  }
+}

--- a/aws/sagemaker/tests/shape.tftest.hcl
+++ b/aws/sagemaker/tests/shape.tftest.hcl
@@ -400,3 +400,297 @@ run "sagemaker_rejects_empty_vpc_id" {
 
   expect_failures = [var.vpc_id]
 }
+
+# -----------------------------------------------------------------------------
+# Real-time inference endpoint (#761).
+# -----------------------------------------------------------------------------
+
+# Studio-only is the default: with enable_inference unset, none of the model /
+# endpoint-config / endpoint resources exist, and the Studio domain is
+# unchanged. This is the "Studio behavior unchanged when flag unset" guard.
+run "sagemaker_no_inference_by_default" {
+  command = plan
+
+  variables {
+    project    = "test"
+    vpc_id     = "vpc-12345"
+    subnet_ids = ["subnet-aaa"]
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_model.inference) == 0
+    error_message = "No model resource may exist when enable_inference is unset (Studio-only default)."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint_configuration.inference) == 0
+    error_message = "No endpoint-configuration may exist when enable_inference is unset."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint.inference) == 0
+    error_message = "No endpoint may exist when enable_inference is unset."
+  }
+
+  # No inference ECR / model-data role policies either.
+  assert {
+    condition     = length(aws_iam_role_policy.inference_ecr_pull) == 0
+    error_message = "No inference ECR-pull policy may exist when enable_inference is unset."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_model_data) == 0
+    error_message = "No inference model-data policy may exist when enable_inference is unset."
+  }
+
+  # No inference = no endpoint metrics, so no alarms (the observability
+  # locals must stay safe to evaluate even when the endpoint is absent).
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.invocation_5xx_high) == 0
+    error_message = "No 5XX alarm may exist when inference is off (no endpoint = no metrics)."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.model_latency_high) == 0
+    error_message = "No latency alarm may exist when inference is off."
+  }
+
+  # Studio domain still provisioned + unchanged (the headline invariant).
+  assert {
+    condition     = aws_sagemaker_domain.studio.domain_name == "test-studio"
+    error_message = "Studio domain must stay provisioned + project-prefixed when inference is off."
+  }
+}
+
+# enable_inference=true with a valid image + ml.* instance type composes the
+# full model / endpoint-config / endpoint trio. Pins names, the image flowing
+# into the model's primary container, the instance type on the production
+# variant, the model→config→endpoint chaining, and the ECR-pull + model-data
+# role policies coming up alongside.
+run "inference_endpoint" {
+  command = plan
+
+  variables {
+    project                = "test"
+    vpc_id                 = "vpc-12345"
+    subnet_ids             = ["subnet-aaa"]
+    enable_inference       = true
+    model_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url         = "s3://my-models/llm/model.tar.gz"
+    endpoint_instance_type = "ml.g5.xlarge"
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_model.inference) == 1
+    error_message = "enable_inference must create exactly one model resource."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].name == "test-model"
+    error_message = "Model name must be project-prefixed (`<project>-model`)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].primary_container[0].image == "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    error_message = "model_image must flow into the model's primary_container image."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].primary_container[0].model_data_url == "s3://my-models/llm/model.tar.gz"
+    error_message = "model_data_url must flow into the model's primary_container model_data_url when supplied."
+  }
+
+  # Note: we can't pin `execution_role_arn == aws_iam_role.studio_execution.arn`
+  # under plan mode — the role ARN is Computed (unknown) so the comparison
+  # short-circuits to "unknown" and terraform test errors. The model→exec-role
+  # wiring is asserted apply-mode in tests/integration.tftest.hcl.
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint_configuration.inference) == 1
+    error_message = "enable_inference must create exactly one endpoint configuration."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].name == "test-endpoint-config"
+    error_message = "Endpoint config name must be project-prefixed (`<project>-endpoint-config`)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].instance_type == "ml.g5.xlarge"
+    error_message = "endpoint_instance_type must flow into the production variant instance_type."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].variant_name == "primary"
+    error_message = "Production variant must be named `primary` (the dimension the observability alarms key on)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].model_name == aws_sagemaker_model.inference[0].name
+    error_message = "Endpoint config production variant must reference the preset's model name."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint.inference) == 1
+    error_message = "enable_inference must create exactly one endpoint."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint.inference[0].name == "test-endpoint"
+    error_message = "Endpoint name must be project-prefixed (`<project>-endpoint`)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint.inference[0].endpoint_config_name == aws_sagemaker_endpoint_configuration.inference[0].name
+    error_message = "Endpoint must bind the preset's endpoint configuration name."
+  }
+
+  # Execution role gains both inference grants when a model_data_url is set.
+  assert {
+    condition     = length(aws_iam_role_policy.inference_ecr_pull) == 1
+    error_message = "Inference must attach an ECR-pull policy to the execution role."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_ecr_pull[0].policy, "ecr:GetAuthorizationToken")
+    error_message = "ECR-pull policy must grant ecr:GetAuthorizationToken (image pull needs the auth token)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_model_data) == 1
+    error_message = "A supplied model_data_url must attach an S3 model-data read policy to the execution role."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_model_data[0].policy, "s3:GetObject")
+    error_message = "Model-data policy must grant s3:GetObject on the artifact bucket."
+  }
+
+  # Observability alarms come up with the endpoint (enable_observability
+  # defaults true), keyed on the endpoint name + primary variant.
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.invocation_5xx_high) == 1
+    error_message = "5XX invocation alarm must be created with the inference endpoint."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].metric_name == "Invocation5XXErrors"
+    error_message = "5XX alarm must watch the Invocation5XXErrors metric (AWS/SageMaker)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].namespace == "AWS/SageMaker"
+    error_message = "5XX alarm namespace must be AWS/SageMaker."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].metric_name == "ModelLatency"
+    error_message = "Latency alarm must watch the ModelLatency metric."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].dimensions["VariantName"] == "primary"
+    error_message = "Alarm must key on the `primary` production variant."
+  }
+}
+
+# When inference is on but no model_data_url is supplied (image bundles its own
+# weights), the ECR-pull policy still attaches but the model-data policy does
+# NOT — least privilege. Companion to the trio run above.
+run "inference_endpoint_without_model_data" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_model.inference) == 1
+    error_message = "Model must still be created when model_data_url is omitted (image bundles weights)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_ecr_pull) == 1
+    error_message = "ECR-pull policy must attach even without a model_data_url."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_model_data) == 0
+    error_message = "No S3 model-data policy may attach when model_data_url is omitted (least privilege)."
+  }
+}
+
+# Positive triangulation companion: a valid ml.* instance type plans cleanly,
+# so the negative below can only fail for the right reason.
+run "inference_valid_instance_type_plans_cleanly" {
+  command = plan
+
+  variables {
+    project                = "test"
+    vpc_id                 = "vpc-12345"
+    subnet_ids             = ["subnet-aaa"]
+    enable_inference       = true
+    model_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    endpoint_instance_type = "ml.m5.xlarge"
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].instance_type == "ml.m5.xlarge"
+    error_message = "A valid ml.* endpoint_instance_type must plan cleanly (companion to rejects_bad_instance_type)."
+  }
+}
+
+# A bare EC2 type (no ml. prefix) is rejected by the endpoint_instance_type
+# validation at plan — the headline #761 rejection axis.
+run "inference_rejects_bad_instance_type" {
+  command = plan
+
+  variables {
+    project                = "test"
+    vpc_id                 = "vpc-12345"
+    subnet_ids             = ["subnet-aaa"]
+    enable_inference       = true
+    model_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    endpoint_instance_type = "m5.xlarge"
+  }
+
+  expect_failures = [var.endpoint_instance_type]
+}
+
+# A non-s3 model_data_url is rejected by the model_data_url validation.
+run "inference_rejects_bad_model_data_url" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url   = "https://not-s3.example.com/model.tar.gz"
+  }
+
+  expect_failures = [var.model_data_url]
+}
+
+# enable_inference=true with an empty model_image is rejected by the
+# aws_sagemaker_model precondition (cross-variable: only required when
+# inference is on, so it lives as a resource precondition, not a var
+# validation). Pins that SageMaker can't be asked to host an image-less model.
+run "inference_rejects_empty_model_image" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    # model_image deliberately left at its empty default.
+  }
+
+  expect_failures = [aws_sagemaker_model.inference]
+}

--- a/aws/sagemaker/tests/shape.tftest.hcl
+++ b/aws/sagemaker/tests/shape.tftest.hcl
@@ -566,6 +566,33 @@ run "inference_endpoint" {
     error_message = "Model-data policy must grant s3:GetObject on the artifact bucket."
   }
 
+  # --- IAM Resource SCOPING (#761 review P1-5) -------------------------------
+  # A mutation that widened the model-data statement to Resource = "*" survived
+  # all 24 shape runs because nothing asserted the scope. Pin both halves: the
+  # statement must name the scoped bucket ARN AND must NOT contain a bare
+  # `"Resource":"*"` (the S3 read must never be account-wide).
+  # Match on the partition-independent suffix (`:s3:::my-models`) — the
+  # mock_provider emits a random partition for data.aws_partition, so we can't
+  # pin the `aws` literal here; the bucket scope is what matters.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_model_data[0].policy, ":s3:::my-models")
+    error_message = "Model-data policy must scope s3:GetObject to the artifact bucket ARN (...:s3:::my-models...), not a wildcard."
+  }
+
+  assert {
+    condition     = !strcontains(replace(aws_iam_role_policy.inference_model_data[0].policy, " ", ""), "\"Resource\":\"*\"")
+    error_message = "Model-data policy must NOT grant Resource = \"*\" on the S3 read — that breaks least privilege (#761 P1-5)."
+  }
+
+  # ECR-pull statement repo scope: the layer/image reads must target a
+  # repository ARN. ecr:GetAuthorizationToken legitimately needs Resource "*",
+  # so we assert the repo ARN is present rather than asserting "no * anywhere".
+  # Partition-independent suffix (mock_provider randomizes the partition).
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_ecr_pull[0].policy, ":ecr:us-east-1:123456789012:repository/*")
+    error_message = "ECR-pull policy must scope BatchGetImage/GetDownloadUrlForLayer to the image's registry repos (in-account image → deploying account), not a bare wildcard (#761 P1-5)."
+  }
+
   # Observability alarms come up with the endpoint (enable_observability
   # defaults true), keyed on the endpoint name + primary variant.
   assert {
@@ -591,6 +618,49 @@ run "inference_endpoint" {
   assert {
     condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].dimensions["VariantName"] == "primary"
     error_message = "Alarm must key on the `primary` production variant."
+  }
+
+  # P2-8: pin the EndpointName dimension alongside VariantName so a mutation
+  # that dropped / mis-keyed the endpoint dimension fails (an alarm keyed only
+  # on VariantName would match every endpoint's primary variant).
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].dimensions["EndpointName"] == "test-endpoint"
+    error_message = "Alarm must key on the endpoint's name via the EndpointName dimension (#761 P2-8)."
+  }
+
+  # --- Alarm direction + statistic + default threshold (#761 review P1-6) ----
+  # An inverted comparison_operator (LessThan...) would make these alarms fire
+  # on healthy traffic and stay silent on the failure they exist to catch, and
+  # survived every prior run. Pin the operator, the statistic, and the default
+  # threshold on BOTH alarms.
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].comparison_operator == "GreaterThanThreshold"
+    error_message = "5XX alarm must fire when errors go ABOVE threshold (GreaterThanThreshold) — an inverted operator alarms on healthy traffic (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].statistic == "Sum"
+    error_message = "5XX alarm must aggregate errors with Sum (count of 5XX per period) (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].threshold == 1
+    error_message = "5XX alarm default threshold must be 1 (any sustained 5XX is actionable) (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].comparison_operator == "GreaterThanThreshold"
+    error_message = "Latency alarm must fire when latency goes ABOVE threshold (GreaterThanThreshold) (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].statistic == "Average"
+    error_message = "Latency alarm must aggregate with Average (mean ModelLatency per period) (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].threshold == 5000000
+    error_message = "Latency alarm default threshold must be 5_000_000µs (5s) (#761 P1-6)."
   }
 }
 
@@ -621,6 +691,44 @@ run "inference_endpoint_without_model_data" {
   assert {
     condition     = length(aws_iam_role_policy.inference_model_data) == 0
     error_message = "No S3 model-data policy may attach when model_data_url is omitted (least privilege)."
+  }
+}
+
+# Cross-account ECR registry scoping (#761 review MED-3). model_image accepts a
+# cross-account image — AWS Deep Learning Containers live in AWS-owned
+# registries (e.g. 763104351884) in the same region, NOT the deploying account.
+# The ECR-pull layer/image-read grant must be scoped to *that* registry's repos
+# or the pull 403s. Pins that the parsed cross-account registry id lands in the
+# repo ARN, and that the deploying account's id does NOT appear there.
+run "inference_ecr_pull_scopes_to_cross_account_dlc_registry" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    # AWS DLC registry account (763104351884), us-east-1. The deploying
+    # account in the mock is a different (mock) id; the repo ARN must carry
+    # 763104351884, not the deploying account.
+    model_image = "763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-tgi-inference:2.0-tgi"
+  }
+
+  # Partition-independent suffix (mock_provider randomizes data.aws_partition);
+  # the cross-account registry id (763104351884) is the load-bearing part.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_ecr_pull[0].policy, ":ecr:us-east-1:763104351884:repository/*")
+    error_message = "ECR-pull policy must scope layer/image reads to the cross-account DLC registry (763104351884) parsed from model_image, not the deploying account (#761 MED-3)."
+  }
+
+  # GetAuthorizationToken legitimately needs Resource "*" (the token isn't
+  # repo-scopable), so a bare "*" is expected in the auth-token statement.
+  # But the layer/image-read statement must be repo-scoped — assert the
+  # cross-account repo ARN is present so a regression to account-wide
+  # (deploying account) scoping fails here.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_ecr_pull[0].policy, "ecr:GetAuthorizationToken")
+    error_message = "ECR-pull policy must still grant ecr:GetAuthorizationToken on \"*\" (the auth token isn't repo-scopable)."
   }
 }
 
@@ -675,6 +783,94 @@ run "inference_rejects_bad_model_data_url" {
   }
 
   expect_failures = [var.model_data_url]
+}
+
+# A bare `s3://` (no bucket, no key) is rejected by the tightened
+# model_data_url validation (#761 review LOW-4). Before the tightening this
+# passed the `^s3://` regex but derived an empty bucket ARN that would 403 the
+# read at apply.
+run "inference_rejects_bare_s3_scheme" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url   = "s3://"
+  }
+
+  expect_failures = [var.model_data_url]
+}
+
+# Bucket-but-no-key (`s3://bucket/`) is also rejected — SageMaker needs the
+# object key to the model.tar.gz, not just a bucket (#761 review LOW-4).
+run "inference_rejects_s3_bucket_without_key" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url   = "s3://my-models/"
+  }
+
+  expect_failures = [var.model_data_url]
+}
+
+# Positive companion for the tightened validation: a full s3://<bucket>/<key>
+# URI still plans cleanly, so the negatives above can only fail for the right
+# reason (rejection-axis triangulation per #614).
+run "inference_full_s3_url_plans_cleanly" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url   = "s3://my-models/llm/model.tar.gz"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_model_data) == 1
+    error_message = "A full s3://<bucket>/<key> model_data_url must plan cleanly and attach the model-data policy (companion to the bare-s3:// / bucket-only rejects)."
+  }
+}
+
+# Gating run (#761 review P2-7): inference ON but observability OFF must
+# suppress BOTH alarms while still standing up the endpoint. Proves
+# enable_observability gates the alarms independently of enable_inference.
+run "inference_without_observability_suppresses_alarms" {
+  command = plan
+
+  variables {
+    project              = "test"
+    vpc_id               = "vpc-12345"
+    subnet_ids           = ["subnet-aaa"]
+    enable_inference     = true
+    enable_observability = false
+    model_image          = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.invocation_5xx_high) == 0
+    error_message = "5XX alarm must be suppressed when enable_observability=false even though inference is on (#761 P2-7)."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.model_latency_high) == 0
+    error_message = "Latency alarm must be suppressed when enable_observability=false even though inference is on (#761 P2-7)."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint.inference) == 1
+    error_message = "The endpoint must still be created when observability is disabled (the two flags are independent) (#761 P2-7)."
+  }
 }
 
 # enable_inference=true with an empty model_image is rejected by the

--- a/aws/sagemaker/variables.tf
+++ b/aws/sagemaker/variables.tf
@@ -113,6 +113,49 @@ variable "studio_users" {
 }
 
 # -----------------------------------------------------------------------------
+# Real-time inference endpoint (#761) — gated on enable_inference. When off,
+# the preset stays Studio-only (the #615 behavior); when on, it adds a
+# model + endpoint-configuration + endpoint trio hosting a servable container.
+# -----------------------------------------------------------------------------
+
+variable "enable_inference" {
+  description = "When true, provision a real-time inference slice (aws_sagemaker_model + aws_sagemaker_endpoint_configuration + aws_sagemaker_endpoint) hosting model_image. When false (default) the preset stays Studio-only and none of the inference resources are created. The Studio domain + execution role are always provisioned regardless."
+  type        = bool
+  default     = false
+}
+
+variable "model_image" {
+  description = "ECR / SageMaker container image URI for the model's primary container (e.g. a Deep Learning Container or an LLM serving image). Required (non-empty) when enable_inference is true — SageMaker cannot host a model without a servable container. Ignored when enable_inference is false."
+  type        = string
+  default     = ""
+}
+
+variable "model_data_url" {
+  description = "Optional S3 URI to the model artifact tarball (model.tar.gz) loaded into the container at startup. Leave empty for images that bundle their own weights (many LLM serving images pull from the hub at runtime). Only consumed when enable_inference is true."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.model_data_url == "" ? true : can(regex("^s3://", var.model_data_url))
+    error_message = "model_data_url must be an s3:// URI (or empty to let the container supply its own weights)."
+  }
+}
+
+variable "endpoint_instance_type" {
+  description = "Instance type for the real-time endpoint's production variant (e.g. ml.m5.xlarge, ml.g5.xlarge for GPU LLM serving). Must be an ml.* family — SageMaker hosting only accepts ml-prefixed instance types. Only consumed when enable_inference is true."
+  type        = string
+  default     = "ml.m5.xlarge"
+
+  validation {
+    # SageMaker hosting instance types are always ml.<family>.<size>. A bare
+    # EC2 type (m5.xlarge) or a typo is rejected at plan so callers don't
+    # discover it only when the endpoint create fails at apply.
+    condition     = can(regex("^ml\\.[a-z0-9]+\\.[a-z0-9]+$", var.endpoint_instance_type))
+    error_message = "endpoint_instance_type must be a SageMaker ml.* hosting instance type (e.g. ml.m5.xlarge, ml.g5.xlarge)."
+  }
+}
+
+# -----------------------------------------------------------------------------
 # IAM policy override
 # -----------------------------------------------------------------------------
 

--- a/aws/sagemaker/variables.tf
+++ b/aws/sagemaker/variables.tf
@@ -136,8 +136,13 @@ variable "model_data_url" {
   default     = ""
 
   validation {
-    condition     = var.model_data_url == "" ? true : can(regex("^s3://", var.model_data_url))
-    error_message = "model_data_url must be an s3:// URI (or empty to let the container supply its own weights)."
+    # Require a bucket AND a key, not a bare `s3://` (which would derive an
+    # empty bucket ARN and 403 the model-data read at apply). Bucket segment:
+    # 3-63 chars, lowercase alphanumeric / hyphen / dot, start+end
+    # alphanumeric (S3 naming). Key segment: at least one non-slash char so
+    # `s3://bucket/` (bucket but no object) is also rejected.
+    condition     = var.model_data_url == "" ? true : can(regex("^s3://[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]/.+", var.model_data_url))
+    error_message = "model_data_url must be a full s3://<bucket>/<key> URI pointing at the model artifact (or empty to let the container supply its own weights). A bare s3:// or bucket-only s3://<bucket>/ is rejected."
   }
 }
 

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -59,6 +59,13 @@ var AWSIAMActions = map[ComponentKey][]string{
 	// create. Specific create permissions catch the fail-fast surface
 	// before terraform hits AWS.
 	KeyAWSSageMaker: {
+		// CloudWatch alarms (#761 review MED-2). observability.tf creates the
+		// invocation-5XX + model-latency alarms by default (enable_observability
+		// defaults true) whenever inference is on, so the deploy principal needs
+		// PutMetricAlarm to create them and DeleteAlarms so `terraform destroy`
+		// can tear them down. Mirrors KeyAWSCloudWatchMonitoring's PutMetricAlarm.
+		"cloudwatch:DeleteAlarms",
+		"cloudwatch:PutMetricAlarm",
 		"iam:AttachRolePolicy",
 		"iam:CreateRole",
 		"iam:PassRole",

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -69,6 +69,14 @@ var AWSIAMActions = map[ComponentKey][]string{
 		"s3:PutEncryptionConfiguration",
 		"sagemaker:CreateDomain",
 		"sagemaker:CreateUserProfile",
+		// Real-time inference endpoint (#761). Only exercised when
+		// enable_inference is set, but listed unconditionally so the
+		// pre-deploy SimulatePrincipalPolicy check (ui-core #192) confirms
+		// the deploy principal can create the model / endpoint-config /
+		// endpoint trio before a deploy attempts it.
+		"sagemaker:CreateModel",
+		"sagemaker:CreateEndpointConfig",
+		"sagemaker:CreateEndpoint",
 	},
 	KeyAWSALB:                  {"elasticloadbalancing:CreateLoadBalancer", "elasticloadbalancing:CreateTargetGroup"},
 	KeyAWSCloudfront:           {"cloudfront:CreateDistribution"},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1344,6 +1344,23 @@ func (m DefaultMapper) BuildModuleValues(
 			if strings.TrimSpace(sm.SageMakerManagedPolicyARN) != "" {
 				vals["sagemaker_managed_policy_arn"] = strings.TrimSpace(sm.SageMakerManagedPolicyARN)
 			}
+			// Real-time inference (#761). enable_inference gates the model /
+			// endpoint-config / endpoint trio; the image / data URL /
+			// instance-type fields only matter when it's on, but emit each
+			// independently (same partial-config contract) so the preset
+			// default wins for any field the caller leaves zero.
+			if sm.EnableInference != nil {
+				vals["enable_inference"] = *sm.EnableInference
+			}
+			if strings.TrimSpace(sm.ModelImage) != "" {
+				vals["model_image"] = strings.TrimSpace(sm.ModelImage)
+			}
+			if strings.TrimSpace(sm.ModelDataURL) != "" {
+				vals["model_data_url"] = strings.TrimSpace(sm.ModelDataURL)
+			}
+			if strings.TrimSpace(sm.EndpointInstanceType) != "" {
+				vals["endpoint_instance_type"] = strings.TrimSpace(sm.EndpointInstanceType)
+			}
 		}
 
 	case KeyAWSCodeBuild:

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -190,6 +190,23 @@ func kitchenSinkConfig() *Config {
 		Instruction     string `json:"instruction,omitempty"`
 		AgentName       string `json:"agentName,omitempty"`
 	}{FoundationModel: "anthropic.claude-3-5-sonnet-20240620-v1:0", Instruction: "You are a helpful assistant that answers questions about the customer's documents.", AgentName: "support-agent"}
+	// AWSSageMaker exercises both the #615 Studio fields and the #761
+	// inference fields so the keys-subset gate confirms every emitted tfvar
+	// (network_mode … enable_inference / model_image / model_data_url /
+	// endpoint_instance_type) is a declared aws/sagemaker variable. Values
+	// are internally consistent with the preset's validations: EnableInference
+	// pairs with a non-empty model_image, an s3:// model_data_url, and an ml.*
+	// endpoint_instance_type so the config would also pass a real plan.
+	cfg.AWSSageMaker = &AWSSageMakerConfig{
+		NetworkMode:               "VpcOnly",
+		WorkspaceBucket:           "kitchen-sink-ml-bucket",
+		StudioUsers:               []string{"alice"},
+		SageMakerManagedPolicyARN: "arn:aws:iam::123456789012:policy/MyScopedSagemaker",
+		EnableInference:           &t,
+		ModelImage:                "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest",
+		ModelDataURL:              "s3://kitchen-sink-ml-bucket/model.tar.gz",
+		EndpointInstanceType:      "ml.g5.xlarge",
+	}
 	cfg.AWSRoute53 = &struct {
 		DomainName   string   `json:"domainName,omitempty"`
 		CreateZone   *bool    `json:"createZone,omitempty"`

--- a/pkg/composer/sagemaker_aws_wiring_test.go
+++ b/pkg/composer/sagemaker_aws_wiring_test.go
@@ -59,7 +59,7 @@ func TestMapper_AWSSageMaker_DefaultConfig(t *testing.T) {
 		"default subnet_ids should be a single-element preview stub list")
 
 	// Optional vars MUST be absent when caller didn't populate cfg.
-	for _, key := range []string{"network_mode", "workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn"} {
+	for _, key := range []string{"network_mode", "workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn", "enable_inference", "model_image", "model_data_url", "endpoint_instance_type"} {
 		_, has := vals[key]
 		require.Falsef(t, has,
 			"mapper must NOT emit %q when caller left cfg.AWSSageMaker nil — module default must win",
@@ -71,6 +71,7 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 	t.Parallel()
 
 	fd := true
+	ei := true
 	cfg := &Config{
 		AWSSageMaker: &AWSSageMakerConfig{
 			VPCID:                       "vpc-real",
@@ -80,6 +81,10 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 			WorkspaceBucketForceDestroy: &fd,
 			StudioUsers:                 []string{"alice", "bob"},
 			SageMakerManagedPolicyARN:   "arn:aws:iam::123456789012:policy/MyScopedSagemaker",
+			EnableInference:             &ei,
+			ModelImage:                  "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm:latest",
+			ModelDataURL:                "s3://my-bucket/model.tar.gz",
+			EndpointInstanceType:        "ml.g5.xlarge",
 		},
 	}
 	m := DefaultMapper{}
@@ -93,6 +98,51 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 	require.Equal(t, true, vals["workspace_bucket_force_destroy"])
 	require.Equal(t, []any{"alice", "bob"}, vals["studio_users"])
 	require.Equal(t, "arn:aws:iam::123456789012:policy/MyScopedSagemaker", vals["sagemaker_managed_policy_arn"])
+	require.Equal(t, true, vals["enable_inference"])
+	require.Equal(t, "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm:latest", vals["model_image"])
+	require.Equal(t, "s3://my-bucket/model.tar.gz", vals["model_data_url"])
+	require.Equal(t, "ml.g5.xlarge", vals["endpoint_instance_type"])
+}
+
+// TestMapper_AWSSageMaker_InferencePartialConfig pins that the inference
+// fields obey the same partial-config contract: setting only EnableInference
+// (e.g. a caller that wants the trio with the preset's default image-less
+// shape rejected at plan) emits enable_inference but leaves model_image /
+// model_data_url / endpoint_instance_type unset so the preset defaults / the
+// non-empty-image precondition own those. Catches a regression where the
+// mapper would emit empty strings that override the preset defaults.
+func TestMapper_AWSSageMaker_InferencePartialConfig(t *testing.T) {
+	t.Parallel()
+
+	ei := true
+	cfg := &Config{
+		AWSSageMaker: &AWSSageMakerConfig{
+			EnableInference: &ei,
+			// ModelImage / ModelDataURL / EndpointInstanceType intentionally
+			// left zero.
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSSageMaker, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, true, vals["enable_inference"])
+	for _, key := range []string{"model_image", "model_data_url", "endpoint_instance_type"} {
+		_, has := vals[key]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left it zero — module default must win",
+			key)
+	}
+
+	// And the false-path: EnableInference=&false must still emit
+	// enable_inference (an explicit deselect the preset must honor), not be
+	// dropped like an empty string.
+	ef := false
+	cfg2 := &Config{AWSSageMaker: &AWSSageMakerConfig{EnableInference: &ef}}
+	vals2, err := m.BuildModuleValues(KeyAWSSageMaker, &Components{}, cfg2, "demo", "us-east-1")
+	require.NoError(t, err)
+	require.Equal(t, false, vals2["enable_inference"],
+		"EnableInference=&false must emit enable_inference=false (explicit opt-out), not be dropped")
 }
 
 // TestMapper_AWSSageMaker_PartialConfig confirms that when only one
@@ -130,7 +180,7 @@ func TestMapper_AWSSageMaker_PartialConfig(t *testing.T) {
 	require.Equal(t, "vpc-00000000preview", vals["vpc_id"])
 	require.Equal(t, []any{"subnet-00000000preview"}, vals["subnet_ids"])
 
-	for _, key := range []string{"workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn"} {
+	for _, key := range []string{"workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn", "enable_inference", "model_image", "model_data_url", "endpoint_instance_type"} {
 		_, has := vals[key]
 		require.Falsef(t, has,
 			"mapper must NOT emit %q when caller left it zero — module default must win",
@@ -153,6 +203,9 @@ func TestMapper_AWSSageMaker_EmptyStringsIgnored(t *testing.T) {
 			WorkspaceBucket:           "   ",
 			StudioUsers:               []string{"alice", "  ", ""},
 			SageMakerManagedPolicyARN: "  ",
+			ModelImage:                "   ",
+			ModelDataURL:              "  ",
+			EndpointInstanceType:      "   ",
 		},
 	}
 	m := DefaultMapper{}
@@ -169,7 +222,8 @@ func TestMapper_AWSSageMaker_EmptyStringsIgnored(t *testing.T) {
 	require.Equal(t, []any{"alice"}, vals["studio_users"])
 
 	// Whitespace-only strings on optional scalar fields → not emitted at all.
-	for _, key := range []string{"network_mode", "workspace_bucket", "sagemaker_managed_policy_arn"} {
+	// enable_inference is a *bool (nil here) so it must also be absent.
+	for _, key := range []string{"network_mode", "workspace_bucket", "sagemaker_managed_policy_arn", "enable_inference", "model_image", "model_data_url", "endpoint_instance_type"} {
 		_, has := vals[key]
 		require.Falsef(t, has,
 			"mapper must NOT emit %q when caller supplied a whitespace-only string",
@@ -340,4 +394,14 @@ func TestAWSIAMPermissions_SageMakerCovered(t *testing.T) {
 		"S3 CreateBucket permission must be in the required set (preset-managed workspace bucket)")
 	require.Contains(t, required, "s3:PutBucketPublicAccessBlock",
 		"PutBucketPublicAccessBlock permission must be in the required set (security default on the workspace bucket)")
+
+	// Real-time inference endpoint (#761) — the model / endpoint-config /
+	// endpoint create permissions must be in the required set so the
+	// pre-deploy simulate catches a principal that can't host a model.
+	require.Contains(t, required, "sagemaker:CreateModel",
+		"SageMaker model create permission must be in the required set (#761 inference endpoint)")
+	require.Contains(t, required, "sagemaker:CreateEndpointConfig",
+		"SageMaker endpoint-config create permission must be in the required set (#761 inference endpoint)")
+	require.Contains(t, required, "sagemaker:CreateEndpoint",
+		"SageMaker endpoint create permission must be in the required set (#761 inference endpoint)")
 }

--- a/pkg/composer/sagemaker_aws_wiring_test.go
+++ b/pkg/composer/sagemaker_aws_wiring_test.go
@@ -404,4 +404,14 @@ func TestAWSIAMPermissions_SageMakerCovered(t *testing.T) {
 		"SageMaker endpoint-config create permission must be in the required set (#761 inference endpoint)")
 	require.Contains(t, required, "sagemaker:CreateEndpoint",
 		"SageMaker endpoint create permission must be in the required set (#761 inference endpoint)")
+
+	// CloudWatch alarm permissions (#761 review MED-2). observability.tf
+	// creates the invocation-5XX + model-latency alarms by default whenever
+	// inference is on; the deploy principal needs PutMetricAlarm to create
+	// them and DeleteAlarms so destroy can clean them up. Without these the
+	// pre-deploy simulate passes but the alarm create/destroy 403s.
+	require.Contains(t, required, "cloudwatch:PutMetricAlarm",
+		"CloudWatch PutMetricAlarm must be in the required set (observability alarms created by default — #761 MED-2)")
+	require.Contains(t, required, "cloudwatch:DeleteAlarms",
+		"CloudWatch DeleteAlarms must be in the required set so terraform destroy can tear down the observability alarms (#761 MED-2)")
 }

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -558,6 +558,18 @@ type AWSSageMakerConfig struct {
 	WorkspaceBucketForceDestroy *bool    `json:"workspaceBucketForceDestroy,omitempty"`
 	StudioUsers                 []string `json:"studioUsers,omitempty"`
 	SageMakerManagedPolicyARN   string   `json:"sagemakerManagedPolicyArn,omitempty"`
+
+	// Real-time inference endpoint (#761). When EnableInference is set, the
+	// preset adds an aws_sagemaker_model + endpoint-configuration + endpoint
+	// trio hosting ModelImage. The Studio domain stays unconditional.
+	// ModelImage is required (validated non-empty in the preset) when
+	// inference is on; ModelDataURL is optional (images may bundle weights).
+	// Unset / nil fields defer to the preset's variables.tf defaults, same
+	// partial-config contract as every other field above.
+	EnableInference      *bool  `json:"enableInference,omitempty"`
+	ModelImage           string `json:"modelImage,omitempty"`
+	ModelDataURL         string `json:"modelDataUrl,omitempty"`
+	EndpointInstanceType string `json:"endpointInstanceType,omitempty"`
 }
 
 // AWSCodeBuildConfig is the caller-facing config for the aws/codebuild

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -308,6 +308,25 @@ var awsServiceMetrics = map[string]AWSObs{
 			{Name: "PassedRequests", Stat: "Sum"},
 		},
 	},
+	// SageMaker real-time inference endpoint invocation metrics (#761).
+	// Published under the AWS/SageMaker namespace from InvokeEndpoint calls,
+	// keyed by EndpointName (+ VariantName, which the panel doesn't dimension
+	// on — the endpoint has a single "primary" variant). Metric names verified
+	// against the AWS/SageMaker endpoint-invocation metric table, NOT memory
+	// (the #764 metric-name regression). ModelLatency / OverheadLatency are in
+	// MICROSECONDS. Only present on stacks with enable_inference=true; a
+	// Studio-only deploy publishes none of these.
+	"sagemaker": {
+		Namespace:     "AWS/SageMaker",
+		DimensionName: "EndpointName",
+		Metrics: []AWSMetricSpec{
+			{Name: "Invocations", Stat: "Sum"},
+			{Name: "ModelLatency", Stat: "Average"},
+			{Name: "OverheadLatency", Stat: "Average"},
+			{Name: "Invocation4XXErrors", Stat: "Sum"},
+			{Name: "Invocation5XXErrors", Stat: "Sum"},
+		},
+	},
 }
 
 // gcpServiceMetrics is the per-service catalog ported from the InsideOut backend's
@@ -552,7 +571,13 @@ var alarmedAWSMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyAWSMSK:          {Module: "aws/msk", Metrics: []string{"OfflinePartitionsCount"}},
 	composer.KeyAWSOpenSearch:   {Module: "aws/opensearch", Metrics: []string{"ClusterStatus.red"}},
 	composer.KeyAWSRDS:          {Module: "aws/rds", Metrics: []string{"CPUUtilization", "FreeStorageSpace"}},
-	composer.KeyAWSSQS:          {Module: "aws/sqs", Metrics: []string{"ApproximateNumberOfMessagesVisible"}},
+	// SageMaker real-time inference endpoint alarms (#761). Invocation5XXErrors
+	// (the model is failing requests) + ModelLatency (the model is responding
+	// slowly). Both alarms only exist on stacks with enable_inference=true;
+	// the gate in aws/sagemaker/observability.tf for_each-suppresses them
+	// otherwise, but the metric_name strings still match this catalog.
+	composer.KeyAWSSageMaker: {Module: "aws/sagemaker", Metrics: []string{"Invocation5XXErrors", "ModelLatency"}},
+	composer.KeyAWSSQS:       {Module: "aws/sqs", Metrics: []string{"ApproximateNumberOfMessagesVisible"}},
 }
 
 // alarmedGCPMetrics is the GCP analogue. Metric strings match


### PR DESCRIPTION
Part of #755 (AWS AI stack), Phase 2 / Layer L3. Deepens the existing `aws/sagemaker` key (Studio-only today) with a real-time inference slice for model serving.

Closes #761
Part of #755

## What

When `enable_inference` is set, the preset adds an `aws_sagemaker_model` + `aws_sagemaker_endpoint_configuration` + `aws_sagemaker_endpoint` trio hosting a servable container. The Studio domain + execution role stay unconditional, so existing Studio-only deploys are unchanged.

## Preset (`aws/sagemaker/`)

- `main.tf`: model / endpoint-config / endpoint gated on `var.enable_inference`. Execution-role ECR-pull policy + S3 model-data read (attached only when `model_data_url` is supplied — least privilege). Non-empty `model_image` enforced via a resource `precondition` (cross-variable, so not a var validation).
- `variables.tf`: `enable_inference`, `model_image`, `model_data_url` (s3:// validation), `endpoint_instance_type` (ml.* validation).
- `outputs.tf`: `endpoint_name` / `endpoint_arn` / `model_name` / `endpoint_config_name` (null when inference off).
- `observability.tf`: `Invocation5XXErrors` + `ModelLatency` alarms keyed on `EndpointName` + `VariantName`, gated on the endpoint existing.

Note: the aws provider 6.x `aws_sagemaker_endpoint` resource exposes no configurable `timeouts` block (verified against `terraform providers schema`); the create still blocks on the provider's built-in InService wait. Metric names verified against the AWS/SageMaker endpoint-invocation docs, not memory.

## Composer

- `AWSSageMakerConfig` gains `EnableInference *bool` + `ModelImage` / `ModelDataURL` / `EndpointInstanceType`, emitted via the partial-config pattern (preset default wins for unset fields).
- `iam_actions`: add `sagemaker:CreateModel` / `CreateEndpointConfig` / `CreateEndpoint` so the pre-deploy simulate covers the inference trio.
- `kitchenSinkConfig` now populates `AWSSageMaker` (internally consistent) so the keys-subset gate exercises the new tfvars.
- New `sagemaker` AWS observability service group + `KeyAWSSageMaker` in `alarmedAWSMetrics`.
- No contracts / wiring change (VPC hard-dep already exists).

## Tests

- `shape.tftest.hcl`: inference trio, Studio-unchanged-when-unset, no-model-data least-privilege path, alarm wiring, and `expect_failures` on bad instance type / bad model_data_url / empty model_image.
- `integration.tftest.hcl`: CI-skipped live apply (stands up a VPC, applies the endpoint to InService). Needs an operator-supplied servable image URI — header documents the required `-var model_image=...`. NOT run here (no creds assumed).
- Mapper partial-config / empty-string / inference-partial tests.

## Local verification

- `terraform test` (aws/sagemaker shape): 24 passed.
- `go test ./pkg/composer ./pkg/observability`: 1777 passed.
- `terraform fmt -check`, `go vet`, `gofmt -l`, tag-lint: clean.
- Mutation-tested the load-bearing assertions (metric-name typo, enable_inference gate, mapper field emission) — each fails red then restores green.