### PR TITLE
perf(reverse-import): raise terraform plan/refresh parallelism + adaptive provider retries (ui-core#420)

### DIFF
--- a/cmd/insideout-import/driftfix/driftfix.go
+++ b/cmd/insideout-import/driftfix/driftfix.go
@@ -39,12 +39,39 @@ const planFile = "driftfix.tfplan"
 // spinning on an attr we can't patch.
 const defaultMaxIterations = 5
 
+// DefaultParallelism is the `-parallelism=<n>` value each drift-convergence
+// `terraform plan` runs at when Options.Parallelism is unset (<= 0). 25
+// matches genconfig.DefaultGenconfigParallelism so the whole reverse-import
+// readback path runs at one consistent, throttle-tuned concurrency rather
+// than a phase-by-phase mix. driftfix is a small absolute slice of the run
+// (≈3m of the measured 1h41m job; luthersystems/ui-core#420) so this is for
+// consistency, not the primary win — but every driftfix plan is the same
+// read-only AWS refresh genconfig does, and the same emitted provider
+// retry_mode = "adaptive" / max_retries tuning backstops the raised
+// concurrency with throttle backoff instead of failures.
+const DefaultParallelism = 25
+
+// parallelismOrDefault returns Options.Parallelism, falling back to
+// DefaultParallelism for the unset (<= 0) zero value so callers stay
+// source-compatible without explicit field-init.
+func (opts Options) parallelismOrDefault() int {
+	if opts.Parallelism <= 0 {
+		return DefaultParallelism
+	}
+	return opts.Parallelism
+}
+
 // Options is the input to Run. Workdir must be the same directory that
 // genconfig.Run produced — driftfix expects generated.tf, providers.tf,
 // imports.tf, and the .terraform dir already in place.
 type Options struct {
 	Workdir       string
 	MaxIterations int
+	// Parallelism overrides the `-parallelism=<n>` flag passed to each
+	// drift-convergence `terraform plan`. 0 (the zero value) uses
+	// DefaultParallelism. See that constant for the throttle-safety
+	// rationale.
+	Parallelism int
 	// Runner is optional; nil means "construct an execRunner from PATH."
 	Runner terraformRunner
 
@@ -154,8 +181,8 @@ func runStack(ctx context.Context, opts Options, stackDir string, out io.Writer)
 	alreadyEscalated := map[string]map[string]struct{}{}
 
 	for iter := 1; iter <= opts.MaxIterations; iter++ {
-		progressf(opts.Stdout, "driftfix: iteration %d: running terraform plan…\n", iter)
-		hasChanges, err := runner.PlanTo(ctx, planPath)
+		progressf(opts.Stdout, "driftfix: iteration %d: running terraform plan (parallelism=%d)…\n", iter, opts.parallelismOrDefault())
+		hasChanges, err := runner.PlanTo(ctx, planPath, opts.parallelismOrDefault())
 		if err != nil {
 			return nil, fmt.Errorf("driftfix iter %d: terraform plan: %w", iter, err)
 		}

--- a/cmd/insideout-import/driftfix/driftfix_test.go
+++ b/cmd/insideout-import/driftfix/driftfix_test.go
@@ -29,11 +29,16 @@ type scriptedRunner struct {
 	showCalls     int
 	validateCalls int
 	calls         []string
+	// lastParallelism records the -parallelism the most recent PlanTo ran
+	// at, so tests can assert Options.Parallelism (defaulted) reaches the
+	// runner (luthersystems/ui-core#420).
+	lastParallelism int
 }
 
-func (r *scriptedRunner) PlanTo(_ context.Context, planFile string) (bool, error) {
+func (r *scriptedRunner) PlanTo(_ context.Context, planFile string, parallelism int) (bool, error) {
 	r.calls = append(r.calls, "plan")
 	r.planCalls++
+	r.lastParallelism = parallelism
 	if r.planErr != nil {
 		return false, r.planErr
 	}
@@ -130,6 +135,40 @@ func TestRun_EmptyPlanFirstIterationReturnsImmediately(t *testing.T) {
 	}
 }
 
+// TestRun_ThreadsParallelismToPlan pins that Options.Parallelism (and its
+// default) reaches the drift-convergence PlanTo end-to-end through Run
+// (luthersystems/ui-core#420). TestPlanToOpts guards the arg builder; this
+// guards the wiring.
+func TestRun_ThreadsParallelismToPlan(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFixture(t, dir)
+		runner := &scriptedRunner{plansByCall: []*tfjson.Plan{emptyPlan()}}
+		if _, err := Run(context.Background(), Options{Workdir: dir, Runner: runner}); err != nil {
+			t.Fatal(err)
+		}
+		if runner.lastParallelism != DefaultParallelism {
+			t.Errorf("plan ran at -parallelism=%d, want default %d", runner.lastParallelism, DefaultParallelism)
+		}
+	})
+
+	t.Run("explicit override", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFixture(t, dir)
+		runner := &scriptedRunner{plansByCall: []*tfjson.Plan{emptyPlan()}}
+		if _, err := Run(context.Background(), Options{Workdir: dir, Parallelism: 42, Runner: runner}); err != nil {
+			t.Fatal(err)
+		}
+		if runner.lastParallelism != 42 {
+			t.Errorf("plan ran at -parallelism=%d, want explicit 42", runner.lastParallelism)
+		}
+	})
+}
+
 // TestRun_ImportOnlyPlanReturnsClean pins the post-2b convergence
 // shape: terraform-exec's Plan reports hasChanges=true for any plan
 // that imports resources, even when there's no actual drift. The loop
@@ -178,9 +217,10 @@ type alwaysHasChangesRunner struct {
 	scriptedRunner
 }
 
-func (r *alwaysHasChangesRunner) PlanTo(_ context.Context, planFile string) (bool, error) {
+func (r *alwaysHasChangesRunner) PlanTo(_ context.Context, planFile string, parallelism int) (bool, error) {
 	r.calls = append(r.calls, "plan")
 	r.planCalls++
+	r.lastParallelism = parallelism
 	idx := r.planCalls - 1
 	if idx >= len(r.plansByCall) {
 		return false, nil

--- a/cmd/insideout-import/driftfix/runner.go
+++ b/cmd/insideout-import/driftfix/runner.go
@@ -20,9 +20,11 @@ import (
 // just produced. The runner's only job is to drive plan-and-show cycles
 // and re-validate after each patch.
 type terraformRunner interface {
-	// PlanTo runs `terraform plan -out=<planFile>`. Returns hasChanges =
-	// true iff the plan contains a non-no-op resource change.
-	PlanTo(ctx context.Context, planFile string) (hasChanges bool, err error)
+	// PlanTo runs `terraform plan -out=<planFile> -parallelism=<parallelism>`.
+	// Returns hasChanges = true iff the plan contains a non-no-op resource
+	// change. parallelism is the resolved (already defaulted) value the
+	// refresh should run at; see driftfix.DefaultParallelism.
+	PlanTo(ctx context.Context, planFile string, parallelism int) (hasChanges bool, err error)
 	// ShowPlan decodes a binary plan file into the typed tfjson.Plan
 	// shape so the patch pass can walk ResourceChanges.
 	ShowPlan(ctx context.Context, planFile string) (*tfjson.Plan, error)
@@ -78,7 +80,7 @@ func newExecRunner(workdir string, stream io.Writer) (*execRunner, error) {
 	return &execRunner{tf: tf, stream: stream}, nil
 }
 
-func (r *execRunner) PlanTo(ctx context.Context, planFile string) (bool, error) {
+func (r *execRunner) PlanTo(ctx context.Context, planFile string, parallelism int) (bool, error) {
 	// Stream the human-readable `terraform plan` diff to the live log for
 	// THIS call only. ShowPlan/Validate emit -json on stdout and
 	// terraform-exec shares one stdout across commands, so restore
@@ -89,7 +91,18 @@ func (r *execRunner) PlanTo(ctx context.Context, planFile string) (bool, error) 
 		r.tf.SetStdout(r.stream)
 		defer r.tf.SetStdout(io.Discard)
 	}
-	return r.tf.Plan(ctx, tfexec.Out(planFile))
+	return r.tf.Plan(ctx, planToOpts(planFile, parallelism)...)
+}
+
+// planToOpts is the pure builder for the drift-convergence plan's tfexec
+// options. Factored out so a unit test can assert this path always passes
+// `-parallelism` (tfexec.Parallelism) alongside the plan-out target without a
+// real terraform binary, mirroring genconfig.planGenerateOpts.
+func planToOpts(planFile string, parallelism int) []tfexec.PlanOption {
+	return []tfexec.PlanOption{
+		tfexec.Out(planFile),
+		tfexec.Parallelism(parallelism),
+	}
 }
 
 func (r *execRunner) ShowPlan(ctx context.Context, planFile string) (*tfjson.Plan, error) {

--- a/cmd/insideout-import/driftfix/runner_test.go
+++ b/cmd/insideout-import/driftfix/runner_test.go
@@ -5,12 +5,52 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestPlanToOpts guards that the drift-convergence plan keeps its
+// tfexec.Parallelism option (luthersystems/ui-core#420). Mirrors
+// genconfig.TestPlanGenerateOpts: a real terraform run would still pass
+// without the flag (just at default-10), so only this assertion catches its
+// removal.
+func TestPlanToOpts(t *testing.T) {
+	t.Parallel()
+
+	const planFile = "/tmp/driftfix.tfplan"
+	const parallelism = 25
+	opts := planToOpts(planFile, parallelism)
+
+	require.Contains(t, opts, tfexec.Out(planFile), "driftfix plan must keep its -out target")
+
+	var foundParallelism bool
+	for _, o := range opts {
+		if reflect.DeepEqual(o, tfexec.Parallelism(parallelism)) {
+			foundParallelism = true
+		}
+	}
+	require.True(t, foundParallelism,
+		"driftfix plan must pass tfexec.Parallelism(%d) (ui-core#420)", parallelism)
+}
+
+// TestDefaultParallelism + TestOptionsParallelismOrDefault pin the default and
+// its fallback, matching genconfig's guards.
+func TestDefaultParallelism(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, 25, DefaultParallelism)
+}
+
+func TestOptionsParallelismOrDefault(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, DefaultParallelism, Options{}.parallelismOrDefault(), "zero value defaults")
+	assert.Equal(t, DefaultParallelism, Options{Parallelism: -1}.parallelismOrDefault(), "negative defaults")
+	assert.Equal(t, 30, Options{Parallelism: 30}.parallelismOrDefault(), "explicit positive honored")
+}
 
 // builtinProviderStack uses only the builtin terraform_data resource
 // (terraform.io/builtin/terraform), so `terraform init` and `plan` both
@@ -59,7 +99,7 @@ func TestExecRunner_JSONCaptureDoesNotLeakToStream(t *testing.T) {
 	// PlanTo writes a binary plan; ShowPlan decodes it via `show -json`, which
 	// captures its JSON payload on stdout internally.
 	planFile := filepath.Join(workdir, "tfplan.bin")
-	_, err = runner.PlanTo(ctx, planFile)
+	_, err = runner.PlanTo(ctx, planFile, DefaultParallelism)
 	require.NoError(t, err)
 	plan, err := runner.ShowPlan(ctx, planFile)
 	require.NoError(t, err)
@@ -110,7 +150,7 @@ func TestExecRunner_PlanStreamsHumanDiffToStream(t *testing.T) {
 	// version-dependent, and it isn't what this test verifies. The streamed
 	// plan text below is the actual contract — PlanTo routes terraform's
 	// stdout to the live log.
-	_, err = runner.PlanTo(ctx, planFile)
+	_, err = runner.PlanTo(ctx, planFile, DefaultParallelism)
 	require.NoError(t, err)
 
 	streamed := stream.String()

--- a/cmd/insideout-import/genconfig/emit.go
+++ b/cmd/insideout-import/genconfig/emit.go
@@ -150,6 +150,7 @@ func emitProviders(dir string, opts providerEmitOptions) error {
 // default provider and every aliased per-region provider render identically.
 func configureAWSProviderBody(b *hclwrite.Body, region string, opts providerEmitOptions) {
 	b.SetAttributeValue("region", cty.StringVal(region))
+	appendAWSRetryTuning(b)
 	if opts.AWSEndpointURL != "" {
 		b.SetAttributeValue("access_key", cty.StringVal("test"))
 		b.SetAttributeValue("secret_key", cty.StringVal("test"))
@@ -163,6 +164,34 @@ func configureAWSProviderBody(b *hclwrite.Body, region string, opts providerEmit
 		}
 	}
 	appendAWSAssumeRole(b, opts.AWSAuth)
+}
+
+// awsProviderMaxRetries is the `max_retries` value emitted on every generated
+// AWS provider block. It equals the AWS provider's own documented default
+// (25), so it is functionally a no-op against today's provider — but emitting
+// it explicitly (a) documents the throttle-resilience intent at the call site
+// and (b) survives any future provider default change. Deliberately NOT
+// lowered (e.g. to 10): the genconfig readback runs at a raised
+// -parallelism (genconfig.DefaultGenconfigParallelism = 25), so the provider
+// must keep at least its default retry budget for the extra concurrent reads
+// to degrade to backoff rather than ThrottlingException failures.
+const awsProviderMaxRetries = 25
+
+// appendAWSRetryTuning emits `retry_mode = "adaptive"` and `max_retries`
+// onto an AWS provider block so the raised plan/refresh -parallelism degrades
+// to throttle backoff instead of failures (luthersystems/ui-core#420).
+//
+// retry_mode = "adaptive" switches the AWS SDK from the default "standard"
+// retryer to the adaptive one: a client-side token-bucket rate limiter that
+// measures throttle responses and paces subsequent calls, so a burst of
+// concurrent Describe/Get reads from the raised parallelism is smoothed back
+// toward the account's real API budget rather than surfacing as a hard
+// ThrottlingException. Both attributes are top-level provider arguments
+// supported by the pinned hashicorp/aws ~> 6.0 provider (retry_mode has been
+// a provider argument since v5.32; max_retries since the SDKv2 migration).
+func appendAWSRetryTuning(b *hclwrite.Body) {
+	b.SetAttributeValue("retry_mode", cty.StringVal("adaptive"))
+	b.SetAttributeValue("max_retries", cty.NumberIntVal(awsProviderMaxRetries))
 }
 
 func appendAWSAssumeRole(body *hclwrite.Body, auth awsProviderAuth) {

--- a/cmd/insideout-import/genconfig/emit_test.go
+++ b/cmd/insideout-import/genconfig/emit_test.go
@@ -129,10 +129,24 @@ func TestEmitProviders_HappyPath(t *testing.T) {
 		"required_providers",
 		`source  = "hashicorp/aws"`,
 		`version = "~> 6.0"`,
-		`region = "us-west-2"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("providers.tf missing %q\n--- got ---\n%s", want, got)
+		}
+	}
+	// hclwrite aligns the `=` columns across the provider block, so match the
+	// region + retry-tuning attrs value-anchored (the retry attrs widen the
+	// gutter). retry_mode = "adaptive" + max_retries are the throttle-safety
+	// pairing for the raised genconfig readback parallelism
+	// (luthersystems/ui-core#420): without them the higher concurrency would
+	// trade wall-clock for ThrottlingException failures.
+	for _, pat := range []string{
+		`region\s*=\s*"us-west-2"`,
+		`retry_mode\s*=\s*"adaptive"`,
+		`max_retries\s*=\s*25`,
+	} {
+		if !regexp.MustCompile(pat).MatchString(got) {
+			t.Errorf("providers.tf missing pattern %q\n--- got ---\n%s", pat, got)
 		}
 	}
 	// LocalStack-only attrs must NOT appear when endpointURL is "".

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -76,6 +76,13 @@ type Options struct {
 	// behavior). Ignored when Runner is injected.
 	Stdout io.Writer
 
+	// Parallelism overrides the `-parallelism=<n>` flag passed to the
+	// `terraform plan -generate-config-out` readback. 0 (the zero value)
+	// uses DefaultGenconfigParallelism. See that constant for the
+	// throttle-safety rationale binding the raised concurrency to the
+	// emitted provider's adaptive retry/backoff.
+	Parallelism int
+
 	// newRunner builds a terraformRunner for a specific region subdir on the
 	// multi-region path, so each concurrent region gets its own runner
 	// instance rather than sharing one (production runs one execRunner per
@@ -83,6 +90,39 @@ type Options struct {
 	// Unexported: production callers never set it — they want the real
 	// execRunner — and only the package's own tests inject per-subdir fakes.
 	newRunner func(workdir string, stdout io.Writer) (terraformRunner, error)
+}
+
+// DefaultGenconfigParallelism is the `-parallelism=<n>` value the genconfig
+// `terraform plan -generate-config-out` readback runs at when Options.
+// Parallelism is unset (<= 0).
+//
+// Why 25 (terraform's own default is 10): the genconfig readback is the
+// dominant cost of a large reverse import — on a measured 481-resource job it
+// was ≈1h32m of a 1h41m run (~91%; see luthersystems/ui-core#420). That phase
+// is `terraform plan -generate-config-out` refreshing every imported resource
+// via AWS Describe/Get reads; it is strictly read-only (plan/refresh, no
+// apply), so raising parallelism just issues more concurrent AWS reads with no
+// mutation risk. 25 ≈ 2.5x the terraform default, the leverage point the
+// ticket sized.
+//
+// Throttle safety: raised parallelism MUST degrade to backoff, not failures.
+// The emitted provider config pairs this with retry_mode = "adaptive" +
+// max_retries = 25 (see emit.go / providers.go), so the AWS SDK's adaptive
+// client-side rate limiter throttles the extra concurrent reads back into a
+// token-bucket-paced stream instead of surfacing ThrottlingException. Without
+// that pairing this default would trade wall-clock for flaky throttle
+// failures; with it, the worst case is the readback degrading back toward the
+// serialized rate, never an error.
+const DefaultGenconfigParallelism = 25
+
+// parallelismOrDefault returns Options.Parallelism, falling back to
+// DefaultGenconfigParallelism for the unset (<= 0) zero value so callers stay
+// source-compatible without explicit field-init. Mirrors providerOrDefault.
+func (opts Options) parallelismOrDefault() int {
+	if opts.Parallelism <= 0 {
+		return DefaultGenconfigParallelism
+	}
+	return opts.Parallelism
 }
 
 // buildRunner returns the terraformRunner to drive the stack in opts.Workdir,
@@ -440,8 +480,8 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 	}
 
 	generatedPath := filepath.Join(opts.Workdir, generatedFile)
-	progressf(opts.Stdout, "genconfig: %s: terraform plan -generate-config-out…\n", scope)
-	if _, err := runner.PlanGenerate(ctx, generatedPath); err != nil {
+	progressf(opts.Stdout, "genconfig: %s: terraform plan -generate-config-out (parallelism=%d)…\n", scope, opts.parallelismOrDefault())
+	if _, err := runner.PlanGenerate(ctx, generatedPath, opts.parallelismOrDefault()); err != nil {
 		// `terraform plan -generate-config-out` writes generated.tf and
 		// then immediately validates the result. For resource types like
 		// aws_lambda_function the validation fails — the AtLeastOneOf

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -41,6 +41,11 @@ type fakeRunner struct {
 	validateCalled  int
 	schemaCalled    int
 	versionCalled   int
+	// lastParallelism records the -parallelism value the readback was
+	// invoked with on the most recent PlanGenerate, so tests can assert the
+	// genconfig path threads Options.Parallelism (defaulted) through to the
+	// runner (luthersystems/ui-core#420).
+	lastParallelism int
 }
 
 // Version models the tfenv warm-up call (#724). The single-region path never
@@ -57,10 +62,11 @@ func (f *fakeRunner) Init(_ context.Context) error {
 	return f.initErr
 }
 
-func (f *fakeRunner) PlanGenerate(_ context.Context, generatedPath string) (bool, error) {
+func (f *fakeRunner) PlanGenerate(_ context.Context, generatedPath string, parallelism int) (bool, error) {
 	f.calls = append(f.calls, "plan")
 	f.planCalled++
 	f.generatedPath = generatedPath
+	f.lastParallelism = parallelism
 	if f.planErr != nil {
 		return false, f.planErr
 	}
@@ -97,10 +103,11 @@ type recoveringFakeRunner struct {
 	planError error
 }
 
-func (r *recoveringFakeRunner) PlanGenerate(ctx context.Context, generatedPath string) (bool, error) {
+func (r *recoveringFakeRunner) PlanGenerate(ctx context.Context, generatedPath string, parallelism int) (bool, error) {
 	r.calls = append(r.calls, "plan")
 	r.planCalled++
 	r.generatedPath = generatedPath
+	r.lastParallelism = parallelism
 	// Write the body first, THEN return the error — the order matters.
 	_ = os.WriteFile(generatedPath, []byte(r.planBody), 0o644)
 	return false, r.planError
@@ -193,6 +200,52 @@ func TestRun_HappyPath(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, providersFile)); err != nil {
 		t.Errorf("providers.tf missing: %v", err)
 	}
+}
+
+// TestRun_ThreadsParallelismToReadback pins that Options.Parallelism (and its
+// default) reaches the readback PlanGenerate call end-to-end through Run, not
+// just inside the pure arg builder (luthersystems/ui-core#420). The
+// default-10 bottleneck the ticket measured was exactly a missing
+// -parallelism on this call; this guards the wiring, TestPlanGenerateOpts
+// guards the arg construction.
+func TestRun_ThreadsParallelismToReadback(t *testing.T) {
+	t.Parallel()
+	mkRunner := func() *fakeRunner {
+		return &fakeRunner{
+			planBody: `resource "aws_sqs_queue" "x" {
+  name = "alpha"
+}
+`,
+			schemas: minimalAWSSchema(),
+		}
+	}
+	resources := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.x", ImportID: "id-x"}},
+	}
+
+	t.Run("default", func(t *testing.T) {
+		t.Parallel()
+		runner := mkRunner()
+		_, err := Run(context.Background(), Options{Workdir: t.TempDir(), Region: "us-east-1", Runner: runner}, resources)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runner.lastParallelism != DefaultGenconfigParallelism {
+			t.Errorf("readback ran at -parallelism=%d, want default %d", runner.lastParallelism, DefaultGenconfigParallelism)
+		}
+	})
+
+	t.Run("explicit override", func(t *testing.T) {
+		t.Parallel()
+		runner := mkRunner()
+		_, err := Run(context.Background(), Options{Workdir: t.TempDir(), Region: "us-east-1", Parallelism: 37, Runner: runner}, resources)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runner.lastParallelism != 37 {
+			t.Errorf("readback ran at -parallelism=%d, want explicit 37", runner.lastParallelism)
+		}
+	})
 }
 
 func TestRun_StreamsMilestoneProgressToStdout(t *testing.T) {
@@ -764,10 +817,11 @@ type regionAwareRunner struct {
 	fakeRunner
 }
 
-func (r *regionAwareRunner) PlanGenerate(_ context.Context, generatedPath string) (bool, error) {
+func (r *regionAwareRunner) PlanGenerate(_ context.Context, generatedPath string, parallelism int) (bool, error) {
 	r.calls = append(r.calls, "plan")
 	r.planCalled++
 	r.generatedPath = generatedPath
+	r.lastParallelism = parallelism
 	importsTF, err := os.ReadFile(filepath.Join(filepath.Dir(generatedPath), importsFile))
 	if err != nil {
 		return false, err
@@ -830,7 +884,10 @@ func TestRun_MultiRegion(t *testing.T) {
 			t.Errorf("missing per-region providers.tf for %s: %v", region, err)
 			continue
 		}
-		if !strings.Contains(string(prov), `region = "`+wantRegion+`"`) {
+		// hclwrite aligns the `=` columns across all provider attributes, so
+		// the retry-tuning attrs (retry_mode/max_retries) widen the region
+		// gutter — match value-anchored rather than on a fixed gutter width.
+		if !regexp.MustCompile(`region\s*=\s*"` + regexp.QuoteMeta(wantRegion) + `"`).Match(prov) {
 			t.Errorf("%s providers.tf not pinned to %s:\n%s", region, wantRegion, prov)
 		}
 		if strings.Contains(string(prov), "alias") {
@@ -853,10 +910,11 @@ type orphanProneRegionRunner struct {
 	orphans map[string]struct{}
 }
 
-func (r *orphanProneRegionRunner) PlanGenerate(_ context.Context, generatedPath string) (bool, error) {
+func (r *orphanProneRegionRunner) PlanGenerate(_ context.Context, generatedPath string, parallelism int) (bool, error) {
 	r.calls = append(r.calls, "plan")
 	r.planCalled++
 	r.generatedPath = generatedPath
+	r.lastParallelism = parallelism
 	importsTF, err := os.ReadFile(filepath.Join(filepath.Dir(generatedPath), importsFile))
 	if err != nil {
 		return false, err

--- a/cmd/insideout-import/genconfig/runner.go
+++ b/cmd/insideout-import/genconfig/runner.go
@@ -23,11 +23,13 @@ type terraformRunner interface {
 	// binary (#724). Running version once forces that install serially.
 	Version(ctx context.Context) error
 	Init(ctx context.Context) error
-	// PlanGenerate runs `terraform plan -generate-config-out=<path>` and
-	// returns whether the plan has changes (which it always does for a fresh
-	// import — generate-config-out only fires when there's something to
-	// generate).
-	PlanGenerate(ctx context.Context, generatedPath string) (changes bool, err error)
+	// PlanGenerate runs `terraform plan -generate-config-out=<path>
+	// -parallelism=<parallelism>` and returns whether the plan has changes
+	// (which it always does for a fresh import — generate-config-out only
+	// fires when there's something to generate). parallelism is the resolved
+	// (already defaulted) value the readback should refresh resources at; see
+	// genconfig.DefaultGenconfigParallelism.
+	PlanGenerate(ctx context.Context, generatedPath string, parallelism int) (changes bool, err error)
 	Validate(ctx context.Context) error
 	ProvidersSchema(ctx context.Context) (*tfjson.ProviderSchemas, error)
 }
@@ -85,8 +87,21 @@ func (r *execRunner) Init(ctx context.Context) error {
 	return r.tf.Init(ctx, tfexec.Upgrade(false))
 }
 
-func (r *execRunner) PlanGenerate(ctx context.Context, generatedPath string) (bool, error) {
-	return r.tf.Plan(ctx, tfexec.GenerateConfigOut(generatedPath))
+func (r *execRunner) PlanGenerate(ctx context.Context, generatedPath string, parallelism int) (bool, error) {
+	return r.tf.Plan(ctx, planGenerateOpts(generatedPath, parallelism)...)
+}
+
+// planGenerateOpts is the pure builder for the genconfig readback's tfexec
+// plan options. Factored out so a unit test can assert the genconfig path
+// always passes `-parallelism` (tfexec.Parallelism) alongside the
+// generate-config-out target without shelling out to a real terraform binary
+// — the mutation-resistant guard for luthersystems/ui-core#420: if someone
+// drops the parallelism option from this path, TestPlanGenerateOpts fails.
+func planGenerateOpts(generatedPath string, parallelism int) []tfexec.PlanOption {
+	return []tfexec.PlanOption{
+		tfexec.GenerateConfigOut(generatedPath),
+		tfexec.Parallelism(parallelism),
+	}
 }
 
 func (r *execRunner) Validate(ctx context.Context) error {

--- a/cmd/insideout-import/genconfig/runner_test.go
+++ b/cmd/insideout-import/genconfig/runner_test.go
@@ -5,12 +5,65 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestPlanGenerateOpts is the mutation-resistant guard for the genconfig
+// readback parallelism (luthersystems/ui-core#420): the genconfig
+// `terraform plan -generate-config-out` phase was ≈91% of a measured
+// 1h41m / 481-resource reverse import, run at terraform's default
+// -parallelism=10. planGenerateOpts MUST pass tfexec.Parallelism alongside
+// the generate-config-out target. If anyone drops the parallelism option from
+// THIS path specifically, this test fails — even though a real terraform run
+// would still "succeed" (just slowly), so no other test would catch the
+// regression.
+func TestPlanGenerateOpts(t *testing.T) {
+	t.Parallel()
+
+	const generated = "/tmp/generated.tf"
+	const parallelism = 25
+	opts := planGenerateOpts(generated, parallelism)
+
+	// The generate-config-out target must still be present.
+	require.Contains(t, opts, tfexec.GenerateConfigOut(generated),
+		"genconfig readback must keep its -generate-config-out target")
+
+	// The parallelism option must be present AND carry the exact value
+	// threaded in. reflect.DeepEqual compares the (unexported) parallelism
+	// field, so a value mutation (e.g. silently forcing 10) also fails here.
+	var foundParallelism bool
+	for _, o := range opts {
+		if reflect.DeepEqual(o, tfexec.Parallelism(parallelism)) {
+			foundParallelism = true
+		}
+	}
+	require.True(t, foundParallelism,
+		"genconfig readback must pass tfexec.Parallelism(%d); dropping -parallelism re-introduces the ui-core#420 default-10 bottleneck", parallelism)
+}
+
+// TestDefaultGenconfigParallelism pins the chosen default so a casual edit
+// back to terraform's default (10) — which would silently undo the
+// ui-core#420 fix — trips the suite. 25 is the value the ticket sized for the
+// readback; see DefaultGenconfigParallelism for the throttle-safety rationale.
+func TestDefaultGenconfigParallelism(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, 25, DefaultGenconfigParallelism)
+}
+
+// TestOptionsParallelismOrDefault pins that the unset (<= 0) zero value falls
+// back to the default and an explicit positive value is honored.
+func TestOptionsParallelismOrDefault(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, DefaultGenconfigParallelism, Options{}.parallelismOrDefault(), "zero value defaults")
+	assert.Equal(t, DefaultGenconfigParallelism, Options{Parallelism: -3}.parallelismOrDefault(), "negative defaults")
+	assert.Equal(t, 40, Options{Parallelism: 40}.parallelismOrDefault(), "explicit positive honored")
+}
 
 // builtinProviderStack is a terraform config that only uses the builtin
 // terraform_data resource (terraform.io/builtin/terraform). It needs no plugin

--- a/pkg/reverseimport/options.go
+++ b/pkg/reverseimport/options.go
@@ -66,6 +66,14 @@ type Options struct {
 	Discoverer            Discoverer
 	ClosureDiscoverer     ClosureDiscoverer
 
+	// Parallelism overrides the `-parallelism=<n>` flag passed to the
+	// engine's final `terraform plan` (the authoritative combined-stack plan
+	// over the full imported set) AND propagated to the genconfig readback /
+	// driftfix passes this engine drives, so the whole reverse-import path
+	// runs at one consistent concurrency. 0 (the zero value) uses
+	// DefaultParallelism. See that constant for the throttle-safety rationale.
+	Parallelism int
+
 	// Stdout receives continuous human-readable progress as Run works
 	// through its phases — provider readback, genconfig, driftfix,
 	// dep-chase, and the final terraform init/validate/plan — plus the
@@ -96,12 +104,38 @@ type deps struct {
 	tf           terraformRunner
 }
 
-func defaultDeps(terraformBinary string, stdout io.Writer) deps {
+// DefaultParallelism is the `-parallelism=<n>` value the engine's final
+// combined-stack `terraform plan` (and the genconfig/driftfix passes it
+// drives) runs at when Options.Parallelism is unset (<= 0). It mirrors
+// genconfig.DefaultGenconfigParallelism (25) so the whole reverse-import
+// readback path — genconfig generate-config-out, driftfix re-plans, and the
+// final authoritative plan — refreshes resources at one consistent,
+// throttle-tuned concurrency rather than terraform's default of 10.
+//
+// Throttle safety: every one of these passes is read-only (plan/refresh, no
+// apply), so raising parallelism only issues more concurrent AWS Describe/Get
+// reads with no mutation risk. The raised concurrency MUST degrade to backoff
+// rather than ThrottlingException failures: the emitted provider config pairs
+// it with retry_mode = "adaptive" + max_retries = 25 (providers.go /
+// genconfig emit.go), so the AWS SDK's adaptive client-side rate limiter
+// paces the reads back into a token-bucket stream under throttle pressure.
+const DefaultParallelism = genconfig.DefaultGenconfigParallelism
+
+// parallelismOrDefault returns Options.Parallelism, falling back to
+// DefaultParallelism for the unset (<= 0) zero value.
+func (o Options) parallelismOrDefault() int {
+	if o.Parallelism <= 0 {
+		return DefaultParallelism
+	}
+	return o.Parallelism
+}
+
+func defaultDeps(terraformBinary string, parallelism int, stdout io.Writer) deps {
 	return deps{
 		runGenconfig: genconfig.Run,
 		runDriftfix:  driftfix.Run,
 		runDepChase:  depchase.Run,
-		tf:           execTerraformRunner{binary: terraformBinary, stdout: stdout},
+		tf:           execTerraformRunner{binary: terraformBinary, parallelism: parallelism, stdout: stdout},
 	}
 }
 
@@ -143,7 +177,7 @@ func (o Options) withDefaults() Options {
 		o.deps.runDriftfix == nil ||
 		o.deps.runDepChase == nil ||
 		o.deps.tf == nil {
-		o.deps = defaultDeps(o.TerraformBinary, o.Stdout)
+		o.deps = defaultDeps(o.TerraformBinary, o.parallelismOrDefault(), o.Stdout)
 	}
 	return o
 }

--- a/pkg/reverseimport/providers.go
+++ b/pkg/reverseimport/providers.go
@@ -105,6 +105,7 @@ func appendAWSImportedProvider(body *hclwrite.Body, alias, region string, opts i
 	prov := body.AppendNewBlock("provider", []string{"aws"})
 	prov.Body().SetAttributeValue("alias", cty.StringVal(alias))
 	prov.Body().SetAttributeValue("region", cty.StringVal(region))
+	appendAWSRetryTuning(prov.Body())
 	if opts.AWSEndpointURL != "" {
 		prov.Body().SetAttributeValue("access_key", cty.StringVal("test"))
 		prov.Body().SetAttributeValue("secret_key", cty.StringVal("test"))
@@ -118,6 +119,26 @@ func appendAWSImportedProvider(body *hclwrite.Body, alias, region string, opts i
 		}
 	}
 	appendAWSAssumeRole(prov.Body(), opts.AWSAuth)
+}
+
+// awsProviderMaxRetries mirrors genconfig.awsProviderMaxRetries (the AWS
+// provider's documented default of 25). Emitted explicitly on the final
+// combined-stack provider blocks so the raised final-plan -parallelism keeps
+// at least the default retry budget and degrades to backoff rather than
+// ThrottlingException failures. Kept as a local copy (not imported) to match
+// the existing appendAWSAssumeRole duplication between this package and
+// genconfig — the two emitters intentionally stay independent.
+const awsProviderMaxRetries = 25
+
+// appendAWSRetryTuning emits `retry_mode = "adaptive"` and `max_retries` onto
+// a final-plan AWS provider block so the raised plan/refresh -parallelism
+// degrades to throttle backoff instead of failures (luthersystems/ui-core
+// #420). Mirrors genconfig.appendAWSRetryTuning; see it for the adaptive-mode
+// rationale. Both attributes are top-level arguments of the pinned
+// hashicorp/aws ~> 6.0 provider.
+func appendAWSRetryTuning(body *hclwrite.Body) {
+	body.SetAttributeValue("retry_mode", cty.StringVal("adaptive"))
+	body.SetAttributeValue("max_retries", cty.NumberIntVal(awsProviderMaxRetries))
 }
 
 func appendAWSAssumeRole(body *hclwrite.Body, auth AWSProviderAuth) {

--- a/pkg/reverseimport/providers_test.go
+++ b/pkg/reverseimport/providers_test.go
@@ -90,10 +90,13 @@ func TestRenderImportedProvidersTF_MultiRegion(t *testing.T) {
 	}
 	// Every emitted AWS provider block carries the throttle-safety retry
 	// tuning (luthersystems/ui-core#420): base + 2 regional = 3 each.
-	if n := strings.Count(s, `retry_mode  = "adaptive"`); n != 3 {
+	// Value-anchored regexes (\s*=\s*), not fixed-gutter strings: hclwrite
+	// re-aligns the = column whenever a block gains a wider attribute, and a
+	// formatting change must not fail a behavior assertion (qa #780).
+	if n := len(regexp.MustCompile(`retry_mode\s*=\s*"adaptive"`).FindAllString(s, -1)); n != 3 {
 		t.Fatalf("expected 3 retry_mode=adaptive attrs (base + 2 regional), got %d:\n%s", n, s)
 	}
-	if n := strings.Count(s, "max_retries = 25"); n != 3 {
+	if n := len(regexp.MustCompile(`max_retries\s*=\s*25`).FindAllString(s, -1)); n != 3 {
 		t.Fatalf("expected 3 max_retries attrs (base + 2 regional), got %d:\n%s", n, s)
 	}
 }

--- a/pkg/reverseimport/providers_test.go
+++ b/pkg/reverseimport/providers_test.go
@@ -1,6 +1,7 @@
 package reverseimport
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -25,14 +26,26 @@ func TestRenderImportedProvidersTF_AWSAssumesProjectRole(t *testing.T) {
 	s := string(body)
 	for _, want := range []string{
 		`provider "aws"`,
-		`alias  = "imported"`,
-		`region = "us-west-2"`,
 		`assume_role`,
 		`role_arn    = "arn:aws:iam::123456789012:role/io-terraform"`,
 		`external_id = "external-123"`,
 	} {
 		if !strings.Contains(s, want) {
 			t.Fatalf("providers-imported.tf missing %q:\n%s", want, s)
+		}
+	}
+	// hclwrite aligns the `=` columns, so the retry-tuning attrs widen the
+	// alias/region gutter — match those value-anchored. retry_mode =
+	// "adaptive" + max_retries are the throttle-safety pairing for the raised
+	// final-plan parallelism (luthersystems/ui-core#420).
+	for _, pat := range []string{
+		`alias\s*=\s*"imported"`,
+		`region\s*=\s*"us-west-2"`,
+		`retry_mode\s*=\s*"adaptive"`,
+		`max_retries\s*=\s*25`,
+	} {
+		if !regexp.MustCompile(pat).MatchString(s) {
+			t.Fatalf("providers-imported.tf missing pattern %q:\n%s", pat, s)
 		}
 	}
 }
@@ -58,20 +71,30 @@ func TestRenderImportedProvidersTF_MultiRegion(t *testing.T) {
 		t.Fatalf("renderImportedProvidersTF() error = %v", err)
 	}
 	s := string(body)
-	for _, want := range []string{
-		`alias  = "imported"`,           // base block (back-compat / fallback)
-		`alias  = "imported_us_east_1"`, // per-region
-		`region = "us-east-1"`,
-		`alias  = "imported_us_west_2"`,
-		`region = "us-west-2"`,
+	// hclwrite aligns the `=` columns and the retry-tuning attrs widen the
+	// gutter, so match value-anchored.
+	for _, pat := range []string{
+		`alias\s*=\s*"imported"`,           // base block (back-compat / fallback)
+		`alias\s*=\s*"imported_us_east_1"`, // per-region
+		`region\s*=\s*"us-east-1"`,
+		`alias\s*=\s*"imported_us_west_2"`,
+		`region\s*=\s*"us-west-2"`,
 	} {
-		if !strings.Contains(s, want) {
-			t.Fatalf("providers-imported.tf missing %q:\n%s", want, s)
+		if !regexp.MustCompile(pat).MatchString(s) {
+			t.Fatalf("providers-imported.tf missing pattern %q:\n%s", pat, s)
 		}
 	}
 	// base + 2 regional = 3 assume_role blocks (one per provider block).
 	if n := strings.Count(s, "assume_role"); n != 3 {
 		t.Fatalf("expected 3 assume_role blocks (base + 2 regional), got %d:\n%s", n, s)
+	}
+	// Every emitted AWS provider block carries the throttle-safety retry
+	// tuning (luthersystems/ui-core#420): base + 2 regional = 3 each.
+	if n := strings.Count(s, `retry_mode  = "adaptive"`); n != 3 {
+		t.Fatalf("expected 3 retry_mode=adaptive attrs (base + 2 regional), got %d:\n%s", n, s)
+	}
+	if n := strings.Count(s, "max_retries = 25"); n != 3 {
+		t.Fatalf("expected 3 max_retries attrs (base + 2 regional), got %d:\n%s", n, s)
 	}
 }
 

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -95,6 +95,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 		AWSEndpointURL: opts.AWSEndpointURL,
 		AWSRoleARN:     awsAuth.RoleARN,
 		AWSExternalID:  awsAuth.ExternalID,
+		Parallelism:    opts.parallelismOrDefault(),
 		Stdout:         opts.Stdout,
 	}
 
@@ -124,7 +125,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	if !opts.SkipDriftFix {
 		opts.progressf("reverse-import: running driftfix…\n")
 		if err := opts.runPhase("driftfix", func() error {
-			_, driftErr := opts.deps.runDriftfix(ctx, driftfix.Options{Workdir: workdir, Stdout: opts.Stdout})
+			_, driftErr := opts.deps.runDriftfix(ctx, driftfix.Options{Workdir: workdir, Parallelism: opts.parallelismOrDefault(), Stdout: opts.Stdout})
 			return driftErr
 		}); err != nil {
 			return result, fmt.Errorf("driftfix: %w", err)
@@ -143,7 +144,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 				return &depchase.GenconfigResult{GeneratedPath: r.GeneratedPath, Resources: r.Resources}, nil
 			},
 			RunDriftfix: func(ictx context.Context) (*depchase.DriftfixResult, error) {
-				r, err := opts.deps.runDriftfix(ictx, driftfix.Options{Workdir: workdir, Stdout: opts.Stdout})
+				r, err := opts.deps.runDriftfix(ictx, driftfix.Options{Workdir: workdir, Parallelism: opts.parallelismOrDefault(), Stdout: opts.Stdout})
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/reverseimport/terraform.go
+++ b/pkg/reverseimport/terraform.go
@@ -59,10 +59,40 @@ func planStderr(err error) string {
 
 type execTerraformRunner struct {
 	binary string
+	// parallelism is the `-parallelism=<n>` value the final combined-stack
+	// plan runs at. 0 falls back to DefaultParallelism so a zero-value
+	// runner (and any test double that constructs one directly) keeps a
+	// sane, throttle-tuned concurrency rather than terraform's default 10.
+	parallelism int
 	// stdout receives the live stdout of the streaming commands (init,
 	// plan) and the stderr of every command. nil falls back to os.Stdout
 	// / os.Stderr so a zero-value runner keeps the historical behavior.
 	stdout io.Writer
+}
+
+// planParallelism resolves the runner's configured parallelism, defaulting a
+// zero/unset value to DefaultParallelism.
+func (r execTerraformRunner) planParallelism() int {
+	if r.parallelism <= 0 {
+		return DefaultParallelism
+	}
+	return r.parallelism
+}
+
+// planArgs is the pure builder for the final `terraform plan` argv. Factored
+// out so a unit test can assert the engine's authoritative plan always carries
+// `-parallelism=<n>` without shelling out to a real terraform binary
+// (luthersystems/ui-core#420). -detailed-exitcode is required so an
+// import-only diff (exit 2) is not mistaken for a failure (see Plan).
+func planArgs(planPath string, parallelism int) []string {
+	return []string{
+		"plan",
+		"-input=false",
+		"-no-color",
+		"-detailed-exitcode",
+		fmt.Sprintf("-parallelism=%d", parallelism),
+		"-out=" + planPath,
+	}
 }
 
 func (r execTerraformRunner) bin() string {
@@ -107,7 +137,7 @@ func (r execTerraformRunner) Plan(ctx context.Context, dir, planPath string) err
 	// sink still receives the same bytes (the import wizard's log console
 	// keeps streaming); the buffer is only read on error.
 	var captured bytes.Buffer
-	cmd := exec.CommandContext(ctx, r.bin(), "plan", "-input=false", "-no-color", "-detailed-exitcode", "-out="+planPath)
+	cmd := exec.CommandContext(ctx, r.bin(), planArgs(planPath, r.planParallelism())...)
 	cmd.Dir = dir
 	cmd.Stdout = r.outW()
 	cmd.Stderr = io.MultiWriter(r.outW(), &captured)

--- a/pkg/reverseimport/terraform_test.go
+++ b/pkg/reverseimport/terraform_test.go
@@ -83,6 +83,65 @@ exit 7
 	}
 }
 
+// TestPlanArgs is the mutation-resistant guard for the final-plan parallelism
+// (luthersystems/ui-core#420): planArgs MUST carry -parallelism=<n> and keep
+// -detailed-exitcode (so an import-only diff isn't read as a failure).
+func TestPlanArgs(t *testing.T) {
+	t.Parallel()
+	args := planArgs("/tmp/tfplan.bin", 25)
+	joined := strings.Join(args, " ")
+	for _, want := range []string{"plan", "-detailed-exitcode", "-parallelism=25", "-out=/tmp/tfplan.bin"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("planArgs missing %q: %v", want, args)
+		}
+	}
+}
+
+// TestPlanParallelismDefaults pins that a zero/unset runner parallelism falls
+// back to DefaultParallelism (25) so the engine's final plan never silently
+// drops back to terraform's default of 10.
+func TestPlanParallelismDefaults(t *testing.T) {
+	t.Parallel()
+	if got := (execTerraformRunner{}).planParallelism(); got != DefaultParallelism {
+		t.Fatalf("zero-value runner planParallelism = %d, want %d", got, DefaultParallelism)
+	}
+	if got := (execTerraformRunner{parallelism: -2}).planParallelism(); got != DefaultParallelism {
+		t.Fatalf("negative runner planParallelism = %d, want %d", got, DefaultParallelism)
+	}
+	if got := (execTerraformRunner{parallelism: 33}).planParallelism(); got != 33 {
+		t.Fatalf("explicit runner planParallelism = %d, want 33", got)
+	}
+	if DefaultParallelism != 25 {
+		t.Fatalf("DefaultParallelism = %d, want 25", DefaultParallelism)
+	}
+}
+
+// TestExecTerraformRunnerPlanPassesParallelism drives the real Plan path
+// against a fake terraform that records its argv, proving the engine's final
+// plan actually shells out with -parallelism. End-to-end complement to
+// TestPlanArgs.
+func TestExecTerraformRunnerPlanPassesParallelism(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "args.txt")
+	bin := writeFakeTerraform(t, dir, `#!/bin/sh
+echo "$@" > `+argsFile+`
+exit 0
+`)
+	planPath := filepath.Join(dir, "tfplan.bin")
+	err := execTerraformRunner{binary: bin, parallelism: 25}.Plan(context.Background(), dir, planPath)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	recorded, readErr := os.ReadFile(argsFile)
+	if readErr != nil {
+		t.Fatalf("read recorded args: %v", readErr)
+	}
+	if !strings.Contains(string(recorded), "-parallelism=25") {
+		t.Fatalf("terraform plan argv missing -parallelism=25: %q", string(recorded))
+	}
+}
+
 func writeFakeTerraform(t *testing.T, dir, script string) string {
 	t.Helper()
 	path := filepath.Join(dir, "terraform")


### PR DESCRIPTION
## Why

A 481-resource reverse-import plan took 1h41m. The measured phase breakdown ([ui-core#420 comment](https://github.com/luthersystems/ui-core/issues/420#issuecomment-4671567328)) shows the genconfig `terraform plan -generate-config-out` readback was about 1h32m of that (~91%). driftfix was ~3m, final plans <2m each. All three terraform runners passed no `-parallelism`, so every refresh ran at terraform's default of 10 against an untuned AWS provider.

This is Option A from the ticket, scoped at the genconfig readback first.

## What

1. Configurable `Parallelism` knob (default 25, vs terraform's default 10) on the genconfig, driftfix, and engine options, mirroring the enrich-concurrency idiom (default const + `0`-means-default helper). Threads into:
   - genconfig `PlanGenerate` — the 91% phase, the primary win
   - driftfix per-iteration `PlanTo` — small absolute slice, applied for consistency
   - the engine's final combined-stack plan (`pkg/reverseimport/terraform.go`)

2. AWS provider retry tuning on both generated provider seams (genconfig readback `providers.tf` and the engine's final-plan providers):
   - `retry_mode = "adaptive"` — the AWS SDK's adaptive client-side token-bucket rate limiter
   - `max_retries = 25` — equals the AWS provider's documented default, emitted explicitly (deliberately not lowered to 10; the raised parallelism needs at least the default retry budget). Both are top-level args of the pinned `hashicorp/aws ~> 6.0` provider; verified valid via `terraform validate`.

## Throttle-safety design

The readback is strictly read-only (plan/refresh, no apply), so raising `-parallelism` only issues more concurrent AWS Describe/Get reads with no mutation risk. The raised concurrency must degrade to backoff, not failures — that is exactly what `retry_mode = "adaptive"` does: it measures throttle responses and paces subsequent calls, smoothing the burst back toward the account's real API budget. Worst case the readback degrades back toward the serialized rate; it never surfaces a ThrottlingException. This rationale is documented on each default const.

## Expected effect

Roughly 2.5-3x cut on the refresh-bound readback absent throttling (parallelism 25 vs 10), with adaptive retries absorbing the extra concurrency under throttle pressure.

## Tests

- Mutation-resistant arg-builder guards: `planGenerateOpts` / `planToOpts` / `planArgs` must carry `-parallelism`. `TestPlanGenerateOpts` locks the genconfig path specifically — a real terraform run would still succeed (just slowly) if the flag were dropped, so only this assertion catches the regression.
- Default + override fallback, and end-to-end propagation through `Run`.
- Provider-HCL golden assertions moved to value-anchored regexes (hclwrite re-aligns `=` columns when the new attrs are added) and gained explicit retry-tuning coverage incl. a per-block count on the multi-region path.
- `golden-stack-hcl` gate passes locally (`make test-golden-stack`); full `go test -race ./...` green.

## Validation

Flag plumbing is unit-tested here. Live confirmation of the wall-clock win happens on the next sizable import — the cust3 test account is post-reaper empty, so no 481-resource rerun is available today.

Part of luthersystems/ui-core#420 (left open: live validation outstanding).
