### PR TITLE
fix(observability): multi-group AWS metric specs; AOSS OCU observed by inspector (#778)

### DIFF
--- a/pkg/observability/component_metrics_test.go
+++ b/pkg/observability/component_metrics_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestComponentMetricsMapping_OnlyKnownKeys ensures every key in
@@ -125,7 +126,8 @@ func TestObservabilityMatchesComponentMetricsMapping_Service(t *testing.T) {
 // TestObservability_AWSEntriesHaveAWSObs ensures every Observability
 // entry whose key is AWS-backed AND whose Service is in
 // awsServiceMetrics has a non-nil AWS field. GCP keys must NOT have a
-// non-nil AWS field.
+// non-nil AWS field. Any AWSExtra groups present (multi-namespace
+// components, #778) must be non-nil and only attached to AWS keys.
 func TestObservability_AWSEntriesHaveAWSObs(t *testing.T) {
 	for k, o := range Observability {
 		if composer.CloudFor(k) == "aws" {
@@ -134,18 +136,63 @@ func TestObservability_AWSEntriesHaveAWSObs(t *testing.T) {
 					"Observability[%s].AWS should be non-nil because service %q has awsServiceMetrics catalog",
 					k, o.Service)
 			}
+			for i, g := range o.AWSExtra {
+				assert.NotNil(t, g,
+					"Observability[%s].AWSExtra[%d] must be non-nil — componentObs only appends real groups", k, i)
+			}
 			assert.Nil(t, o.GCP,
 				"Observability[%s].GCP must be nil (key is AWS)", k)
 			continue
 		}
 		assert.Nil(t, o.AWS,
 			"Observability[%s].AWS must be nil (key is GCP)", k)
+		assert.Empty(t, o.AWSExtra,
+			"Observability[%s].AWSExtra must be empty (key is GCP)", k)
 		if _, hasMetrics := gcpServiceMetrics[o.Service]; hasMetrics {
 			assert.NotNil(t, o.GCP,
 				"Observability[%s].GCP should be non-nil because service %q has gcpServiceMetrics catalog",
 				k, o.Service)
 		}
 	}
+}
+
+// TestObservability_OpenSearchHasAOSSGroup is the #778 multi-group
+// contract pinned to the data model: aws_opensearch carries the managed
+// AWS/ES + DomainName group as its primary AWS group AND the serverless
+// AWS/AOSS + ClientId group in AWSExtra. SearchOCU / IndexingOCU live in
+// the AOSS group with Alarmed=true (flipped from
+// alarmedAWSMetrics[KeyAWSOpenSearch]) and the Sum stat.
+func TestObservability_OpenSearchHasAOSSGroup(t *testing.T) {
+	o, ok := Observability[composer.KeyAWSOpenSearch]
+	require.True(t, ok, "aws_opensearch must have an Observability record")
+
+	require.NotNil(t, o.AWS, "primary AWS group (managed AWS/ES) must be present")
+	assert.Equal(t, "AWS/ES", o.AWS.Namespace)
+	assert.Equal(t, "DomainName", o.AWS.DimensionName)
+
+	require.Len(t, o.AWSExtra, 1, "aws_opensearch must carry exactly one extra group (AOSS)")
+	aoss := o.AWSExtra[0]
+	require.NotNil(t, aoss)
+	assert.Equal(t, "AWS/AOSS", aoss.Namespace)
+	assert.Equal(t, "ClientId", aoss.DimensionName)
+
+	byName := make(map[string]AWSMetricSpec, len(aoss.Metrics))
+	for _, m := range aoss.Metrics {
+		byName[m.Name] = m
+	}
+	for _, name := range []string{"SearchOCU", "IndexingOCU"} {
+		spec, present := byName[name]
+		require.True(t, present, "AOSS group must carry %q", name)
+		assert.Equal(t, "Sum", spec.Stat, "%q must use the Sum stat", name)
+		assert.True(t, spec.Alarmed,
+			"%q must be Alarmed=true — it is registered in alarmedAWSMetrics[KeyAWSOpenSearch]", name)
+	}
+
+	// AWSGroups() exposes both groups in order for the metric-fetch path.
+	groups := o.AWSGroups()
+	require.Len(t, groups, 2)
+	assert.Equal(t, "AWS/ES", groups[0].Namespace)
+	assert.Equal(t, "AWS/AOSS", groups[1].Namespace)
 }
 
 // TestObservability_AlarmedSpecsHaveAuthorityEntry is the post-C9
@@ -169,14 +216,17 @@ func TestObservability_AlarmedSpecsHaveAuthorityEntry(t *testing.T) {
 				gcpAuthority[m] = true
 			}
 		}
-		if o.AWS != nil {
-			for _, m := range o.AWS.Metrics {
+		// Walk every AWS group (primary + AWSExtra) so an Alarmed flip in a
+		// multi-namespace component's extra group (the AOSS SearchOCU /
+		// IndexingOCU, #778) is held to the same authority contract.
+		for _, g := range o.AWSGroups() {
+			for _, m := range g.Metrics {
 				if !m.Alarmed {
 					continue
 				}
 				assert.True(t, awsAuthority[m.Name],
-					"Observability[%s].AWS.Metrics[%q].Alarmed=true but %q not in alarmedAWSMetrics[%s] — service catalog must remain Alarmed=false; flips happen via the per-key authority map",
-					k, m.Name, m.Name, k)
+					"Observability[%s].AWS group (namespace %s) metric %q has Alarmed=true but %q not in alarmedAWSMetrics[%s] — service catalog must remain Alarmed=false; flips happen via the per-key authority map",
+					k, g.Namespace, m.Name, m.Name, k)
 			}
 		}
 		if o.GCP != nil {

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -23,14 +23,49 @@ type ComponentObservability struct {
 	// in ComponentMetricsMapping[k].Service.
 	Service string
 
-	// AWS is populated for AWS-backed components and carries the
-	// CloudWatch namespace / dimension / metric specs that drive both the
-	// metric-fetch wrapper and the per-component alarm authoring.
-	// nil for GCP components or AWS components with no metric surface.
+	// AWS is the primary CloudWatch namespace / dimension / metric group
+	// for AWS-backed components. It drives both the metric-fetch wrapper
+	// and the per-component alarm authoring. nil for GCP components or AWS
+	// components with no metric surface.
+	//
+	// Most components have exactly one namespace/dimension group, carried
+	// here. A few components publish across more than one namespace (e.g.
+	// aws_opensearch covers managed domains under AWS/ES + DomainName AND
+	// serverless collections under AWS/AOSS + ClientId, #778). Those carry
+	// their extra groups in AWSExtra; single-group callers keep reading
+	// AWS unchanged. AWSGroups() returns the full set (AWS first, then
+	// AWSExtra) for callers that must walk every group.
 	AWS *AWSObs
+
+	// AWSExtra carries additional CloudWatch namespace/dimension groups
+	// for AWS-backed components that publish across more than one
+	// namespace. Empty/nil for the single-group common case. Entries are
+	// never nil (componentObs only appends non-nil groups). See AWS above
+	// and AWSGroups().
+	AWSExtra []*AWSObs
 
 	// GCP is populated for GCP-backed components.
 	GCP *GCPObs
+}
+
+// AWSGroups returns every AWS namespace/dimension group on the record in
+// stable order: the primary AWS group first (when set), then each
+// AWSExtra group. nil entries are filtered out, so the result is safe to
+// range over directly. Returns an empty (non-nil-bearing) slice for
+// records with no AWS surface. Multi-group consumers — the metric-fetch
+// query builder and the alarm-flip in componentObs — iterate this rather
+// than touching AWS / AWSExtra directly.
+func (c ComponentObservability) AWSGroups() []*AWSObs {
+	groups := make([]*AWSObs, 0, 1+len(c.AWSExtra))
+	if c.AWS != nil {
+		groups = append(groups, c.AWS)
+	}
+	for _, g := range c.AWSExtra {
+		if g != nil {
+			groups = append(groups, g)
+		}
+	}
+	return groups
 }
 
 // AWSObs is the AWS half of ComponentObservability. Mirrors the InsideOut backend's
@@ -214,6 +249,25 @@ var awsServiceMetrics = map[string]AWSObs{
 			{Name: "FreeStorageSpace", Stat: "Average"},
 			{Name: "CPUUtilization", Stat: "Average"},
 			{Name: "JVMMemoryPressure", Stat: "Average"},
+		},
+	},
+	// OpenSearch Serverless (AOSS) OCU consumption — the second
+	// namespace/dimension group attached to KeyAWSOpenSearch (#778).
+	// AWS/AOSS publishes SearchOCU / IndexingOCU at the ACCOUNT level under
+	// the ClientId dimension (= account ID); there is no per-collection OCU
+	// breakdown (verified against the AWS/AOSS metrics reference, 2026-06,
+	// same source the aws/opensearch observability.tf OCU alarms cite). Stat
+	// is Sum: these metrics publish with Sum (OCU-units consumed in the
+	// period); Maximum returns an empty series. This is NOT a standalone
+	// service binding — no ComponentMetricsMapping entry points at
+	// "opensearch_aoss"; it exists solely as the catalog source for the
+	// AOSS group componentObs() attaches to KeyAWSOpenSearch via AWSExtra.
+	"opensearch_aoss": {
+		Namespace:     "AWS/AOSS",
+		DimensionName: "ClientId",
+		Metrics: []AWSMetricSpec{
+			{Name: "SearchOCU", Stat: "Sum"},
+			{Name: "IndexingOCU", Stat: "Sum"},
 		},
 	},
 	"bedrock": {
@@ -511,14 +565,31 @@ func componentObs(k composer.ComponentKey) ComponentObservability {
 	o := ComponentObservability{Service: binding.Service}
 	if composer.CloudFor(k) == "aws" {
 		o.AWS = awsObsFor(binding.Service)
-		if author, ok := alarmedAWSMetrics[k]; ok && o.AWS != nil {
+		// OpenSearch publishes across two namespaces: managed domains
+		// under AWS/ES (the primary group above) and serverless
+		// collections under AWS/AOSS (#778). Attach the AOSS catalog as
+		// an extra group so the inspector can see SearchOCU / IndexingOCU
+		// alongside the managed-domain metrics. The catalog copy is
+		// per-record (awsObsFor clones Metrics) so the Alarmed flip below
+		// won't mutate the shared catalog.
+		if k == composer.KeyAWSOpenSearch {
+			if aoss := awsObsFor("opensearch_aoss"); aoss != nil {
+				o.AWSExtra = append(o.AWSExtra, aoss)
+			}
+		}
+		// Flip Alarmed across every namespace group so an alarmed metric
+		// in the AOSS group (SearchOCU / IndexingOCU) is marked the same
+		// way an AWS/ES metric (ClusterStatus.red) is.
+		if author, ok := alarmedAWSMetrics[k]; ok {
 			set := make(map[string]bool, len(author.Metrics))
 			for _, m := range author.Metrics {
 				set[m] = true
 			}
-			for i := range o.AWS.Metrics {
-				if set[o.AWS.Metrics[i].Name] {
-					o.AWS.Metrics[i].Alarmed = true
+			for _, g := range o.AWSGroups() {
+				for i := range g.Metrics {
+					if set[g.Metrics[i].Name] {
+						g.Metrics[i].Alarmed = true
+					}
 				}
 			}
 		}
@@ -569,8 +640,14 @@ var alarmedAWSMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyAWSElastiCache:  {Module: "aws/elasticache", Metrics: []string{"CPUUtilization"}},
 	composer.KeyAWSLambda:       {Module: "aws/lambda", Metrics: []string{"Errors"}},
 	composer.KeyAWSMSK:          {Module: "aws/msk", Metrics: []string{"OfflinePartitionsCount"}},
-	composer.KeyAWSOpenSearch:   {Module: "aws/opensearch", Metrics: []string{"ClusterStatus.red"}},
-	composer.KeyAWSRDS:          {Module: "aws/rds", Metrics: []string{"CPUUtilization", "FreeStorageSpace"}},
+	// ClusterStatus.red (managed, AWS/ES) plus the two serverless OCU
+	// alarms (AWS/AOSS, #758) now that the AOSS namespace group exists in
+	// the catalog (#778). All three have aws_cloudwatch_metric_alarm
+	// resources in aws/opensearch/observability.tf; the for_each gates
+	// suppress whichever pair doesn't match the deployment_type, but the
+	// metric_name strings still match this catalog.
+	composer.KeyAWSOpenSearch: {Module: "aws/opensearch", Metrics: []string{"ClusterStatus.red", "SearchOCU", "IndexingOCU"}},
+	composer.KeyAWSRDS:        {Module: "aws/rds", Metrics: []string{"CPUUtilization", "FreeStorageSpace"}},
 	// SageMaker real-time inference endpoint alarms (#761). Invocation5XXErrors
 	// (the model is failing requests) + ModelLatency (the model is responding
 	// slowly). Both alarms only exist on stacks with enable_inference=true;

--- a/pkg/observability/component_observability_test.go
+++ b/pkg/observability/component_observability_test.go
@@ -93,3 +93,76 @@ func TestGCPMetricDefinitions_FirestoreAlarmBinding(t *testing.T) {
 			mt)
 	}
 }
+
+// TestEveryAlarmedAWSMetricExistsInSomeGroup is the AWS analogue of the
+// firestore alarm-binding pin: for EVERY component in alarmedAWSMetrics,
+// each declared metric_name must appear in at least one of that
+// component's namespace/dimension groups (primary AWS or any AWSExtra),
+// otherwise componentObs() can never flip Alarmed=true and the inspector
+// stays blind to a metric production is paging on.
+//
+// This is the contract #778 had to satisfy to retire the
+// excludedFromAuthority entries: registering SearchOCU / IndexingOCU in
+// alarmedAWSMetrics[KeyAWSOpenSearch] WITHOUT the AOSS catalog group would
+// pass the HCL drift gates but leave Alarmed unset (the explicitly
+// rejected shortcut in the issue). This test fails on exactly that.
+func TestEveryAlarmedAWSMetricExistsInSomeGroup(t *testing.T) {
+	t.Parallel()
+	for k, author := range alarmedAWSMetrics {
+		o, ok := Observability[k]
+		require.Truef(t, ok, "alarmedAWSMetrics[%s] has no Observability record", k)
+
+		catalog := map[string]struct{}{}
+		for _, g := range o.AWSGroups() {
+			for _, m := range g.Metrics {
+				catalog[m.Name] = struct{}{}
+			}
+		}
+		for _, name := range author.Metrics {
+			_, present := catalog[name]
+			assert.Truef(t, present,
+				"alarmedAWSMetrics[%s] references metric %q which is in NO group of Observability[%s] (primary AWS + AWSExtra); componentObs() can never flip Alarmed and the inspector stays blind — add the metric to the catalog group, do not just register the alarm",
+				k, name, k)
+		}
+	}
+}
+
+// TestOpenSearchAOSSAlarmBinding pins the #778 contract concretely: the
+// two AOSS OCU alarms registered in alarmedAWSMetrics[KeyAWSOpenSearch]
+// must resolve to specs in the AOSS catalog group (AWS/AOSS) and emerge
+// from componentObs() with Alarmed=true. Mirrors the firestore alarm
+// binding pin for the multi-group AWS case.
+func TestOpenSearchAOSSAlarmBinding(t *testing.T) {
+	t.Parallel()
+
+	author, ok := alarmedAWSMetrics[composer.KeyAWSOpenSearch]
+	require.True(t, ok, "alarmedAWSMetrics must bind KeyAWSOpenSearch")
+	for _, want := range []string{"SearchOCU", "IndexingOCU"} {
+		assert.Containsf(t, author.Metrics, want,
+			"alarmedAWSMetrics[KeyAWSOpenSearch] must register %q (#778)", want)
+	}
+
+	// The AOSS specs must live in the catalog group so the flip lands.
+	aoss, ok := awsServiceMetrics["opensearch_aoss"]
+	require.True(t, ok, `awsServiceMetrics["opensearch_aoss"] must be present`)
+	aossNames := map[string]struct{}{}
+	for _, m := range aoss.Metrics {
+		aossNames[m.Name] = struct{}{}
+	}
+	assert.Contains(t, aossNames, "SearchOCU")
+	assert.Contains(t, aossNames, "IndexingOCU")
+
+	// Round-trip through the built Observability record: the AOSS group's
+	// SearchOCU / IndexingOCU come out Alarmed=true.
+	o := Observability[composer.KeyAWSOpenSearch]
+	alarmed := map[string]bool{}
+	for _, g := range o.AWSGroups() {
+		for _, m := range g.Metrics {
+			if m.Alarmed {
+				alarmed[m.Name] = true
+			}
+		}
+	}
+	assert.True(t, alarmed["SearchOCU"], "SearchOCU must come out Alarmed=true")
+	assert.True(t, alarmed["IndexingOCU"], "IndexingOCU must come out Alarmed=true")
+}

--- a/pkg/observability/contract_test.go
+++ b/pkg/observability/contract_test.go
@@ -92,13 +92,19 @@ func TestObservabilityDeferred_OnlyForUnalarmedComponents(t *testing.T) {
 		}
 		anyUnalarmed := false
 		hasAnyMetric := false
-		if o.AWS != nil {
-			for _, m := range o.AWS.Metrics {
+		// Walk every AWS group (primary + AWSExtra) so a multi-namespace
+		// component (aws_opensearch's AOSS group, #778) is judged on its
+		// full metric surface, not just the primary group.
+		for _, g := range o.AWSGroups() {
+			for _, m := range g.Metrics {
 				hasAnyMetric = true
 				if !m.Alarmed {
 					anyUnalarmed = true
 					break
 				}
+			}
+			if anyUnalarmed {
+				break
 			}
 		}
 		if !anyUnalarmed && o.GCP != nil {

--- a/pkg/observability/metrics/aws.go
+++ b/pkg/observability/metrics/aws.go
@@ -53,8 +53,11 @@ func ParseMetricsFilter(filtersJSON string) MetricsFilter {
 
 // Fetch is the public metric-fetch entry point. It walks every
 // resource in resources, builds the CloudWatch GetMetricData query set
-// off obs, issues one GetMetricData call per resource, and assembles
-// the per-resource MetricSeries slice into a MetricsResult.
+// off every namespace/dimension group in groups (one element for the
+// single-namespace common case; several for multi-namespace components
+// like aws_opensearch — #778), issues one GetMetricData call per
+// resource, and assembles the per-resource MetricSeries slice into a
+// MetricsResult. Callers pass ComponentObservability.AWSGroups().
 //
 // service is the inspector-side join key from
 // observability.ComponentObservability.Service ("ec2", "rds",
@@ -80,15 +83,26 @@ func Fetch(
 	ctx context.Context,
 	clients *Clients,
 	service string,
-	obs *observability.AWSObs,
+	groups []*observability.AWSObs,
 	resources []ResourceID,
 	mf MetricsFilter,
 ) (MetricsResult, error) {
 	if clients == nil {
 		return MetricsResult{}, fmt.Errorf("metrics: clients is required")
 	}
-	if obs == nil {
-		return MetricsResult{}, fmt.Errorf("metrics: obs is required for service %q", service)
+	// At least one non-nil group is required. Most services pass exactly
+	// one (Observability[k].AWS); multi-namespace components like
+	// aws_opensearch pass several via ComponentObservability.AWSGroups()
+	// (#778).
+	hasGroup := false
+	for _, g := range groups {
+		if g != nil {
+			hasGroup = true
+			break
+		}
+	}
+	if !hasGroup {
+		return MetricsResult{}, fmt.Errorf("metrics: at least one obs group is required for service %q", service)
 	}
 
 	// Apply per-service overrides (mirrors aws_metrics.go:666-672).
@@ -129,7 +143,7 @@ func Fetch(
 
 	var out []ResourceMetrics
 	for _, res := range resources {
-		queries := BuildGetMetricDataQueries(obs, res, service)
+		queries := BuildGetMetricDataQueries(groups, res, service)
 		series, err := getMetricData(ctx, cw, queries, startTime, endTime, int32(clampedPeriod)) //nolint:gosec // clamped to [1, 86400]
 		if err != nil {
 			// Per-resource failures log and skip; matches the InsideOut backend's
@@ -153,8 +167,23 @@ func Fetch(
 }
 
 // BuildGetMetricDataQueries constructs the per-resource MetricDataQuery
-// slice from obs. Mirrors the InsideOut backend's BuildMetricDataQueries
-// (aws_metrics.go:712).
+// slice from every namespace/dimension group in groups. Mirrors the
+// InsideOut backend's BuildMetricDataQueries (aws_metrics.go:712), extended to
+// walk multiple groups (#778): aws_opensearch publishes managed-domain
+// metrics under AWS/ES + DomainName AND serverless OCU metrics under
+// AWS/AOSS + ClientId, so a single resource emits queries across both
+// namespaces. Single-group services pass a one-element slice and get the
+// original behavior.
+//
+// Query IDs are globally unique across groups ("m0", "m1", …) so a
+// multi-group GetMetricData call never collides — CloudWatch rejects
+// duplicate query IDs in one request.
+//
+// res.DimensionName overrides the dimension name ONLY for the primary
+// (first) group — the per-resource ID was discovered against that group's
+// dimension. Extra groups use their own DimensionName (e.g. the AOSS
+// group's account-level ClientId), which is fixed by the namespace, not
+// by the per-resource override.
 //
 // Two service-shaped quirks survive intact:
 //
@@ -168,55 +197,62 @@ func Fetch(
 // Period on each MetricStat is a placeholder (300); getMetricData
 // overwrites it with the caller's clamped period before issuing the
 // CloudWatch call.
-func BuildGetMetricDataQueries(obs *observability.AWSObs, res ResourceID, service string) []cwtypes.MetricDataQuery {
-	if obs == nil {
-		return nil
-	}
-	dimName := res.DimensionName
-	if dimName == "" {
-		dimName = obs.DimensionName
-	}
-
-	queries := make([]cwtypes.MetricDataQuery, 0, len(obs.Metrics))
-	for i, m := range obs.Metrics {
-		id := fmt.Sprintf("m%d", i)
-
-		dimensions := []cwtypes.Dimension{{
-			Name:  aws.String(dimName),
-			Value: aws.String(res.ID),
-		}}
-
-		if service == serviceCloudFront {
-			dimensions = append(dimensions, cwtypes.Dimension{
-				Name:  aws.String("Region"),
-				Value: aws.String("Global"),
-			})
+func BuildGetMetricDataQueries(groups []*observability.AWSObs, res ResourceID, service string) []cwtypes.MetricDataQuery {
+	var queries []cwtypes.MetricDataQuery
+	primary := true
+	for _, obs := range groups {
+		if obs == nil {
+			continue
 		}
+		// The per-resource dimension override only applies to the primary
+		// group; extra groups carry a namespace-fixed dimension of their
+		// own (the AOSS group's ClientId, #778).
+		dimName := obs.DimensionName
+		if primary && res.DimensionName != "" {
+			dimName = res.DimensionName
+		}
+		primary = false
 
-		if service == serviceS3 {
-			storageType := "StandardStorage"
-			if m.Name == "NumberOfObjects" {
-				storageType = "AllStorageTypes"
+		for _, m := range obs.Metrics {
+			id := fmt.Sprintf("m%d", len(queries))
+
+			dimensions := []cwtypes.Dimension{{
+				Name:  aws.String(dimName),
+				Value: aws.String(res.ID),
+			}}
+
+			if service == serviceCloudFront {
+				dimensions = append(dimensions, cwtypes.Dimension{
+					Name:  aws.String("Region"),
+					Value: aws.String("Global"),
+				})
 			}
-			dimensions = append(dimensions, cwtypes.Dimension{
-				Name:  aws.String("StorageType"),
-				Value: aws.String(storageType),
+
+			if service == serviceS3 {
+				storageType := "StandardStorage"
+				if m.Name == "NumberOfObjects" {
+					storageType = "AllStorageTypes"
+				}
+				dimensions = append(dimensions, cwtypes.Dimension{
+					Name:  aws.String("StorageType"),
+					Value: aws.String(storageType),
+				})
+			}
+
+			queries = append(queries, cwtypes.MetricDataQuery{
+				Id:    aws.String(id),
+				Label: aws.String(m.Name),
+				MetricStat: &cwtypes.MetricStat{
+					Metric: &cwtypes.Metric{
+						Namespace:  aws.String(obs.Namespace),
+						MetricName: aws.String(m.Name),
+						Dimensions: dimensions,
+					},
+					Period: aws.Int32(300), // overwritten by getMetricData
+					Stat:   aws.String(m.Stat),
+				},
 			})
 		}
-
-		queries = append(queries, cwtypes.MetricDataQuery{
-			Id:    aws.String(id),
-			Label: aws.String(m.Name),
-			MetricStat: &cwtypes.MetricStat{
-				Metric: &cwtypes.Metric{
-					Namespace:  aws.String(obs.Namespace),
-					MetricName: aws.String(m.Name),
-					Dimensions: dimensions,
-				},
-				Period: aws.Int32(300), // overwritten by getMetricData
-				Stat:   aws.String(m.Stat),
-			},
-		})
 	}
 	return queries
 }

--- a/pkg/observability/metrics/aws_test.go
+++ b/pkg/observability/metrics/aws_test.go
@@ -79,6 +79,26 @@ func awsSpecForService(t *testing.T, key composer.ComponentKey, wantService stri
 	return o.AWS
 }
 
+// awsGroups pulls the full set of AWS namespace/dimension groups for a
+// key (primary + AWSExtra) — the slice the production Fetch /
+// BuildGetMetricDataQueries callers pass. Most keys yield exactly one
+// group; multi-namespace components (aws_opensearch, #778) yield more.
+func awsGroups(t *testing.T, key composer.ComponentKey) []*observability.AWSObs {
+	t.Helper()
+	o, ok := observability.Lookup(key)
+	require.True(t, ok, "Lookup(%q) must return a record", key)
+	groups := o.AWSGroups()
+	require.NotEmpty(t, groups, "%q must have at least one AWS group", key)
+	return groups
+}
+
+// oneGroup wraps a single *AWSObs into the slice the multi-group
+// BuildGetMetricDataQueries / Fetch signatures expect, so single-group
+// tests read cleanly.
+func oneGroup(obs *observability.AWSObs) []*observability.AWSObs {
+	return []*observability.AWSObs{obs}
+}
+
 // --- ParseMetricsFilter (from the InsideOut backend aws_metrics_test.go:163) ---
 
 func TestParseMetricsFilter(t *testing.T) {
@@ -157,7 +177,7 @@ func TestBuildGetMetricDataQueries_VerifiesDimensionValues(t *testing.T) {
 			t.Parallel()
 			obs := awsSpecForService(t, tt.key, tt.service)
 			res := ResourceID{ID: tt.resourceID, DimensionName: obs.DimensionName}
-			queries := BuildGetMetricDataQueries(obs, res, tt.service)
+			queries := BuildGetMetricDataQueries(oneGroup(obs), res, tt.service)
 
 			require.Len(t, queries, tt.wantCount)
 
@@ -193,7 +213,7 @@ func TestBuildGetMetricDataQueries_CloudFrontRegionGlobal(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSCloudfront, "cloudfront")
 	res := ResourceID{ID: "E123456", DimensionName: "DistributionId"}
-	queries := BuildGetMetricDataQueries(obs, res, "cloudfront")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "cloudfront")
 
 	for _, q := range queries {
 		dims := q.MetricStat.Metric.Dimensions
@@ -214,7 +234,7 @@ func TestBuildGetMetricDataQueries_APIGatewayHTTPv2MetricNames(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSAPIGateway, "apigateway")
 	res := ResourceID{ID: "abc123def4", DimensionName: "ApiId"}
-	queries := BuildGetMetricDataQueries(obs, res, "apigateway")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "apigateway")
 
 	got := make(map[string]struct{}, len(queries))
 	for _, q := range queries {
@@ -240,7 +260,7 @@ func TestBuildGetMetricDataQueries_CloudFrontAdditionalMetrics(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSCloudfront, "cloudfront")
 	res := ResourceID{ID: "E1234567890", DimensionName: "DistributionId"}
-	queries := BuildGetMetricDataQueries(obs, res, "cloudfront")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "cloudfront")
 
 	got := make(map[string]struct{}, len(queries))
 	for _, q := range queries {
@@ -271,7 +291,7 @@ func TestBuildGetMetricDataQueries_S3StorageType(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSS3, "s3")
 	res := ResourceID{ID: "my-bucket", DimensionName: "BucketName"}
-	queries := BuildGetMetricDataQueries(obs, res, "s3")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "s3")
 
 	for _, q := range queries {
 		dims := q.MetricStat.Metric.Dimensions
@@ -307,11 +327,81 @@ func TestBuildGetMetricDataQueries_NilObs(t *testing.T) {
 func TestBuildGetMetricDataQueries_DimensionFallback(t *testing.T) {
 	t.Parallel()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-blank"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-blank"}, "ec2")
 	require.NotEmpty(t, queries)
 	dims := queries[0].MetricStat.Metric.Dimensions
 	require.NotEmpty(t, dims)
 	assert.Equal(t, "InstanceId", aws.ToString(dims[0].Name))
+}
+
+// TestBuildGetMetricDataQueries_OpenSearchMultiGroup is the #778
+// multi-group contract: aws_opensearch carries the managed AWS/ES group
+// (DomainName) AND the serverless AWS/AOSS group (ClientId), so a single
+// resource emits queries across BOTH namespaces in one call.
+//
+// This doubles as the mutation guard for the multi-group query builder:
+// the assertions on the AOSS half (AWS/AOSS namespace, ClientId
+// dimension, SearchOCU + IndexingOCU metrics) fail if BuildGetMetricDataQueries
+// ever stops iterating past the first group — drop the AWSExtra group and
+// the wantNamespaces/wantDims maps below go unsatisfied.
+func TestBuildGetMetricDataQueries_OpenSearchMultiGroup(t *testing.T) {
+	t.Parallel()
+	groups := awsGroups(t, composer.KeyAWSOpenSearch)
+	require.Len(t, groups, 2,
+		"aws_opensearch must expose two AWS groups: managed AWS/ES + serverless AWS/AOSS (#778)")
+
+	// The primary group's dimension override is honored; the AOSS group
+	// keeps its own ClientId regardless of the per-resource dimension.
+	res := ResourceID{ID: "io-projx-search", DimensionName: "DomainName"}
+	queries := BuildGetMetricDataQueries(groups, res, "opensearch")
+
+	totalMetrics := len(groups[0].Metrics) + len(groups[1].Metrics)
+	require.Len(t, queries, totalMetrics,
+		"query count must span both groups (managed + AOSS)")
+
+	// Query IDs must be globally unique across groups — CloudWatch
+	// rejects duplicate IDs in one GetMetricData request.
+	seenIDs := make(map[string]bool, len(queries))
+	// Map each metric name to the (namespace, dimensionName) it must carry.
+	wantNamespace := map[string]string{}
+	wantDim := map[string]string{}
+	for _, m := range groups[0].Metrics { // AWS/ES + DomainName
+		wantNamespace[m.Name] = "AWS/ES"
+		wantDim[m.Name] = "DomainName"
+	}
+	for _, m := range groups[1].Metrics { // AWS/AOSS + ClientId
+		wantNamespace[m.Name] = "AWS/AOSS"
+		wantDim[m.Name] = "ClientId"
+	}
+	// Assert the AOSS half is actually present (guards a one-group regression).
+	require.Contains(t, wantNamespace, "SearchOCU", "AOSS group must carry SearchOCU")
+	require.Contains(t, wantNamespace, "IndexingOCU", "AOSS group must carry IndexingOCU")
+
+	gotAOSS := 0
+	for _, q := range queries {
+		require.NotNil(t, q.MetricStat)
+		id := aws.ToString(q.Id)
+		assert.False(t, seenIDs[id], "duplicate query ID %q across groups", id)
+		seenIDs[id] = true
+
+		name := aws.ToString(q.MetricStat.Metric.MetricName)
+		ns := aws.ToString(q.MetricStat.Metric.Namespace)
+		dims := q.MetricStat.Metric.Dimensions
+		require.NotEmpty(t, dims, "metric %q must carry a dimension", name)
+
+		assert.Equal(t, wantNamespace[name], ns,
+			"metric %q must publish under namespace %q", name, wantNamespace[name])
+		assert.Equal(t, wantDim[name], aws.ToString(dims[0].Name),
+			"metric %q must carry dimension %q", name, wantDim[name])
+
+		if ns == "AWS/AOSS" {
+			gotAOSS++
+			assert.Equal(t, "Sum", aws.ToString(q.MetricStat.Stat),
+				"AOSS OCU metric %q must use the Sum stat", name)
+		}
+	}
+	assert.Equal(t, len(groups[1].Metrics), gotAOSS,
+		"every AOSS metric must produce exactly one query (the second group must be iterated)")
 }
 
 // --- getMetricData (the unexported CW response shaper) ---
@@ -340,7 +430,7 @@ func TestGetMetricData_HappyPath(t *testing.T) {
 	}
 
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-abc123"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc123"}, "ec2")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -387,7 +477,7 @@ func TestGetMetricData_MismatchedTimestampsAndValues(t *testing.T) {
 	}
 
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -405,7 +495,7 @@ func TestGetMetricData_EmptyResults(t *testing.T) {
 
 	now := time.Now().UTC()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -418,7 +508,7 @@ func TestGetMetricData_APIError(t *testing.T) {
 
 	now := time.Now().UTC()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
 	_, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.Error(t, err)
@@ -430,7 +520,7 @@ func TestGetMetricData_APIError(t *testing.T) {
 func TestFetch_NilClients(t *testing.T) {
 	t.Parallel()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	_, err := Fetch(context.Background(), nil, "ec2", obs, []ResourceID{{ID: "i-abc"}}, MetricsFilter{Hours: 6, Period: 300})
+	_, err := Fetch(context.Background(), nil, "ec2", oneGroup(obs), []ResourceID{{ID: "i-abc"}}, MetricsFilter{Hours: 6, Period: 300})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "clients is required")
 }
@@ -438,9 +528,18 @@ func TestFetch_NilClients(t *testing.T) {
 func TestFetch_NilObs(t *testing.T) {
 	t.Parallel()
 	c := clientsWithCW(&fakeCloudWatch{})
-	_, err := Fetch(context.Background(), c, "ec2", nil, []ResourceID{{ID: "i-abc"}}, MetricsFilter{Hours: 6, Period: 300})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "obs is required")
+	// Both a nil slice and a slice of only-nil groups must be rejected —
+	// the multi-group signature can't build any query from either.
+	for name, groups := range map[string][]*observability.AWSObs{
+		"nil slice":          nil,
+		"slice of nil group": {nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Fetch(context.Background(), c, "ec2", groups, []ResourceID{{ID: "i-abc"}}, MetricsFilter{Hours: 6, Period: 300})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "at least one obs group is required")
+		})
+	}
 }
 
 func TestFetch_ZeroResources(t *testing.T) {
@@ -448,7 +547,7 @@ func TestFetch_ZeroResources(t *testing.T) {
 	mock := &fakeCloudWatch{}
 	c := clientsWithCW(mock)
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	result, err := Fetch(context.Background(), c, "ec2", obs, nil, MetricsFilter{Hours: 6, Period: 300})
+	result, err := Fetch(context.Background(), c, "ec2", oneGroup(obs), nil, MetricsFilter{Hours: 6, Period: 300})
 
 	require.NoError(t, err)
 	assert.Equal(t, "ec2", result.Service)
@@ -476,7 +575,7 @@ func TestFetch_S3PeriodAndHoursOverride(t *testing.T) {
 
 	c := clientsWithCW(mock)
 	obs := awsSpecForService(t, composer.KeyAWSS3, "s3")
-	result, err := Fetch(context.Background(), c, "s3", obs,
+	result, err := Fetch(context.Background(), c, "s3", oneGroup(obs),
 		[]ResourceID{{ID: "my-bucket", DimensionName: "BucketName"}},
 		MetricsFilter{Hours: 6, Period: 300})
 
@@ -505,7 +604,7 @@ func TestFetch_S3DoesNotShortenLongerHours(t *testing.T) {
 	mock := &fakeCloudWatch{output: &cloudwatch.GetMetricDataOutput{}}
 	c := clientsWithCW(mock)
 	obs := awsSpecForService(t, composer.KeyAWSS3, "s3")
-	result, err := Fetch(context.Background(), c, "s3", obs,
+	result, err := Fetch(context.Background(), c, "s3", oneGroup(obs),
 		[]ResourceID{{ID: "my-bucket", DimensionName: "BucketName"}},
 		MetricsFilter{Hours: 72, Period: 300})
 
@@ -552,7 +651,7 @@ func TestFetch_CloudFrontRoutesToUSEast1AndReturnsAllMetrics(t *testing.T) {
 	cfMock := &fakeCloudWatch{output: &cloudwatch.GetMetricDataOutput{MetricDataResults: cfResults}}
 
 	c := clientsWithCFOverride(defaultMock, cfMock)
-	result, err := Fetch(context.Background(), c, "cloudfront", cfObs,
+	result, err := Fetch(context.Background(), c, "cloudfront", oneGroup(cfObs),
 		[]ResourceID{{ID: "E123", DimensionName: "DistributionId"}},
 		MetricsFilter{Hours: 6, Period: 300})
 
@@ -581,7 +680,7 @@ func TestFetch_PartialResourceFailure_Skips(t *testing.T) {
 	mock := &fakeCloudWatch{err: errors.New("throttled")}
 	c := clientsWithCW(mock)
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	result, err := Fetch(context.Background(), c, "ec2", obs,
+	result, err := Fetch(context.Background(), c, "ec2", oneGroup(obs),
 		[]ResourceID{{ID: "i-good"}, {ID: "i-bad"}},
 		MetricsFilter{Hours: 6, Period: 300})
 
@@ -610,7 +709,7 @@ func TestFetch_EC2_EndToEnd(t *testing.T) {
 
 	c := clientsWithCW(mock)
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	result, err := Fetch(context.Background(), c, "ec2", obs,
+	result, err := Fetch(context.Background(), c, "ec2", oneGroup(obs),
 		[]ResourceID{{ID: "i-abc123", DimensionName: "InstanceId"}},
 		MetricsFilter{Hours: 12, Period: 600})
 
@@ -625,6 +724,72 @@ func TestFetch_EC2_EndToEnd(t *testing.T) {
 	assert.Equal(t, "CPUUtilization", result.Resources[0].Metrics[0].Name)
 }
 
+// TestFetch_OpenSearchMultiGroup_RoundTripsBothNamespaces is the #778
+// end-to-end multi-group exercise: aws_opensearch's managed AWS/ES
+// metrics and serverless AWS/AOSS OCU metrics must BOTH issue in a single
+// GetMetricData call and round-trip by name → value through Fetch. The
+// fake echoes one value per metric in the request, so a regression that
+// stops iterating past the first group drops the AOSS metrics and the
+// round-trip map comes up short.
+func TestFetch_OpenSearchMultiGroup_RoundTripsBothNamespaces(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	groups := awsGroups(t, composer.KeyAWSOpenSearch)
+	require.Len(t, groups, 2, "aws_opensearch must expose managed + AOSS groups (#778)")
+
+	// Build one MetricDataResult per metric across both groups, with a
+	// unique value so cross-wiring is caught.
+	var results []cwtypes.MetricDataResult
+	wantValues := map[string]float64{}
+	i := 0
+	for _, g := range groups {
+		for _, m := range g.Metrics {
+			i++
+			v := float64(i)
+			wantValues[m.Name] = v
+			results = append(results, cwtypes.MetricDataResult{
+				Label:      aws.String(m.Name),
+				Timestamps: []time.Time{now},
+				Values:     []float64{v},
+			})
+		}
+	}
+	mock := &fakeCloudWatch{output: &cloudwatch.GetMetricDataOutput{MetricDataResults: results}}
+	c := clientsWithCW(mock)
+
+	result, err := Fetch(context.Background(), c, "opensearch", groups,
+		[]ResourceID{{ID: "io-projx-search", DimensionName: "DomainName"}},
+		MetricsFilter{Hours: 6, Period: 300})
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+
+	// A single GetMetricData call carries queries from BOTH namespaces.
+	require.NotNil(t, mock.lastInput)
+	sawES, sawAOSS := false, false
+	for _, q := range mock.lastInput.MetricDataQueries {
+		switch aws.ToString(q.MetricStat.Metric.Namespace) {
+		case "AWS/ES":
+			sawES = true
+		case "AWS/AOSS":
+			sawAOSS = true
+		}
+	}
+	assert.True(t, sawES, "request must carry AWS/ES (managed) queries")
+	assert.True(t, sawAOSS, "request must carry AWS/AOSS (serverless OCU) queries")
+
+	gotValues := map[string]float64{}
+	for _, m := range result.Resources[0].Metrics {
+		require.Len(t, m.Datapoints, 1, "metric %q should have one datapoint", m.Name)
+		gotValues[m.Name] = m.Datapoints[0].Average
+	}
+	assert.Equal(t, wantValues, gotValues,
+		"every metric across both namespaces must round-trip by name → value")
+	// Spot-check the AOSS metrics are present specifically.
+	assert.Contains(t, gotValues, "SearchOCU")
+	assert.Contains(t, gotValues, "IndexingOCU")
+}
+
 // TestFetch_ClampsHugePeriodToOneDay locks the period clamp at 86400
 // (the max GetMetricData accepts). Anyone passing Period=999999 (an
 // older default in some inspector code paths) gets the supported
@@ -636,7 +801,7 @@ func TestFetch_ClampsHugePeriodToOneDay(t *testing.T) {
 	}
 	c := clientsWithCW(mock)
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	_, err := Fetch(context.Background(), c, "ec2", obs,
+	_, err := Fetch(context.Background(), c, "ec2", oneGroup(obs),
 		[]ResourceID{{ID: "i-abc", DimensionName: "InstanceId"}},
 		MetricsFilter{Hours: 6, Period: 9_999_999})
 
@@ -650,11 +815,15 @@ func TestFetch_ClampsHugePeriodToOneDay(t *testing.T) {
 
 // --- Spec-coverage drift tests ---
 
-// TestEveryAlarmedAWSSpecHasMetricFetchCoverage walks every component
-// key whose AWS spec has at least one metric and confirms the spec
-// passes through BuildGetMetricDataQueries to a non-empty query slice
-// with the expected dimension. Catches drift between the per-component
-// authority (observability.AWSObs) and the metric-fetch builder.
+// TestEveryAWSSpecBuildsValidQueries walks every component key whose AWS
+// surface has at least one metric and confirms EVERY namespace/dimension
+// group (primary + AWSExtra) passes through BuildGetMetricDataQueries
+// with its own namespace, dimension name, metric name, and stat intact.
+// Catches drift between the per-component authority
+// (observability.ComponentObservability.AWSGroups) and the metric-fetch
+// builder — including a multi-namespace component (aws_opensearch's AOSS
+// group, #778) whose extra group must survive the builder under its own
+// AWS/AOSS + ClientId shape, not the primary AWS/ES + DomainName shape.
 //
 // Stops short of asserting Fetch end-to-end per key (that's covered
 // for ec2/s3/cloudfront above) — the drift this test catches is "a key
@@ -664,27 +833,47 @@ func TestEveryAWSSpecBuildsValidQueries(t *testing.T) {
 	t.Parallel()
 	for _, k := range composer.AllComponentKeys {
 		o, ok := observability.Lookup(k)
-		if !ok || o.AWS == nil || len(o.AWS.Metrics) == 0 {
+		groups := o.AWSGroups()
+		if !ok || len(groups) == 0 {
+			continue
+		}
+		totalMetrics := 0
+		for _, g := range groups {
+			totalMetrics += len(g.Metrics)
+		}
+		if totalMetrics == 0 {
 			continue
 		}
 		t.Run(string(k), func(t *testing.T) {
 			t.Parallel()
-			res := ResourceID{ID: "test-id", DimensionName: o.AWS.DimensionName}
-			queries := BuildGetMetricDataQueries(o.AWS, res, o.Service)
-			require.Len(t, queries, len(o.AWS.Metrics),
-				"%s: query count must match spec metric count", k)
-			for i, q := range queries {
-				require.NotNil(t, q.MetricStat, "%s metric[%d]: MetricStat must be set", k, i)
-				assert.Equal(t, o.AWS.Namespace, aws.ToString(q.MetricStat.Metric.Namespace),
-					"%s metric[%d]: namespace drift", k, i)
-				assert.Equal(t, o.AWS.Metrics[i].Name, aws.ToString(q.MetricStat.Metric.MetricName),
-					"%s metric[%d]: name drift", k, i)
-				assert.Equal(t, o.AWS.Metrics[i].Stat, aws.ToString(q.MetricStat.Stat),
-					"%s metric[%d]: stat drift", k, i)
-				dims := q.MetricStat.Metric.Dimensions
-				require.NotEmpty(t, dims, "%s metric[%d]: must carry the resource dimension", k, i)
-				assert.Equal(t, o.AWS.DimensionName, aws.ToString(dims[0].Name),
-					"%s metric[%d]: dimension name drift", k, i)
+			// Leave res.DimensionName empty so each group falls back to
+			// its own DimensionName — the whole point of the multi-group
+			// shape is that the AOSS group keeps ClientId even though the
+			// primary group is DomainName.
+			res := ResourceID{ID: "test-id"}
+			queries := BuildGetMetricDataQueries(groups, res, o.Service)
+			require.Len(t, queries, totalMetrics,
+				"%s: query count must match the sum of metrics across all groups", k)
+
+			// Walk groups in order; queries are emitted group-by-group so
+			// the running index stays aligned with (group, metric).
+			qi := 0
+			for gi, g := range groups {
+				for mi, m := range g.Metrics {
+					q := queries[qi]
+					require.NotNil(t, q.MetricStat, "%s group[%d] metric[%d]: MetricStat must be set", k, gi, mi)
+					assert.Equal(t, g.Namespace, aws.ToString(q.MetricStat.Metric.Namespace),
+						"%s group[%d] metric[%d]: namespace drift", k, gi, mi)
+					assert.Equal(t, m.Name, aws.ToString(q.MetricStat.Metric.MetricName),
+						"%s group[%d] metric[%d]: name drift", k, gi, mi)
+					assert.Equal(t, m.Stat, aws.ToString(q.MetricStat.Stat),
+						"%s group[%d] metric[%d]: stat drift", k, gi, mi)
+					dims := q.MetricStat.Metric.Dimensions
+					require.NotEmpty(t, dims, "%s group[%d] metric[%d]: must carry the resource dimension", k, gi, mi)
+					assert.Equal(t, g.DimensionName, aws.ToString(dims[0].Name),
+						"%s group[%d] metric[%d]: dimension name drift", k, gi, mi)
+					qi++
+				}
 			}
 		})
 	}
@@ -700,12 +889,16 @@ func TestAllSpecsHaveValidStats(t *testing.T) {
 	}
 	for _, k := range composer.AllComponentKeys {
 		o, ok := observability.Lookup(k)
-		if !ok || o.AWS == nil {
+		if !ok {
 			continue
 		}
-		for _, m := range o.AWS.Metrics {
-			assert.True(t, validStats[m.Stat],
-				"key %s metric %s has invalid stat: %s", k, m.Name, m.Stat)
+		// Validate every group, not just the primary — the AOSS group's
+		// SearchOCU / IndexingOCU stats (Sum) must be checked too (#778).
+		for _, g := range o.AWSGroups() {
+			for _, m := range g.Metrics {
+				assert.True(t, validStats[m.Stat],
+					"key %s metric %s (namespace %s) has invalid stat: %s", k, m.Name, g.Namespace, m.Stat)
+			}
 		}
 	}
 }

--- a/pkg/observability/observability_alarms_test.go
+++ b/pkg/observability/observability_alarms_test.go
@@ -46,12 +46,13 @@ var excludedFromAuthority = map[string]string{
 	// gke entry to gcpServiceMetrics in a follow-up to retire this
 	// exclusion.
 	"gcp/gke:kubernetes.io/node/cpu/allocatable_utilization": "#204",
-	// aws/opensearch AOSS OCU alarms (#758) live in namespace AWS/AOSS with
-	// the account-level ClientId dimension; the catalog's "opensearch"
-	// service group is AWS/ES + DomainName (managed domains), so these are
-	// HCL-only until an AOSS-scoped AWSMetricSpec group exists (#778).
-	"aws/opensearch:SearchOCU":   "#778",
-	"aws/opensearch:IndexingOCU": "#778",
+	// NOTE (#778): the aws/opensearch AOSS OCU alarms (SearchOCU /
+	// IndexingOCU, namespace AWS/AOSS) used to be HCL-only exclusions here
+	// because the catalog only carried the managed AWS/ES group. They now
+	// live in the catalog as the AOSS namespace group on KeyAWSOpenSearch
+	// (AWSExtra) and are registered in alarmedAWSMetrics[KeyAWSOpenSearch],
+	// so the forward + reverse authority gates cover them directly — no
+	// exclusion needed.
 }
 
 // awsModuleAuthor inverts alarmedAWSMetrics by module path so the reverse


### PR DESCRIPTION
Stacked on #779 (sagemaker endpoint). Base auto-retargets to `main` when #779 merges.

## What

Extend the inspector data model so a component key can carry more than one CloudWatch namespace/dimension group, then wire the metric-fetch path to walk every group. This lets the inspector see `aws_opensearch`'s serverless OCU metrics (`AWS/AOSS` + `ClientId`: `SearchOCU`, `IndexingOCU`) alongside the managed-domain metrics (`AWS/ES` + `DomainName`).

The five steps from the issue comment:

1. Model: keep the primary `AWS *AWSObs`, add `AWSExtra []*AWSObs`, plus an `AWSGroups()` helper returning the full ordered set.
2. `componentObs()` attaches the AOSS catalog group to `KeyAWSOpenSearch` via `AWSExtra` and flips `Alarmed` across all groups.
3. `Fetch` + `BuildGetMetricDataQueries` take `[]*AWSObs` and iterate every group in one `GetMetricData` call (globally-unique query IDs).
4. The single-record test assumptions in `metrics/aws_test.go`, `component_metrics_test.go`, `contract_test.go` updated to the multi-group shape, with new multi-group cases added (not weakened).
5. `SearchOCU`/`IndexingOCU` registered in `alarmedAWSMetrics[KeyAWSOpenSearch]`; the two `#778` `excludedFromAuthority` entries retired.

## Model shape chosen

Keep `AWS` as the primary group + add `AWSExtra []*AWSObs`, rather than migrating `AWS` to a slice. Reasoning: a slice migration would force every `o.AWS != nil` / `o.AWS.Metrics` / `o.AWS.Namespace` reader (15+ across four test files plus `componentObs`) to index `[0]` or loop; the additive `AWSExtra` field leaves all single-group readers unchanged and confines the loop to the three multi-group consumers. `AWSGroups()` gives those consumers one clean iterator.

## Dimension nuance

The AOSS group's dimension is account-level `ClientId`, distinct from the per-resource `DomainName`. The query builder applies the per-resource `ResourceID.DimensionName` override only to the primary group; extra groups keep their namespace-fixed dimension.

## Tests / QC

- Multi-group query-builder + `Fetch` round-trip cases prove both namespaces issue in one request.
- AWS analogue of the firestore alarm-binding pin: every metric in `alarmedAWSMetrics` must exist in some catalog group of that component, so `componentObs` can flip `Alarmed` — this fails on the "register the alarm without the catalog group" shortcut the issue explicitly rejected.
- Mutation-tested: dropping the second group from the query builder fails 3 multi-group tests; reverting `alarmedAWSMetrics` to drop the OCU entries fails the binding + reverse-authority gates.
- `go test ./pkg/observability/... -count=1` green; `go build ./...`, `go vet`, `gofmt` clean.

Closes #778