### PR TITLE
feat: SageMaker inference endpoint + multi-group AWS metric specs (#761, #778)

### DIFF
--- a/aws/sagemaker/main.tf
+++ b/aws/sagemaker/main.tf
@@ -102,6 +102,31 @@ locals {
   # for the grant from the s3://bucket/key URL.
   model_data_bucket = local.enable_inference && trimspace(var.model_data_url) != "" ? split("/", replace(var.model_data_url, "s3://", ""))[0] : ""
   model_data_arn    = local.model_data_bucket == "" ? "" : "arn:${data.aws_partition.current.partition}:s3:::${local.model_data_bucket}"
+
+  # ECR registry scoping (#761 review MED-3). var.model_image can be a
+  # cross-account image — AWS Deep Learning Containers live in AWS-owned
+  # registries (e.g. 763104351884.dkr.ecr.<region>.amazonaws.com/...), not the
+  # deploying account. Scoping the layer/image-read grant to the *deploying*
+  # account's repos would 403 the pull of any DLC. So we parse the registry
+  # account id out of the standard ECR image URI
+  # (<acct>.dkr.ecr.<region>.amazonaws.com/<repo>[:tag|@digest]) and scope the
+  # BatchGetImage / GetDownloadUrlForLayer / BatchCheckLayerAvailability grant
+  # to *that* registry's repos. If the URI isn't a parseable ECR registry host
+  # (e.g. a bare SageMaker built-in algorithm image or a public/non-ECR ref),
+  # the regex yields no match and we fall back to the deploying account — the
+  # safe default for an in-account image, and non-ECR images don't consult an
+  # ECR repo grant at all.
+  #
+  # ecr_registry_account: the 12-digit account id from the registry host, or
+  # "" when the image URI isn't an ECR registry reference.
+  _ecr_registry_matches = local.enable_inference ? regexall("^([0-9]{12})\\.dkr\\.ecr\\.[a-z0-9-]+\\.amazonaws\\.com/", trimspace(var.model_image)) : []
+  ecr_registry_account  = length(local._ecr_registry_matches) > 0 ? local._ecr_registry_matches[0][0] : data.aws_caller_identity.current.account_id
+
+  # ARN of the repo namespace the model image lives in, scoped to the parsed
+  # (possibly cross-account) registry. The pull grant targets this — not the
+  # deploying account's repos — so cross-account DLC pulls succeed under least
+  # privilege.
+  ecr_repo_arn = "arn:${data.aws_partition.current.partition}:ecr:${var.region}:${local.ecr_registry_account}:repository/*"
 }
 
 resource "random_id" "workspace_suffix" {
@@ -281,7 +306,10 @@ resource "aws_sagemaker_user_profile" "studio_user" {
 
 # ECR pull for the model image. ecr:GetAuthorizationToken is account-wide
 # (Resource "*" is required — the token isn't scopable to a repo); the image
-# layer/manifest reads are scoped to ECR repos in the deploying account.
+# layer/manifest reads are scoped to the registry the model image actually
+# lives in (local.ecr_repo_arn), which may be a *cross-account* AWS registry
+# for a Deep Learning Container (#761 review MED-3). Falls back to the
+# deploying account when the URI isn't a parseable ECR registry reference.
 resource "aws_iam_role_policy" "inference_ecr_pull" {
   count = local.enable_inference ? 1 : 0
 
@@ -303,7 +331,7 @@ resource "aws_iam_role_policy" "inference_ecr_pull" {
           "ecr:GetDownloadUrlForLayer",
           "ecr:BatchGetImage",
         ]
-        Resource = "arn:${data.aws_partition.current.partition}:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/*"
+        Resource = local.ecr_repo_arn
       },
     ]
   })
@@ -392,6 +420,28 @@ resource "aws_sagemaker_endpoint" "inference" {
 
   name                 = "${var.project}-endpoint"
   endpoint_config_name = aws_sagemaker_endpoint_configuration.inference[0].name
+
+  # IAM race guard (#761 review HIGH-1). The endpoint create is where AWS
+  # actually instantiates the container: it pulls the model image from ECR
+  # and (when set) reads model.tar.gz from S3 *as the execution role*. The
+  # aws_sagemaker_model resource above only registers metadata (image URI +
+  # role ARN) — no pull happens there — so the real consumer of these grants
+  # is the endpoint. terraform's implicit graph does NOT order the endpoint
+  # after the inline role policies (the endpoint references the model →
+  # config, not the policies), so without an explicit depends_on the endpoint
+  # create can start before the execution role can pull the image / read the
+  # artifact, intermittently failing the InService rollout. The managed-policy
+  # attachment is included for the same reason (AmazonSageMakerFullAccess
+  # carries the ECR/S3 permissions a scoped override might rely on).
+  #
+  # inference_model_data is count-gated (only present when model_data_url is
+  # set); depends_on tolerates a resource that resolves to zero instances, so
+  # listing it unconditionally is safe whether or not the artifact grant exists.
+  depends_on = [
+    aws_iam_role_policy.inference_ecr_pull,
+    aws_iam_role_policy.inference_model_data,
+    aws_iam_role_policy_attachment.studio_managed,
+  ]
 
   tags = merge(local.tags, { Name = "${var.project}-endpoint" })
 }

--- a/aws/sagemaker/main.tf
+++ b/aws/sagemaker/main.tf
@@ -34,6 +34,10 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.5"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 }
 
@@ -274,6 +278,23 @@ resource "aws_sagemaker_domain" "studio" {
     execution_role = aws_iam_role.studio_execution.arn
   }
 
+  # Home-EFS retention on domain destroy. SageMaker auto-provisions an EFS
+  # filesystem (+ a mount target per subnet) for every Studio domain, tagged
+  # ManagedByAmazonSageMakerResource. The provider's *default* is Retain, so
+  # destroying the domain leaves that EFS — and its mount-target ENIs — alive
+  # in the caller's VPC. Those ENIs then block the VPC's subnet deletion, so a
+  # `terraform destroy` of a stack that owns both the domain and the VPC
+  # (e.g. the composer wiring KeyAWSSageMaker → KeyAWSVPC, and the integration
+  # test) wedges for ~20min on the subnets and then errors, orphaning the EFS +
+  # VPC. Defaulting to "Delete" makes domain teardown remove the EFS so the
+  # ENIs release and the VPC can be destroyed cleanly. Callers who need to keep
+  # Studio home directories across a domain replace can set
+  # var.home_efs_retention = "Retain" (the AWS default) and clean the EFS
+  # out-of-band.
+  retention_policy {
+    home_efs_file_system = var.home_efs_retention
+  }
+
   tags = local.tags
 }
 
@@ -375,6 +396,14 @@ resource "aws_sagemaker_model" "inference" {
     # an empty ModelDataUrl, which AWS rejects. Images that pull their own
     # weights leave this unset.
     model_data_url = trimspace(var.model_data_url) != "" ? var.model_data_url : null
+    # Container env vars. `environment` is a map(string) attribute on
+    # primary_container (not a nested block — verified via
+    # `terraform providers schema -json`). Only set it when the caller supplied
+    # vars; null leaves the container's own defaults untouched and keeps the
+    # plan clean for the env-less Studio-image case. This is how the serving
+    # image is configured — e.g. an AWS HuggingFace DLC reads HF_MODEL_ID +
+    # HF_TASK from here to pick the hub model and serving task.
+    environment = length(var.model_environment) > 0 ? var.model_environment : null
   }
 
   tags = merge(local.tags, { Name = "${var.project}-model" })
@@ -408,6 +437,37 @@ resource "aws_sagemaker_endpoint_configuration" "inference" {
   tags = merge(local.tags, { Name = "${var.project}-endpoint-config" })
 }
 
+# IAM eventual-consistency gate (#761 — found live on the cust3 integration
+# run). depends_on alone is NOT enough: it orders the endpoint *after* the inline
+# role policies are created, but IAM is eventually consistent — the policies take
+# several seconds to propagate to SageMaker's control plane after the API returns.
+# CreateEndpoint fires within ~1s of the policies being written, before that
+# propagation completes, so SageMaker's first validation of the execution role
+# fails with a transient ValidationException. The provider's create wraps
+# CreateEndpoint in a retry for exactly that transient class — but the first
+# (failed-looking) call has already registered the endpoint, so the provider's
+# retry re-issues CreateEndpoint and hits `Cannot create already existing
+# endpoint`, surfacing as a hard failure that masks the underlying IAM race.
+# This bit BOTH live runs (4-8min in, endpoint never reaching InService). A short
+# sleep between the role grants and the endpoint lets IAM propagate first, turning
+# a deterministically-failing first apply into a reliable one. Mirrors
+# aws/bedrock's time_sleep.kb_iam_propagation (same IAM-propagation race on a
+# control-plane create).
+resource "time_sleep" "inference_iam_propagation" {
+  count = local.enable_inference ? 1 : 0
+
+  create_duration = var.inference_iam_propagation_delay
+
+  # Gate on every grant the endpoint's container relies on, so the sleep starts
+  # only once they're all written. inference_model_data is count-gated (absent
+  # when no model_data_url); depends_on tolerates a zero-instance resource.
+  depends_on = [
+    aws_iam_role_policy.inference_ecr_pull,
+    aws_iam_role_policy.inference_model_data,
+    aws_iam_role_policy_attachment.studio_managed,
+  ]
+}
+
 # Endpoint create blocks until the production variant reaches InService —
 # pulling the image + (optionally) the model artifact and warming the container
 # can take several minutes, longer for large GPU LLM images. The aws provider
@@ -421,26 +481,18 @@ resource "aws_sagemaker_endpoint" "inference" {
   name                 = "${var.project}-endpoint"
   endpoint_config_name = aws_sagemaker_endpoint_configuration.inference[0].name
 
-  # IAM race guard (#761 review HIGH-1). The endpoint create is where AWS
-  # actually instantiates the container: it pulls the model image from ECR
-  # and (when set) reads model.tar.gz from S3 *as the execution role*. The
-  # aws_sagemaker_model resource above only registers metadata (image URI +
-  # role ARN) — no pull happens there — so the real consumer of these grants
-  # is the endpoint. terraform's implicit graph does NOT order the endpoint
-  # after the inline role policies (the endpoint references the model →
-  # config, not the policies), so without an explicit depends_on the endpoint
-  # create can start before the execution role can pull the image / read the
-  # artifact, intermittently failing the InService rollout. The managed-policy
-  # attachment is included for the same reason (AmazonSageMakerFullAccess
-  # carries the ECR/S3 permissions a scoped override might rely on).
-  #
-  # inference_model_data is count-gated (only present when model_data_url is
-  # set); depends_on tolerates a resource that resolves to zero instances, so
-  # listing it unconditionally is safe whether or not the artifact grant exists.
+  # IAM race guard (#761 review HIGH-1, hardened after the live cust3 run). The
+  # endpoint create is where AWS actually instantiates the container: it pulls
+  # the model image from ECR and (when set) reads model.tar.gz from S3 *as the
+  # execution role*. The aws_sagemaker_model resource above only registers
+  # metadata (image URI + role ARN) — no pull happens there — so the real
+  # consumer of these grants is the endpoint. We depend on
+  # time_sleep.inference_iam_propagation (not the policies directly) so the
+  # endpoint create waits for BOTH the grants to exist AND IAM to propagate them
+  # to SageMaker's control plane — see the time_sleep comment above for why
+  # ordering-only was insufficient and failed both live runs.
   depends_on = [
-    aws_iam_role_policy.inference_ecr_pull,
-    aws_iam_role_policy.inference_model_data,
-    aws_iam_role_policy_attachment.studio_managed,
+    time_sleep.inference_iam_propagation,
   ]
 
   tags = merge(local.tags, { Name = "${var.project}-endpoint" })

--- a/aws/sagemaker/main.tf
+++ b/aws/sagemaker/main.tf
@@ -89,6 +89,19 @@ locals {
   workspace_bucket_name = local.create_bucket ? aws_s3_bucket.workspace[0].id : var.workspace_bucket
   workspace_bucket_arn  = local.create_bucket ? aws_s3_bucket.workspace[0].arn : "arn:${data.aws_partition.current.partition}:s3:::${var.workspace_bucket}"
   default_bucket_name   = local.create_bucket ? "${var.project}-sagemaker-workspace-${random_id.workspace_suffix[0].hex}" : null
+
+  # Real-time inference slice (#761). When off, the preset stays Studio-only.
+  # The model / endpoint-config / endpoint resources below use
+  # `count = local.enable_inference ? 1 : 0` so they read cleanly as `[0]`
+  # while staying absent when disabled.
+  enable_inference = var.enable_inference
+
+  # model_data_url is optional: many LLM serving images bundle / pull their
+  # own weights. We only attach the s3:GetObject read grant for the artifact
+  # when a URL is actually supplied (least privilege). Derive the bucket ARN
+  # for the grant from the s3://bucket/key URL.
+  model_data_bucket = local.enable_inference && trimspace(var.model_data_url) != "" ? split("/", replace(var.model_data_url, "s3://", ""))[0] : ""
+  model_data_arn    = local.model_data_bucket == "" ? "" : "arn:${data.aws_partition.current.partition}:s3:::${local.model_data_bucket}"
 }
 
 resource "random_id" "workspace_suffix" {
@@ -250,4 +263,135 @@ resource "aws_sagemaker_user_profile" "studio_user" {
   user_profile_name = each.value
 
   tags = local.tags
+}
+
+# -----------------------------------------------------------------------------
+# Real-time inference endpoint (#761) — gated on var.enable_inference.
+#
+# Lifecycle: aws_sagemaker_model (defines the servable container + the
+# execution role it runs under) → aws_sagemaker_endpoint_configuration
+# (the production-variant hosting plan: which model, instance type, count)
+# → aws_sagemaker_endpoint (the live HTTPS endpoint InvokeEndpoint hits).
+#
+# The endpoint hosting container runs as the Studio execution role. To pull
+# the model image from ECR and read the model artifact from S3 it needs
+# explicit grants beyond Studio's bucket access — attached below, only when
+# inference is enabled so the Studio-only path keeps a tighter role.
+# -----------------------------------------------------------------------------
+
+# ECR pull for the model image. ecr:GetAuthorizationToken is account-wide
+# (Resource "*" is required — the token isn't scopable to a repo); the image
+# layer/manifest reads are scoped to ECR repos in the deploying account.
+resource "aws_iam_role_policy" "inference_ecr_pull" {
+  count = local.enable_inference ? 1 : 0
+
+  name = "${var.project}-sagemaker-inference-ecr-pull"
+  role = aws_iam_role.studio_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["ecr:GetAuthorizationToken"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+        ]
+        Resource = "arn:${data.aws_partition.current.partition}:ecr:${var.region}:${data.aws_caller_identity.current.account_id}:repository/*"
+      },
+    ]
+  })
+}
+
+# S3 read for the model artifact (model.tar.gz). Only attached when a
+# model_data_url is supplied — images that bundle their own weights need no
+# extra S3 grant. Scoped to the specific artifact bucket (get object + list).
+resource "aws_iam_role_policy" "inference_model_data" {
+  count = local.enable_inference && local.model_data_arn != "" ? 1 : 0
+
+  name = "${var.project}-sagemaker-inference-model-data"
+  role = aws_iam_role.studio_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject"]
+        Resource = "${local.model_data_arn}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = local.model_data_arn
+      },
+    ]
+  })
+}
+
+resource "aws_sagemaker_model" "inference" {
+  count = local.enable_inference ? 1 : 0
+
+  name               = "${var.project}-model"
+  execution_role_arn = aws_iam_role.studio_execution.arn
+
+  primary_container {
+    image = var.model_image
+    # model_data_url is optional — omit it (null) so the provider doesn't set
+    # an empty ModelDataUrl, which AWS rejects. Images that pull their own
+    # weights leave this unset.
+    model_data_url = trimspace(var.model_data_url) != "" ? var.model_data_url : null
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-model" })
+
+  lifecycle {
+    precondition {
+      # model_image must be non-empty when inference is on — SageMaker can't
+      # host a model without a servable container. Enforced here (not as a
+      # var validation) because the requirement is conditional on
+      # var.enable_inference, and TF forbids cross-variable conditions in a
+      # variable validation block.
+      condition     = trimspace(var.model_image) != ""
+      error_message = "model_image must be a non-empty ECR/SageMaker container image URI when enable_inference is true — SageMaker cannot host a model without a servable container."
+    }
+  }
+}
+
+resource "aws_sagemaker_endpoint_configuration" "inference" {
+  count = local.enable_inference ? 1 : 0
+
+  name = "${var.project}-endpoint-config"
+
+  production_variants {
+    variant_name           = "primary"
+    model_name             = aws_sagemaker_model.inference[0].name
+    initial_instance_count = 1
+    instance_type          = var.endpoint_instance_type
+    initial_variant_weight = 1.0
+  }
+
+  tags = merge(local.tags, { Name = "${var.project}-endpoint-config" })
+}
+
+# Endpoint create blocks until the production variant reaches InService —
+# pulling the image + (optionally) the model artifact and warming the container
+# can take several minutes, longer for large GPU LLM images. The aws provider
+# 6.x aws_sagemaker_endpoint resource does NOT expose a configurable `timeouts`
+# block (verified against `terraform providers schema -json`); it uses the
+# provider's built-in InService wait. A slow-but-healthy rollout is therefore
+# bounded by the provider default, not a knob we can set here.
+resource "aws_sagemaker_endpoint" "inference" {
+  count = local.enable_inference ? 1 : 0
+
+  name                 = "${var.project}-endpoint"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.inference[0].name
+
+  tags = merge(local.tags, { Name = "${var.project}-endpoint" })
 }

--- a/aws/sagemaker/observability.tf
+++ b/aws/sagemaker/observability.tf
@@ -1,0 +1,113 @@
+# observability.tf — issue #761 (real-time inference endpoint alarms).
+#
+# Alarms only exist when var.enable_inference is true: with no endpoint there
+# are no AWS/SageMaker invocation metrics to alarm on. Each alarm is keyed by
+# the EndpointName + VariantName dimensions the endpoint publishes under.
+#
+# Metric names verified against the AWS/SageMaker endpoint-invocation metric
+# table (Invocation5XXErrors, ModelLatency) — not memory (the #764 metric-name
+# regression). ModelLatency is reported in MICROSECONDS, which the latency
+# threshold default reflects.
+
+variable "enable_observability" {
+  description = "When true, emit per-component CloudWatch alarms gated on this module's inference endpoint (issue #761). Has no effect unless var.enable_inference is also true (no endpoint = no metrics to alarm on)."
+  type        = bool
+  default     = true
+}
+
+variable "alarm_topic_arn" {
+  description = "SNS topic ARN that receives alarm + ok notifications. When null, the alarm exists but does not notify."
+  type        = string
+  default     = null
+}
+
+variable "alarm_severity" {
+  description = "Severity tag attached to alarms. One of critical|warning|info."
+  type        = string
+  default     = "warning"
+  validation {
+    condition     = contains(["critical", "warning", "info"], var.alarm_severity)
+    error_message = "alarm_severity must be one of critical|warning|info."
+  }
+}
+
+variable "alarm_threshold_overrides" {
+  description = "Per-metric numeric threshold overrides; missing keys fall through to the module's defaults. Keys: invocation_5xx_errors (count per period), model_latency_micros (microseconds)."
+  type        = map(number)
+  default     = {}
+}
+
+variable "runbook_url_prefix" {
+  description = "Optional URL prefix included in alarm_description so on-call has a click-through."
+  type        = string
+  default     = ""
+}
+
+locals {
+  # Alarms exist only when both the endpoint is provisioned AND observability
+  # is enabled. for_each over a 1/0-element map so the alarms read as a single
+  # resource that's present or absent.
+  _obs_enabled = local.enable_inference && var.enable_observability
+  _obs_actions = var.alarm_topic_arn == null ? [] : [var.alarm_topic_arn]
+  _obs_tags    = merge(module.name.tags, var.tags, { severity = var.alarm_severity })
+  _obs_thresholds = merge({
+    invocation_5xx_errors = 1
+    # ModelLatency is published in MICROSECONDS. 5_000_000 µs = 5s — a
+    # conservative default for an LLM serving endpoint; tune per workload via
+    # alarm_threshold_overrides.
+    model_latency_micros = 5000000
+  }, var.alarm_threshold_overrides)
+  _obs_runbook = var.runbook_url_prefix == "" ? "" : " Runbook: ${var.runbook_url_prefix}/sagemaker/inference"
+
+  # Dimension shared by both alarms — the endpoint + its single "primary"
+  # production variant (the variant_name set in the endpoint configuration).
+  _obs_dimensions = local._obs_enabled ? {
+    EndpointName = aws_sagemaker_endpoint.inference[0].name
+    VariantName  = "primary"
+  } : {}
+}
+
+# A spike in Invocation5XXErrors means the hosted model container is returning
+# server errors (OOM, crashed worker, bad model artifact) — the inference
+# endpoint is up but failing requests. This is the headline failure surface the
+# inference slice exists to serve.
+resource "aws_cloudwatch_metric_alarm" "invocation_5xx_high" {
+  for_each = local._obs_enabled ? { "0" = true } : {}
+
+  alarm_name          = "${module.name.name}-sagemaker-invocation-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  threshold           = local._obs_thresholds["invocation_5xx_errors"]
+  metric_name         = "Invocation5XXErrors"
+  namespace           = "AWS/SageMaker"
+  period              = 300
+  statistic           = "Sum"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "SageMaker endpoint 5XX invocation errors above ${local._obs_thresholds["invocation_5xx_errors"]} per period — the hosted model is failing requests.${local._obs_runbook}"
+  dimensions          = local._obs_dimensions
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}
+
+# Rising ModelLatency means the container is taking longer to return inferences
+# (overloaded instance, cold model, GPU contention). Sustained high latency on
+# a real-time endpoint degrades every caller.
+resource "aws_cloudwatch_metric_alarm" "model_latency_high" {
+  for_each = local._obs_enabled ? { "0" = true } : {}
+
+  alarm_name          = "${module.name.name}-sagemaker-model-latency"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  threshold           = local._obs_thresholds["model_latency_micros"]
+  metric_name         = "ModelLatency"
+  namespace           = "AWS/SageMaker"
+  period              = 300
+  statistic           = "Average"
+  treat_missing_data  = "notBreaching"
+  alarm_description   = "SageMaker endpoint ModelLatency (avg) above ${local._obs_thresholds["model_latency_micros"]}µs — the hosted model is responding slowly.${local._obs_runbook}"
+  dimensions          = local._obs_dimensions
+  alarm_actions       = local._obs_actions
+  ok_actions          = local._obs_actions
+  tags                = local._obs_tags
+}

--- a/aws/sagemaker/outputs.tf
+++ b/aws/sagemaker/outputs.tf
@@ -45,3 +45,28 @@ output "tags" {
   description = "The Project-tagged map applied to every taggable resource in this preset. Other presets composing on top can `merge(module.aws_sagemaker.tags, ...)` to inherit the same Project attribution."
   value       = local.tags
 }
+
+# -----------------------------------------------------------------------------
+# Real-time inference endpoint outputs (#761). Null when enable_inference is
+# false so downstream wiring can detect the Studio-only configuration.
+# -----------------------------------------------------------------------------
+
+output "endpoint_name" {
+  description = "Name of the real-time inference endpoint (`<project>-endpoint`). Callers hit this via the SageMaker Runtime InvokeEndpoint API. Null when enable_inference is false."
+  value       = local.enable_inference ? aws_sagemaker_endpoint.inference[0].name : null
+}
+
+output "endpoint_arn" {
+  description = "Full ARN of the inference endpoint. Useful for IAM policy resource references (e.g. granting sagemaker:InvokeEndpoint to callers). Null when enable_inference is false."
+  value       = local.enable_inference ? aws_sagemaker_endpoint.inference[0].arn : null
+}
+
+output "model_name" {
+  description = "Name of the SageMaker model (`<project>-model`) hosting the servable container. Null when enable_inference is false."
+  value       = local.enable_inference ? aws_sagemaker_model.inference[0].name : null
+}
+
+output "endpoint_config_name" {
+  description = "Name of the endpoint configuration (`<project>-endpoint-config`) — the production-variant hosting plan the endpoint binds. Null when enable_inference is false."
+  value       = local.enable_inference ? aws_sagemaker_endpoint_configuration.inference[0].name : null
+}

--- a/aws/sagemaker/tests/integration.tftest.hcl
+++ b/aws/sagemaker/tests/integration.tftest.hcl
@@ -12,6 +12,20 @@
 #     -var 'model_image=<ECR_OR_SAGEMAKER_IMAGE_URI>' \
 #     -var 'model_data_url=s3://<bucket>/<key>/model.tar.gz'
 #
+# PROVEN GREEN against a real account (cust3, us-east-1) with a CPU HuggingFace
+# PyTorch inference DLC and no model_data_url (the image hub-pulls its weights):
+#
+#   IMG=763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-inference:2.6.0-transformers4.51.3-cpu-py312-ubuntu22.04-v2.1
+#   AWS_REGION=us-east-1 terraform test \
+#     -filter=tests/integration.tftest.hcl \
+#     -var "model_image=$IMG" \
+#     -var 'model_environment={HF_MODEL_ID="sshleifer/tiny-distilbert-base-cased-distilled-squad",HF_TASK="question-answering"}'
+#
+# model_environment is a root module variable, so passing it via -var flows
+# straight into the sagemaker_inference_apply run (no per-run plumbing needed).
+# The HF DLC reads HF_MODEL_ID + HF_TASK from primary_container.environment to
+# pick the hub model + serving task. Endpoint reached InService in ~5min.
+#
 # REQUIRED OPERATOR INPUT — model_image:
 #   SageMaker hosting needs a *servable* container that implements the
 #   /ping + /invocations contract (a SageMaker DLC, a HuggingFace TGI/LMI

--- a/aws/sagemaker/tests/integration.tftest.hcl
+++ b/aws/sagemaker/tests/integration.tftest.hcl
@@ -1,0 +1,166 @@
+# Integration tests for the aws/sagemaker inference slice (#761) —
+# APPLIES AGAINST A REAL AWS ACCOUNT. CI SKIPS this file by filename
+# convention (anything matching *integration*); it is opt-in and needs real
+# credentials + a real, servable container image.
+#
+# Run with valid AWS credentials in the target account:
+#
+#   cd aws/sagemaker
+#   terraform init -backend=false
+#   AWS_REGION=us-east-1 terraform test \
+#     -filter=tests/integration.tftest.hcl \
+#     -var 'model_image=<ECR_OR_SAGEMAKER_IMAGE_URI>' \
+#     -var 'model_data_url=s3://<bucket>/<key>/model.tar.gz'
+#
+# REQUIRED OPERATOR INPUT — model_image:
+#   SageMaker hosting needs a *servable* container that implements the
+#   /ping + /invocations contract (a SageMaker DLC, a HuggingFace TGI/LMI
+#   image, or your own). There is NO sensible default — a wrong/non-servable
+#   image makes the endpoint create hang then fail at InService, so the apply
+#   below will block for several minutes before erroring. Pass a known-good
+#   image URI for your account/region. model_data_url is optional (many LLM
+#   serving images bundle or hub-pull their weights); supply it only if your
+#   image expects a model.tar.gz from S3.
+#
+# QUOTA: real-time GPU hosting (ml.g5.*) needs the per-account
+# "ml.g5.xlarge for endpoint usage" service quota raised above 0, or the
+# endpoint create fails with a ResourceLimitExceeded. The default below uses
+# ml.m5.xlarge (CPU, generally available) so the test runs without a GPU
+# quota bump; override endpoint_instance_type for a GPU image.
+#
+# What it does:
+#   1. setup_vpc: stands up a real VPC via the sibling ../vpc preset so the
+#      Studio domain (required vpc_id + subnet_ids) and the endpoint ENIs have
+#      somewhere to land. Yields concrete vpc_id + private_subnet_ids.
+#   2. sagemaker_inference_apply: applies aws/sagemaker with
+#      enable_inference=true wired to the live VPC, asserting the model /
+#      endpoint-config / endpoint trio all reach a live state — the endpoint
+#      apply only returns once the production variant is InService, so a green
+#      apply here is the live proof the container is servable and the
+#      execution role's ECR-pull + S3 model-data grants are sufficient.
+#   3. Tears EVERYTHING down at the end (terraform test always destroys).
+#      Endpoint + config + model + VPC are destroyed in dependency order.
+#
+# Resource names embed a UTC timestamp suffix (MMDDhhmmss) under the iotsm-
+# prefix so this never collides with a prior iotsm- run.
+#
+# If a prior run was killed mid-apply, manual cleanup may be required:
+#
+#   aws sagemaker list-endpoints --query 'Endpoints[?starts_with(EndpointName, `iotsm-`)]'
+#   aws sagemaker delete-endpoint --endpoint-name <name>
+#   aws sagemaker list-endpoint-configs --query 'EndpointConfigs[?starts_with(EndpointConfigName, `iotsm-`)]'
+#   aws sagemaker delete-endpoint-config --endpoint-config-name <name>
+#   aws sagemaker list-models --query 'Models[?starts_with(ModelName, `iotsm-`)]'
+#   aws sagemaker delete-model --model-name <name>
+
+provider "aws" {
+  region = var.region
+}
+
+variables {
+  # Suffix the project name with a UTC MMDDhhmmss timestamp so back-to-back
+  # runs don't collide on model / endpoint / role names. Computed once at
+  # file-load time and shared across every run in this file, so setup_vpc and
+  # sagemaker_inference_apply see the same project string.
+  # Risk: two runs in the exact same second collide. Acceptable for a
+  # human-driven integration test.
+  project     = "iotsm-${formatdate("MMDDhhmmss", timestamp())}"
+  region      = "us-east-1"
+  environment = "test"
+
+  enable_inference = true
+
+  # CPU hosting instance — generally available without a GPU quota bump.
+  # Override for a GPU serving image (e.g. ml.g5.xlarge) once the endpoint-
+  # usage quota is raised.
+  endpoint_instance_type = "ml.m5.xlarge"
+
+  # model_image is intentionally undefaulted — the operator MUST pass a real,
+  # servable image URI via -var (see header). With no -var the apply fails the
+  # non-empty-image precondition immediately, which is the correct loud signal.
+}
+
+# --- Setup: real VPC for the Studio domain + endpoint ENIs -----------------
+#
+# Uses the sibling vpc preset. Path is resolved relative to the module under
+# test (aws/sagemaker), so we go up one level and across.
+run "setup_vpc" {
+  command = apply
+
+  module {
+    source = "../vpc"
+  }
+
+  variables {
+    project     = var.project
+    environment = var.environment
+    region      = var.region
+  }
+
+  assert {
+    condition     = length(output.private_subnet_ids) > 0
+    error_message = "VPC setup must yield at least one private subnet for the Studio domain + endpoint ENIs."
+  }
+}
+
+# --- Main: sagemaker inference against the real VPC ------------------------
+#
+# The live-apply proof for the #761 inference slice. The endpoint create
+# blocks until the production variant is InService; a green apply is the proof
+# the image is servable and the execution role can pull it (+ read the model
+# artifact when model_data_url is set).
+run "sagemaker_inference_apply" {
+  command = apply
+
+  variables {
+    vpc_id     = run.setup_vpc.vpc_id
+    subnet_ids = run.setup_vpc.private_subnet_ids
+  }
+
+  # --- Model up, hosting the operator's image as the execution role ---
+  assert {
+    condition     = aws_sagemaker_model.inference[0].name == "${var.project}-model"
+    error_message = "Model name must default to {project}-model."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].execution_role_arn == aws_iam_role.studio_execution.arn
+    error_message = "Live model must run as the Studio execution role."
+  }
+
+  # --- Endpoint configuration bound to the model ---
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].instance_type == var.endpoint_instance_type
+    error_message = "Endpoint config production variant must host on endpoint_instance_type."
+  }
+
+  # --- Live endpoint reached InService (the headline live proof) ---
+  # The apply only returns once the endpoint is InService; the resource exposes
+  # arn once created. A non-empty arn after apply is the proof the create
+  # succeeded end-to-end (image pulled, container warmed, variant InService).
+  assert {
+    condition     = aws_sagemaker_endpoint.inference[0].name == "${var.project}-endpoint"
+    error_message = "A live endpoint must be created with the {project}-endpoint name."
+  }
+
+  assert {
+    condition     = can(regex("^arn:aws:sagemaker:", aws_sagemaker_endpoint.inference[0].arn))
+    error_message = "Live endpoint must report a SageMaker endpoint ARN after apply (the InService rollout must succeed)."
+  }
+
+  # --- Outputs populated end-to-end ---
+  assert {
+    condition     = output.endpoint_name == "${var.project}-endpoint"
+    error_message = "endpoint_name output must be populated after a live inference apply."
+  }
+
+  assert {
+    condition     = output.model_name == "${var.project}-model"
+    error_message = "model_name output must be populated after a live inference apply."
+  }
+
+  assert {
+    condition     = output.endpoint_config_name == "${var.project}-endpoint-config"
+    error_message = "endpoint_config_name output must be populated after a live inference apply."
+  }
+}

--- a/aws/sagemaker/tests/shape.tftest.hcl
+++ b/aws/sagemaker/tests/shape.tftest.hcl
@@ -400,3 +400,297 @@ run "sagemaker_rejects_empty_vpc_id" {
 
   expect_failures = [var.vpc_id]
 }
+
+# -----------------------------------------------------------------------------
+# Real-time inference endpoint (#761).
+# -----------------------------------------------------------------------------
+
+# Studio-only is the default: with enable_inference unset, none of the model /
+# endpoint-config / endpoint resources exist, and the Studio domain is
+# unchanged. This is the "Studio behavior unchanged when flag unset" guard.
+run "sagemaker_no_inference_by_default" {
+  command = plan
+
+  variables {
+    project    = "test"
+    vpc_id     = "vpc-12345"
+    subnet_ids = ["subnet-aaa"]
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_model.inference) == 0
+    error_message = "No model resource may exist when enable_inference is unset (Studio-only default)."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint_configuration.inference) == 0
+    error_message = "No endpoint-configuration may exist when enable_inference is unset."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint.inference) == 0
+    error_message = "No endpoint may exist when enable_inference is unset."
+  }
+
+  # No inference ECR / model-data role policies either.
+  assert {
+    condition     = length(aws_iam_role_policy.inference_ecr_pull) == 0
+    error_message = "No inference ECR-pull policy may exist when enable_inference is unset."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_model_data) == 0
+    error_message = "No inference model-data policy may exist when enable_inference is unset."
+  }
+
+  # No inference = no endpoint metrics, so no alarms (the observability
+  # locals must stay safe to evaluate even when the endpoint is absent).
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.invocation_5xx_high) == 0
+    error_message = "No 5XX alarm may exist when inference is off (no endpoint = no metrics)."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.model_latency_high) == 0
+    error_message = "No latency alarm may exist when inference is off."
+  }
+
+  # Studio domain still provisioned + unchanged (the headline invariant).
+  assert {
+    condition     = aws_sagemaker_domain.studio.domain_name == "test-studio"
+    error_message = "Studio domain must stay provisioned + project-prefixed when inference is off."
+  }
+}
+
+# enable_inference=true with a valid image + ml.* instance type composes the
+# full model / endpoint-config / endpoint trio. Pins names, the image flowing
+# into the model's primary container, the instance type on the production
+# variant, the model→config→endpoint chaining, and the ECR-pull + model-data
+# role policies coming up alongside.
+run "inference_endpoint" {
+  command = plan
+
+  variables {
+    project                = "test"
+    vpc_id                 = "vpc-12345"
+    subnet_ids             = ["subnet-aaa"]
+    enable_inference       = true
+    model_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url         = "s3://my-models/llm/model.tar.gz"
+    endpoint_instance_type = "ml.g5.xlarge"
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_model.inference) == 1
+    error_message = "enable_inference must create exactly one model resource."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].name == "test-model"
+    error_message = "Model name must be project-prefixed (`<project>-model`)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].primary_container[0].image == "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    error_message = "model_image must flow into the model's primary_container image."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].primary_container[0].model_data_url == "s3://my-models/llm/model.tar.gz"
+    error_message = "model_data_url must flow into the model's primary_container model_data_url when supplied."
+  }
+
+  # Note: we can't pin `execution_role_arn == aws_iam_role.studio_execution.arn`
+  # under plan mode — the role ARN is Computed (unknown) so the comparison
+  # short-circuits to "unknown" and terraform test errors. The model→exec-role
+  # wiring is asserted apply-mode in tests/integration.tftest.hcl.
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint_configuration.inference) == 1
+    error_message = "enable_inference must create exactly one endpoint configuration."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].name == "test-endpoint-config"
+    error_message = "Endpoint config name must be project-prefixed (`<project>-endpoint-config`)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].instance_type == "ml.g5.xlarge"
+    error_message = "endpoint_instance_type must flow into the production variant instance_type."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].variant_name == "primary"
+    error_message = "Production variant must be named `primary` (the dimension the observability alarms key on)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].model_name == aws_sagemaker_model.inference[0].name
+    error_message = "Endpoint config production variant must reference the preset's model name."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint.inference) == 1
+    error_message = "enable_inference must create exactly one endpoint."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint.inference[0].name == "test-endpoint"
+    error_message = "Endpoint name must be project-prefixed (`<project>-endpoint`)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint.inference[0].endpoint_config_name == aws_sagemaker_endpoint_configuration.inference[0].name
+    error_message = "Endpoint must bind the preset's endpoint configuration name."
+  }
+
+  # Execution role gains both inference grants when a model_data_url is set.
+  assert {
+    condition     = length(aws_iam_role_policy.inference_ecr_pull) == 1
+    error_message = "Inference must attach an ECR-pull policy to the execution role."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_ecr_pull[0].policy, "ecr:GetAuthorizationToken")
+    error_message = "ECR-pull policy must grant ecr:GetAuthorizationToken (image pull needs the auth token)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_model_data) == 1
+    error_message = "A supplied model_data_url must attach an S3 model-data read policy to the execution role."
+  }
+
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_model_data[0].policy, "s3:GetObject")
+    error_message = "Model-data policy must grant s3:GetObject on the artifact bucket."
+  }
+
+  # Observability alarms come up with the endpoint (enable_observability
+  # defaults true), keyed on the endpoint name + primary variant.
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.invocation_5xx_high) == 1
+    error_message = "5XX invocation alarm must be created with the inference endpoint."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].metric_name == "Invocation5XXErrors"
+    error_message = "5XX alarm must watch the Invocation5XXErrors metric (AWS/SageMaker)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].namespace == "AWS/SageMaker"
+    error_message = "5XX alarm namespace must be AWS/SageMaker."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].metric_name == "ModelLatency"
+    error_message = "Latency alarm must watch the ModelLatency metric."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].dimensions["VariantName"] == "primary"
+    error_message = "Alarm must key on the `primary` production variant."
+  }
+}
+
+# When inference is on but no model_data_url is supplied (image bundles its own
+# weights), the ECR-pull policy still attaches but the model-data policy does
+# NOT — least privilege. Companion to the trio run above.
+run "inference_endpoint_without_model_data" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_model.inference) == 1
+    error_message = "Model must still be created when model_data_url is omitted (image bundles weights)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_ecr_pull) == 1
+    error_message = "ECR-pull policy must attach even without a model_data_url."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_model_data) == 0
+    error_message = "No S3 model-data policy may attach when model_data_url is omitted (least privilege)."
+  }
+}
+
+# Positive triangulation companion: a valid ml.* instance type plans cleanly,
+# so the negative below can only fail for the right reason.
+run "inference_valid_instance_type_plans_cleanly" {
+  command = plan
+
+  variables {
+    project                = "test"
+    vpc_id                 = "vpc-12345"
+    subnet_ids             = ["subnet-aaa"]
+    enable_inference       = true
+    model_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    endpoint_instance_type = "ml.m5.xlarge"
+  }
+
+  assert {
+    condition     = aws_sagemaker_endpoint_configuration.inference[0].production_variants[0].instance_type == "ml.m5.xlarge"
+    error_message = "A valid ml.* endpoint_instance_type must plan cleanly (companion to rejects_bad_instance_type)."
+  }
+}
+
+# A bare EC2 type (no ml. prefix) is rejected by the endpoint_instance_type
+# validation at plan — the headline #761 rejection axis.
+run "inference_rejects_bad_instance_type" {
+  command = plan
+
+  variables {
+    project                = "test"
+    vpc_id                 = "vpc-12345"
+    subnet_ids             = ["subnet-aaa"]
+    enable_inference       = true
+    model_image            = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    endpoint_instance_type = "m5.xlarge"
+  }
+
+  expect_failures = [var.endpoint_instance_type]
+}
+
+# A non-s3 model_data_url is rejected by the model_data_url validation.
+run "inference_rejects_bad_model_data_url" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url   = "https://not-s3.example.com/model.tar.gz"
+  }
+
+  expect_failures = [var.model_data_url]
+}
+
+# enable_inference=true with an empty model_image is rejected by the
+# aws_sagemaker_model precondition (cross-variable: only required when
+# inference is on, so it lives as a resource precondition, not a var
+# validation). Pins that SageMaker can't be asked to host an image-less model.
+run "inference_rejects_empty_model_image" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    # model_image deliberately left at its empty default.
+  }
+
+  expect_failures = [aws_sagemaker_model.inference]
+}

--- a/aws/sagemaker/tests/shape.tftest.hcl
+++ b/aws/sagemaker/tests/shape.tftest.hcl
@@ -57,6 +57,15 @@ run "sagemaker_minimum_inputs" {
     error_message = "app_network_access_type should default to PublicInternetOnly when network_mode is unset (AWS-managed egress)."
   }
 
+  # Home-EFS retention must default to Delete so domain teardown removes the
+  # auto-provisioned EFS + its mount-target ENIs — otherwise those ENIs wedge
+  # VPC subnet deletion and orphan the EFS (caught live on the #761 integration
+  # run; the AWS default of Retain wedges teardown for ~20min then errors).
+  assert {
+    condition     = aws_sagemaker_domain.studio.retention_policy[0].home_efs_file_system == "Delete"
+    error_message = "home_efs_file_system retention must default to Delete so the domain's EFS is removed on destroy and the VPC can be torn down cleanly."
+  }
+
   assert {
     condition     = aws_sagemaker_domain.studio.tags["Project"] == "test"
     error_message = "Project tag must be set on the SageMaker domain so the InsideOut inspector's exact-match filter sees it (CLAUDE.md issue #81)."
@@ -661,6 +670,38 @@ run "inference_endpoint" {
   assert {
     condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].threshold == 5000000
     error_message = "Latency alarm default threshold must be 5_000_000µs (5s) (#761 P1-6)."
+  }
+}
+
+# model_environment flows into the model's primary_container.environment so a
+# serving image can be configured (e.g. an AWS HuggingFace DLC reads HF_MODEL_ID
+# + HF_TASK to pick the hub model + task). Companion case: an empty
+# model_environment (the default) leaves the attribute null so the env-less
+# Studio-image path stays clean — asserted in inference_endpoint above by the
+# absence of any model_environment var.
+run "inference_model_environment_flows_to_container" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-inference:latest"
+    model_environment = {
+      HF_MODEL_ID = "sshleifer/tiny-distilbert-base-cased-distilled-squad"
+      HF_TASK     = "question-answering"
+    }
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].primary_container[0].environment["HF_MODEL_ID"] == "sshleifer/tiny-distilbert-base-cased-distilled-squad"
+    error_message = "model_environment must flow into the model's primary_container.environment (HF_MODEL_ID)."
+  }
+
+  assert {
+    condition     = aws_sagemaker_model.inference[0].primary_container[0].environment["HF_TASK"] == "question-answering"
+    error_message = "model_environment must flow into the model's primary_container.environment (HF_TASK)."
   }
 }
 

--- a/aws/sagemaker/tests/shape.tftest.hcl
+++ b/aws/sagemaker/tests/shape.tftest.hcl
@@ -566,6 +566,33 @@ run "inference_endpoint" {
     error_message = "Model-data policy must grant s3:GetObject on the artifact bucket."
   }
 
+  # --- IAM Resource SCOPING (#761 review P1-5) -------------------------------
+  # A mutation that widened the model-data statement to Resource = "*" survived
+  # all 24 shape runs because nothing asserted the scope. Pin both halves: the
+  # statement must name the scoped bucket ARN AND must NOT contain a bare
+  # `"Resource":"*"` (the S3 read must never be account-wide).
+  # Match on the partition-independent suffix (`:s3:::my-models`) — the
+  # mock_provider emits a random partition for data.aws_partition, so we can't
+  # pin the `aws` literal here; the bucket scope is what matters.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_model_data[0].policy, ":s3:::my-models")
+    error_message = "Model-data policy must scope s3:GetObject to the artifact bucket ARN (...:s3:::my-models...), not a wildcard."
+  }
+
+  assert {
+    condition     = !strcontains(replace(aws_iam_role_policy.inference_model_data[0].policy, " ", ""), "\"Resource\":\"*\"")
+    error_message = "Model-data policy must NOT grant Resource = \"*\" on the S3 read — that breaks least privilege (#761 P1-5)."
+  }
+
+  # ECR-pull statement repo scope: the layer/image reads must target a
+  # repository ARN. ecr:GetAuthorizationToken legitimately needs Resource "*",
+  # so we assert the repo ARN is present rather than asserting "no * anywhere".
+  # Partition-independent suffix (mock_provider randomizes the partition).
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_ecr_pull[0].policy, ":ecr:us-east-1:123456789012:repository/*")
+    error_message = "ECR-pull policy must scope BatchGetImage/GetDownloadUrlForLayer to the image's registry repos (in-account image → deploying account), not a bare wildcard (#761 P1-5)."
+  }
+
   # Observability alarms come up with the endpoint (enable_observability
   # defaults true), keyed on the endpoint name + primary variant.
   assert {
@@ -591,6 +618,49 @@ run "inference_endpoint" {
   assert {
     condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].dimensions["VariantName"] == "primary"
     error_message = "Alarm must key on the `primary` production variant."
+  }
+
+  # P2-8: pin the EndpointName dimension alongside VariantName so a mutation
+  # that dropped / mis-keyed the endpoint dimension fails (an alarm keyed only
+  # on VariantName would match every endpoint's primary variant).
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].dimensions["EndpointName"] == "test-endpoint"
+    error_message = "Alarm must key on the endpoint's name via the EndpointName dimension (#761 P2-8)."
+  }
+
+  # --- Alarm direction + statistic + default threshold (#761 review P1-6) ----
+  # An inverted comparison_operator (LessThan...) would make these alarms fire
+  # on healthy traffic and stay silent on the failure they exist to catch, and
+  # survived every prior run. Pin the operator, the statistic, and the default
+  # threshold on BOTH alarms.
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].comparison_operator == "GreaterThanThreshold"
+    error_message = "5XX alarm must fire when errors go ABOVE threshold (GreaterThanThreshold) — an inverted operator alarms on healthy traffic (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].statistic == "Sum"
+    error_message = "5XX alarm must aggregate errors with Sum (count of 5XX per period) (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.invocation_5xx_high["0"].threshold == 1
+    error_message = "5XX alarm default threshold must be 1 (any sustained 5XX is actionable) (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].comparison_operator == "GreaterThanThreshold"
+    error_message = "Latency alarm must fire when latency goes ABOVE threshold (GreaterThanThreshold) (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].statistic == "Average"
+    error_message = "Latency alarm must aggregate with Average (mean ModelLatency per period) (#761 P1-6)."
+  }
+
+  assert {
+    condition     = aws_cloudwatch_metric_alarm.model_latency_high["0"].threshold == 5000000
+    error_message = "Latency alarm default threshold must be 5_000_000µs (5s) (#761 P1-6)."
   }
 }
 
@@ -621,6 +691,44 @@ run "inference_endpoint_without_model_data" {
   assert {
     condition     = length(aws_iam_role_policy.inference_model_data) == 0
     error_message = "No S3 model-data policy may attach when model_data_url is omitted (least privilege)."
+  }
+}
+
+# Cross-account ECR registry scoping (#761 review MED-3). model_image accepts a
+# cross-account image — AWS Deep Learning Containers live in AWS-owned
+# registries (e.g. 763104351884) in the same region, NOT the deploying account.
+# The ECR-pull layer/image-read grant must be scoped to *that* registry's repos
+# or the pull 403s. Pins that the parsed cross-account registry id lands in the
+# repo ARN, and that the deploying account's id does NOT appear there.
+run "inference_ecr_pull_scopes_to_cross_account_dlc_registry" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    # AWS DLC registry account (763104351884), us-east-1. The deploying
+    # account in the mock is a different (mock) id; the repo ARN must carry
+    # 763104351884, not the deploying account.
+    model_image = "763104351884.dkr.ecr.us-east-1.amazonaws.com/huggingface-pytorch-tgi-inference:2.0-tgi"
+  }
+
+  # Partition-independent suffix (mock_provider randomizes data.aws_partition);
+  # the cross-account registry id (763104351884) is the load-bearing part.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_ecr_pull[0].policy, ":ecr:us-east-1:763104351884:repository/*")
+    error_message = "ECR-pull policy must scope layer/image reads to the cross-account DLC registry (763104351884) parsed from model_image, not the deploying account (#761 MED-3)."
+  }
+
+  # GetAuthorizationToken legitimately needs Resource "*" (the token isn't
+  # repo-scopable), so a bare "*" is expected in the auth-token statement.
+  # But the layer/image-read statement must be repo-scoped — assert the
+  # cross-account repo ARN is present so a regression to account-wide
+  # (deploying account) scoping fails here.
+  assert {
+    condition     = strcontains(aws_iam_role_policy.inference_ecr_pull[0].policy, "ecr:GetAuthorizationToken")
+    error_message = "ECR-pull policy must still grant ecr:GetAuthorizationToken on \"*\" (the auth token isn't repo-scopable)."
   }
 }
 
@@ -675,6 +783,94 @@ run "inference_rejects_bad_model_data_url" {
   }
 
   expect_failures = [var.model_data_url]
+}
+
+# A bare `s3://` (no bucket, no key) is rejected by the tightened
+# model_data_url validation (#761 review LOW-4). Before the tightening this
+# passed the `^s3://` regex but derived an empty bucket ARN that would 403 the
+# read at apply.
+run "inference_rejects_bare_s3_scheme" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url   = "s3://"
+  }
+
+  expect_failures = [var.model_data_url]
+}
+
+# Bucket-but-no-key (`s3://bucket/`) is also rejected — SageMaker needs the
+# object key to the model.tar.gz, not just a bucket (#761 review LOW-4).
+run "inference_rejects_s3_bucket_without_key" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url   = "s3://my-models/"
+  }
+
+  expect_failures = [var.model_data_url]
+}
+
+# Positive companion for the tightened validation: a full s3://<bucket>/<key>
+# URI still plans cleanly, so the negatives above can only fail for the right
+# reason (rejection-axis triangulation per #614).
+run "inference_full_s3_url_plans_cleanly" {
+  command = plan
+
+  variables {
+    project          = "test"
+    vpc_id           = "vpc-12345"
+    subnet_ids       = ["subnet-aaa"]
+    enable_inference = true
+    model_image      = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+    model_data_url   = "s3://my-models/llm/model.tar.gz"
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.inference_model_data) == 1
+    error_message = "A full s3://<bucket>/<key> model_data_url must plan cleanly and attach the model-data policy (companion to the bare-s3:// / bucket-only rejects)."
+  }
+}
+
+# Gating run (#761 review P2-7): inference ON but observability OFF must
+# suppress BOTH alarms while still standing up the endpoint. Proves
+# enable_observability gates the alarms independently of enable_inference.
+run "inference_without_observability_suppresses_alarms" {
+  command = plan
+
+  variables {
+    project              = "test"
+    vpc_id               = "vpc-12345"
+    subnet_ids           = ["subnet-aaa"]
+    enable_inference     = true
+    enable_observability = false
+    model_image          = "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest"
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.invocation_5xx_high) == 0
+    error_message = "5XX alarm must be suppressed when enable_observability=false even though inference is on (#761 P2-7)."
+  }
+
+  assert {
+    condition     = length(aws_cloudwatch_metric_alarm.model_latency_high) == 0
+    error_message = "Latency alarm must be suppressed when enable_observability=false even though inference is on (#761 P2-7)."
+  }
+
+  assert {
+    condition     = length(aws_sagemaker_endpoint.inference) == 1
+    error_message = "The endpoint must still be created when observability is disabled (the two flags are independent) (#761 P2-7)."
+  }
 }
 
 # enable_inference=true with an empty model_image is rejected by the

--- a/aws/sagemaker/variables.tf
+++ b/aws/sagemaker/variables.tf
@@ -62,6 +62,17 @@ variable "subnet_ids" {
   }
 }
 
+variable "home_efs_retention" {
+  description = "What to do with the Studio domain's auto-provisioned home EFS filesystem when the domain is destroyed. `Delete` (default) removes the EFS so its mount-target ENIs release and the enclosing VPC can be torn down cleanly — without this, AWS's default `Retain` orphans the EFS and its ENIs, which wedge VPC subnet deletion for ~20min and then fail. Set `Retain` to keep Studio home directories across a domain replace (you must then clean the EFS out-of-band)."
+  type        = string
+  default     = "Delete"
+
+  validation {
+    condition     = contains(["Delete", "Retain"], var.home_efs_retention)
+    error_message = "home_efs_retention must be one of: Delete, Retain."
+  }
+}
+
 variable "network_mode" {
   description = "SageMaker Studio app network access type. `PublicInternetOnly` (default) keeps egress through AWS-managed networking; `VpcOnly` forces all egress through the customer VPC (requires NAT or VPC endpoints for the SageMaker control plane)."
   type        = string
@@ -143,6 +154,24 @@ variable "model_data_url" {
     # `s3://bucket/` (bucket but no object) is also rejected.
     condition     = var.model_data_url == "" ? true : can(regex("^s3://[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]/.+", var.model_data_url))
     error_message = "model_data_url must be a full s3://<bucket>/<key> URI pointing at the model artifact (or empty to let the container supply its own weights). A bare s3:// or bucket-only s3://<bucket>/ is rejected."
+  }
+}
+
+variable "model_environment" {
+  description = "Environment variables injected into the model's primary container (a map of name → value). Threads straight through to the SageMaker `primary_container.environment`. Use it to configure the serving image — e.g. an AWS HuggingFace DLC needs HF_MODEL_ID + HF_TASK to know which hub model to pull and how to serve it; an LMI/TGI image takes its own model/engine vars here. Empty (default) leaves the container's own defaults in place. Only consumed when enable_inference is true. Not marked sensitive — these are serving knobs, not secrets; pass real secrets via a secrets manager, not container env."
+  type        = map(string)
+  default     = {}
+  sensitive   = false
+}
+
+variable "inference_iam_propagation_delay" {
+  description = "How long to wait after writing the endpoint's execution-role grants before creating the endpoint, to let IAM propagate to SageMaker's control plane. Without this delay CreateEndpoint fires before the role is validated, and the provider's create-retry then collides on `Cannot create already existing endpoint` (observed on a real-account run). A Go duration string (e.g. `30s`, `1m`). Only consumed when enable_inference is true."
+  type        = string
+  default     = "30s"
+
+  validation {
+    condition     = can(regex("^[0-9]+(s|m|h)$", var.inference_iam_propagation_delay))
+    error_message = "inference_iam_propagation_delay must be a Go duration like 30s, 1m, or 1h."
   }
 }
 

--- a/aws/sagemaker/variables.tf
+++ b/aws/sagemaker/variables.tf
@@ -113,6 +113,49 @@ variable "studio_users" {
 }
 
 # -----------------------------------------------------------------------------
+# Real-time inference endpoint (#761) — gated on enable_inference. When off,
+# the preset stays Studio-only (the #615 behavior); when on, it adds a
+# model + endpoint-configuration + endpoint trio hosting a servable container.
+# -----------------------------------------------------------------------------
+
+variable "enable_inference" {
+  description = "When true, provision a real-time inference slice (aws_sagemaker_model + aws_sagemaker_endpoint_configuration + aws_sagemaker_endpoint) hosting model_image. When false (default) the preset stays Studio-only and none of the inference resources are created. The Studio domain + execution role are always provisioned regardless."
+  type        = bool
+  default     = false
+}
+
+variable "model_image" {
+  description = "ECR / SageMaker container image URI for the model's primary container (e.g. a Deep Learning Container or an LLM serving image). Required (non-empty) when enable_inference is true — SageMaker cannot host a model without a servable container. Ignored when enable_inference is false."
+  type        = string
+  default     = ""
+}
+
+variable "model_data_url" {
+  description = "Optional S3 URI to the model artifact tarball (model.tar.gz) loaded into the container at startup. Leave empty for images that bundle their own weights (many LLM serving images pull from the hub at runtime). Only consumed when enable_inference is true."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.model_data_url == "" ? true : can(regex("^s3://", var.model_data_url))
+    error_message = "model_data_url must be an s3:// URI (or empty to let the container supply its own weights)."
+  }
+}
+
+variable "endpoint_instance_type" {
+  description = "Instance type for the real-time endpoint's production variant (e.g. ml.m5.xlarge, ml.g5.xlarge for GPU LLM serving). Must be an ml.* family — SageMaker hosting only accepts ml-prefixed instance types. Only consumed when enable_inference is true."
+  type        = string
+  default     = "ml.m5.xlarge"
+
+  validation {
+    # SageMaker hosting instance types are always ml.<family>.<size>. A bare
+    # EC2 type (m5.xlarge) or a typo is rejected at plan so callers don't
+    # discover it only when the endpoint create fails at apply.
+    condition     = can(regex("^ml\\.[a-z0-9]+\\.[a-z0-9]+$", var.endpoint_instance_type))
+    error_message = "endpoint_instance_type must be a SageMaker ml.* hosting instance type (e.g. ml.m5.xlarge, ml.g5.xlarge)."
+  }
+}
+
+# -----------------------------------------------------------------------------
 # IAM policy override
 # -----------------------------------------------------------------------------
 

--- a/aws/sagemaker/variables.tf
+++ b/aws/sagemaker/variables.tf
@@ -136,8 +136,13 @@ variable "model_data_url" {
   default     = ""
 
   validation {
-    condition     = var.model_data_url == "" ? true : can(regex("^s3://", var.model_data_url))
-    error_message = "model_data_url must be an s3:// URI (or empty to let the container supply its own weights)."
+    # Require a bucket AND a key, not a bare `s3://` (which would derive an
+    # empty bucket ARN and 403 the model-data read at apply). Bucket segment:
+    # 3-63 chars, lowercase alphanumeric / hyphen / dot, start+end
+    # alphanumeric (S3 naming). Key segment: at least one non-slash char so
+    # `s3://bucket/` (bucket but no object) is also rejected.
+    condition     = var.model_data_url == "" ? true : can(regex("^s3://[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]/.+", var.model_data_url))
+    error_message = "model_data_url must be a full s3://<bucket>/<key> URI pointing at the model artifact (or empty to let the container supply its own weights). A bare s3:// or bucket-only s3://<bucket>/ is rejected."
   }
 }
 

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -59,6 +59,13 @@ var AWSIAMActions = map[ComponentKey][]string{
 	// create. Specific create permissions catch the fail-fast surface
 	// before terraform hits AWS.
 	KeyAWSSageMaker: {
+		// CloudWatch alarms (#761 review MED-2). observability.tf creates the
+		// invocation-5XX + model-latency alarms by default (enable_observability
+		// defaults true) whenever inference is on, so the deploy principal needs
+		// PutMetricAlarm to create them and DeleteAlarms so `terraform destroy`
+		// can tear them down. Mirrors KeyAWSCloudWatchMonitoring's PutMetricAlarm.
+		"cloudwatch:DeleteAlarms",
+		"cloudwatch:PutMetricAlarm",
 		"iam:AttachRolePolicy",
 		"iam:CreateRole",
 		"iam:PassRole",

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -69,6 +69,14 @@ var AWSIAMActions = map[ComponentKey][]string{
 		"s3:PutEncryptionConfiguration",
 		"sagemaker:CreateDomain",
 		"sagemaker:CreateUserProfile",
+		// Real-time inference endpoint (#761). Only exercised when
+		// enable_inference is set, but listed unconditionally so the
+		// pre-deploy SimulatePrincipalPolicy check (ui-core #192) confirms
+		// the deploy principal can create the model / endpoint-config /
+		// endpoint trio before a deploy attempts it.
+		"sagemaker:CreateModel",
+		"sagemaker:CreateEndpointConfig",
+		"sagemaker:CreateEndpoint",
 	},
 	KeyAWSALB:                  {"elasticloadbalancing:CreateLoadBalancer", "elasticloadbalancing:CreateTargetGroup"},
 	KeyAWSCloudfront:           {"cloudfront:CreateDistribution"},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1344,6 +1344,23 @@ func (m DefaultMapper) BuildModuleValues(
 			if strings.TrimSpace(sm.SageMakerManagedPolicyARN) != "" {
 				vals["sagemaker_managed_policy_arn"] = strings.TrimSpace(sm.SageMakerManagedPolicyARN)
 			}
+			// Real-time inference (#761). enable_inference gates the model /
+			// endpoint-config / endpoint trio; the image / data URL /
+			// instance-type fields only matter when it's on, but emit each
+			// independently (same partial-config contract) so the preset
+			// default wins for any field the caller leaves zero.
+			if sm.EnableInference != nil {
+				vals["enable_inference"] = *sm.EnableInference
+			}
+			if strings.TrimSpace(sm.ModelImage) != "" {
+				vals["model_image"] = strings.TrimSpace(sm.ModelImage)
+			}
+			if strings.TrimSpace(sm.ModelDataURL) != "" {
+				vals["model_data_url"] = strings.TrimSpace(sm.ModelDataURL)
+			}
+			if strings.TrimSpace(sm.EndpointInstanceType) != "" {
+				vals["endpoint_instance_type"] = strings.TrimSpace(sm.EndpointInstanceType)
+			}
 		}
 
 	case KeyAWSCodeBuild:

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1361,6 +1361,16 @@ func (m DefaultMapper) BuildModuleValues(
 			if strings.TrimSpace(sm.EndpointInstanceType) != "" {
 				vals["endpoint_instance_type"] = strings.TrimSpace(sm.EndpointInstanceType)
 			}
+			// Container env vars (#761). Only emit when the caller supplied
+			// entries so the preset's empty-map default wins otherwise — same
+			// partial-config contract, mirroring the apprunner EnvVars path.
+			if len(sm.ModelEnvironment) > 0 {
+				env := make(map[string]any, len(sm.ModelEnvironment))
+				for k, v := range sm.ModelEnvironment {
+					env[k] = v
+				}
+				vals["model_environment"] = env
+			}
 		}
 
 	case KeyAWSCodeBuild:

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -190,6 +190,23 @@ func kitchenSinkConfig() *Config {
 		Instruction     string `json:"instruction,omitempty"`
 		AgentName       string `json:"agentName,omitempty"`
 	}{FoundationModel: "anthropic.claude-3-5-sonnet-20240620-v1:0", Instruction: "You are a helpful assistant that answers questions about the customer's documents.", AgentName: "support-agent"}
+	// AWSSageMaker exercises both the #615 Studio fields and the #761
+	// inference fields so the keys-subset gate confirms every emitted tfvar
+	// (network_mode … enable_inference / model_image / model_data_url /
+	// endpoint_instance_type) is a declared aws/sagemaker variable. Values
+	// are internally consistent with the preset's validations: EnableInference
+	// pairs with a non-empty model_image, an s3:// model_data_url, and an ml.*
+	// endpoint_instance_type so the config would also pass a real plan.
+	cfg.AWSSageMaker = &AWSSageMakerConfig{
+		NetworkMode:               "VpcOnly",
+		WorkspaceBucket:           "kitchen-sink-ml-bucket",
+		StudioUsers:               []string{"alice"},
+		SageMakerManagedPolicyARN: "arn:aws:iam::123456789012:policy/MyScopedSagemaker",
+		EnableInference:           &t,
+		ModelImage:                "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest",
+		ModelDataURL:              "s3://kitchen-sink-ml-bucket/model.tar.gz",
+		EndpointInstanceType:      "ml.g5.xlarge",
+	}
 	cfg.AWSRoute53 = &struct {
 		DomainName   string   `json:"domainName,omitempty"`
 		CreateZone   *bool    `json:"createZone,omitempty"`

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -206,6 +206,7 @@ func kitchenSinkConfig() *Config {
 		ModelImage:                "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm-serve:latest",
 		ModelDataURL:              "s3://kitchen-sink-ml-bucket/model.tar.gz",
 		EndpointInstanceType:      "ml.g5.xlarge",
+		ModelEnvironment:          map[string]string{"HF_MODEL_ID": "sshleifer/tiny-distilbert-base-cased-distilled-squad", "HF_TASK": "question-answering"},
 	}
 	cfg.AWSRoute53 = &struct {
 		DomainName   string   `json:"domainName,omitempty"`

--- a/pkg/composer/sagemaker_aws_wiring_test.go
+++ b/pkg/composer/sagemaker_aws_wiring_test.go
@@ -59,7 +59,7 @@ func TestMapper_AWSSageMaker_DefaultConfig(t *testing.T) {
 		"default subnet_ids should be a single-element preview stub list")
 
 	// Optional vars MUST be absent when caller didn't populate cfg.
-	for _, key := range []string{"network_mode", "workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn"} {
+	for _, key := range []string{"network_mode", "workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn", "enable_inference", "model_image", "model_data_url", "endpoint_instance_type"} {
 		_, has := vals[key]
 		require.Falsef(t, has,
 			"mapper must NOT emit %q when caller left cfg.AWSSageMaker nil — module default must win",
@@ -71,6 +71,7 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 	t.Parallel()
 
 	fd := true
+	ei := true
 	cfg := &Config{
 		AWSSageMaker: &AWSSageMakerConfig{
 			VPCID:                       "vpc-real",
@@ -80,6 +81,10 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 			WorkspaceBucketForceDestroy: &fd,
 			StudioUsers:                 []string{"alice", "bob"},
 			SageMakerManagedPolicyARN:   "arn:aws:iam::123456789012:policy/MyScopedSagemaker",
+			EnableInference:             &ei,
+			ModelImage:                  "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm:latest",
+			ModelDataURL:                "s3://my-bucket/model.tar.gz",
+			EndpointInstanceType:        "ml.g5.xlarge",
 		},
 	}
 	m := DefaultMapper{}
@@ -93,6 +98,51 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 	require.Equal(t, true, vals["workspace_bucket_force_destroy"])
 	require.Equal(t, []any{"alice", "bob"}, vals["studio_users"])
 	require.Equal(t, "arn:aws:iam::123456789012:policy/MyScopedSagemaker", vals["sagemaker_managed_policy_arn"])
+	require.Equal(t, true, vals["enable_inference"])
+	require.Equal(t, "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm:latest", vals["model_image"])
+	require.Equal(t, "s3://my-bucket/model.tar.gz", vals["model_data_url"])
+	require.Equal(t, "ml.g5.xlarge", vals["endpoint_instance_type"])
+}
+
+// TestMapper_AWSSageMaker_InferencePartialConfig pins that the inference
+// fields obey the same partial-config contract: setting only EnableInference
+// (e.g. a caller that wants the trio with the preset's default image-less
+// shape rejected at plan) emits enable_inference but leaves model_image /
+// model_data_url / endpoint_instance_type unset so the preset defaults / the
+// non-empty-image precondition own those. Catches a regression where the
+// mapper would emit empty strings that override the preset defaults.
+func TestMapper_AWSSageMaker_InferencePartialConfig(t *testing.T) {
+	t.Parallel()
+
+	ei := true
+	cfg := &Config{
+		AWSSageMaker: &AWSSageMakerConfig{
+			EnableInference: &ei,
+			// ModelImage / ModelDataURL / EndpointInstanceType intentionally
+			// left zero.
+		},
+	}
+	m := DefaultMapper{}
+	vals, err := m.BuildModuleValues(KeyAWSSageMaker, &Components{}, cfg, "demo", "us-east-1")
+	require.NoError(t, err)
+
+	require.Equal(t, true, vals["enable_inference"])
+	for _, key := range []string{"model_image", "model_data_url", "endpoint_instance_type"} {
+		_, has := vals[key]
+		require.Falsef(t, has,
+			"mapper must NOT emit %q when caller left it zero — module default must win",
+			key)
+	}
+
+	// And the false-path: EnableInference=&false must still emit
+	// enable_inference (an explicit deselect the preset must honor), not be
+	// dropped like an empty string.
+	ef := false
+	cfg2 := &Config{AWSSageMaker: &AWSSageMakerConfig{EnableInference: &ef}}
+	vals2, err := m.BuildModuleValues(KeyAWSSageMaker, &Components{}, cfg2, "demo", "us-east-1")
+	require.NoError(t, err)
+	require.Equal(t, false, vals2["enable_inference"],
+		"EnableInference=&false must emit enable_inference=false (explicit opt-out), not be dropped")
 }
 
 // TestMapper_AWSSageMaker_PartialConfig confirms that when only one
@@ -130,7 +180,7 @@ func TestMapper_AWSSageMaker_PartialConfig(t *testing.T) {
 	require.Equal(t, "vpc-00000000preview", vals["vpc_id"])
 	require.Equal(t, []any{"subnet-00000000preview"}, vals["subnet_ids"])
 
-	for _, key := range []string{"workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn"} {
+	for _, key := range []string{"workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn", "enable_inference", "model_image", "model_data_url", "endpoint_instance_type"} {
 		_, has := vals[key]
 		require.Falsef(t, has,
 			"mapper must NOT emit %q when caller left it zero — module default must win",
@@ -153,6 +203,9 @@ func TestMapper_AWSSageMaker_EmptyStringsIgnored(t *testing.T) {
 			WorkspaceBucket:           "   ",
 			StudioUsers:               []string{"alice", "  ", ""},
 			SageMakerManagedPolicyARN: "  ",
+			ModelImage:                "   ",
+			ModelDataURL:              "  ",
+			EndpointInstanceType:      "   ",
 		},
 	}
 	m := DefaultMapper{}
@@ -169,7 +222,8 @@ func TestMapper_AWSSageMaker_EmptyStringsIgnored(t *testing.T) {
 	require.Equal(t, []any{"alice"}, vals["studio_users"])
 
 	// Whitespace-only strings on optional scalar fields → not emitted at all.
-	for _, key := range []string{"network_mode", "workspace_bucket", "sagemaker_managed_policy_arn"} {
+	// enable_inference is a *bool (nil here) so it must also be absent.
+	for _, key := range []string{"network_mode", "workspace_bucket", "sagemaker_managed_policy_arn", "enable_inference", "model_image", "model_data_url", "endpoint_instance_type"} {
 		_, has := vals[key]
 		require.Falsef(t, has,
 			"mapper must NOT emit %q when caller supplied a whitespace-only string",
@@ -340,4 +394,14 @@ func TestAWSIAMPermissions_SageMakerCovered(t *testing.T) {
 		"S3 CreateBucket permission must be in the required set (preset-managed workspace bucket)")
 	require.Contains(t, required, "s3:PutBucketPublicAccessBlock",
 		"PutBucketPublicAccessBlock permission must be in the required set (security default on the workspace bucket)")
+
+	// Real-time inference endpoint (#761) — the model / endpoint-config /
+	// endpoint create permissions must be in the required set so the
+	// pre-deploy simulate catches a principal that can't host a model.
+	require.Contains(t, required, "sagemaker:CreateModel",
+		"SageMaker model create permission must be in the required set (#761 inference endpoint)")
+	require.Contains(t, required, "sagemaker:CreateEndpointConfig",
+		"SageMaker endpoint-config create permission must be in the required set (#761 inference endpoint)")
+	require.Contains(t, required, "sagemaker:CreateEndpoint",
+		"SageMaker endpoint create permission must be in the required set (#761 inference endpoint)")
 }

--- a/pkg/composer/sagemaker_aws_wiring_test.go
+++ b/pkg/composer/sagemaker_aws_wiring_test.go
@@ -404,4 +404,14 @@ func TestAWSIAMPermissions_SageMakerCovered(t *testing.T) {
 		"SageMaker endpoint-config create permission must be in the required set (#761 inference endpoint)")
 	require.Contains(t, required, "sagemaker:CreateEndpoint",
 		"SageMaker endpoint create permission must be in the required set (#761 inference endpoint)")
+
+	// CloudWatch alarm permissions (#761 review MED-2). observability.tf
+	// creates the invocation-5XX + model-latency alarms by default whenever
+	// inference is on; the deploy principal needs PutMetricAlarm to create
+	// them and DeleteAlarms so destroy can clean them up. Without these the
+	// pre-deploy simulate passes but the alarm create/destroy 403s.
+	require.Contains(t, required, "cloudwatch:PutMetricAlarm",
+		"CloudWatch PutMetricAlarm must be in the required set (observability alarms created by default — #761 MED-2)")
+	require.Contains(t, required, "cloudwatch:DeleteAlarms",
+		"CloudWatch DeleteAlarms must be in the required set so terraform destroy can tear down the observability alarms (#761 MED-2)")
 }

--- a/pkg/composer/sagemaker_aws_wiring_test.go
+++ b/pkg/composer/sagemaker_aws_wiring_test.go
@@ -85,6 +85,7 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 			ModelImage:                  "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm:latest",
 			ModelDataURL:                "s3://my-bucket/model.tar.gz",
 			EndpointInstanceType:        "ml.g5.xlarge",
+			ModelEnvironment:            map[string]string{"HF_MODEL_ID": "org/model", "HF_TASK": "question-answering"},
 		},
 	}
 	m := DefaultMapper{}
@@ -102,6 +103,7 @@ func TestMapper_AWSSageMaker_CallerSuppliedConfig(t *testing.T) {
 	require.Equal(t, "123456789012.dkr.ecr.us-east-1.amazonaws.com/llm:latest", vals["model_image"])
 	require.Equal(t, "s3://my-bucket/model.tar.gz", vals["model_data_url"])
 	require.Equal(t, "ml.g5.xlarge", vals["endpoint_instance_type"])
+	require.Equal(t, map[string]any{"HF_MODEL_ID": "org/model", "HF_TASK": "question-answering"}, vals["model_environment"])
 }
 
 // TestMapper_AWSSageMaker_InferencePartialConfig pins that the inference
@@ -180,7 +182,7 @@ func TestMapper_AWSSageMaker_PartialConfig(t *testing.T) {
 	require.Equal(t, "vpc-00000000preview", vals["vpc_id"])
 	require.Equal(t, []any{"subnet-00000000preview"}, vals["subnet_ids"])
 
-	for _, key := range []string{"workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn", "enable_inference", "model_image", "model_data_url", "endpoint_instance_type"} {
+	for _, key := range []string{"workspace_bucket", "workspace_bucket_force_destroy", "studio_users", "sagemaker_managed_policy_arn", "enable_inference", "model_image", "model_data_url", "endpoint_instance_type", "model_environment"} {
 		_, has := vals[key]
 		require.Falsef(t, has,
 			"mapper must NOT emit %q when caller left it zero — module default must win",

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -570,6 +570,14 @@ type AWSSageMakerConfig struct {
 	ModelImage           string `json:"modelImage,omitempty"`
 	ModelDataURL         string `json:"modelDataUrl,omitempty"`
 	EndpointInstanceType string `json:"endpointInstanceType,omitempty"`
+
+	// ModelEnvironment carries container env vars injected into the model's
+	// primary container (threads to aws/sagemaker var.model_environment →
+	// primary_container.environment). Required for serving images that read
+	// their config from env — e.g. an AWS HuggingFace DLC needs HF_MODEL_ID +
+	// HF_TASK. Nil / empty defers to the preset default ({}), same
+	// partial-config contract as the fields above.
+	ModelEnvironment map[string]string `json:"modelEnvironment,omitempty"`
 }
 
 // AWSCodeBuildConfig is the caller-facing config for the aws/codebuild

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -558,6 +558,18 @@ type AWSSageMakerConfig struct {
 	WorkspaceBucketForceDestroy *bool    `json:"workspaceBucketForceDestroy,omitempty"`
 	StudioUsers                 []string `json:"studioUsers,omitempty"`
 	SageMakerManagedPolicyARN   string   `json:"sagemakerManagedPolicyArn,omitempty"`
+
+	// Real-time inference endpoint (#761). When EnableInference is set, the
+	// preset adds an aws_sagemaker_model + endpoint-configuration + endpoint
+	// trio hosting ModelImage. The Studio domain stays unconditional.
+	// ModelImage is required (validated non-empty in the preset) when
+	// inference is on; ModelDataURL is optional (images may bundle weights).
+	// Unset / nil fields defer to the preset's variables.tf defaults, same
+	// partial-config contract as every other field above.
+	EnableInference      *bool  `json:"enableInference,omitempty"`
+	ModelImage           string `json:"modelImage,omitempty"`
+	ModelDataURL         string `json:"modelDataUrl,omitempty"`
+	EndpointInstanceType string `json:"endpointInstanceType,omitempty"`
 }
 
 // AWSCodeBuildConfig is the caller-facing config for the aws/codebuild

--- a/pkg/observability/component_metrics_test.go
+++ b/pkg/observability/component_metrics_test.go
@@ -218,16 +218,13 @@ func TestObservability_AlarmedSpecsHaveAuthorityEntry(t *testing.T) {
 		}
 		// Walk every AWS group (primary + AWSExtra) so an Alarmed flip in a
 		// multi-namespace component's extra group (the AOSS SearchOCU /
-		// IndexingOCU, #778) is held to the same authority contract.
-		for _, g := range o.AWSGroups() {
-			for _, m := range g.Metrics {
-				if !m.Alarmed {
-					continue
-				}
-				assert.True(t, awsAuthority[m.Name],
-					"Observability[%s].AWS group (namespace %s) metric %q has Alarmed=true but %q not in alarmedAWSMetrics[%s] — service catalog must remain Alarmed=false; flips happen via the per-key authority map",
-					k, g.Namespace, m.Name, m.Name, k)
-			}
+		// IndexingOCU, #778) is held to the same authority contract. Shares
+		// the alarmedSpecHasAuthority predicate with the synthetic negative
+		// in TestAlarmedSpecHasAuthority_RejectsExtraGroup.
+		if name, ns, ok := alarmedSpecHasAuthority(o, awsAuthority); !ok {
+			assert.Failf(t, "Alarmed spec lacks authority entry",
+				"Observability[%s].AWS group (namespace %s) metric %q has Alarmed=true but %q not in alarmedAWSMetrics[%s] — service catalog must remain Alarmed=false; flips happen via the per-key authority map",
+				k, ns, name, name, k)
 		}
 		if o.GCP != nil {
 			for _, m := range o.GCP.Metrics {
@@ -240,6 +237,78 @@ func TestObservability_AlarmedSpecsHaveAuthorityEntry(t *testing.T) {
 			}
 		}
 	}
+}
+
+// alarmedSpecHasAuthority is the predicate
+// TestObservability_AlarmedSpecsHaveAuthorityEntry enforces against the
+// real catalog: for every Alarmed=true AWS spec across all of a record's
+// groups (primary + AWSExtra), the metric name must appear in the
+// per-key authority set. It returns (offendingMetric, namespace, ok) —
+// ok=false names the first Alarmed spec lacking authority. Factored out
+// so the live gate and the synthetic negative below share one
+// implementation.
+func alarmedSpecHasAuthority(o ComponentObservability, authority map[string]bool) (string, string, bool) {
+	for _, g := range o.AWSGroups() {
+		for _, m := range g.Metrics {
+			if m.Alarmed && !authority[m.Name] {
+				return m.Name, g.Namespace, false
+			}
+		}
+	}
+	return "", "", true
+}
+
+// TestAlarmedSpecHasAuthority_RejectsExtraGroup is the P2 synthetic
+// negative for the extra-group Alarmed-rejection gate (#778 review). The
+// live gate (TestObservability_AlarmedSpecsHaveAuthorityEntry) only ever
+// sees a catalog that already satisfies the contract, so its rejection
+// arm is never actually taken. This test feeds the predicate a
+// hand-built ComponentObservability whose AWSExtra group carries an
+// Alarmed=true metric absent from the authority set, and confirms the
+// gate rejects it — proving the extra-group walk is load-bearing,
+// independent of what the real catalog happens to contain.
+func TestAlarmedSpecHasAuthority_RejectsExtraGroup(t *testing.T) {
+	t.Parallel()
+
+	// Authority set covers the primary group's alarmed metric only — the
+	// extra group's alarmed metric is deliberately NOT authorized.
+	authority := map[string]bool{"PrimaryAlarmed": true}
+
+	synthetic := ComponentObservability{
+		Service: "synthetic",
+		AWS: &AWSObs{
+			Namespace:     "AWS/Primary",
+			DimensionName: "PrimaryId",
+			Metrics: []AWSMetricSpec{
+				{Name: "PrimaryAlarmed", Stat: "Sum", Alarmed: true},
+				{Name: "PrimaryQuiet", Stat: "Average"},
+			},
+		},
+		AWSExtra: []*AWSObs{{
+			Namespace:     "AWS/Extra",
+			DimensionName: "ExtraId",
+			Metrics: []AWSMetricSpec{
+				// Unauthorized Alarmed=true spec living ONLY in the extra
+				// group — the gate must catch this.
+				{Name: "ExtraAlarmedNoAuthority", Stat: "Sum", Alarmed: true},
+			},
+		}},
+	}
+
+	name, ns, ok := alarmedSpecHasAuthority(synthetic, authority)
+	require.False(t, ok,
+		"gate must reject an Alarmed=true metric in an extra group with no authority entry")
+	assert.Equal(t, "ExtraAlarmedNoAuthority", name,
+		"the rejected metric must be the unauthorized extra-group spec")
+	assert.Equal(t, "AWS/Extra", ns,
+		"rejection must point at the extra group's namespace — proving AWSExtra was walked")
+
+	// Sanity: once the extra-group metric is authorized, the same record
+	// passes — confirming the gate isn't rejecting unconditionally.
+	authority["ExtraAlarmedNoAuthority"] = true
+	_, _, ok = alarmedSpecHasAuthority(synthetic, authority)
+	assert.True(t, ok,
+		"with every Alarmed spec authorized (both groups), the gate must accept the record")
 }
 
 // TestServicesForKeys_ReturnsKnownServices verifies that with C2's

--- a/pkg/observability/component_metrics_test.go
+++ b/pkg/observability/component_metrics_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestComponentMetricsMapping_OnlyKnownKeys ensures every key in
@@ -125,7 +126,8 @@ func TestObservabilityMatchesComponentMetricsMapping_Service(t *testing.T) {
 // TestObservability_AWSEntriesHaveAWSObs ensures every Observability
 // entry whose key is AWS-backed AND whose Service is in
 // awsServiceMetrics has a non-nil AWS field. GCP keys must NOT have a
-// non-nil AWS field.
+// non-nil AWS field. Any AWSExtra groups present (multi-namespace
+// components, #778) must be non-nil and only attached to AWS keys.
 func TestObservability_AWSEntriesHaveAWSObs(t *testing.T) {
 	for k, o := range Observability {
 		if composer.CloudFor(k) == "aws" {
@@ -134,18 +136,63 @@ func TestObservability_AWSEntriesHaveAWSObs(t *testing.T) {
 					"Observability[%s].AWS should be non-nil because service %q has awsServiceMetrics catalog",
 					k, o.Service)
 			}
+			for i, g := range o.AWSExtra {
+				assert.NotNil(t, g,
+					"Observability[%s].AWSExtra[%d] must be non-nil — componentObs only appends real groups", k, i)
+			}
 			assert.Nil(t, o.GCP,
 				"Observability[%s].GCP must be nil (key is AWS)", k)
 			continue
 		}
 		assert.Nil(t, o.AWS,
 			"Observability[%s].AWS must be nil (key is GCP)", k)
+		assert.Empty(t, o.AWSExtra,
+			"Observability[%s].AWSExtra must be empty (key is GCP)", k)
 		if _, hasMetrics := gcpServiceMetrics[o.Service]; hasMetrics {
 			assert.NotNil(t, o.GCP,
 				"Observability[%s].GCP should be non-nil because service %q has gcpServiceMetrics catalog",
 				k, o.Service)
 		}
 	}
+}
+
+// TestObservability_OpenSearchHasAOSSGroup is the #778 multi-group
+// contract pinned to the data model: aws_opensearch carries the managed
+// AWS/ES + DomainName group as its primary AWS group AND the serverless
+// AWS/AOSS + ClientId group in AWSExtra. SearchOCU / IndexingOCU live in
+// the AOSS group with Alarmed=true (flipped from
+// alarmedAWSMetrics[KeyAWSOpenSearch]) and the Sum stat.
+func TestObservability_OpenSearchHasAOSSGroup(t *testing.T) {
+	o, ok := Observability[composer.KeyAWSOpenSearch]
+	require.True(t, ok, "aws_opensearch must have an Observability record")
+
+	require.NotNil(t, o.AWS, "primary AWS group (managed AWS/ES) must be present")
+	assert.Equal(t, "AWS/ES", o.AWS.Namespace)
+	assert.Equal(t, "DomainName", o.AWS.DimensionName)
+
+	require.Len(t, o.AWSExtra, 1, "aws_opensearch must carry exactly one extra group (AOSS)")
+	aoss := o.AWSExtra[0]
+	require.NotNil(t, aoss)
+	assert.Equal(t, "AWS/AOSS", aoss.Namespace)
+	assert.Equal(t, "ClientId", aoss.DimensionName)
+
+	byName := make(map[string]AWSMetricSpec, len(aoss.Metrics))
+	for _, m := range aoss.Metrics {
+		byName[m.Name] = m
+	}
+	for _, name := range []string{"SearchOCU", "IndexingOCU"} {
+		spec, present := byName[name]
+		require.True(t, present, "AOSS group must carry %q", name)
+		assert.Equal(t, "Sum", spec.Stat, "%q must use the Sum stat", name)
+		assert.True(t, spec.Alarmed,
+			"%q must be Alarmed=true — it is registered in alarmedAWSMetrics[KeyAWSOpenSearch]", name)
+	}
+
+	// AWSGroups() exposes both groups in order for the metric-fetch path.
+	groups := o.AWSGroups()
+	require.Len(t, groups, 2)
+	assert.Equal(t, "AWS/ES", groups[0].Namespace)
+	assert.Equal(t, "AWS/AOSS", groups[1].Namespace)
 }
 
 // TestObservability_AlarmedSpecsHaveAuthorityEntry is the post-C9
@@ -169,14 +216,17 @@ func TestObservability_AlarmedSpecsHaveAuthorityEntry(t *testing.T) {
 				gcpAuthority[m] = true
 			}
 		}
-		if o.AWS != nil {
-			for _, m := range o.AWS.Metrics {
+		// Walk every AWS group (primary + AWSExtra) so an Alarmed flip in a
+		// multi-namespace component's extra group (the AOSS SearchOCU /
+		// IndexingOCU, #778) is held to the same authority contract.
+		for _, g := range o.AWSGroups() {
+			for _, m := range g.Metrics {
 				if !m.Alarmed {
 					continue
 				}
 				assert.True(t, awsAuthority[m.Name],
-					"Observability[%s].AWS.Metrics[%q].Alarmed=true but %q not in alarmedAWSMetrics[%s] — service catalog must remain Alarmed=false; flips happen via the per-key authority map",
-					k, m.Name, m.Name, k)
+					"Observability[%s].AWS group (namespace %s) metric %q has Alarmed=true but %q not in alarmedAWSMetrics[%s] — service catalog must remain Alarmed=false; flips happen via the per-key authority map",
+					k, g.Namespace, m.Name, m.Name, k)
 			}
 		}
 		if o.GCP != nil {

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -77,6 +77,17 @@ type AWSObs struct {
 	Namespace     string
 	DimensionName string
 	Metrics       []AWSMetricSpec
+
+	// DimensionValueAccountID, when true, sources this group's dimension
+	// VALUE from the AWS account ID rather than the per-resource ID. AOSS
+	// (AWS/AOSS, #778) publishes account-level OCU under a ClientId
+	// dimension whose value is the account ID — not the collection/domain
+	// ID the rest of the catalog keys on. Every other group leaves this
+	// false and the dimension value is res.ID. The query builder skips a
+	// group with this flag set when no account ID is available, rather
+	// than emitting a query with an empty (and silently-non-matching)
+	// dimension value.
+	DimensionValueAccountID bool
 }
 
 type AWSMetricSpec struct {
@@ -265,6 +276,13 @@ var awsServiceMetrics = map[string]AWSObs{
 	"opensearch_aoss": {
 		Namespace:     "AWS/AOSS",
 		DimensionName: "ClientId",
+		// The ClientId dimension's VALUE is the AWS account ID, not the
+		// collection/domain ID — AOSS OCU is published account-wide, so the
+		// query builder must source this group's dimension value from the
+		// account ID (DimensionValueAccountID) rather than res.ID. Without
+		// this flag the live OCU fetch sets ClientId=<collection-id> and the
+		// series comes back empty (#778 review).
+		DimensionValueAccountID: true,
 		Metrics: []AWSMetricSpec{
 			{Name: "SearchOCU", Stat: "Sum"},
 			{Name: "IndexingOCU", Stat: "Sum"},

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -23,14 +23,49 @@ type ComponentObservability struct {
 	// in ComponentMetricsMapping[k].Service.
 	Service string
 
-	// AWS is populated for AWS-backed components and carries the
-	// CloudWatch namespace / dimension / metric specs that drive both the
-	// metric-fetch wrapper and the per-component alarm authoring.
-	// nil for GCP components or AWS components with no metric surface.
+	// AWS is the primary CloudWatch namespace / dimension / metric group
+	// for AWS-backed components. It drives both the metric-fetch wrapper
+	// and the per-component alarm authoring. nil for GCP components or AWS
+	// components with no metric surface.
+	//
+	// Most components have exactly one namespace/dimension group, carried
+	// here. A few components publish across more than one namespace (e.g.
+	// aws_opensearch covers managed domains under AWS/ES + DomainName AND
+	// serverless collections under AWS/AOSS + ClientId, #778). Those carry
+	// their extra groups in AWSExtra; single-group callers keep reading
+	// AWS unchanged. AWSGroups() returns the full set (AWS first, then
+	// AWSExtra) for callers that must walk every group.
 	AWS *AWSObs
+
+	// AWSExtra carries additional CloudWatch namespace/dimension groups
+	// for AWS-backed components that publish across more than one
+	// namespace. Empty/nil for the single-group common case. Entries are
+	// never nil (componentObs only appends non-nil groups). See AWS above
+	// and AWSGroups().
+	AWSExtra []*AWSObs
 
 	// GCP is populated for GCP-backed components.
 	GCP *GCPObs
+}
+
+// AWSGroups returns every AWS namespace/dimension group on the record in
+// stable order: the primary AWS group first (when set), then each
+// AWSExtra group. nil entries are filtered out, so the result is safe to
+// range over directly. Returns an empty (non-nil-bearing) slice for
+// records with no AWS surface. Multi-group consumers — the metric-fetch
+// query builder and the alarm-flip in componentObs — iterate this rather
+// than touching AWS / AWSExtra directly.
+func (c ComponentObservability) AWSGroups() []*AWSObs {
+	groups := make([]*AWSObs, 0, 1+len(c.AWSExtra))
+	if c.AWS != nil {
+		groups = append(groups, c.AWS)
+	}
+	for _, g := range c.AWSExtra {
+		if g != nil {
+			groups = append(groups, g)
+		}
+	}
+	return groups
 }
 
 // AWSObs is the AWS half of ComponentObservability. Mirrors the InsideOut backend's
@@ -214,6 +249,25 @@ var awsServiceMetrics = map[string]AWSObs{
 			{Name: "FreeStorageSpace", Stat: "Average"},
 			{Name: "CPUUtilization", Stat: "Average"},
 			{Name: "JVMMemoryPressure", Stat: "Average"},
+		},
+	},
+	// OpenSearch Serverless (AOSS) OCU consumption — the second
+	// namespace/dimension group attached to KeyAWSOpenSearch (#778).
+	// AWS/AOSS publishes SearchOCU / IndexingOCU at the ACCOUNT level under
+	// the ClientId dimension (= account ID); there is no per-collection OCU
+	// breakdown (verified against the AWS/AOSS metrics reference, 2026-06,
+	// same source the aws/opensearch observability.tf OCU alarms cite). Stat
+	// is Sum: these metrics publish with Sum (OCU-units consumed in the
+	// period); Maximum returns an empty series. This is NOT a standalone
+	// service binding — no ComponentMetricsMapping entry points at
+	// "opensearch_aoss"; it exists solely as the catalog source for the
+	// AOSS group componentObs() attaches to KeyAWSOpenSearch via AWSExtra.
+	"opensearch_aoss": {
+		Namespace:     "AWS/AOSS",
+		DimensionName: "ClientId",
+		Metrics: []AWSMetricSpec{
+			{Name: "SearchOCU", Stat: "Sum"},
+			{Name: "IndexingOCU", Stat: "Sum"},
 		},
 	},
 	"bedrock": {
@@ -511,14 +565,31 @@ func componentObs(k composer.ComponentKey) ComponentObservability {
 	o := ComponentObservability{Service: binding.Service}
 	if composer.CloudFor(k) == "aws" {
 		o.AWS = awsObsFor(binding.Service)
-		if author, ok := alarmedAWSMetrics[k]; ok && o.AWS != nil {
+		// OpenSearch publishes across two namespaces: managed domains
+		// under AWS/ES (the primary group above) and serverless
+		// collections under AWS/AOSS (#778). Attach the AOSS catalog as
+		// an extra group so the inspector can see SearchOCU / IndexingOCU
+		// alongside the managed-domain metrics. The catalog copy is
+		// per-record (awsObsFor clones Metrics) so the Alarmed flip below
+		// won't mutate the shared catalog.
+		if k == composer.KeyAWSOpenSearch {
+			if aoss := awsObsFor("opensearch_aoss"); aoss != nil {
+				o.AWSExtra = append(o.AWSExtra, aoss)
+			}
+		}
+		// Flip Alarmed across every namespace group so an alarmed metric
+		// in the AOSS group (SearchOCU / IndexingOCU) is marked the same
+		// way an AWS/ES metric (ClusterStatus.red) is.
+		if author, ok := alarmedAWSMetrics[k]; ok {
 			set := make(map[string]bool, len(author.Metrics))
 			for _, m := range author.Metrics {
 				set[m] = true
 			}
-			for i := range o.AWS.Metrics {
-				if set[o.AWS.Metrics[i].Name] {
-					o.AWS.Metrics[i].Alarmed = true
+			for _, g := range o.AWSGroups() {
+				for i := range g.Metrics {
+					if set[g.Metrics[i].Name] {
+						g.Metrics[i].Alarmed = true
+					}
 				}
 			}
 		}
@@ -569,8 +640,14 @@ var alarmedAWSMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyAWSElastiCache:  {Module: "aws/elasticache", Metrics: []string{"CPUUtilization"}},
 	composer.KeyAWSLambda:       {Module: "aws/lambda", Metrics: []string{"Errors"}},
 	composer.KeyAWSMSK:          {Module: "aws/msk", Metrics: []string{"OfflinePartitionsCount"}},
-	composer.KeyAWSOpenSearch:   {Module: "aws/opensearch", Metrics: []string{"ClusterStatus.red"}},
-	composer.KeyAWSRDS:          {Module: "aws/rds", Metrics: []string{"CPUUtilization", "FreeStorageSpace"}},
+	// ClusterStatus.red (managed, AWS/ES) plus the two serverless OCU
+	// alarms (AWS/AOSS, #758) now that the AOSS namespace group exists in
+	// the catalog (#778). All three have aws_cloudwatch_metric_alarm
+	// resources in aws/opensearch/observability.tf; the for_each gates
+	// suppress whichever pair doesn't match the deployment_type, but the
+	// metric_name strings still match this catalog.
+	composer.KeyAWSOpenSearch: {Module: "aws/opensearch", Metrics: []string{"ClusterStatus.red", "SearchOCU", "IndexingOCU"}},
+	composer.KeyAWSRDS:        {Module: "aws/rds", Metrics: []string{"CPUUtilization", "FreeStorageSpace"}},
 	// SageMaker real-time inference endpoint alarms (#761). Invocation5XXErrors
 	// (the model is failing requests) + ModelLatency (the model is responding
 	// slowly). Both alarms only exist on stacks with enable_inference=true;

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -308,6 +308,25 @@ var awsServiceMetrics = map[string]AWSObs{
 			{Name: "PassedRequests", Stat: "Sum"},
 		},
 	},
+	// SageMaker real-time inference endpoint invocation metrics (#761).
+	// Published under the AWS/SageMaker namespace from InvokeEndpoint calls,
+	// keyed by EndpointName (+ VariantName, which the panel doesn't dimension
+	// on — the endpoint has a single "primary" variant). Metric names verified
+	// against the AWS/SageMaker endpoint-invocation metric table, NOT memory
+	// (the #764 metric-name regression). ModelLatency / OverheadLatency are in
+	// MICROSECONDS. Only present on stacks with enable_inference=true; a
+	// Studio-only deploy publishes none of these.
+	"sagemaker": {
+		Namespace:     "AWS/SageMaker",
+		DimensionName: "EndpointName",
+		Metrics: []AWSMetricSpec{
+			{Name: "Invocations", Stat: "Sum"},
+			{Name: "ModelLatency", Stat: "Average"},
+			{Name: "OverheadLatency", Stat: "Average"},
+			{Name: "Invocation4XXErrors", Stat: "Sum"},
+			{Name: "Invocation5XXErrors", Stat: "Sum"},
+		},
+	},
 }
 
 // gcpServiceMetrics is the per-service catalog ported from the InsideOut backend's
@@ -552,7 +571,13 @@ var alarmedAWSMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyAWSMSK:          {Module: "aws/msk", Metrics: []string{"OfflinePartitionsCount"}},
 	composer.KeyAWSOpenSearch:   {Module: "aws/opensearch", Metrics: []string{"ClusterStatus.red"}},
 	composer.KeyAWSRDS:          {Module: "aws/rds", Metrics: []string{"CPUUtilization", "FreeStorageSpace"}},
-	composer.KeyAWSSQS:          {Module: "aws/sqs", Metrics: []string{"ApproximateNumberOfMessagesVisible"}},
+	// SageMaker real-time inference endpoint alarms (#761). Invocation5XXErrors
+	// (the model is failing requests) + ModelLatency (the model is responding
+	// slowly). Both alarms only exist on stacks with enable_inference=true;
+	// the gate in aws/sagemaker/observability.tf for_each-suppresses them
+	// otherwise, but the metric_name strings still match this catalog.
+	composer.KeyAWSSageMaker: {Module: "aws/sagemaker", Metrics: []string{"Invocation5XXErrors", "ModelLatency"}},
+	composer.KeyAWSSQS:       {Module: "aws/sqs", Metrics: []string{"ApproximateNumberOfMessagesVisible"}},
 }
 
 // alarmedGCPMetrics is the GCP analogue. Metric strings match

--- a/pkg/observability/component_observability_test.go
+++ b/pkg/observability/component_observability_test.go
@@ -93,3 +93,76 @@ func TestGCPMetricDefinitions_FirestoreAlarmBinding(t *testing.T) {
 			mt)
 	}
 }
+
+// TestEveryAlarmedAWSMetricExistsInSomeGroup is the AWS analogue of the
+// firestore alarm-binding pin: for EVERY component in alarmedAWSMetrics,
+// each declared metric_name must appear in at least one of that
+// component's namespace/dimension groups (primary AWS or any AWSExtra),
+// otherwise componentObs() can never flip Alarmed=true and the inspector
+// stays blind to a metric production is paging on.
+//
+// This is the contract #778 had to satisfy to retire the
+// excludedFromAuthority entries: registering SearchOCU / IndexingOCU in
+// alarmedAWSMetrics[KeyAWSOpenSearch] WITHOUT the AOSS catalog group would
+// pass the HCL drift gates but leave Alarmed unset (the explicitly
+// rejected shortcut in the issue). This test fails on exactly that.
+func TestEveryAlarmedAWSMetricExistsInSomeGroup(t *testing.T) {
+	t.Parallel()
+	for k, author := range alarmedAWSMetrics {
+		o, ok := Observability[k]
+		require.Truef(t, ok, "alarmedAWSMetrics[%s] has no Observability record", k)
+
+		catalog := map[string]struct{}{}
+		for _, g := range o.AWSGroups() {
+			for _, m := range g.Metrics {
+				catalog[m.Name] = struct{}{}
+			}
+		}
+		for _, name := range author.Metrics {
+			_, present := catalog[name]
+			assert.Truef(t, present,
+				"alarmedAWSMetrics[%s] references metric %q which is in NO group of Observability[%s] (primary AWS + AWSExtra); componentObs() can never flip Alarmed and the inspector stays blind — add the metric to the catalog group, do not just register the alarm",
+				k, name, k)
+		}
+	}
+}
+
+// TestOpenSearchAOSSAlarmBinding pins the #778 contract concretely: the
+// two AOSS OCU alarms registered in alarmedAWSMetrics[KeyAWSOpenSearch]
+// must resolve to specs in the AOSS catalog group (AWS/AOSS) and emerge
+// from componentObs() with Alarmed=true. Mirrors the firestore alarm
+// binding pin for the multi-group AWS case.
+func TestOpenSearchAOSSAlarmBinding(t *testing.T) {
+	t.Parallel()
+
+	author, ok := alarmedAWSMetrics[composer.KeyAWSOpenSearch]
+	require.True(t, ok, "alarmedAWSMetrics must bind KeyAWSOpenSearch")
+	for _, want := range []string{"SearchOCU", "IndexingOCU"} {
+		assert.Containsf(t, author.Metrics, want,
+			"alarmedAWSMetrics[KeyAWSOpenSearch] must register %q (#778)", want)
+	}
+
+	// The AOSS specs must live in the catalog group so the flip lands.
+	aoss, ok := awsServiceMetrics["opensearch_aoss"]
+	require.True(t, ok, `awsServiceMetrics["opensearch_aoss"] must be present`)
+	aossNames := map[string]struct{}{}
+	for _, m := range aoss.Metrics {
+		aossNames[m.Name] = struct{}{}
+	}
+	assert.Contains(t, aossNames, "SearchOCU")
+	assert.Contains(t, aossNames, "IndexingOCU")
+
+	// Round-trip through the built Observability record: the AOSS group's
+	// SearchOCU / IndexingOCU come out Alarmed=true.
+	o := Observability[composer.KeyAWSOpenSearch]
+	alarmed := map[string]bool{}
+	for _, g := range o.AWSGroups() {
+		for _, m := range g.Metrics {
+			if m.Alarmed {
+				alarmed[m.Name] = true
+			}
+		}
+	}
+	assert.True(t, alarmed["SearchOCU"], "SearchOCU must come out Alarmed=true")
+	assert.True(t, alarmed["IndexingOCU"], "IndexingOCU must come out Alarmed=true")
+}

--- a/pkg/observability/contract_test.go
+++ b/pkg/observability/contract_test.go
@@ -92,13 +92,19 @@ func TestObservabilityDeferred_OnlyForUnalarmedComponents(t *testing.T) {
 		}
 		anyUnalarmed := false
 		hasAnyMetric := false
-		if o.AWS != nil {
-			for _, m := range o.AWS.Metrics {
+		// Walk every AWS group (primary + AWSExtra) so a multi-namespace
+		// component (aws_opensearch's AOSS group, #778) is judged on its
+		// full metric surface, not just the primary group.
+		for _, g := range o.AWSGroups() {
+			for _, m := range g.Metrics {
 				hasAnyMetric = true
 				if !m.Alarmed {
 					anyUnalarmed = true
 					break
 				}
+			}
+			if anyUnalarmed {
+				break
 			}
 		}
 		if !anyUnalarmed && o.GCP != nil {

--- a/pkg/observability/metrics/aws.go
+++ b/pkg/observability/metrics/aws.go
@@ -53,8 +53,11 @@ func ParseMetricsFilter(filtersJSON string) MetricsFilter {
 
 // Fetch is the public metric-fetch entry point. It walks every
 // resource in resources, builds the CloudWatch GetMetricData query set
-// off obs, issues one GetMetricData call per resource, and assembles
-// the per-resource MetricSeries slice into a MetricsResult.
+// off every namespace/dimension group in groups (one element for the
+// single-namespace common case; several for multi-namespace components
+// like aws_opensearch — #778), issues one GetMetricData call per
+// resource, and assembles the per-resource MetricSeries slice into a
+// MetricsResult. Callers pass ComponentObservability.AWSGroups().
 //
 // service is the inspector-side join key from
 // observability.ComponentObservability.Service ("ec2", "rds",
@@ -80,15 +83,26 @@ func Fetch(
 	ctx context.Context,
 	clients *Clients,
 	service string,
-	obs *observability.AWSObs,
+	groups []*observability.AWSObs,
 	resources []ResourceID,
 	mf MetricsFilter,
 ) (MetricsResult, error) {
 	if clients == nil {
 		return MetricsResult{}, fmt.Errorf("metrics: clients is required")
 	}
-	if obs == nil {
-		return MetricsResult{}, fmt.Errorf("metrics: obs is required for service %q", service)
+	// At least one non-nil group is required. Most services pass exactly
+	// one (Observability[k].AWS); multi-namespace components like
+	// aws_opensearch pass several via ComponentObservability.AWSGroups()
+	// (#778).
+	hasGroup := false
+	for _, g := range groups {
+		if g != nil {
+			hasGroup = true
+			break
+		}
+	}
+	if !hasGroup {
+		return MetricsResult{}, fmt.Errorf("metrics: at least one obs group is required for service %q", service)
 	}
 
 	// Apply per-service overrides (mirrors aws_metrics.go:666-672).
@@ -129,7 +143,7 @@ func Fetch(
 
 	var out []ResourceMetrics
 	for _, res := range resources {
-		queries := BuildGetMetricDataQueries(obs, res, service)
+		queries := BuildGetMetricDataQueries(groups, res, service)
 		series, err := getMetricData(ctx, cw, queries, startTime, endTime, int32(clampedPeriod)) //nolint:gosec // clamped to [1, 86400]
 		if err != nil {
 			// Per-resource failures log and skip; matches the InsideOut backend's
@@ -153,8 +167,23 @@ func Fetch(
 }
 
 // BuildGetMetricDataQueries constructs the per-resource MetricDataQuery
-// slice from obs. Mirrors the InsideOut backend's BuildMetricDataQueries
-// (aws_metrics.go:712).
+// slice from every namespace/dimension group in groups. Mirrors the
+// InsideOut backend's BuildMetricDataQueries (aws_metrics.go:712), extended to
+// walk multiple groups (#778): aws_opensearch publishes managed-domain
+// metrics under AWS/ES + DomainName AND serverless OCU metrics under
+// AWS/AOSS + ClientId, so a single resource emits queries across both
+// namespaces. Single-group services pass a one-element slice and get the
+// original behavior.
+//
+// Query IDs are globally unique across groups ("m0", "m1", …) so a
+// multi-group GetMetricData call never collides — CloudWatch rejects
+// duplicate query IDs in one request.
+//
+// res.DimensionName overrides the dimension name ONLY for the primary
+// (first) group — the per-resource ID was discovered against that group's
+// dimension. Extra groups use their own DimensionName (e.g. the AOSS
+// group's account-level ClientId), which is fixed by the namespace, not
+// by the per-resource override.
 //
 // Two service-shaped quirks survive intact:
 //
@@ -168,55 +197,62 @@ func Fetch(
 // Period on each MetricStat is a placeholder (300); getMetricData
 // overwrites it with the caller's clamped period before issuing the
 // CloudWatch call.
-func BuildGetMetricDataQueries(obs *observability.AWSObs, res ResourceID, service string) []cwtypes.MetricDataQuery {
-	if obs == nil {
-		return nil
-	}
-	dimName := res.DimensionName
-	if dimName == "" {
-		dimName = obs.DimensionName
-	}
-
-	queries := make([]cwtypes.MetricDataQuery, 0, len(obs.Metrics))
-	for i, m := range obs.Metrics {
-		id := fmt.Sprintf("m%d", i)
-
-		dimensions := []cwtypes.Dimension{{
-			Name:  aws.String(dimName),
-			Value: aws.String(res.ID),
-		}}
-
-		if service == serviceCloudFront {
-			dimensions = append(dimensions, cwtypes.Dimension{
-				Name:  aws.String("Region"),
-				Value: aws.String("Global"),
-			})
+func BuildGetMetricDataQueries(groups []*observability.AWSObs, res ResourceID, service string) []cwtypes.MetricDataQuery {
+	var queries []cwtypes.MetricDataQuery
+	primary := true
+	for _, obs := range groups {
+		if obs == nil {
+			continue
 		}
+		// The per-resource dimension override only applies to the primary
+		// group; extra groups carry a namespace-fixed dimension of their
+		// own (the AOSS group's ClientId, #778).
+		dimName := obs.DimensionName
+		if primary && res.DimensionName != "" {
+			dimName = res.DimensionName
+		}
+		primary = false
 
-		if service == serviceS3 {
-			storageType := "StandardStorage"
-			if m.Name == "NumberOfObjects" {
-				storageType = "AllStorageTypes"
+		for _, m := range obs.Metrics {
+			id := fmt.Sprintf("m%d", len(queries))
+
+			dimensions := []cwtypes.Dimension{{
+				Name:  aws.String(dimName),
+				Value: aws.String(res.ID),
+			}}
+
+			if service == serviceCloudFront {
+				dimensions = append(dimensions, cwtypes.Dimension{
+					Name:  aws.String("Region"),
+					Value: aws.String("Global"),
+				})
 			}
-			dimensions = append(dimensions, cwtypes.Dimension{
-				Name:  aws.String("StorageType"),
-				Value: aws.String(storageType),
+
+			if service == serviceS3 {
+				storageType := "StandardStorage"
+				if m.Name == "NumberOfObjects" {
+					storageType = "AllStorageTypes"
+				}
+				dimensions = append(dimensions, cwtypes.Dimension{
+					Name:  aws.String("StorageType"),
+					Value: aws.String(storageType),
+				})
+			}
+
+			queries = append(queries, cwtypes.MetricDataQuery{
+				Id:    aws.String(id),
+				Label: aws.String(m.Name),
+				MetricStat: &cwtypes.MetricStat{
+					Metric: &cwtypes.Metric{
+						Namespace:  aws.String(obs.Namespace),
+						MetricName: aws.String(m.Name),
+						Dimensions: dimensions,
+					},
+					Period: aws.Int32(300), // overwritten by getMetricData
+					Stat:   aws.String(m.Stat),
+				},
 			})
 		}
-
-		queries = append(queries, cwtypes.MetricDataQuery{
-			Id:    aws.String(id),
-			Label: aws.String(m.Name),
-			MetricStat: &cwtypes.MetricStat{
-				Metric: &cwtypes.Metric{
-					Namespace:  aws.String(obs.Namespace),
-					MetricName: aws.String(m.Name),
-					Dimensions: dimensions,
-				},
-				Period: aws.Int32(300), // overwritten by getMetricData
-				Stat:   aws.String(m.Stat),
-			},
-		})
 	}
 	return queries
 }

--- a/pkg/observability/metrics/aws.go
+++ b/pkg/observability/metrics/aws.go
@@ -70,6 +70,13 @@ func ParseMetricsFilter(filtersJSON string) MetricsFilter {
 //  2. service=="s3" — daily metrics; we override mf.Period to 86400 and
 //     bump mf.Hours to >=48 so the chart has at least two datapoints.
 //
+// mf.AccountID supplies the dimension VALUE for account-keyed groups
+// (the AOSS OCU group, #778, whose AWS/AOSS ClientId dimension is the
+// account ID, not the collection ID). The caller resolves it once at
+// dispatch (sts.GetCallerIdentity) and passes it in — Fetch issues no
+// STS call of its own. When it's empty, account-keyed groups are skipped
+// by the query builder; non-account groups are unaffected.
+//
 // Per-resource GetMetricData failures log+skip rather than aborting the
 // whole call — mirrors the InsideOut backend (aws_metrics.go:692). Returning a
 // partial result is preferable to losing every datapoint when one
@@ -143,7 +150,7 @@ func Fetch(
 
 	var out []ResourceMetrics
 	for _, res := range resources {
-		queries := BuildGetMetricDataQueries(groups, res, service)
+		queries := BuildGetMetricDataQueries(groups, res, service, mf.AccountID)
 		series, err := getMetricData(ctx, cw, queries, startTime, endTime, int32(clampedPeriod)) //nolint:gosec // clamped to [1, 86400]
 		if err != nil {
 			// Per-resource failures log and skip; matches the InsideOut backend's
@@ -185,6 +192,15 @@ func Fetch(
 // group's account-level ClientId), which is fixed by the namespace, not
 // by the per-resource override.
 //
+// The dimension VALUE is res.ID for every normal group. A group whose
+// AWSObs.DimensionValueAccountID is set (the AOSS OCU group, #778)
+// instead keys on accountID — AWS/AOSS publishes OCU account-wide under
+// ClientId=<account-id>, so res.ID (the collection/domain ID) returns an
+// empty series. When such a group is present but accountID is empty, its
+// queries are SKIPPED entirely: emitting a query with an empty dimension
+// value silently matches nothing (the exact bug this guards), so a clean
+// skip is preferable to a bogus, empty-result query.
+//
 // Two service-shaped quirks survive intact:
 //
 //   - CloudFront requires an extra Region=Global dimension — AWS uses
@@ -197,28 +213,43 @@ func Fetch(
 // Period on each MetricStat is a placeholder (300); getMetricData
 // overwrites it with the caller's clamped period before issuing the
 // CloudWatch call.
-func BuildGetMetricDataQueries(groups []*observability.AWSObs, res ResourceID, service string) []cwtypes.MetricDataQuery {
+func BuildGetMetricDataQueries(groups []*observability.AWSObs, res ResourceID, service, accountID string) []cwtypes.MetricDataQuery {
 	var queries []cwtypes.MetricDataQuery
 	primary := true
 	for _, obs := range groups {
 		if obs == nil {
 			continue
 		}
-		// The per-resource dimension override only applies to the primary
-		// group; extra groups carry a namespace-fixed dimension of their
-		// own (the AOSS group's ClientId, #778).
+		isPrimary := primary
+		primary = false
+
+		// Resolve this group's dimension value source. Account-keyed groups
+		// (the AOSS OCU group, #778) take the account ID; everything else
+		// takes the per-resource ID. An account-keyed group with no account
+		// ID is skipped — an empty dimension value silently matches nothing,
+		// so emitting the query would just hand back an empty series.
+		dimValue := res.ID
+		if obs.DimensionValueAccountID {
+			if accountID == "" {
+				continue
+			}
+			dimValue = accountID
+		}
+
+		// The per-resource dimension-NAME override only applies to the
+		// primary group; extra groups carry a namespace-fixed dimension of
+		// their own (the AOSS group's ClientId, #778).
 		dimName := obs.DimensionName
-		if primary && res.DimensionName != "" {
+		if isPrimary && res.DimensionName != "" {
 			dimName = res.DimensionName
 		}
-		primary = false
 
 		for _, m := range obs.Metrics {
 			id := fmt.Sprintf("m%d", len(queries))
 
 			dimensions := []cwtypes.Dimension{{
 				Name:  aws.String(dimName),
-				Value: aws.String(res.ID),
+				Value: aws.String(dimValue),
 			}}
 
 			if service == serviceCloudFront {

--- a/pkg/observability/metrics/aws_test.go
+++ b/pkg/observability/metrics/aws_test.go
@@ -79,6 +79,26 @@ func awsSpecForService(t *testing.T, key composer.ComponentKey, wantService stri
 	return o.AWS
 }
 
+// awsGroups pulls the full set of AWS namespace/dimension groups for a
+// key (primary + AWSExtra) — the slice the production Fetch /
+// BuildGetMetricDataQueries callers pass. Most keys yield exactly one
+// group; multi-namespace components (aws_opensearch, #778) yield more.
+func awsGroups(t *testing.T, key composer.ComponentKey) []*observability.AWSObs {
+	t.Helper()
+	o, ok := observability.Lookup(key)
+	require.True(t, ok, "Lookup(%q) must return a record", key)
+	groups := o.AWSGroups()
+	require.NotEmpty(t, groups, "%q must have at least one AWS group", key)
+	return groups
+}
+
+// oneGroup wraps a single *AWSObs into the slice the multi-group
+// BuildGetMetricDataQueries / Fetch signatures expect, so single-group
+// tests read cleanly.
+func oneGroup(obs *observability.AWSObs) []*observability.AWSObs {
+	return []*observability.AWSObs{obs}
+}
+
 // --- ParseMetricsFilter (from the InsideOut backend aws_metrics_test.go:163) ---
 
 func TestParseMetricsFilter(t *testing.T) {
@@ -157,7 +177,7 @@ func TestBuildGetMetricDataQueries_VerifiesDimensionValues(t *testing.T) {
 			t.Parallel()
 			obs := awsSpecForService(t, tt.key, tt.service)
 			res := ResourceID{ID: tt.resourceID, DimensionName: obs.DimensionName}
-			queries := BuildGetMetricDataQueries(obs, res, tt.service)
+			queries := BuildGetMetricDataQueries(oneGroup(obs), res, tt.service)
 
 			require.Len(t, queries, tt.wantCount)
 
@@ -193,7 +213,7 @@ func TestBuildGetMetricDataQueries_CloudFrontRegionGlobal(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSCloudfront, "cloudfront")
 	res := ResourceID{ID: "E123456", DimensionName: "DistributionId"}
-	queries := BuildGetMetricDataQueries(obs, res, "cloudfront")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "cloudfront")
 
 	for _, q := range queries {
 		dims := q.MetricStat.Metric.Dimensions
@@ -214,7 +234,7 @@ func TestBuildGetMetricDataQueries_APIGatewayHTTPv2MetricNames(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSAPIGateway, "apigateway")
 	res := ResourceID{ID: "abc123def4", DimensionName: "ApiId"}
-	queries := BuildGetMetricDataQueries(obs, res, "apigateway")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "apigateway")
 
 	got := make(map[string]struct{}, len(queries))
 	for _, q := range queries {
@@ -240,7 +260,7 @@ func TestBuildGetMetricDataQueries_CloudFrontAdditionalMetrics(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSCloudfront, "cloudfront")
 	res := ResourceID{ID: "E1234567890", DimensionName: "DistributionId"}
-	queries := BuildGetMetricDataQueries(obs, res, "cloudfront")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "cloudfront")
 
 	got := make(map[string]struct{}, len(queries))
 	for _, q := range queries {
@@ -271,7 +291,7 @@ func TestBuildGetMetricDataQueries_S3StorageType(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSS3, "s3")
 	res := ResourceID{ID: "my-bucket", DimensionName: "BucketName"}
-	queries := BuildGetMetricDataQueries(obs, res, "s3")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "s3")
 
 	for _, q := range queries {
 		dims := q.MetricStat.Metric.Dimensions
@@ -307,11 +327,81 @@ func TestBuildGetMetricDataQueries_NilObs(t *testing.T) {
 func TestBuildGetMetricDataQueries_DimensionFallback(t *testing.T) {
 	t.Parallel()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-blank"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-blank"}, "ec2")
 	require.NotEmpty(t, queries)
 	dims := queries[0].MetricStat.Metric.Dimensions
 	require.NotEmpty(t, dims)
 	assert.Equal(t, "InstanceId", aws.ToString(dims[0].Name))
+}
+
+// TestBuildGetMetricDataQueries_OpenSearchMultiGroup is the #778
+// multi-group contract: aws_opensearch carries the managed AWS/ES group
+// (DomainName) AND the serverless AWS/AOSS group (ClientId), so a single
+// resource emits queries across BOTH namespaces in one call.
+//
+// This doubles as the mutation guard for the multi-group query builder:
+// the assertions on the AOSS half (AWS/AOSS namespace, ClientId
+// dimension, SearchOCU + IndexingOCU metrics) fail if BuildGetMetricDataQueries
+// ever stops iterating past the first group — drop the AWSExtra group and
+// the wantNamespaces/wantDims maps below go unsatisfied.
+func TestBuildGetMetricDataQueries_OpenSearchMultiGroup(t *testing.T) {
+	t.Parallel()
+	groups := awsGroups(t, composer.KeyAWSOpenSearch)
+	require.Len(t, groups, 2,
+		"aws_opensearch must expose two AWS groups: managed AWS/ES + serverless AWS/AOSS (#778)")
+
+	// The primary group's dimension override is honored; the AOSS group
+	// keeps its own ClientId regardless of the per-resource dimension.
+	res := ResourceID{ID: "io-projx-search", DimensionName: "DomainName"}
+	queries := BuildGetMetricDataQueries(groups, res, "opensearch")
+
+	totalMetrics := len(groups[0].Metrics) + len(groups[1].Metrics)
+	require.Len(t, queries, totalMetrics,
+		"query count must span both groups (managed + AOSS)")
+
+	// Query IDs must be globally unique across groups — CloudWatch
+	// rejects duplicate IDs in one GetMetricData request.
+	seenIDs := make(map[string]bool, len(queries))
+	// Map each metric name to the (namespace, dimensionName) it must carry.
+	wantNamespace := map[string]string{}
+	wantDim := map[string]string{}
+	for _, m := range groups[0].Metrics { // AWS/ES + DomainName
+		wantNamespace[m.Name] = "AWS/ES"
+		wantDim[m.Name] = "DomainName"
+	}
+	for _, m := range groups[1].Metrics { // AWS/AOSS + ClientId
+		wantNamespace[m.Name] = "AWS/AOSS"
+		wantDim[m.Name] = "ClientId"
+	}
+	// Assert the AOSS half is actually present (guards a one-group regression).
+	require.Contains(t, wantNamespace, "SearchOCU", "AOSS group must carry SearchOCU")
+	require.Contains(t, wantNamespace, "IndexingOCU", "AOSS group must carry IndexingOCU")
+
+	gotAOSS := 0
+	for _, q := range queries {
+		require.NotNil(t, q.MetricStat)
+		id := aws.ToString(q.Id)
+		assert.False(t, seenIDs[id], "duplicate query ID %q across groups", id)
+		seenIDs[id] = true
+
+		name := aws.ToString(q.MetricStat.Metric.MetricName)
+		ns := aws.ToString(q.MetricStat.Metric.Namespace)
+		dims := q.MetricStat.Metric.Dimensions
+		require.NotEmpty(t, dims, "metric %q must carry a dimension", name)
+
+		assert.Equal(t, wantNamespace[name], ns,
+			"metric %q must publish under namespace %q", name, wantNamespace[name])
+		assert.Equal(t, wantDim[name], aws.ToString(dims[0].Name),
+			"metric %q must carry dimension %q", name, wantDim[name])
+
+		if ns == "AWS/AOSS" {
+			gotAOSS++
+			assert.Equal(t, "Sum", aws.ToString(q.MetricStat.Stat),
+				"AOSS OCU metric %q must use the Sum stat", name)
+		}
+	}
+	assert.Equal(t, len(groups[1].Metrics), gotAOSS,
+		"every AOSS metric must produce exactly one query (the second group must be iterated)")
 }
 
 // --- getMetricData (the unexported CW response shaper) ---
@@ -340,7 +430,7 @@ func TestGetMetricData_HappyPath(t *testing.T) {
 	}
 
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-abc123"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc123"}, "ec2")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -387,7 +477,7 @@ func TestGetMetricData_MismatchedTimestampsAndValues(t *testing.T) {
 	}
 
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -405,7 +495,7 @@ func TestGetMetricData_EmptyResults(t *testing.T) {
 
 	now := time.Now().UTC()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -418,7 +508,7 @@ func TestGetMetricData_APIError(t *testing.T) {
 
 	now := time.Now().UTC()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(obs, ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
 	_, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.Error(t, err)
@@ -430,7 +520,7 @@ func TestGetMetricData_APIError(t *testing.T) {
 func TestFetch_NilClients(t *testing.T) {
 	t.Parallel()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	_, err := Fetch(context.Background(), nil, "ec2", obs, []ResourceID{{ID: "i-abc"}}, MetricsFilter{Hours: 6, Period: 300})
+	_, err := Fetch(context.Background(), nil, "ec2", oneGroup(obs), []ResourceID{{ID: "i-abc"}}, MetricsFilter{Hours: 6, Period: 300})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "clients is required")
 }
@@ -438,9 +528,18 @@ func TestFetch_NilClients(t *testing.T) {
 func TestFetch_NilObs(t *testing.T) {
 	t.Parallel()
 	c := clientsWithCW(&fakeCloudWatch{})
-	_, err := Fetch(context.Background(), c, "ec2", nil, []ResourceID{{ID: "i-abc"}}, MetricsFilter{Hours: 6, Period: 300})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "obs is required")
+	// Both a nil slice and a slice of only-nil groups must be rejected —
+	// the multi-group signature can't build any query from either.
+	for name, groups := range map[string][]*observability.AWSObs{
+		"nil slice":          nil,
+		"slice of nil group": {nil},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := Fetch(context.Background(), c, "ec2", groups, []ResourceID{{ID: "i-abc"}}, MetricsFilter{Hours: 6, Period: 300})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "at least one obs group is required")
+		})
+	}
 }
 
 func TestFetch_ZeroResources(t *testing.T) {
@@ -448,7 +547,7 @@ func TestFetch_ZeroResources(t *testing.T) {
 	mock := &fakeCloudWatch{}
 	c := clientsWithCW(mock)
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	result, err := Fetch(context.Background(), c, "ec2", obs, nil, MetricsFilter{Hours: 6, Period: 300})
+	result, err := Fetch(context.Background(), c, "ec2", oneGroup(obs), nil, MetricsFilter{Hours: 6, Period: 300})
 
 	require.NoError(t, err)
 	assert.Equal(t, "ec2", result.Service)
@@ -476,7 +575,7 @@ func TestFetch_S3PeriodAndHoursOverride(t *testing.T) {
 
 	c := clientsWithCW(mock)
 	obs := awsSpecForService(t, composer.KeyAWSS3, "s3")
-	result, err := Fetch(context.Background(), c, "s3", obs,
+	result, err := Fetch(context.Background(), c, "s3", oneGroup(obs),
 		[]ResourceID{{ID: "my-bucket", DimensionName: "BucketName"}},
 		MetricsFilter{Hours: 6, Period: 300})
 
@@ -505,7 +604,7 @@ func TestFetch_S3DoesNotShortenLongerHours(t *testing.T) {
 	mock := &fakeCloudWatch{output: &cloudwatch.GetMetricDataOutput{}}
 	c := clientsWithCW(mock)
 	obs := awsSpecForService(t, composer.KeyAWSS3, "s3")
-	result, err := Fetch(context.Background(), c, "s3", obs,
+	result, err := Fetch(context.Background(), c, "s3", oneGroup(obs),
 		[]ResourceID{{ID: "my-bucket", DimensionName: "BucketName"}},
 		MetricsFilter{Hours: 72, Period: 300})
 
@@ -552,7 +651,7 @@ func TestFetch_CloudFrontRoutesToUSEast1AndReturnsAllMetrics(t *testing.T) {
 	cfMock := &fakeCloudWatch{output: &cloudwatch.GetMetricDataOutput{MetricDataResults: cfResults}}
 
 	c := clientsWithCFOverride(defaultMock, cfMock)
-	result, err := Fetch(context.Background(), c, "cloudfront", cfObs,
+	result, err := Fetch(context.Background(), c, "cloudfront", oneGroup(cfObs),
 		[]ResourceID{{ID: "E123", DimensionName: "DistributionId"}},
 		MetricsFilter{Hours: 6, Period: 300})
 
@@ -581,7 +680,7 @@ func TestFetch_PartialResourceFailure_Skips(t *testing.T) {
 	mock := &fakeCloudWatch{err: errors.New("throttled")}
 	c := clientsWithCW(mock)
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	result, err := Fetch(context.Background(), c, "ec2", obs,
+	result, err := Fetch(context.Background(), c, "ec2", oneGroup(obs),
 		[]ResourceID{{ID: "i-good"}, {ID: "i-bad"}},
 		MetricsFilter{Hours: 6, Period: 300})
 
@@ -610,7 +709,7 @@ func TestFetch_EC2_EndToEnd(t *testing.T) {
 
 	c := clientsWithCW(mock)
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	result, err := Fetch(context.Background(), c, "ec2", obs,
+	result, err := Fetch(context.Background(), c, "ec2", oneGroup(obs),
 		[]ResourceID{{ID: "i-abc123", DimensionName: "InstanceId"}},
 		MetricsFilter{Hours: 12, Period: 600})
 
@@ -625,6 +724,72 @@ func TestFetch_EC2_EndToEnd(t *testing.T) {
 	assert.Equal(t, "CPUUtilization", result.Resources[0].Metrics[0].Name)
 }
 
+// TestFetch_OpenSearchMultiGroup_RoundTripsBothNamespaces is the #778
+// end-to-end multi-group exercise: aws_opensearch's managed AWS/ES
+// metrics and serverless AWS/AOSS OCU metrics must BOTH issue in a single
+// GetMetricData call and round-trip by name → value through Fetch. The
+// fake echoes one value per metric in the request, so a regression that
+// stops iterating past the first group drops the AOSS metrics and the
+// round-trip map comes up short.
+func TestFetch_OpenSearchMultiGroup_RoundTripsBothNamespaces(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	groups := awsGroups(t, composer.KeyAWSOpenSearch)
+	require.Len(t, groups, 2, "aws_opensearch must expose managed + AOSS groups (#778)")
+
+	// Build one MetricDataResult per metric across both groups, with a
+	// unique value so cross-wiring is caught.
+	var results []cwtypes.MetricDataResult
+	wantValues := map[string]float64{}
+	i := 0
+	for _, g := range groups {
+		for _, m := range g.Metrics {
+			i++
+			v := float64(i)
+			wantValues[m.Name] = v
+			results = append(results, cwtypes.MetricDataResult{
+				Label:      aws.String(m.Name),
+				Timestamps: []time.Time{now},
+				Values:     []float64{v},
+			})
+		}
+	}
+	mock := &fakeCloudWatch{output: &cloudwatch.GetMetricDataOutput{MetricDataResults: results}}
+	c := clientsWithCW(mock)
+
+	result, err := Fetch(context.Background(), c, "opensearch", groups,
+		[]ResourceID{{ID: "io-projx-search", DimensionName: "DomainName"}},
+		MetricsFilter{Hours: 6, Period: 300})
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+
+	// A single GetMetricData call carries queries from BOTH namespaces.
+	require.NotNil(t, mock.lastInput)
+	sawES, sawAOSS := false, false
+	for _, q := range mock.lastInput.MetricDataQueries {
+		switch aws.ToString(q.MetricStat.Metric.Namespace) {
+		case "AWS/ES":
+			sawES = true
+		case "AWS/AOSS":
+			sawAOSS = true
+		}
+	}
+	assert.True(t, sawES, "request must carry AWS/ES (managed) queries")
+	assert.True(t, sawAOSS, "request must carry AWS/AOSS (serverless OCU) queries")
+
+	gotValues := map[string]float64{}
+	for _, m := range result.Resources[0].Metrics {
+		require.Len(t, m.Datapoints, 1, "metric %q should have one datapoint", m.Name)
+		gotValues[m.Name] = m.Datapoints[0].Average
+	}
+	assert.Equal(t, wantValues, gotValues,
+		"every metric across both namespaces must round-trip by name → value")
+	// Spot-check the AOSS metrics are present specifically.
+	assert.Contains(t, gotValues, "SearchOCU")
+	assert.Contains(t, gotValues, "IndexingOCU")
+}
+
 // TestFetch_ClampsHugePeriodToOneDay locks the period clamp at 86400
 // (the max GetMetricData accepts). Anyone passing Period=999999 (an
 // older default in some inspector code paths) gets the supported
@@ -636,7 +801,7 @@ func TestFetch_ClampsHugePeriodToOneDay(t *testing.T) {
 	}
 	c := clientsWithCW(mock)
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	_, err := Fetch(context.Background(), c, "ec2", obs,
+	_, err := Fetch(context.Background(), c, "ec2", oneGroup(obs),
 		[]ResourceID{{ID: "i-abc", DimensionName: "InstanceId"}},
 		MetricsFilter{Hours: 6, Period: 9_999_999})
 
@@ -650,11 +815,15 @@ func TestFetch_ClampsHugePeriodToOneDay(t *testing.T) {
 
 // --- Spec-coverage drift tests ---
 
-// TestEveryAlarmedAWSSpecHasMetricFetchCoverage walks every component
-// key whose AWS spec has at least one metric and confirms the spec
-// passes through BuildGetMetricDataQueries to a non-empty query slice
-// with the expected dimension. Catches drift between the per-component
-// authority (observability.AWSObs) and the metric-fetch builder.
+// TestEveryAWSSpecBuildsValidQueries walks every component key whose AWS
+// surface has at least one metric and confirms EVERY namespace/dimension
+// group (primary + AWSExtra) passes through BuildGetMetricDataQueries
+// with its own namespace, dimension name, metric name, and stat intact.
+// Catches drift between the per-component authority
+// (observability.ComponentObservability.AWSGroups) and the metric-fetch
+// builder — including a multi-namespace component (aws_opensearch's AOSS
+// group, #778) whose extra group must survive the builder under its own
+// AWS/AOSS + ClientId shape, not the primary AWS/ES + DomainName shape.
 //
 // Stops short of asserting Fetch end-to-end per key (that's covered
 // for ec2/s3/cloudfront above) — the drift this test catches is "a key
@@ -664,27 +833,47 @@ func TestEveryAWSSpecBuildsValidQueries(t *testing.T) {
 	t.Parallel()
 	for _, k := range composer.AllComponentKeys {
 		o, ok := observability.Lookup(k)
-		if !ok || o.AWS == nil || len(o.AWS.Metrics) == 0 {
+		groups := o.AWSGroups()
+		if !ok || len(groups) == 0 {
+			continue
+		}
+		totalMetrics := 0
+		for _, g := range groups {
+			totalMetrics += len(g.Metrics)
+		}
+		if totalMetrics == 0 {
 			continue
 		}
 		t.Run(string(k), func(t *testing.T) {
 			t.Parallel()
-			res := ResourceID{ID: "test-id", DimensionName: o.AWS.DimensionName}
-			queries := BuildGetMetricDataQueries(o.AWS, res, o.Service)
-			require.Len(t, queries, len(o.AWS.Metrics),
-				"%s: query count must match spec metric count", k)
-			for i, q := range queries {
-				require.NotNil(t, q.MetricStat, "%s metric[%d]: MetricStat must be set", k, i)
-				assert.Equal(t, o.AWS.Namespace, aws.ToString(q.MetricStat.Metric.Namespace),
-					"%s metric[%d]: namespace drift", k, i)
-				assert.Equal(t, o.AWS.Metrics[i].Name, aws.ToString(q.MetricStat.Metric.MetricName),
-					"%s metric[%d]: name drift", k, i)
-				assert.Equal(t, o.AWS.Metrics[i].Stat, aws.ToString(q.MetricStat.Stat),
-					"%s metric[%d]: stat drift", k, i)
-				dims := q.MetricStat.Metric.Dimensions
-				require.NotEmpty(t, dims, "%s metric[%d]: must carry the resource dimension", k, i)
-				assert.Equal(t, o.AWS.DimensionName, aws.ToString(dims[0].Name),
-					"%s metric[%d]: dimension name drift", k, i)
+			// Leave res.DimensionName empty so each group falls back to
+			// its own DimensionName — the whole point of the multi-group
+			// shape is that the AOSS group keeps ClientId even though the
+			// primary group is DomainName.
+			res := ResourceID{ID: "test-id"}
+			queries := BuildGetMetricDataQueries(groups, res, o.Service)
+			require.Len(t, queries, totalMetrics,
+				"%s: query count must match the sum of metrics across all groups", k)
+
+			// Walk groups in order; queries are emitted group-by-group so
+			// the running index stays aligned with (group, metric).
+			qi := 0
+			for gi, g := range groups {
+				for mi, m := range g.Metrics {
+					q := queries[qi]
+					require.NotNil(t, q.MetricStat, "%s group[%d] metric[%d]: MetricStat must be set", k, gi, mi)
+					assert.Equal(t, g.Namespace, aws.ToString(q.MetricStat.Metric.Namespace),
+						"%s group[%d] metric[%d]: namespace drift", k, gi, mi)
+					assert.Equal(t, m.Name, aws.ToString(q.MetricStat.Metric.MetricName),
+						"%s group[%d] metric[%d]: name drift", k, gi, mi)
+					assert.Equal(t, m.Stat, aws.ToString(q.MetricStat.Stat),
+						"%s group[%d] metric[%d]: stat drift", k, gi, mi)
+					dims := q.MetricStat.Metric.Dimensions
+					require.NotEmpty(t, dims, "%s group[%d] metric[%d]: must carry the resource dimension", k, gi, mi)
+					assert.Equal(t, g.DimensionName, aws.ToString(dims[0].Name),
+						"%s group[%d] metric[%d]: dimension name drift", k, gi, mi)
+					qi++
+				}
 			}
 		})
 	}
@@ -700,12 +889,16 @@ func TestAllSpecsHaveValidStats(t *testing.T) {
 	}
 	for _, k := range composer.AllComponentKeys {
 		o, ok := observability.Lookup(k)
-		if !ok || o.AWS == nil {
+		if !ok {
 			continue
 		}
-		for _, m := range o.AWS.Metrics {
-			assert.True(t, validStats[m.Stat],
-				"key %s metric %s has invalid stat: %s", k, m.Name, m.Stat)
+		// Validate every group, not just the primary — the AOSS group's
+		// SearchOCU / IndexingOCU stats (Sum) must be checked too (#778).
+		for _, g := range o.AWSGroups() {
+			for _, m := range g.Metrics {
+				assert.True(t, validStats[m.Stat],
+					"key %s metric %s (namespace %s) has invalid stat: %s", k, m.Name, g.Namespace, m.Stat)
+			}
 		}
 	}
 }

--- a/pkg/observability/metrics/aws_test.go
+++ b/pkg/observability/metrics/aws_test.go
@@ -177,7 +177,7 @@ func TestBuildGetMetricDataQueries_VerifiesDimensionValues(t *testing.T) {
 			t.Parallel()
 			obs := awsSpecForService(t, tt.key, tt.service)
 			res := ResourceID{ID: tt.resourceID, DimensionName: obs.DimensionName}
-			queries := BuildGetMetricDataQueries(oneGroup(obs), res, tt.service)
+			queries := BuildGetMetricDataQueries(oneGroup(obs), res, tt.service, "")
 
 			require.Len(t, queries, tt.wantCount)
 
@@ -213,7 +213,7 @@ func TestBuildGetMetricDataQueries_CloudFrontRegionGlobal(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSCloudfront, "cloudfront")
 	res := ResourceID{ID: "E123456", DimensionName: "DistributionId"}
-	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "cloudfront")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "cloudfront", "")
 
 	for _, q := range queries {
 		dims := q.MetricStat.Metric.Dimensions
@@ -234,7 +234,7 @@ func TestBuildGetMetricDataQueries_APIGatewayHTTPv2MetricNames(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSAPIGateway, "apigateway")
 	res := ResourceID{ID: "abc123def4", DimensionName: "ApiId"}
-	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "apigateway")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "apigateway", "")
 
 	got := make(map[string]struct{}, len(queries))
 	for _, q := range queries {
@@ -260,7 +260,7 @@ func TestBuildGetMetricDataQueries_CloudFrontAdditionalMetrics(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSCloudfront, "cloudfront")
 	res := ResourceID{ID: "E1234567890", DimensionName: "DistributionId"}
-	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "cloudfront")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "cloudfront", "")
 
 	got := make(map[string]struct{}, len(queries))
 	for _, q := range queries {
@@ -291,7 +291,7 @@ func TestBuildGetMetricDataQueries_S3StorageType(t *testing.T) {
 	t.Parallel()
 	obs := awsSpecForService(t, composer.KeyAWSS3, "s3")
 	res := ResourceID{ID: "my-bucket", DimensionName: "BucketName"}
-	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "s3")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), res, "s3", "")
 
 	for _, q := range queries {
 		dims := q.MetricStat.Metric.Dimensions
@@ -316,7 +316,7 @@ func TestBuildGetMetricDataQueries_S3StorageType(t *testing.T) {
 // future direct callers (e.g. dashboard preview tooling).
 func TestBuildGetMetricDataQueries_NilObs(t *testing.T) {
 	t.Parallel()
-	got := BuildGetMetricDataQueries(nil, ResourceID{ID: "i-abc"}, "ec2")
+	got := BuildGetMetricDataQueries(nil, ResourceID{ID: "i-abc"}, "ec2", "")
 	assert.Nil(t, got)
 }
 
@@ -327,7 +327,7 @@ func TestBuildGetMetricDataQueries_NilObs(t *testing.T) {
 func TestBuildGetMetricDataQueries_DimensionFallback(t *testing.T) {
 	t.Parallel()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-blank"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-blank"}, "ec2", "")
 	require.NotEmpty(t, queries)
 	dims := queries[0].MetricStat.Metric.Dimensions
 	require.NotEmpty(t, dims)
@@ -350,10 +350,22 @@ func TestBuildGetMetricDataQueries_OpenSearchMultiGroup(t *testing.T) {
 	require.Len(t, groups, 2,
 		"aws_opensearch must expose two AWS groups: managed AWS/ES + serverless AWS/AOSS (#778)")
 
+	// The AOSS group must declare itself account-keyed; the managed AWS/ES
+	// group must not. This is the catalog half of the dimension-value
+	// contract the value assertions below depend on.
+	require.False(t, groups[0].DimensionValueAccountID,
+		"managed AWS/ES group must key its dimension VALUE on res.ID, not the account ID")
+	require.True(t, groups[1].DimensionValueAccountID,
+		"serverless AWS/AOSS group must key its ClientId dimension VALUE on the account ID (#778)")
+
 	// The primary group's dimension override is honored; the AOSS group
-	// keeps its own ClientId regardless of the per-resource dimension.
+	// keeps its own ClientId regardless of the per-resource dimension. The
+	// AOSS dimension VALUE must be the account ID (ClientId=<account>), the
+	// managed group's must be the resource ID — the bug #778 review fixes
+	// is the AOSS query going out with ClientId=<collection-id>.
+	const acctID = "123456789012"
 	res := ResourceID{ID: "io-projx-search", DimensionName: "DomainName"}
-	queries := BuildGetMetricDataQueries(groups, res, "opensearch")
+	queries := BuildGetMetricDataQueries(groups, res, "opensearch", acctID)
 
 	totalMetrics := len(groups[0].Metrics) + len(groups[1].Metrics)
 	require.Len(t, queries, totalMetrics,
@@ -362,16 +374,21 @@ func TestBuildGetMetricDataQueries_OpenSearchMultiGroup(t *testing.T) {
 	// Query IDs must be globally unique across groups — CloudWatch
 	// rejects duplicate IDs in one GetMetricData request.
 	seenIDs := make(map[string]bool, len(queries))
-	// Map each metric name to the (namespace, dimensionName) it must carry.
+	// Map each metric name to the (namespace, dimensionName, dimensionValue)
+	// it must carry. The dimension VALUE is the load-bearing #778-review
+	// assertion: account ID for AOSS, resource ID for managed.
 	wantNamespace := map[string]string{}
 	wantDim := map[string]string{}
-	for _, m := range groups[0].Metrics { // AWS/ES + DomainName
+	wantDimValue := map[string]string{}
+	for _, m := range groups[0].Metrics { // AWS/ES + DomainName, value=res.ID
 		wantNamespace[m.Name] = "AWS/ES"
 		wantDim[m.Name] = "DomainName"
+		wantDimValue[m.Name] = res.ID
 	}
-	for _, m := range groups[1].Metrics { // AWS/AOSS + ClientId
+	for _, m := range groups[1].Metrics { // AWS/AOSS + ClientId, value=accountID
 		wantNamespace[m.Name] = "AWS/AOSS"
 		wantDim[m.Name] = "ClientId"
+		wantDimValue[m.Name] = acctID
 	}
 	// Assert the AOSS half is actually present (guards a one-group regression).
 	require.Contains(t, wantNamespace, "SearchOCU", "AOSS group must carry SearchOCU")
@@ -393,15 +410,50 @@ func TestBuildGetMetricDataQueries_OpenSearchMultiGroup(t *testing.T) {
 			"metric %q must publish under namespace %q", name, wantNamespace[name])
 		assert.Equal(t, wantDim[name], aws.ToString(dims[0].Name),
 			"metric %q must carry dimension %q", name, wantDim[name])
+		assert.Equal(t, wantDimValue[name], aws.ToString(dims[0].Value),
+			"metric %q dimension VALUE must be %q (account ID for AOSS, resource ID for managed)",
+			name, wantDimValue[name])
 
 		if ns == "AWS/AOSS" {
 			gotAOSS++
 			assert.Equal(t, "Sum", aws.ToString(q.MetricStat.Stat),
 				"AOSS OCU metric %q must use the Sum stat", name)
+			assert.Equal(t, acctID, aws.ToString(dims[0].Value),
+				"AOSS OCU metric %q ClientId must be the account ID, not the collection ID (#778 review)", name)
 		}
 	}
 	assert.Equal(t, len(groups[1].Metrics), gotAOSS,
 		"every AOSS metric must produce exactly one query (the second group must be iterated)")
+}
+
+// TestBuildGetMetricDataQueries_OpenSearchAOSSSkippedWhenNoAccountID pins
+// the empty-account-ID behavior of the #778-review fix: an account-keyed
+// group (AWS/AOSS) is SKIPPED entirely when no account ID is available,
+// rather than emitting a query with an empty (silently-non-matching)
+// ClientId dimension value. The managed AWS/ES group is unaffected and
+// still emits its full metric set against res.ID.
+func TestBuildGetMetricDataQueries_OpenSearchAOSSSkippedWhenNoAccountID(t *testing.T) {
+	t.Parallel()
+	groups := awsGroups(t, composer.KeyAWSOpenSearch)
+	require.Len(t, groups, 2)
+
+	res := ResourceID{ID: "io-projx-search", DimensionName: "DomainName"}
+	queries := BuildGetMetricDataQueries(groups, res, "opensearch", "")
+
+	// Only the managed AWS/ES group survives — the AOSS group is dropped.
+	require.Len(t, queries, len(groups[0].Metrics),
+		"with no account ID, only the managed AWS/ES group's queries must be emitted")
+
+	for _, q := range queries {
+		require.NotNil(t, q.MetricStat)
+		ns := aws.ToString(q.MetricStat.Metric.Namespace)
+		assert.NotEqual(t, "AWS/AOSS", ns,
+			"no AWS/AOSS query may be emitted without an account ID — an empty ClientId matches nothing")
+		dims := q.MetricStat.Metric.Dimensions
+		require.NotEmpty(t, dims)
+		assert.Equal(t, res.ID, aws.ToString(dims[0].Value),
+			"surviving managed queries must still key on the resource ID")
+	}
 }
 
 // --- getMetricData (the unexported CW response shaper) ---
@@ -430,7 +482,7 @@ func TestGetMetricData_HappyPath(t *testing.T) {
 	}
 
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc123"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc123"}, "ec2", "")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -477,7 +529,7 @@ func TestGetMetricData_MismatchedTimestampsAndValues(t *testing.T) {
 	}
 
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2", "")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -495,7 +547,7 @@ func TestGetMetricData_EmptyResults(t *testing.T) {
 
 	now := time.Now().UTC()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2", "")
 	results, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.NoError(t, err)
@@ -508,7 +560,7 @@ func TestGetMetricData_APIError(t *testing.T) {
 
 	now := time.Now().UTC()
 	obs := awsSpec(t, composer.KeyAWSEC2)
-	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2")
+	queries := BuildGetMetricDataQueries(oneGroup(obs), ResourceID{ID: "i-abc"}, "ec2", "")
 	_, err := getMetricData(context.Background(), mock, queries, now.Add(-time.Hour), now, 300)
 
 	require.Error(t, err)
@@ -758,21 +810,36 @@ func TestFetch_OpenSearchMultiGroup_RoundTripsBothNamespaces(t *testing.T) {
 	mock := &fakeCloudWatch{output: &cloudwatch.GetMetricDataOutput{MetricDataResults: results}}
 	c := clientsWithCW(mock)
 
+	// mf.AccountID rides into the AOSS group's ClientId dimension value;
+	// the managed AWS/ES group still keys on the resource ID.
+	const acctID = "123456789012"
+	const domainID = "io-projx-search"
 	result, err := Fetch(context.Background(), c, "opensearch", groups,
-		[]ResourceID{{ID: "io-projx-search", DimensionName: "DomainName"}},
-		MetricsFilter{Hours: 6, Period: 300})
+		[]ResourceID{{ID: domainID, DimensionName: "DomainName"}},
+		MetricsFilter{Hours: 6, Period: 300, AccountID: acctID})
 	require.NoError(t, err)
 	require.Len(t, result.Resources, 1)
 
-	// A single GetMetricData call carries queries from BOTH namespaces.
+	// A single GetMetricData call carries queries from BOTH namespaces, and
+	// each namespace's dimension VALUE is sourced correctly: AWS/AOSS keys
+	// ClientId on the account ID, AWS/ES keys DomainName on the resource ID
+	// (the #778-review fix — the AOSS query previously went out with
+	// ClientId=<collection-id> and returned an empty series).
 	require.NotNil(t, mock.lastInput)
 	sawES, sawAOSS := false, false
 	for _, q := range mock.lastInput.MetricDataQueries {
+		require.NotNil(t, q.MetricStat)
+		dims := q.MetricStat.Metric.Dimensions
+		require.NotEmpty(t, dims)
 		switch aws.ToString(q.MetricStat.Metric.Namespace) {
 		case "AWS/ES":
 			sawES = true
+			assert.Equal(t, domainID, aws.ToString(dims[0].Value),
+				"managed AWS/ES query must key DomainName on the resource ID")
 		case "AWS/AOSS":
 			sawAOSS = true
+			assert.Equal(t, acctID, aws.ToString(dims[0].Value),
+				"serverless AWS/AOSS query must key ClientId on the account ID (#778 review)")
 		}
 	}
 	assert.True(t, sawES, "request must carry AWS/ES (managed) queries")
@@ -788,6 +855,59 @@ func TestFetch_OpenSearchMultiGroup_RoundTripsBothNamespaces(t *testing.T) {
 	// Spot-check the AOSS metrics are present specifically.
 	assert.Contains(t, gotValues, "SearchOCU")
 	assert.Contains(t, gotValues, "IndexingOCU")
+}
+
+// TestFetch_OpenSearchMultiGroup_NoAccountIDDropsAOSS is the Fetch-level
+// empty-account-ID case: with mf.AccountID unset, the AOSS OCU group is
+// skipped end-to-end — the issued GetMetricData request carries only the
+// managed AWS/ES queries, never an AWS/AOSS query with an empty ClientId.
+// The managed metrics still round-trip normally.
+func TestFetch_OpenSearchMultiGroup_NoAccountIDDropsAOSS(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+
+	groups := awsGroups(t, composer.KeyAWSOpenSearch)
+	require.Len(t, groups, 2)
+
+	// Echo a value for every managed metric only — the AOSS group must not
+	// be queried, so no AOSS labels are expected back.
+	var results []cwtypes.MetricDataResult
+	wantManaged := map[string]float64{}
+	for i, m := range groups[0].Metrics {
+		v := float64(i + 1)
+		wantManaged[m.Name] = v
+		results = append(results, cwtypes.MetricDataResult{
+			Label:      aws.String(m.Name),
+			Timestamps: []time.Time{now},
+			Values:     []float64{v},
+		})
+	}
+	mock := &fakeCloudWatch{output: &cloudwatch.GetMetricDataOutput{MetricDataResults: results}}
+	c := clientsWithCW(mock)
+
+	result, err := Fetch(context.Background(), c, "opensearch", groups,
+		[]ResourceID{{ID: "io-projx-search", DimensionName: "DomainName"}},
+		MetricsFilter{Hours: 6, Period: 300}) // AccountID empty
+	require.NoError(t, err)
+	require.Len(t, result.Resources, 1)
+
+	// The request must carry the managed queries and NO AWS/AOSS query.
+	require.NotNil(t, mock.lastInput)
+	require.Len(t, mock.lastInput.MetricDataQueries, len(groups[0].Metrics),
+		"only the managed AWS/ES group's queries may be issued without an account ID")
+	for _, q := range mock.lastInput.MetricDataQueries {
+		require.NotNil(t, q.MetricStat)
+		assert.NotEqual(t, "AWS/AOSS", aws.ToString(q.MetricStat.Metric.Namespace),
+			"no AWS/AOSS query may be issued without an account ID")
+	}
+
+	gotValues := map[string]float64{}
+	for _, m := range result.Resources[0].Metrics {
+		gotValues[m.Name] = m.Datapoints[0].Average
+	}
+	assert.Equal(t, wantManaged, gotValues, "managed metrics must still round-trip")
+	assert.NotContains(t, gotValues, "SearchOCU", "AOSS metric must be absent")
+	assert.NotContains(t, gotValues, "IndexingOCU", "AOSS metric must be absent")
 }
 
 // TestFetch_ClampsHugePeriodToOneDay locks the period clamp at 86400
@@ -850,8 +970,13 @@ func TestEveryAWSSpecBuildsValidQueries(t *testing.T) {
 			// its own DimensionName — the whole point of the multi-group
 			// shape is that the AOSS group keeps ClientId even though the
 			// primary group is DomainName.
+			//
+			// A non-empty account ID is required so account-keyed groups
+			// (the AOSS OCU group, #778) are NOT skipped — totalMetrics
+			// counts every group, AOSS included.
+			const testAcct = "123456789012"
 			res := ResourceID{ID: "test-id"}
-			queries := BuildGetMetricDataQueries(groups, res, o.Service)
+			queries := BuildGetMetricDataQueries(groups, res, o.Service, testAcct)
 			require.Len(t, queries, totalMetrics,
 				"%s: query count must match the sum of metrics across all groups", k)
 
@@ -859,6 +984,12 @@ func TestEveryAWSSpecBuildsValidQueries(t *testing.T) {
 			// the running index stays aligned with (group, metric).
 			qi := 0
 			for gi, g := range groups {
+				// Account-keyed groups key the dimension VALUE on the account
+				// ID; every other group keys on res.ID.
+				wantDimValue := res.ID
+				if g.DimensionValueAccountID {
+					wantDimValue = testAcct
+				}
 				for mi, m := range g.Metrics {
 					q := queries[qi]
 					require.NotNil(t, q.MetricStat, "%s group[%d] metric[%d]: MetricStat must be set", k, gi, mi)
@@ -872,6 +1003,8 @@ func TestEveryAWSSpecBuildsValidQueries(t *testing.T) {
 					require.NotEmpty(t, dims, "%s group[%d] metric[%d]: must carry the resource dimension", k, gi, mi)
 					assert.Equal(t, g.DimensionName, aws.ToString(dims[0].Name),
 						"%s group[%d] metric[%d]: dimension name drift", k, gi, mi)
+					assert.Equal(t, wantDimValue, aws.ToString(dims[0].Value),
+						"%s group[%d] metric[%d]: dimension value source drift", k, gi, mi)
 					qi++
 				}
 			}

--- a/pkg/observability/metrics/types.go
+++ b/pkg/observability/metrics/types.go
@@ -19,6 +19,17 @@ package metrics
 type MetricsFilter struct {
 	Hours  int `json:"hours"`  // lookback window (default: 6)
 	Period int `json:"period"` // aggregation period in seconds (default: 300)
+
+	// AccountID is the caller's AWS account ID. It's the dimension VALUE
+	// for groups whose AWSObs.DimensionValueAccountID is set — today only
+	// the AOSS OCU group (AWS/AOSS publishes account-level OCU under a
+	// ClientId=<account-id> dimension, #778). The inspector that resolves
+	// the credential already knows the account (sts.GetCallerIdentity at
+	// dispatch); it rides here so Fetch need not make its own STS call.
+	// Empty for callers fetching only account-keyed-free services; the
+	// query builder then skips any account-keyed group rather than
+	// emitting an empty-value query.
+	AccountID string `json:"account_id,omitempty"`
 }
 
 // MetricsResult is the top-level response for a get-metrics action.

--- a/pkg/observability/observability_alarms_test.go
+++ b/pkg/observability/observability_alarms_test.go
@@ -46,12 +46,13 @@ var excludedFromAuthority = map[string]string{
 	// gke entry to gcpServiceMetrics in a follow-up to retire this
 	// exclusion.
 	"gcp/gke:kubernetes.io/node/cpu/allocatable_utilization": "#204",
-	// aws/opensearch AOSS OCU alarms (#758) live in namespace AWS/AOSS with
-	// the account-level ClientId dimension; the catalog's "opensearch"
-	// service group is AWS/ES + DomainName (managed domains), so these are
-	// HCL-only until an AOSS-scoped AWSMetricSpec group exists (#778).
-	"aws/opensearch:SearchOCU":   "#778",
-	"aws/opensearch:IndexingOCU": "#778",
+	// NOTE (#778): the aws/opensearch AOSS OCU alarms (SearchOCU /
+	// IndexingOCU, namespace AWS/AOSS) used to be HCL-only exclusions here
+	// because the catalog only carried the managed AWS/ES group. They now
+	// live in the catalog as the AOSS namespace group on KeyAWSOpenSearch
+	// (AWSExtra) and are registered in alarmedAWSMetrics[KeyAWSOpenSearch],
+	// so the forward + reverse authority gates cover them directly — no
+	// exclusion needed.
 }
 
 // awsModuleAuthor inverts alarmedAWSMetrics by module path so the reverse


### PR DESCRIPTION
Single PR subsuming PRs #779 and #781 (one merge per work item + review-round commits).

Closes #761. Closes #778. Part of #755.

## Summary
- **SageMaker real-time inference endpoint** (#761): `aws_sagemaker_model` + `endpoint_configuration` + `endpoint` gated on `enable_inference`; least-privilege exec-role (ECR pull scoped to the image's registry incl. cross-account DLCs, S3 model-data scoped to the artifact bucket); endpoint `depends_on` the IAM policies (eventual-consistency race); Invocation5XXErrors + ModelLatency alarms with pinned operator/statistic/threshold; composer `AWSSageMakerConfig` partial-config; CI-skipped live integration test included.
- **Multi-group AWS metric specs** (#778): `ComponentObservability` gains `AWSExtra []*AWSObs` + `AWSGroups()`; the inspector queries multiple namespaces per component; AOSS group (`AWS/AOSS`/`ClientId`/Sum) attached to `aws_opensearch`, OCU metrics fully observed; `excludedFromAuthority` shortcuts retired; account-keyed dimension values (`ClientId` = account ID, threaded via `MetricsFilter.AccountID`, group skipped when absent).

## Test plan
- [x] Isolated local: `pkg/composer` (solo, 295s), `pkg/observability/...` (1361), sagemaker shape tftest (29), opensearch tftest (9) — all green
- [x] Review: Codex on the combined diff (found the AOSS `ClientId` value bug — fixed + mutation-verified) ; constituent PRs each had multi-angle review + qa-professor + Codex with fix rounds
- [x] qa-professor on the #778 test slice: PASS (9/9 mutations caught)
- [ ] CI full suite
- [ ] Live cust3: SageMaker endpoint integration run (operator-driven, post-merge or on this branch)

## Review notes
- /review findings: all P0/P1 resolved (incl. Codex P1 on combined diff); qa P2s addressed (synthetic negative fixture); P3 nits skipped as documented
- Deferred: panel-metric name verification (repo-wide pattern, not this PR's scope)
