### PR TITLE
feat(discover): per-type results callback (OnTypeDiscovered) + export DiscoverTypesConcurrency

### DIFF
--- a/cmd/insideout-import/awsdiscover/args.go
+++ b/cmd/insideout-import/awsdiscover/args.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 // DiscoverArgs is the per-call input shape consumed by the aggregator's
@@ -37,6 +38,57 @@ type DiscoverArgs struct {
 	TagSelectors []TagSelector
 	AccountID    string
 	Emitter      progress.Emitter
+
+	// OnTypeDiscovered, when non-nil, is invoked by DiscoverTypes exactly
+	// once per requested type AS THAT TYPE COMPLETES its Discover phase,
+	// carrying the type's discovered resources. It is the per-type RESULTS
+	// counterpart to the Emitter's TypeProgressEmitter.TypeDone (which
+	// reports only the type's COUNT). A consumer that needs to STREAM each
+	// type's resources as the scan progresses — rather than waiting for
+	// the whole DiscoverTypes call to return its flattened slice — sets
+	// this callback. The flagship consumer is reliable's streaming discover
+	// path (luthersystems/reliable#2060), which previously fanned out one
+	// single-type DiscoverTypes call per type purely to observe per-type
+	// completion; this hook lets it collapse that fan-out back to a single
+	// call. See reliable#2065 for the re-implementation that motivated this.
+	//
+	// Contract:
+	//
+	//   - INVOKED ONCE PER REQUESTED TYPE. Every type passed to (or
+	//     defaulted by) DiscoverTypes fires exactly one callback, including
+	//     a type whose Discover yielded nothing and a type DOWNGRADED by the
+	//     PerTypeTimeout fence (delivered with an EMPTY, non-nil slice) — so
+	//     a consumer driving a progress denominator off the callbacks still
+	//     advances to 100%.
+	//
+	//   - SERIALIZED. DiscoverTypes serializes callback invocations under an
+	//     internal mutex, so the callback does NOT need its own locking even
+	//     though the per-type Discover calls run concurrently under the
+	//     aggregator's errgroup. Invocations are NOT ordered by selection
+	//     order — they fire in TYPE-COMPLETION order, so a fast type's
+	//     callback can run while a slow type is still in flight (that is the
+	//     point: it enables streaming). The flattened slice DiscoverTypes
+	//     RETURNS is still ordered by selection order, unchanged.
+	//
+	//   - tfType is the Terraform resource type (e.g. "aws_s3_bucket"); the
+	//     resources slice aliases the same backing array stored for the
+	//     return value, so a callback that needs to RETAIN entries beyond
+	//     the invocation should copy them (the aggregator does not mutate
+	//     the slice afterward, but callers should not assume exclusive
+	//     ownership).
+	//
+	//   - FAILURE SEMANTICS (matches streaming): the callback is NOT invoked
+	//     after DiscoverTypes returns an error. On a fail-fast abort (a
+	//     non-timeout per-type error or parent-ctx cancellation cancels the
+	//     errgroup), types that COMPLETED before the failure MAY already have
+	//     fired their callback — that is inherent to streaming and the
+	//     consumer must tolerate a partial set of callbacks followed by a
+	//     non-nil error. Types that never started, and the failing type
+	//     itself, do NOT fire. No type ever fires more than once.
+	//
+	// Nil OnTypeDiscovered is the back-compat default: zero behavior change
+	// for the CLI and mars, which consume DiscoverTypes today without it.
+	OnTypeDiscovered func(tfType string, resources []imported.ImportedResource)
 
 	// PerTypeTimeout, when > 0, bounds the wall time a single per-type
 	// Discoverer.Discover call may consume inside DiscoverTypes's

--- a/cmd/insideout-import/awsdiscover/args.go
+++ b/cmd/insideout-import/awsdiscover/args.go
@@ -70,12 +70,27 @@ type DiscoverArgs struct {
 	//     point: it enables streaming). The flattened slice DiscoverTypes
 	//     RETURNS is still ordered by selection order, unchanged.
 	//
-	//   - tfType is the Terraform resource type (e.g. "aws_s3_bucket"); the
-	//     resources slice aliases the same backing array stored for the
-	//     return value, so a callback that needs to RETAIN entries beyond
-	//     the invocation should copy them (the aggregator does not mutate
-	//     the slice afterward, but callers should not assume exclusive
-	//     ownership).
+	//   - tfType is the Terraform resource type (e.g. "aws_s3_bucket"). The
+	//     delivered slice is an ISOLATED SNAPSHOT — a fresh slice whose
+	//     elements are value copies with a cloned Identity.NativeIDs map — so
+	//     the callback may retain it and process it asynchronously without
+	//     racing the aggregator's later mutation (see next bullet).
+	//
+	//   - DISCOVERY-PHASE results, NOT the fully-resolved terminal set. The
+	//     callback fires as each type finishes its per-type Discover, which is
+	//     BEFORE DiscoverTypes runs its cross-type augmentation passes —
+	//     resolveVPCChildVPCIDs (stamps NativeIDs["vpc_id"] on
+	//     aws_internet_gateway / aws_vpc_dhcp_options) and
+	//     resolveParentAddresses (stamps Identity.ParentAddress). Those passes
+	//     need the FULL cross-type set, so they cannot run per type and only
+	//     execute after every type has completed; they mutate the slice
+	//     DiscoverTypes RETURNS, never the isolated snapshot. A consumer that
+	//     needs the resolved parent linkage (FK closure / parent addresses)
+	//     must therefore read it from the returned slice, not from the
+	//     streamed callbacks. This matches how the streaming consumer already
+	//     treats per-type batches: reliable's resource_batch sink is the live
+	//     "services as we find them" progress feed and explicitly defers
+	//     dependency resolution to the terminal result.
 	//
 	//   - FAILURE SEMANTICS (matches streaming): the callback is NOT invoked
 	//     after DiscoverTypes returns an error. On a fail-fast abort (a

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -14,7 +14,7 @@
 // can mock the SDK boundary without depending on real AWS credentials.
 // The aggregator (AWSDiscoverer) wires real SDK clients in production and
 // fans out to the registered per-type discoverers concurrently under a
-// bounded errgroup (defaultDiscoverTypesConcurrency).
+// bounded errgroup (DiscoverTypesConcurrency).
 package awsdiscover
 
 import (
@@ -34,11 +34,23 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
-// defaultDiscoverTypesConcurrency caps the number of per-service
-// discoverers DiscoverTypes runs concurrently. Each selected
-// Discoverer already has its own internal bounded fan-out for per-item
-// SDK calls (tag fetches, GetResource walks); this constant bounds the
-// service-level layer on top.
+// DiscoverTypesConcurrency caps the number of per-service discoverers
+// DiscoverTypes runs concurrently — the TYPE-level fan-out limit. Each
+// selected Discoverer already has its own internal bounded fan-out for
+// per-item SDK calls (tag fetches, GetResource walks); this constant
+// bounds the service-level layer on top of that.
+//
+// NOT to be confused with DefaultMaxConcurrency (= 10), which is the
+// PER-RESOURCE GetResource / tag-fetch fan-out cap inside a single
+// discoverer. The two govern different layers: DiscoverTypesConcurrency
+// is "how many resource TYPES discover at once", DefaultMaxConcurrency
+// is "how many per-item SDK calls one type issues at once". A downstream
+// consumer that fans out single-type DiscoverTypes calls itself (e.g.
+// reliable's streaming discover path, which issues one call per type to
+// receive per-type results as they land) should bound its own fan-out by
+// THIS constant, not DefaultMaxConcurrency — using the per-resource cap
+// there would 2.5× the intended type-level control-plane call rate (the
+// confusion that produced reliable#2065 codex round 2).
 //
 // Originally 8 (#629); lowered to 4 (#632) after staging hit a
 // ThrottlingException from CloudControl ListResources during the
@@ -48,7 +60,7 @@ import (
 // without multiplying account-wide QPS by the registered-type count.
 // See also: defaultDiscoverStartupJitterMax for the per-goroutine
 // jitter applied before the first AWS call.
-const defaultDiscoverTypesConcurrency = 4
+const DiscoverTypesConcurrency = 4
 
 // defaultDiscoverStartupJitterMax bounds the random sleep applied
 // before each per-service goroutine's first AWS call. Without
@@ -480,7 +492,7 @@ func (a *AWSDiscoverer) DiscoverByID(ctx context.Context, tfType, id, region, ac
 
 // DiscoverTypes runs the selected per-service discoverers concurrently
 // under a bounded errgroup (default concurrency:
-// defaultDiscoverTypesConcurrency). Per-item concurrency already lives
+// DiscoverTypesConcurrency). Per-item concurrency already lives
 // inside each discoverer (tag-fanout, sub-resource walks); adding
 // service-level fan-out shortens wall time for multi-service imports
 // without changing per-service throttle behavior. Unknown type names
@@ -568,7 +580,7 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(defaultDiscoverTypesConcurrency)
+	g.SetLimit(DiscoverTypesConcurrency)
 	// Per-goroutine startup jitter (#632). Without this, all N
 	// service goroutines unblock at t=0 and their first
 	// ListResources / Describe* calls land in the same burst,

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -590,19 +590,26 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	// delivered with an empty, non-nil slice so the consumer's progress
 	// denominator still advances. A nil callback short-circuits before the
 	// lock so the back-compat path takes zero overhead.
+	//
+	// The delivered slice is an ISOLATED snapshot, not an alias of the
+	// returned rows: the cross-type augmentation passes that run after
+	// g.Wait() (resolveVPCChildVPCIDs mutates Identity.NativeIDs["vpc_id"];
+	// resolveParentAddresses sets Identity.ParentAddress) would otherwise
+	// mutate structs already handed to the callback — a hazard for a consumer
+	// that retains or asynchronously processes the batch (codex reliable#2065
+	// round 2). snapshotForCallback copies each element by value (isolating
+	// every scalar, including ParentAddress) and clones the NativeIDs map
+	// (the only map a post-Wait pass mutates today), so the callback's view
+	// is frozen at discovery time regardless of later augmentation.
 	var cbMu sync.Mutex
 	onTypeDiscovered := func(tfType string, resources []imported.ImportedResource) {
 		if args.OnTypeDiscovered == nil {
 			return
 		}
-		if resources == nil {
-			// Normalize the downgraded/empty case to a non-nil empty slice
-			// so consumers can rely on a stable "delivered, zero rows" shape.
-			resources = []imported.ImportedResource{}
-		}
+		snapshot := snapshotForCallback(resources)
 		cbMu.Lock()
 		defer cbMu.Unlock()
-		args.OnTypeDiscovered(tfType, resources)
+		args.OnTypeDiscovered(tfType, snapshot)
 	}
 
 	g, gctx := errgroup.WithContext(ctx)
@@ -741,4 +748,38 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	resolveParentAddresses(all)
 	args.Emitter.StageFinish("discover", len(all), time.Since(stageStart))
 	return all, nil
+}
+
+// snapshotForCallback returns an isolated copy of a per-type result slice
+// for delivery to DiscoverArgs.OnTypeDiscovered, so the post-g.Wait()
+// cross-type augmentation passes can't mutate structs already handed to a
+// streaming consumer (codex reliable#2065 round 2).
+//
+// It copies every element by VALUE — which already isolates all scalar
+// fields, notably Identity.ParentAddress (set by resolveParentAddresses) —
+// and additionally clones Identity.NativeIDs, the only map a post-Wait pass
+// mutates today (resolveVPCChildVPCIDs stamps NativeIDs["vpc_id"]). The
+// other reference fields (Tags, Attributes, ProviderIdentity, Attrs, the
+// *PresetMatch / *ForceTakeover pointers, …) are NOT touched by any
+// post-Wait augmentation, so they are intentionally shared rather than
+// deep-copied — a full deep copy would be a maintenance hazard that goes
+// stale every time the IR grows a field. INVARIANT: if a future post-Wait
+// pass mutates an additional reference field on a delivered resource, clone
+// it here too (and extend TestOnTypeDiscovered_SnapshotIsolatesNativeIDs).
+//
+// nil/empty in → non-nil empty slice out, so consumers get a stable
+// "delivered, zero rows" shape for downgraded / empty types.
+func snapshotForCallback(in []imported.ImportedResource) []imported.ImportedResource {
+	out := make([]imported.ImportedResource, len(in))
+	copy(out, in)
+	for i := range out {
+		if src := out[i].Identity.NativeIDs; src != nil {
+			clone := make(map[string]string, len(src))
+			for k, v := range src {
+				clone[k] = v
+			}
+			out[i].Identity.NativeIDs = clone
+		}
+	}
+	return out
 }

--- a/cmd/insideout-import/awsdiscover/awsdiscover.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"math/rand"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -579,6 +580,31 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 		}
 	}
 
+	// Per-type RESULTS callback (#739 follow-up / reliable#2060). When the
+	// caller sets args.OnTypeDiscovered, deliver each type's discovered
+	// resources as that type completes — the streaming counterpart to the
+	// count-only emitTypeDone above. The per-type Discover calls run
+	// concurrently under the errgroup below, so onTypeDiscovered SERIALIZES
+	// invocations under cbMu: the documented contract promises consumers
+	// don't need their own locking. A timed-out (downgraded) type is
+	// delivered with an empty, non-nil slice so the consumer's progress
+	// denominator still advances. A nil callback short-circuits before the
+	// lock so the back-compat path takes zero overhead.
+	var cbMu sync.Mutex
+	onTypeDiscovered := func(tfType string, resources []imported.ImportedResource) {
+		if args.OnTypeDiscovered == nil {
+			return
+		}
+		if resources == nil {
+			// Normalize the downgraded/empty case to a non-nil empty slice
+			// so consumers can rely on a stable "delivered, zero rows" shape.
+			resources = []imported.ImportedResource{}
+		}
+		cbMu.Lock()
+		defer cbMu.Unlock()
+		args.OnTypeDiscovered(tfType, resources)
+	}
+
 	g, gctx := errgroup.WithContext(ctx)
 	g.SetLimit(DiscoverTypesConcurrency)
 	// Per-goroutine startup jitter (#632). Without this, all N
@@ -625,6 +651,19 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 			// Non-timeout errors still propagate through the errgroup
 			// so a genuine API failure (Throttling, invalid creds)
 			// continues to fail-fast as before.
+			//
+			// Fence scope (reliable#2065 audit): the ONLY per-type work in
+			// this goroutine is d.Discover(callCtx, args), so wrapping that
+			// single call covers the type's entire unit of work. The two
+			// SDK-backed augmentation passes — resolveVPCChildVPCIDs and
+			// resolveParentAddresses — run ONCE over the fully-assembled set
+			// AFTER g.Wait() (below), not per type, and the RGT prefetch runs
+			// ONCE up front before the fan-out. None of them is per-type, so
+			// there is nothing per-type sitting outside this fence to widen
+			// it over. (Downstream reliable's old per-call fan-out needed an
+			// extra outer fence only because IT re-ran the prefetch + VPC pass
+			// for every single-type call; that is an artifact of fanning out
+			// single-type calls, not a gap here.)
 			callCtx := gctx
 			var cancel context.CancelFunc
 			if args.PerTypeTimeout > 0 {
@@ -650,14 +689,18 @@ func (a *AWSDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 					results[i] = nil
 					// This type completed (with a partial / empty
 					// result); count it toward N-of-total so the
-					// progress denominator still reaches the total.
+					// progress denominator still reaches the total, and
+					// stream an empty result slice to the per-type
+					// RESULTS callback so its denominator advances too.
 					emitTypeDone(d.ResourceType(), 0)
+					onTypeDiscovered(d.ResourceType(), nil)
 					return nil
 				}
 				return fmt.Errorf("%s: %w", d.ResourceType(), err)
 			}
 			results[i] = entries
 			emitTypeDone(d.ResourceType(), len(entries))
+			onTypeDiscovered(d.ResourceType(), entries)
 			return nil
 		})
 	}

--- a/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
+++ b/cmd/insideout-import/awsdiscover/awsdiscover_parallel_test.go
@@ -71,8 +71,8 @@ func TestDiscoverTypes_RunsServicesConcurrently(t *testing.T) {
 	}
 	t.Parallel()
 
-	if defaultDiscoverTypesConcurrency < 2 {
-		t.Fatalf("defaultDiscoverTypesConcurrency=%d; this test requires >=2 to assert parallel execution", defaultDiscoverTypesConcurrency)
+	if DiscoverTypesConcurrency < 2 {
+		t.Fatalf("DiscoverTypesConcurrency=%d; this test requires >=2 to assert parallel execution", DiscoverTypesConcurrency)
 	}
 
 	var concurrent, maxObserved int32
@@ -190,7 +190,7 @@ func TestDiscoverTypes_ErrorWrapShapeMatchesPreParallel(t *testing.T) {
 }
 
 // TestDiscoverTypes_ConcurrencyCappedAtDefault pins
-// defaultDiscoverTypesConcurrency (= 4 per #632, lowered from 8 in
+// DiscoverTypesConcurrency (= 4 per #632, lowered from 8 in
 // #629) by registering more services than the cap and asserting the
 // observed-concurrent max never exceeds the limit. Catches an
 // accidental g.SetLimit() drop or a future bump that re-introduces
@@ -204,8 +204,8 @@ func TestDiscoverTypes_ConcurrencyCappedAtDefault(t *testing.T) {
 	// Pin the expected cap. If the constant changes intentionally,
 	// update the literal here so the failure mode is obvious.
 	const wantCap = 4
-	if defaultDiscoverTypesConcurrency != wantCap {
-		t.Fatalf("defaultDiscoverTypesConcurrency=%d, want %d — if you intentionally changed the cap, update this test and TestProductionLoadConfig retry pins to match (#632)", defaultDiscoverTypesConcurrency, wantCap)
+	if DiscoverTypesConcurrency != wantCap {
+		t.Fatalf("DiscoverTypesConcurrency=%d, want %d — if you intentionally changed the cap, update this test and TestProductionLoadConfig retry pins to match (#632)", DiscoverTypesConcurrency, wantCap)
 	}
 
 	const services = wantCap * 2 // 8: enough to expose any cap > wantCap
@@ -237,7 +237,7 @@ func TestDiscoverTypes_ConcurrencyCappedAtDefault(t *testing.T) {
 	}
 	got := atomic.LoadInt32(&maxObserved)
 	if int(got) > wantCap {
-		t.Errorf("maxObserved=%d, want <=%d (cap exceeded — g.SetLimit(defaultDiscoverTypesConcurrency) regressed)", got, wantCap)
+		t.Errorf("maxObserved=%d, want <=%d (cap exceeded — g.SetLimit(DiscoverTypesConcurrency) regressed)", got, wantCap)
 	}
 	// And it must have actually saturated the cap — otherwise the
 	// test isn't asserting anything (e.g. accidental serialization

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -240,7 +240,7 @@ func (d *cloudControlDiscoverer) ResourceType() string { return d.cfg.TFType }
 
 // listRetry* bound the throttle backoff retryThrottled applies around each
 // CloudControl ListResources page. Discovery fans up to
-// defaultDiscoverTypesConcurrency resource types across a shared per-region
+// DiscoverTypesConcurrency resource types across a shared per-region
 // CloudControl rate budget, so a downstream service throttle — surfaced as a
 // 400 handler-FAILED "Rate exceeded" the SDK adaptive retryer does not
 // classify as retryable — is retried here before we give up and skip the

--- a/cmd/insideout-import/awsdiscover/enrich.go
+++ b/cmd/insideout-import/awsdiscover/enrich.go
@@ -54,7 +54,7 @@ import (
 // a parallel one without unbounded fan-out hammering the AWS API rate
 // limits.
 //
-// Pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
+// Pinned to 4 to mirror awsdiscover.DiscoverTypesConcurrency,
 // which was lowered from 8 to 4 in #632 after 8 simultaneous t=0
 // kickoffs tripped CloudControl's per-account rate budget with a
 // ThrottlingException.

--- a/cmd/insideout-import/awsdiscover/ontypediscovered_test.go
+++ b/cmd/insideout-import/awsdiscover/ontypediscovered_test.go
@@ -1,0 +1,400 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Tests for DiscoverArgs.OnTypeDiscovered — the per-type RESULTS callback
+// (reliable#2060). The callback is the streaming counterpart to the
+// count-only TypeProgressEmitter.TypeDone: it delivers each type's
+// discovered resources AS THAT TYPE COMPLETES, so a consumer can stream
+// per-type batches without fanning out one single-type DiscoverTypes call
+// per type (the reliable#2065 workaround this hook retires).
+//
+// Contract under test (see DiscoverArgs.OnTypeDiscovered doc):
+//   - invoked exactly once per requested type, including empty/downgraded
+//     types (empty non-nil slice);
+//   - invocations serialized (no callback-side locking required, -race clean);
+//   - completion-ordered (a fast type fires while a slow type is in flight);
+//   - not invoked for the failing type or types that never started on a
+//     fail-fast abort, and never invoked more than once.
+
+// recordingCB is a test sink for OnTypeDiscovered that deliberately mutates
+// shared state WITHOUT its own lock. Under -race this proves the aggregator
+// serializes invocations: if it didn't, the concurrent map write + counter
+// increment would trip the race detector (and the counts would tear).
+type recordingCB struct {
+	byType map[string][]string // tfType -> resource addresses, unguarded on purpose
+	order  []string            // completion order of tfTypes, unguarded on purpose
+	calls  int                 // total invocations, unguarded on purpose
+}
+
+func newRecordingCB() *recordingCB {
+	return &recordingCB{byType: map[string][]string{}}
+}
+
+func (r *recordingCB) fn(tfType string, resources []imported.ImportedResource) {
+	addrs := make([]string, 0, len(resources))
+	for _, res := range resources {
+		addrs = append(addrs, res.Identity.Address)
+	}
+	r.byType[tfType] = addrs
+	r.order = append(r.order, tfType)
+	r.calls++
+}
+
+// TestOnTypeDiscovered_DeliversEachTypeOnce asserts the headline contract:
+// every requested type fires the callback exactly once with that type's
+// resources, and the union of delivered resources equals the flattened
+// return value. Running with -race additionally proves the invocations are
+// serialized (the callback mutates an unguarded map/slice/counter).
+func TestOnTypeDiscovered_DeliversEachTypeOnce(t *testing.T) {
+	t.Parallel()
+
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1"), ir("a2")}}
+	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
+	c := &fakeDiscoverer{t: "type_c", out: nil} // zero-result type still fires once
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b, "type_c": c}}
+
+	cb := newRecordingCB()
+	args := argsBasic()
+	args.OnTypeDiscovered = cb.fn
+
+	got, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b", "type_c"}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Exactly one callback per requested type.
+	if cb.calls != 3 {
+		t.Errorf("callback fired %d times, want 3 (once per requested type)", cb.calls)
+	}
+	for _, want := range []string{"type_a", "type_b", "type_c"} {
+		if _, ok := cb.byType[want]; !ok {
+			t.Errorf("type %q never delivered to callback", want)
+		}
+	}
+	// Per-type resources match.
+	if !reflect.DeepEqual(cb.byType["type_a"], []string{"a1", "a2"}) {
+		t.Errorf("type_a resources = %v, want [a1 a2]", cb.byType["type_a"])
+	}
+	if !reflect.DeepEqual(cb.byType["type_b"], []string{"b1"}) {
+		t.Errorf("type_b resources = %v, want [b1]", cb.byType["type_b"])
+	}
+	// Zero-result type fires with an empty (non-nil) slice.
+	if got, want := cb.byType["type_c"], []string{}; !reflect.DeepEqual(got, want) {
+		t.Errorf("type_c resources = %v, want [] (zero-result type still delivered)", got)
+	}
+
+	// The flattened return value still groups by selection order, unchanged.
+	gotAddrs := make([]string, len(got))
+	for i, r := range got {
+		gotAddrs[i] = r.Identity.Address
+	}
+	if want := []string{"a1", "a2", "b1"}; !reflect.DeepEqual(gotAddrs, want) {
+		t.Errorf("returned slice = %v, want %v (selection order preserved)", gotAddrs, want)
+	}
+}
+
+// TestOnTypeDiscovered_DeliversEmptyOnDowngrade asserts a type DOWNGRADED by
+// the PerTypeTimeout fence still fires the callback exactly once, with an
+// EMPTY non-nil slice — so a consumer driving a progress denominator off the
+// callbacks advances to 100% even when a slow type yields nothing.
+func TestOnTypeDiscovered_DeliversEmptyOnDowngrade(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	slow := &sleepDiscoverer{t: "type_slow", out: []imported.ImportedResource{ir("slow1")}, sleep: 500 * time.Millisecond}
+	fast := &fakeDiscoverer{t: "type_fast", out: []imported.ImportedResource{ir("fast1")}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_slow": slow, "type_fast": fast}}
+
+	cb := newRecordingCB()
+	args := argsBasic()
+	args.PerTypeTimeout = 50 * time.Millisecond
+	args.OnTypeDiscovered = cb.fn
+
+	got, err := agg.DiscoverTypes(context.Background(), []string{"type_slow", "type_fast"}, args)
+	if err != nil {
+		t.Fatalf("DiscoverTypes returned error on per-type timeout (partial result expected): %v", err)
+	}
+
+	// Both types fired exactly once.
+	if cb.calls != 2 {
+		t.Errorf("callback fired %d times, want 2", cb.calls)
+	}
+	// The fast type delivered its row.
+	if !reflect.DeepEqual(cb.byType["type_fast"], []string{"fast1"}) {
+		t.Errorf("type_fast resources = %v, want [fast1]", cb.byType["type_fast"])
+	}
+	// The downgraded type delivered an empty non-nil slice.
+	slowRes, ok := cb.byType["type_slow"]
+	if !ok {
+		t.Fatal("downgraded type_slow never delivered to callback")
+	}
+	if slowRes == nil || len(slowRes) != 0 {
+		t.Errorf("downgraded type_slow resources = %v, want [] (empty non-nil)", slowRes)
+	}
+	// And the returned slice only carries the fast type's row.
+	if len(got) != 1 || got[0].Identity.Address != "fast1" {
+		t.Errorf("returned slice = %v, want [fast1]", got)
+	}
+}
+
+// barrierDiscoverer blocks Discover until release is closed (the slow type)
+// or returns immediately after signalling started (the fast type). Used to
+// pin the streaming-order guarantee.
+type barrierDiscoverer struct {
+	t       string
+	out     []imported.ImportedResource
+	block   bool
+	started chan struct{} // closed when Discover is entered (slow type)
+	release chan struct{} // Discover returns once this is closed (slow type)
+}
+
+func (b *barrierDiscoverer) ResourceType() string { return b.t }
+
+func (b *barrierDiscoverer) Discover(ctx context.Context, _ DiscoverArgs) ([]imported.ImportedResource, error) {
+	if b.block {
+		if b.started != nil {
+			close(b.started)
+		}
+		select {
+		case <-b.release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return b.out, nil
+}
+
+func (b *barrierDiscoverer) DiscoverByID(_ context.Context, _, _, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, ErrNotSupported
+}
+
+// TestOnTypeDiscovered_StreamsBeforeScanCompletes is the streaming-order
+// guard: a fast type's callback MUST fire while a slow type is still in
+// flight. A regression that gathered all per-type results and only fired the
+// callbacks after g.Wait() (defeating streaming) would deadlock here — the
+// fast callback would never run, so the slow type would never be released,
+// so the bounded escape hatch fires a clean failure instead of hanging CI.
+//
+// Mirrors reliable's TestRunAWSDiscoverWithPerTypeTimeout_StreamsBatchesBeforeScanCompletes.
+func TestOnTypeDiscovered_StreamsBeforeScanCompletes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	slowStarted := make(chan struct{})
+	slowRelease := make(chan struct{})
+	slow := &barrierDiscoverer{
+		t:       "type_slow",
+		out:     []imported.ImportedResource{ir("slow1")},
+		block:   true,
+		started: slowStarted,
+		release: slowRelease,
+	}
+	fast := &barrierDiscoverer{t: "type_fast", out: []imported.ImportedResource{ir("fast1")}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_slow": slow, "type_fast": fast}}
+
+	fastCallbackFired := make(chan struct{})
+	var once sync.Once
+	args := argsBasic()
+	args.OnTypeDiscovered = func(tfType string, _ []imported.ImportedResource) {
+		if tfType == "type_fast" {
+			once.Do(func() { close(fastCallbackFired) })
+		}
+	}
+
+	done := make(chan struct{})
+	var got []imported.ImportedResource
+	var gotErr error
+	go func() {
+		got, gotErr = agg.DiscoverTypes(context.Background(), []string{"type_slow", "type_fast"}, args)
+		close(done)
+	}()
+
+	// Wait for the slow type to be IN FLIGHT, then assert the fast type's
+	// callback fires before we release the slow type. If the implementation
+	// gathered-then-emitted, the fast callback would not fire until after
+	// g.Wait(), which can't happen until we release slow — deadlock, caught
+	// by the escape-hatch timeout.
+	select {
+	case <-slowStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow type never entered Discover")
+	}
+	select {
+	case <-fastCallbackFired:
+		// Good: fast type streamed its callback while slow was still blocked.
+	case <-time.After(2 * time.Second):
+		close(slowRelease) // unblock so the goroutine can exit cleanly
+		t.Fatal("fast type's OnTypeDiscovered did not fire while the slow type was still in flight — results are not streaming (gather-then-emit regression)")
+	}
+
+	// Release the slow type and let the call finish.
+	close(slowRelease)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("DiscoverTypes did not return after releasing the slow type")
+	}
+	if gotErr != nil {
+		t.Fatalf("DiscoverTypes returned error: %v", gotErr)
+	}
+	if len(got) != 2 {
+		t.Errorf("len(got)=%d, want 2", len(got))
+	}
+}
+
+// TestOnTypeDiscovered_FailFastNoDuplicateOrPhantom asserts the failure
+// semantics: on a fail-fast abort (a non-timeout per-type error cancels the
+// errgroup), the callback is never invoked for the failing type, never
+// invoked more than once for any type, and never invoked for a type that
+// never started. A type that COMPLETED before the failure MAY have fired —
+// that is acceptable streaming behavior — so we assert the bounds, not an
+// exact set. The aggregator must still return the error.
+func TestOnTypeDiscovered_FailFastNoDuplicateOrPhantom(t *testing.T) {
+	if testing.Short() {
+		t.Skip("timing-sensitive; skip in -short")
+	}
+	t.Parallel()
+
+	// type_boom fails immediately; type_slow would sleep but should observe
+	// ctx.Done() (fail-fast) and bail without delivering. With concurrency 4
+	// both kick off together.
+	boom := &sleepDiscoverer{t: "type_boom", sleep: 0, err: errors.New("boom")}
+	slow := &sleepDiscoverer{t: "type_slow", out: []imported.ImportedResource{ir("slow1")}, sleep: 500 * time.Millisecond}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_boom": boom, "type_slow": slow}}
+
+	var mu sync.Mutex
+	delivered := map[string]int{}
+	args := argsBasic()
+	args.OnTypeDiscovered = func(tfType string, _ []imported.ImportedResource) {
+		mu.Lock()
+		delivered[tfType]++
+		mu.Unlock()
+	}
+
+	_, err := agg.DiscoverTypes(context.Background(), []string{"type_boom", "type_slow"}, args)
+	if err == nil {
+		t.Fatal("expected error from failing discoverer")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// The failing type must never deliver.
+	if n := delivered["type_boom"]; n != 0 {
+		t.Errorf("failing type_boom delivered %d times, want 0", n)
+	}
+	// No type fires more than once.
+	for tfType, n := range delivered {
+		if n > 1 {
+			t.Errorf("type %q delivered %d times, want <=1 (no duplicate delivery)", tfType, n)
+		}
+	}
+	// No phantom types (anything outside the requested set).
+	for tfType := range delivered {
+		if tfType != "type_slow" {
+			t.Errorf("unexpected type %q delivered (never-started / phantom)", tfType)
+		}
+	}
+}
+
+// TestOnTypeDiscovered_NilCallbackIsBackCompat pins the back-compat path: a
+// nil OnTypeDiscovered runs byte-for-byte the no-callback behavior (the CLI
+// and mars shape today). The returned slice is identical and no panic occurs.
+func TestOnTypeDiscovered_NilCallbackIsBackCompat(t *testing.T) {
+	t.Parallel()
+
+	a := &fakeDiscoverer{t: "type_a", out: []imported.ImportedResource{ir("a1")}}
+	b := &fakeDiscoverer{t: "type_b", out: []imported.ImportedResource{ir("b1")}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"type_a": a, "type_b": b}}
+
+	args := argsBasic() // OnTypeDiscovered is nil
+	got, err := agg.DiscoverTypes(context.Background(), []string{"type_a", "type_b"}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotAddrs := make([]string, len(got))
+	for i, r := range got {
+		gotAddrs[i] = r.Identity.Address
+	}
+	if want := []string{"a1", "b1"}; !reflect.DeepEqual(gotAddrs, want) {
+		t.Errorf("returned slice = %v, want %v", gotAddrs, want)
+	}
+}
+
+// TestOnTypeDiscovered_ConcurrentSerialized stresses the serialization
+// guarantee under -race: many types complete concurrently and the callback
+// mutates an unguarded counter. The aggregator's internal cbMu must serialize
+// the invocations — without it, -race trips and/or the counter tears. We pin
+// the exact call count to catch a torn increment, and run enough types to
+// saturate the concurrency cap so invocations genuinely overlap in time.
+func TestOnTypeDiscovered_ConcurrentSerialized(t *testing.T) {
+	t.Parallel()
+
+	const types = 12 // > DiscoverTypesConcurrency so the fan-out genuinely overlaps
+	byType := make(map[string]Discoverer, types)
+	names := make([]string, 0, types)
+	for i := range types {
+		name := "type_" + string(rune('a'+i))
+		byType[name] = &fakeDiscoverer{t: name, out: []imported.ImportedResource{ir(name + "1")}}
+		names = append(names, name)
+	}
+	agg := &AWSDiscoverer{byType: byType}
+
+	// Unguarded counter on purpose: the aggregator serializes invocations,
+	// so this increment is safe; -race proves it.
+	var calls int
+	seen := map[string]struct{}{}
+	args := argsBasic()
+	args.OnTypeDiscovered = func(tfType string, _ []imported.ImportedResource) {
+		calls++
+		seen[tfType] = struct{}{}
+	}
+
+	if _, err := agg.DiscoverTypes(context.Background(), names, args); err != nil {
+		t.Fatal(err)
+	}
+	if calls != types {
+		t.Errorf("callback fired %d times, want %d (torn counter ⇒ serialization broken)", calls, types)
+	}
+	gotNames := make([]string, 0, len(seen))
+	for n := range seen {
+		gotNames = append(gotNames, n)
+	}
+	slices.Sort(gotNames)
+	slices.Sort(names)
+	if !reflect.DeepEqual(gotNames, names) {
+		t.Errorf("delivered types = %v, want %v", gotNames, names)
+	}
+}
+
+// TestDiscoverTypesConcurrency_PinnedValue is the exported-constant pin: the
+// type-level fan-out cap is 4 (#632), and it is EXPORTED so downstream
+// consumers (reliable#2065) can bound their own fan-out by the same value
+// instead of guessing. A regression that unexported it fails to compile this
+// reference; a regression that changes the value fails the assertion.
+func TestDiscoverTypesConcurrency_PinnedValue(t *testing.T) {
+	t.Parallel()
+	if DiscoverTypesConcurrency != 4 {
+		t.Errorf("DiscoverTypesConcurrency = %d, want 4 (type-level fan-out cap, #632)", DiscoverTypesConcurrency)
+	}
+	// Sanity: it is distinct from the per-resource GetResource cap. The two
+	// govern different layers (reliable#2065 codex round 2 conflated them).
+	if DiscoverTypesConcurrency == DefaultMaxConcurrency {
+		t.Errorf("DiscoverTypesConcurrency (%d) must not equal DefaultMaxConcurrency (%d) — they are different layers",
+			DiscoverTypesConcurrency, DefaultMaxConcurrency)
+	}
+}

--- a/cmd/insideout-import/awsdiscover/ontypediscovered_test.go
+++ b/cmd/insideout-import/awsdiscover/ontypediscovered_test.go
@@ -381,6 +381,116 @@ func TestOnTypeDiscovered_ConcurrentSerialized(t *testing.T) {
 	}
 }
 
+// nativeIDDiscoverer returns one resource carrying a NativeIDs map, so the
+// snapshot-isolation test can prove the delivered batch's map is a distinct
+// object from the one in the returned slice (the slice resolveVPCChildVPCIDs
+// would mutate after g.Wait()).
+type nativeIDDiscoverer struct {
+	t   string
+	out []imported.ImportedResource
+}
+
+func (n *nativeIDDiscoverer) ResourceType() string { return n.t }
+func (n *nativeIDDiscoverer) Discover(_ context.Context, _ DiscoverArgs) ([]imported.ImportedResource, error) {
+	return n.out, nil
+}
+func (n *nativeIDDiscoverer) DiscoverByID(_ context.Context, _, _, _ string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, ErrNotSupported
+}
+
+// TestOnTypeDiscovered_SnapshotIsolatesNativeIDs pins the snapshot-isolation
+// contract (codex reliable#2065 round 2): the resources delivered to the
+// callback must NOT alias the NativeIDs maps in the returned slice, so a
+// post-g.Wait() augmentation pass (resolveVPCChildVPCIDs stamps
+// NativeIDs["vpc_id"]) cannot mutate a struct a streaming consumer retained.
+//
+// We simulate the post-pass mutation directly on the returned slice's map and
+// assert the retained callback snapshot is unaffected — a regression that
+// dropped the map clone (or aliased the slice) would let the mutation bleed
+// through.
+func TestOnTypeDiscovered_SnapshotIsolatesNativeIDs(t *testing.T) {
+	t.Parallel()
+
+	res := ir("igw1")
+	res.Identity.NativeIDs = map[string]string{"internet_gateway_id": "igw-123"}
+	d := &nativeIDDiscoverer{t: "aws_internet_gateway", out: []imported.ImportedResource{res}}
+	agg := &AWSDiscoverer{byType: map[string]Discoverer{"aws_internet_gateway": d}}
+
+	var retained []imported.ImportedResource
+	args := argsBasic()
+	args.OnTypeDiscovered = func(_ string, resources []imported.ImportedResource) {
+		retained = resources // a streaming consumer holding the batch
+	}
+
+	got, err := agg.DiscoverTypes(context.Background(), []string{"aws_internet_gateway"}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(retained) != 1 || len(got) != 1 {
+		t.Fatalf("retained=%d got=%d, want 1 each", len(retained), len(got))
+	}
+
+	// The delivered snapshot must not share the returned slice's NativeIDs map.
+	if &retained[0].Identity.NativeIDs == &got[0].Identity.NativeIDs {
+		t.Fatal("snapshot shares the NativeIDs map header with the returned slice")
+	}
+	// Simulate the post-g.Wait() augmentation mutating the RETURNED row.
+	got[0].Identity.NativeIDs["vpc_id"] = "vpc-999"
+	if _, leaked := retained[0].Identity.NativeIDs["vpc_id"]; leaked {
+		t.Error("post-discovery NativeIDs mutation bled into the callback snapshot — snapshot is not isolated")
+	}
+}
+
+// TestSnapshotForCallback_DeepCopiesNativeIDsAndIsolatesScalars unit-tests the
+// helper directly: scalar fields are value-copied (so a ParentAddress stamp on
+// the original doesn't reach the snapshot) and NativeIDs is a distinct map.
+func TestSnapshotForCallback_DeepCopiesNativeIDsAndIsolatesScalars(t *testing.T) {
+	t.Parallel()
+
+	in := []imported.ImportedResource{{
+		Identity: imported.ResourceIdentity{
+			Type:      "aws_internet_gateway",
+			Address:   "igw1",
+			NativeIDs: map[string]string{"internet_gateway_id": "igw-123"},
+		},
+	}}
+	out := snapshotForCallback(in)
+	if len(out) != 1 {
+		t.Fatalf("len(out)=%d, want 1", len(out))
+	}
+	// Mutate the ORIGINAL after snapshotting (mimics resolveParentAddresses +
+	// resolveVPCChildVPCIDs running post-g.Wait() on the returned rows).
+	in[0].Identity.ParentAddress = "aws_vpc.main"
+	in[0].Identity.NativeIDs["vpc_id"] = "vpc-999"
+
+	if out[0].Identity.ParentAddress != "" {
+		t.Errorf("ParentAddress leaked into snapshot: %q", out[0].Identity.ParentAddress)
+	}
+	if _, leaked := out[0].Identity.NativeIDs["vpc_id"]; leaked {
+		t.Error("NativeIDs mutation leaked into snapshot")
+	}
+	// The pre-existing NativeIDs entry must survive the clone.
+	if out[0].Identity.NativeIDs["internet_gateway_id"] != "igw-123" {
+		t.Errorf("snapshot dropped pre-existing NativeIDs entry: %v", out[0].Identity.NativeIDs)
+	}
+}
+
+// TestSnapshotForCallback_NilAndEmpty pins the nil/empty normalization: a nil
+// or empty input yields a non-nil empty slice, so consumers see a stable
+// "delivered, zero rows" shape for downgraded / empty types.
+func TestSnapshotForCallback_NilAndEmpty(t *testing.T) {
+	t.Parallel()
+	for _, in := range [][]imported.ImportedResource{nil, {}} {
+		out := snapshotForCallback(in)
+		if out == nil {
+			t.Errorf("snapshotForCallback(%v) = nil, want non-nil empty slice", in)
+		}
+		if len(out) != 0 {
+			t.Errorf("snapshotForCallback(%v) len=%d, want 0", in, len(out))
+		}
+	}
+}
+
 // TestDiscoverTypesConcurrency_PinnedValue is the exported-constant pin: the
 // type-level fan-out cap is 4 (#632), and it is EXPORTED so downstream
 // consumers (reliable#2065) can bound their own fan-out by the same value

--- a/cmd/insideout-import/gcpdiscover/args.go
+++ b/cmd/insideout-import/gcpdiscover/args.go
@@ -1,6 +1,9 @@
 package gcpdiscover
 
-import "github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+import (
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
 
 // DiscoverArgs is the per-call input shape consumed by the aggregator's
 // DiscoverTypes. Mirrors awsdiscover.DiscoverArgs minus AccountID
@@ -24,6 +27,39 @@ type DiscoverArgs struct {
 	Regions      []string
 	TagSelectors []TagSelector
 	Emitter      progress.Emitter
+
+	// OnTypeDiscovered, when non-nil, is invoked by DiscoverTypes exactly
+	// once per requested type AS THAT TYPE COMPLETES, carrying the type's
+	// discovered resources. It is the GCP twin of
+	// awsdiscover.DiscoverArgs.OnTypeDiscovered (reliable#2060) — the
+	// per-type RESULTS counterpart to the count-only
+	// TypeProgressEmitter.TypeDone — so the reliable streaming discover path
+	// can consume one DiscoverTypes call instead of fanning out single-type
+	// calls to observe per-type results.
+	//
+	// Contract (mirrors the AWS twin):
+	//
+	//   - INVOKED ONCE PER REQUESTED TYPE, including a type that yielded no
+	//     resources (delivered with an EMPTY, non-nil slice), so a consumer
+	//     driving a progress denominator off the callbacks still advances to
+	//     100%.
+	//
+	//   - SERIALIZED. DiscoverTypes serializes callback invocations under an
+	//     internal mutex, so the callback needs no locking of its own.
+	//     Invocations fire in COMPLETION order: CAI-backed types tick in a
+	//     burst as the bulk SearchAllResources translation lands, then
+	//     non-CAI types tick one at a time as their per-service listers
+	//     return. The flattened slice DiscoverTypes RETURNS is unchanged.
+	//
+	//   - FAILURE SEMANTICS: not invoked after DiscoverTypes returns an
+	//     error. The GCP path is largely sequential after the bulk CAI
+	//     search, so on an error mid-scan, types translated before the
+	//     failure MAY already have fired — the consumer must tolerate a
+	//     partial set of callbacks followed by a non-nil error. No type ever
+	//     fires more than once.
+	//
+	// Nil OnTypeDiscovered is the back-compat default (CLI / mars unchanged).
+	OnTypeDiscovered func(tfType string, resources []imported.ImportedResource)
 }
 
 // TagSelector is a single operator-supplied label-equality clause. See

--- a/cmd/insideout-import/gcpdiscover/args.go
+++ b/cmd/insideout-import/gcpdiscover/args.go
@@ -51,6 +51,15 @@ type DiscoverArgs struct {
 	//     non-CAI types tick one at a time as their per-service listers
 	//     return. The flattened slice DiscoverTypes RETURNS is unchanged.
 	//
+	//   - The delivered slice is an ISOLATED SNAPSHOT (fresh slice,
+	//     value-copied elements, cloned NativeIDs), as with the AWS twin, so a
+	//     consumer may retain and process it asynchronously. Unlike AWS, the
+	//     GCP path runs NO post-completion cross-type augmentation pass —
+	//     address/parent resolution happens inline in FromAsset via the shared
+	//     addressBook during the CAI translation loop, before delivery — so
+	//     the snapshot already carries the final field values that appear in
+	//     the returned slice.
+	//
 	//   - FAILURE SEMANTICS: not invoked after DiscoverTypes returns an
 	//     error. The GCP path is largely sequential after the bulk CAI
 	//     search, so on an error mid-scan, types translated before the

--- a/cmd/insideout-import/gcpdiscover/enrich.go
+++ b/cmd/insideout-import/gcpdiscover/enrich.go
@@ -36,7 +36,7 @@ import (
 // a parallel one without unbounded fan-out hammering the GCP API rate
 // limits.
 //
-// Pinned to 4 to mirror awsdiscover.defaultDiscoverTypesConcurrency,
+// Pinned to 4 to mirror awsdiscover.DiscoverTypesConcurrency,
 // which was lowered from 8 to 4 in #632 after 8 simultaneous t=0
 // kickoffs tripped CloudControl's per-account rate budget with a
 // ThrottlingException.

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -36,6 +36,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
@@ -524,6 +525,28 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 		}
 	}
 
+	// Per-type RESULTS callback (reliable#2060) — the GCP twin of
+	// awsdiscover's hook. Delivers each type's resources as it completes;
+	// the count-only emitTypeDone above and this RESULTS callback fire
+	// together at every per-type completion point. The GCP path is mostly
+	// sequential after the bulk CAI search, but the non-CAI listers' own
+	// fan-out (and any future parallelism) means we still serialize under
+	// cbMu so the documented "no consumer-side locking" contract holds.
+	// A zero-result type is delivered with an empty, non-nil slice. A nil
+	// callback short-circuits before the lock (zero back-compat overhead).
+	var cbMu sync.Mutex
+	onTypeDiscovered := func(tfType string, resources []imported.ImportedResource) {
+		if args.OnTypeDiscovered == nil {
+			return
+		}
+		if resources == nil {
+			resources = []imported.ImportedResource{}
+		}
+		cbMu.Lock()
+		defer cbMu.Unlock()
+		args.OnTypeDiscovered(tfType, resources)
+	}
+
 	stageStart := time.Now()
 	args.Emitter.ServiceStart(gcpServiceSlug, "")
 	results, err := g.searchBuckets(ctx, scope, args, labelsBucket, namePrefixBucket, parentBucket)
@@ -545,7 +568,10 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	for _, d := range selected {
 		bucket := byAsset[d.AssetType()]
 		sort.SliceStable(bucket, func(i, j int) bool { return bucket[i].Name < bucket[j].Name })
-		typeFound := 0
+		// Per-type rows for the OnTypeDiscovered callback (reliable#2060):
+		// collect this type's translated resources so we can stream them as
+		// the type completes, in addition to appending to the shared `out`.
+		var typeRows []imported.ImportedResource
 		for _, r := range bucket {
 			imp := d.FromAsset(book, r, g.projectID)
 			// A discoverer that returns a zero-valued ImportedResource
@@ -559,14 +585,16 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 			}
 			args.Emitter.ItemFound(gcpServiceSlug, r.Location, imp.Identity.Type, imp.Identity.ImportID)
 			out = append(out, imp)
-			typeFound++
+			typeRows = append(typeRows, imp)
 		}
-		// Per-type progress (#699): emit one event per CAI-backed type as
-		// its assets finish translating. Non-CAI types are handled in the
-		// dedicated phase below, so skip them here — that keeps each type
-		// emitting exactly once and the N-of-total count accurate.
+		// Per-type progress (#699) + results (reliable#2060): emit one event
+		// per CAI-backed type as its assets finish translating. Non-CAI types
+		// are handled in the dedicated phase below, so skip them here — that
+		// keeps each type emitting exactly once and the N-of-total count
+		// accurate.
 		if d.ScopeStyle() != ScopeStyleNonCAI {
-			emitTypeDone(d.ResourceType(), typeFound)
+			emitTypeDone(d.ResourceType(), len(typeRows))
+			onTypeDiscovered(d.ResourceType(), typeRows)
 		}
 	}
 	args.Emitter.ServiceFinish(gcpServiceSlug, "", len(out), time.Since(stageStart))
@@ -602,7 +630,7 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 				args.Emitter.ServiceFinish(nonCAIServiceSlug, "", len(nonCAIResults), time.Since(nonCAIStart))
 				return nil, fmt.Errorf("non-CAI list for %q: %w", d.ResourceType(), err)
 			}
-			typeFound := 0
+			var typeRows []imported.ImportedResource
 			for _, r := range rs {
 				if r.Identity.Type == "" {
 					continue
@@ -614,11 +642,13 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 				book.add(r.Identity.Address)
 				args.Emitter.ItemFound(nonCAIServiceSlug, r.Identity.Location, r.Identity.Type, r.Identity.ImportID)
 				nonCAIResults = append(nonCAIResults, r)
-				typeFound++
+				typeRows = append(typeRows, r)
 			}
-			// Per-type progress (#699): non-CAI types complete one at a
-			// time after their service-specific lister returns.
-			emitTypeDone(d.ResourceType(), typeFound)
+			// Per-type progress (#699) + results (reliable#2060): non-CAI
+			// types complete one at a time after their service-specific
+			// lister returns.
+			emitTypeDone(d.ResourceType(), len(typeRows))
+			onTypeDiscovered(d.ResourceType(), typeRows)
 		}
 		args.Emitter.ServiceFinish(nonCAIServiceSlug, "", len(nonCAIResults), time.Since(nonCAIStart))
 		out = append(out, nonCAIResults...)

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -534,17 +534,22 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 	// cbMu so the documented "no consumer-side locking" contract holds.
 	// A zero-result type is delivered with an empty, non-nil slice. A nil
 	// callback short-circuits before the lock (zero back-compat overhead).
+	//
+	// As with the AWS twin, the delivered slice is an ISOLATED SNAPSHOT
+	// (fresh slice, value-copied elements, cloned NativeIDs) so a consumer
+	// may retain and process it asynchronously. GCP runs no post-completion
+	// augmentation pass, so today nothing mutates the originals — but the
+	// snapshot keeps the cross-cloud contract uniform and future-proofs
+	// against a later per-type augmentation.
 	var cbMu sync.Mutex
 	onTypeDiscovered := func(tfType string, resources []imported.ImportedResource) {
 		if args.OnTypeDiscovered == nil {
 			return
 		}
-		if resources == nil {
-			resources = []imported.ImportedResource{}
-		}
+		snapshot := snapshotForCallback(resources)
 		cbMu.Lock()
 		defer cbMu.Unlock()
-		args.OnTypeDiscovered(tfType, resources)
+		args.OnTypeDiscovered(tfType, snapshot)
 	}
 
 	stageStart := time.Now()
@@ -656,6 +661,28 @@ func (g *GCPDiscoverer) DiscoverTypes(ctx context.Context, types []string, args 
 
 	args.Emitter.StageFinish("discover", len(out), time.Since(stageStart))
 	return out, nil
+}
+
+// snapshotForCallback returns an isolated copy of a per-type result slice
+// for delivery to DiscoverArgs.OnTypeDiscovered — the GCP twin of
+// awsdiscover.snapshotForCallback. It copies every element by value and
+// clones Identity.NativeIDs so a streaming consumer may retain the batch
+// without aliasing the rows in the returned slice. The GCP path runs no
+// post-completion augmentation pass, so this is defensive symmetry rather
+// than a fix for an observed mutation. nil/empty in → non-nil empty out.
+func snapshotForCallback(in []imported.ImportedResource) []imported.ImportedResource {
+	out := make([]imported.ImportedResource, len(in))
+	copy(out, in)
+	for i := range out {
+		if src := out[i].Identity.NativeIDs; src != nil {
+			clone := make(map[string]string, len(src))
+			for k, v := range src {
+				clone[k] = v
+			}
+			out[i].Identity.NativeIDs = clone
+		}
+	}
+	return out
 }
 
 // nonCAIDiscovererHasLister checks each non-CAI discoverer's

--- a/cmd/insideout-import/gcpdiscover/ontypediscovered_test.go
+++ b/cmd/insideout-import/gcpdiscover/ontypediscovered_test.go
@@ -1,0 +1,172 @@
+package gcpdiscover
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// Tests for DiscoverArgs.OnTypeDiscovered — the GCP twin of the per-type
+// RESULTS callback (reliable#2060). Mirrors the awsdiscover-package tests.
+// The GCP path is largely sequential (one bulk CAI search, then per-type
+// translation, then a sequential non-CAI lister phase), so the callbacks
+// fire in completion order without genuine concurrency; the serialization
+// mutex is still asserted -race-clean via an unguarded counter.
+
+// gcpRecordingCB records per-type deliveries with an intentionally
+// unguarded map/slice/counter — under -race this proves DiscoverTypes
+// serializes invocations (consumers need no locking of their own).
+type gcpRecordingCB struct {
+	byType map[string][]string
+	order  []string
+	calls  int
+}
+
+func newGCPRecordingCB() *gcpRecordingCB {
+	return &gcpRecordingCB{byType: map[string][]string{}}
+}
+
+func (r *gcpRecordingCB) fn(tfType string, resources []imported.ImportedResource) {
+	addrs := make([]string, 0, len(resources))
+	for _, res := range resources {
+		addrs = append(addrs, res.Identity.ImportID)
+	}
+	r.byType[tfType] = addrs
+	r.order = append(r.order, tfType)
+	r.calls++
+}
+
+// TestOnTypeDiscovered_GCP_DeliversEachTypeOnce asserts the headline
+// contract across BOTH GCP dispatch paths: CAI-backed types (translated
+// from the bulk SearchAllResources) and a non-CAI type (listed separately).
+// Each requested type fires exactly once with its resources, including a
+// zero-result non-CAI type (empty non-nil slice). Run with -race this also
+// proves serialization (the callback mutates an unguarded map/slice/counter).
+func TestOnTypeDiscovered_GCP_DeliversEachTypeOnce(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAssetSearcher{results: []gcpAssetResult{
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/zeta", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+		{Name: "//storage.googleapis.com/io-foo-bucket", AssetType: "storage.googleapis.com/Bucket", Project: "real-proj", Location: "us-central1"},
+	}}
+	// google_logging_project_sink is ScopeStyleNonCAI; with the default
+	// (nil) SinkLister its ListNonCAI returns empty — exercises the
+	// non-CAI zero-result delivery.
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+
+	cb := newGCPRecordingCB()
+	types := []string{"google_pubsub_topic", "google_storage_bucket", "google_logging_project_sink"}
+	got, err := g.DiscoverTypes(context.Background(), types, DiscoverArgs{Project: "io-foo", Emitter: &recordingEmitter{}, OnTypeDiscovered: cb.fn})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cb.calls != 3 {
+		t.Errorf("callback fired %d times, want 3 (once per requested type)", cb.calls)
+	}
+	// CAI-backed types deliver their translated rows.
+	if got := cb.byType["google_pubsub_topic"]; len(got) != 2 {
+		t.Errorf("google_pubsub_topic delivered %v, want 2 rows", got)
+	}
+	if got := cb.byType["google_storage_bucket"]; len(got) != 1 {
+		t.Errorf("google_storage_bucket delivered %v, want 1 row", got)
+	}
+	// The zero-result non-CAI type still delivered, with an empty non-nil slice.
+	sinkRes, ok := cb.byType["google_logging_project_sink"]
+	if !ok {
+		t.Fatal("non-CAI google_logging_project_sink never delivered to callback")
+	}
+	if sinkRes == nil || len(sinkRes) != 0 {
+		t.Errorf("google_logging_project_sink delivered %v, want [] (empty non-nil)", sinkRes)
+	}
+	// The flattened return value carries the CAI rows (3 total here).
+	if len(got) != 3 {
+		t.Errorf("len(got)=%d, want 3", len(got))
+	}
+}
+
+// TestOnTypeDiscovered_GCP_NonCAIPopulatedLister asserts a non-CAI type
+// with a real lister delivers its filtered rows exactly once via the
+// callback — covering the non-CAI completion point with populated results.
+func TestOnTypeDiscovered_GCP_NonCAIPopulatedLister(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAssetSearcher{results: []gcpAssetResult{
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+	}}
+	sinkLister := &fakeLoggingSinkLister{sinks: []gcpLoggingSink{
+		{Name: "io-foo-audit-sink", FullName: "projects/real-proj/sinks/io-foo-audit-sink", Destination: "storage.googleapis.com/io-foo-audit"},
+		{Name: "io-foo-flow-sink", FullName: "projects/real-proj/sinks/io-foo-flow-sink", Destination: "storage.googleapis.com/io-foo-flow"},
+		// Builtin + non-stack sinks are filtered out by ListNonCAI.
+		{Name: "_Default", FullName: "projects/real-proj/sinks/_Default"},
+		{Name: "other-stack-sink", FullName: "projects/real-proj/sinks/other-stack-sink"},
+	}}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{SinkLister: sinkLister})
+
+	cb := newGCPRecordingCB()
+	types := []string{"google_pubsub_topic", "google_logging_project_sink"}
+	if _, err := g.DiscoverTypes(context.Background(), types, DiscoverArgs{Project: "io-foo", Emitter: &recordingEmitter{}, OnTypeDiscovered: cb.fn}); err != nil {
+		t.Fatal(err)
+	}
+
+	if cb.calls != 2 {
+		t.Errorf("callback fired %d times, want 2 (one per type, no double-emit)", cb.calls)
+	}
+	if got := cb.byType["google_pubsub_topic"]; len(got) != 1 {
+		t.Errorf("google_pubsub_topic delivered %v, want 1 row", got)
+	}
+	// Only the two stack-scoped sinks survive ListNonCAI's filter.
+	if got := cb.byType["google_logging_project_sink"]; len(got) != 2 {
+		t.Errorf("google_logging_project_sink delivered %v, want 2 rows", got)
+	}
+}
+
+// TestOnTypeDiscovered_GCP_NilCallbackIsBackCompat pins back-compat: a nil
+// callback runs the unchanged behavior without panic and returns the same
+// flattened slice.
+func TestOnTypeDiscovered_GCP_NilCallbackIsBackCompat(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAssetSearcher{results: []gcpAssetResult{
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+	}}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_pubsub_topic"}, DiscoverArgs{Emitter: &recordingEmitter{}}) // nil callback
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len(got)=%d, want 1", len(got))
+	}
+}
+
+// TestOnTypeDiscovered_GCP_DeliveredSetMatchesRequested asserts the union
+// of delivered types equals the requested set (no phantom, no missing).
+func TestOnTypeDiscovered_GCP_DeliveredSetMatchesRequested(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAssetSearcher{results: []gcpAssetResult{
+		{Name: "//pubsub.googleapis.com/projects/real-proj/topics/alpha", AssetType: "pubsub.googleapis.com/Topic", Project: "real-proj"},
+		{Name: "//storage.googleapis.com/io-foo-bucket", AssetType: "storage.googleapis.com/Bucket", Project: "real-proj", Location: "us-central1"},
+	}}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+
+	cb := newGCPRecordingCB()
+	want := []string{"google_pubsub_topic", "google_storage_bucket", "google_logging_project_sink"}
+	if _, err := g.DiscoverTypes(context.Background(), want, DiscoverArgs{Project: "io-foo", Emitter: &recordingEmitter{}, OnTypeDiscovered: cb.fn}); err != nil {
+		t.Fatal(err)
+	}
+	gotTypes := make([]string, 0, len(cb.byType))
+	for tfType := range cb.byType {
+		gotTypes = append(gotTypes, tfType)
+	}
+	slices.Sort(gotTypes)
+	slices.Sort(want)
+	if !reflect.DeepEqual(gotTypes, want) {
+		t.Errorf("delivered types = %v, want %v", gotTypes, want)
+	}
+}


### PR DESCRIPTION
Part of luthersystems/reliable#2060.

## Motivation

reliable's streaming discover path needs to emit per-type resource batches as the scan progresses. Upstream offered only a count-only per-type signal (`progress.TypeProgressEmitter.TypeDone` reports a type's COUNT, not its resources), so reliable fanned out one single-type `DiscoverTypes` call per type purely to observe per-type RESULTS as each type completed (reliable#2065).

That downstream re-implementation caused three review bugs (lost streaming, wrong concurrency constant, lost ancillary fence) before it stabilized. This PR moves the capability where it belongs — upstream — so reliable can collapse its bounded fan-out back to a single `DiscoverTypes` call.

## Changes

- **Per-type RESULTS callback.** New `DiscoverArgs.OnTypeDiscovered func(tfType string, resources []imported.ImportedResource)` on both `awsdiscover` and `gcpdiscover`, invoked by `DiscoverTypes` exactly once per requested type as that type completes its Discover phase, carrying the type's discovered resources.
- **Exported the type-level concurrency cap.** `defaultDiscoverTypesConcurrency` → exported `awsdiscover.DiscoverTypesConcurrency` (= 4), with a doc comment distinguishing it from `DefaultMaxConcurrency` (= 10, the per-resource GetResource cap). Reviewers conflated the two in reliable#2065 round 2; downstream fan-out should bound itself by this constant.
- **GCP parity.** Same hook on `gcpdiscover.DiscoverArgs`, wired at both per-type completion points (CAI-backed translation loop + non-CAI lister phase).

## Callback contract (what shipped)

Signature: `func(tfType string, resources []imported.ImportedResource)`

- **Once per requested type.** Every requested (or defaulted) type fires exactly one callback, including a zero-result type and a type DOWNGRADED by the `PerTypeTimeout` fence (delivered with an empty, non-nil slice) so a consumer's progress denominator still advances to 100%.
- **Serialized.** `DiscoverTypes` serializes invocations under an internal mutex, so consumers need no locking even though per-type Discover runs concurrently under the errgroup. Invocations fire in completion order (a fast type fires while a slow type is in flight — that is the streaming point). The flattened slice `DiscoverTypes` returns stays in selection order, unchanged.
- **Isolated snapshot.** The delivered slice is a fresh slice of value-copied elements with a cloned `Identity.NativeIDs` map, so a consumer may retain or asynchronously process the batch without racing the post-`g.Wait()` augmentation passes (see fence-audit below).
- **Discovery-phase results.** The callback fires before the cross-type augmentation passes, so parent linkage (FK closure / `ParentAddress`) is a terminal-result concern read from the returned slice — matching how reliable's `resource_batch` sink already treats streamed batches (it defers dependency resolution to the terminal result).
- **Failure semantics (match streaming).** Not invoked after `DiscoverTypes` returns an error. On a fail-fast abort (non-timeout per-type error or parent-ctx cancellation), types completed before the failure MAY have fired; the failing type and never-started types do NOT fire; no type ever fires more than once.
- **Nil callback is the back-compat default** — zero behavior change for the CLI and mars, which consume `DiscoverTypes` today without it.

## Fence-audit finding (reliable#2065)

The reliable review asked whether per-type ancillary work runs OUTSIDE the upstream `PerTypeTimeout` fence. Audit result: **no — the fence is correctly scoped, no widening needed.**

- The per-type goroutine's only work is `d.Discover(callCtx, args)`, already fully wrapped by the `PerTypeTimeout` child context.
- `resolveVPCChildVPCIDs` (stamps `NativeIDs["vpc_id"]`) and `resolveParentAddresses` (stamps `ParentAddress`) run ONCE over the fully-assembled set after `g.Wait()` — not per type.
- The RGT prefetch runs ONCE up front, before the fan-out — not per type (confirmed).

reliable's old per-call fan-out needed an extra outer fence only because IT re-ran the prefetch + VPC pass for every single-type call — an artifact of fanning out single-type calls, not a gap in the aggregator. Documented in code at the fence site rather than changing behavior.

These same post-`g.Wait()` passes are why the callback delivers an isolated snapshot (codex round 2): they mutate the returned rows after delivery, so the streamed batch is value-copied + `NativeIDs`-cloned to keep a retained batch stable.

## GCP parity decision

Adding the hook to GCP was mechanical, so it is included. The GCP `DiscoverTypes` shape differs (one bulk CAI `SearchAllResources` then per-type translation, plus a sequential non-CAI lister phase) but it has the same per-type completion points the count-only `emitTypeDone` already fires at. GCP runs no post-completion augmentation pass (address/parent resolution is inline in `FromAsset` via the `addressBook`), so its snapshot is defensive symmetry rather than a fix.

## Downstream

reliable will consume this to collapse its bounded per-type fan-out (one `DiscoverTypes` call per type) back to a single `DiscoverTypes` call that sets `OnTypeDiscovered`, retiring the re-implementation that caused the three review bugs.

## Verification

- `go test -race ./cmd/insideout-import/... ./pkg/imported/...` — all pass (the discover packages plus every package consuming `DiscoverArgs`).
- gofmt + `go vet` clean.
- Codex review: clean (no actionable correctness issues) after resolving two P2 rounds (streaming fidelity → snapshot isolation).
- Back-compat: nil callback = byte-for-byte unchanged for CLI/mars; constant rename keeps the same value and call site.
