### PR TITLE
feat(vertex_ai): Vertex Endpoint + Model Garden serving (#768)

### DIFF
--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -81,9 +81,17 @@ locals {
   serving_endpoint_name = tostring(parseint(substr(sha256(var.project), 0, 8), 16))
 
   # The Model Garden one-shot deployment is created only when serving is on AND
-  # a model is named. A bare endpoint (no model) is the enable_serving-only
-  # path; attach a model out-of-band there.
+  # a model is named. It provisions its OWN managed endpoint (with the model
+  # deployed onto it), so the bare endpoint below is mutually exclusive with it:
+  # creating both would leave an empty bare endpoint sitting next to the real
+  # one the model lives on, and the outputs would point at the empty shell.
   model_garden_enabled = var.enable_serving && var.model_garden_model != null
+
+  # The bare serving endpoint is the enable_serving-WITHOUT-a-model path: a
+  # generic attach point for custom/other models, deployed out-of-band. When a
+  # Model Garden model IS named, that resource owns the endpoint instead, so the
+  # bare endpoint is NOT created (mutually exclusive count-gate).
+  bare_endpoint_enabled = var.enable_serving && var.model_garden_model == null
 
   # Attach dedicated accelerators only when an accelerator type is requested.
   # CPU-only serving (the default) omits the machine_spec accelerator fields so
@@ -230,26 +238,35 @@ resource "google_vertex_ai_index_endpoint_deployed_index" "this" {
 
 # --- Model serving (Endpoint + Model Garden) — issue #768 -------------------
 #
-# google_vertex_ai_endpoint:                            serving endpoint (a
+# google_vertex_ai_endpoint:                            bare serving endpoint (a
 #   managed front door for online predictions). Created when enable_serving is
-#   true. PUBLIC by default; the private-endpoint story is unchanged here (it
-#   reuses the same #774 PSC peering range the Vector Search endpoint needs and
-#   is out of scope for this issue).
+#   true AND no Model Garden model is named — the generic attach point for
+#   custom models deployed out-of-band. PUBLIC by default; the private-endpoint
+#   story is unchanged here (it reuses the same #774 PSC peering range the
+#   Vector Search endpoint needs and is out of scope for this issue).
 # google_vertex_ai_endpoint_with_model_garden_deployment: one-shot deploy of an
 #   open Model Garden model (Gemma/Llama/etc) onto its OWN managed endpoint.
 #   Created when enable_serving is true AND model_garden_model is named. The
 #   deploy is the long pole — model downloads + replica spin-up routinely take
 #   30+ minutes — so create/delete carry generous 60m timeouts.
 #
+# The two are MUTUALLY EXCLUSIVE: model_garden manages its own endpoint, so when
+# a model is named the bare endpoint is suppressed. Otherwise the bare endpoint
+# would sit empty next to the real one and the endpoint_id/endpoint_name outputs
+# would point at the empty shell (the bug fixed under #768 review). The outputs
+# return whichever endpoint actually exists.
+#
 # Resources verified against hashicorp/google v7.x (GA tier; both resources are
 # in the GA provider — see PR notes). The dataset and Vector Search resources
 # above are untouched by enable_serving.
 
-# A bare serving endpoint. Models can be deployed onto it out-of-band; the
-# Model Garden resource below provisions its own endpoint, so this one is the
-# generic attach point for custom/other models.
+# A bare serving endpoint, the generic attach point for custom/other models
+# deployed out-of-band. Created ONLY on the enable_serving-without-a-model path:
+# when a Model Garden model is named, the model_garden resource below provisions
+# its own endpoint with the model on it, so this bare one is suppressed (they are
+# mutually exclusive — see local.bare_endpoint_enabled / local.model_garden_enabled).
 resource "google_vertex_ai_endpoint" "serving" {
-  count        = var.enable_serving ? 1 : 0
+  count        = local.bare_endpoint_enabled ? 1 : 0
   name         = local.serving_endpoint_name
   display_name = "${var.project}-serving-endpoint"
   description  = "InsideOut Vertex AI serving endpoint for ${var.project}"

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -70,6 +70,25 @@ locals {
   network_canonical = local.vector_search_private ? (
     "projects/${data.google_project.this.number}/global/networks/${local.network_name}"
   ) : null
+
+  # --- Model serving (#768) -------------------------------------------------
+  # google_vertex_ai_endpoint.name must be NUMERIC, no leading zeros, <=10
+  # digits (the endpoint's resource id). Derive a deterministic number from
+  # var.project so the name is stable across applies for a given stack: parse
+  # the first 8 hex chars of sha256(project) -> an integer <= 4294967295 (10
+  # digits max). tostring renders an int without leading zeros, so the API
+  # constraint holds.
+  serving_endpoint_name = tostring(parseint(substr(sha256(var.project), 0, 8), 16))
+
+  # The Model Garden one-shot deployment is created only when serving is on AND
+  # a model is named. A bare endpoint (no model) is the enable_serving-only
+  # path; attach a model out-of-band there.
+  model_garden_enabled = var.enable_serving && var.model_garden_model != null
+
+  # Attach dedicated accelerators only when an accelerator type is requested.
+  # CPU-only serving (the default) omits the machine_spec accelerator fields so
+  # the deployment does not demand GPU quota it doesn't need.
+  serving_accelerator_enabled = var.serving_accelerator_type != null
 }
 
 # Resolves the caller's project to its numeric project number, which the
@@ -205,6 +224,98 @@ resource "google_vertex_ai_index_endpoint_deployed_index" "this" {
     precondition {
       condition     = var.deployed_index_max_replicas >= var.deployed_index_min_replicas
       error_message = "deployed_index_max_replicas must be >= deployed_index_min_replicas."
+    }
+  }
+}
+
+# --- Model serving (Endpoint + Model Garden) — issue #768 -------------------
+#
+# google_vertex_ai_endpoint:                            serving endpoint (a
+#   managed front door for online predictions). Created when enable_serving is
+#   true. PUBLIC by default; the private-endpoint story is unchanged here (it
+#   reuses the same #774 PSC peering range the Vector Search endpoint needs and
+#   is out of scope for this issue).
+# google_vertex_ai_endpoint_with_model_garden_deployment: one-shot deploy of an
+#   open Model Garden model (Gemma/Llama/etc) onto its OWN managed endpoint.
+#   Created when enable_serving is true AND model_garden_model is named. The
+#   deploy is the long pole — model downloads + replica spin-up routinely take
+#   30+ minutes — so create/delete carry generous 60m timeouts.
+#
+# Resources verified against hashicorp/google v7.x (GA tier; both resources are
+# in the GA provider — see PR notes). The dataset and Vector Search resources
+# above are untouched by enable_serving.
+
+# A bare serving endpoint. Models can be deployed onto it out-of-band; the
+# Model Garden resource below provisions its own endpoint, so this one is the
+# generic attach point for custom/other models.
+resource "google_vertex_ai_endpoint" "serving" {
+  count        = var.enable_serving ? 1 : 0
+  name         = local.serving_endpoint_name
+  display_name = "${var.project}-serving-endpoint"
+  description  = "InsideOut Vertex AI serving endpoint for ${var.project}"
+  # location is the required, canonical field on this resource (region is a
+  # legacy alias and redundant when location is set). The sibling dataset/index
+  # resources only expose region, hence the differing field here.
+  location = var.region
+  project  = var.project_id
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+}
+
+# One-shot Model Garden open-model deployment onto a managed endpoint. EULA
+# acceptance and accelerator quota are operator concerns (see var docs): many
+# open models won't deploy until model_garden_accept_eula is true, and a GPU
+# accelerator_type needs matching quota in the project/region.
+resource "google_vertex_ai_endpoint_with_model_garden_deployment" "model_garden" {
+  count                = local.model_garden_enabled ? 1 : 0
+  publisher_model_name = var.model_garden_model
+  location             = var.region
+  project              = var.project_id
+
+  model_config {
+    accept_eula = var.model_garden_accept_eula
+  }
+
+  deploy_config {
+    dedicated_resources {
+      min_replica_count = var.serving_min_replicas
+      max_replica_count = var.serving_max_replicas
+
+      machine_spec {
+        machine_type = var.serving_machine_type
+        # Accelerator fields only when a GPU/TPU type is requested; CPU-only
+        # serving leaves them unset so no accelerator quota is demanded.
+        accelerator_type  = local.serving_accelerator_enabled ? var.serving_accelerator_type : null
+        accelerator_count = local.serving_accelerator_enabled ? var.serving_accelerator_count : null
+      }
+    }
+  }
+
+  # Model deploys run long (download + replica spin-up). Stay well clear of the
+  # provider's shorter defaults.
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
+
+  lifecycle {
+    # Cross-variable invariants live here (a per-variable validation may only
+    # reference its own variable):
+    #   - autoscaling ceiling must not sit below the floor;
+    #   - an accelerator TYPE without a positive COUNT (or vice versa) is a
+    #     half-configured GPU request that the API would reject at apply.
+    precondition {
+      condition     = var.serving_max_replicas >= var.serving_min_replicas
+      error_message = "serving_max_replicas must be >= serving_min_replicas."
+    }
+    precondition {
+      condition     = (var.serving_accelerator_type == null) == (var.serving_accelerator_count == 0)
+      error_message = "serving_accelerator_type and serving_accelerator_count must be set together: a type requires count > 0, and count > 0 requires a type."
     }
   }
 }

--- a/gcp/vertex_ai/observability.tf
+++ b/gcp/vertex_ai/observability.tf
@@ -37,11 +37,17 @@ variable "alarm_threshold_overrides" {
 locals {
   _obs_user_labels = { project = var.project, severity = var.alarm_severity }
   _obs_thresholds = merge({
-    query_latency_p99_ms = 500
+    query_latency_p99_ms      = 500
+    prediction_latency_p99_ms = 2000
+    prediction_error_rate     = 1
   }, var.alarm_threshold_overrides)
 
   # Alarms only make sense when Vector Search is serving queries.
   _obs_enabled = var.enable_observability && var.enable_vector_search
+
+  # Serving alarms (prediction latency / errors) only make sense when a serving
+  # endpoint exists. Gated on enable_serving, independent of Vector Search.
+  _obs_serving_enabled = var.enable_observability && var.enable_serving
 }
 
 resource "google_monitoring_alert_policy" "vector_search_query_latency_high" {
@@ -67,6 +73,68 @@ resource "google_monitoring_alert_policy" "vector_search_query_latency_high" {
       aggregations {
         alignment_period   = "60s"
         per_series_aligner = "ALIGN_PERCENTILE_99"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+  user_labels           = local._obs_user_labels
+}
+
+# --- Serving alarms (#768) --------------------------------------------------
+# Online-prediction latency + error alarms on the serving endpoint. Emitted
+# only when enable_serving (and observability) are on; the bare dataset / a
+# Vector-Search-only stack has no online-prediction surface to alarm on.
+#
+# Metric paths + monitored resource verified against Google's official metrics
+# list (cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform) and the
+# pkg/observability `vertexai` catalog (registered in alarmedGCPMetrics so the
+# inspector flips Alarmed=true): prediction/online/prediction_latencies and
+# prediction/online/error_count, both reported on
+# aiplatform.googleapis.com/Endpoint.
+
+resource "google_monitoring_alert_policy" "serving_prediction_latency_high" {
+  for_each = local._obs_serving_enabled ? { "0" = true } : {}
+
+  project      = var.project_id
+  display_name = "${var.project}-vertex-prediction-latency"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Online prediction p99 latency above ${local._obs_thresholds["prediction_latency_p99_ms"]}ms"
+    condition_threshold {
+      filter          = "metric.type=\"aiplatform.googleapis.com/prediction/online/prediction_latencies\" AND resource.type=\"aiplatform.googleapis.com/Endpoint\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local._obs_thresholds["prediction_latency_p99_ms"]
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_PERCENTILE_99"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+  user_labels           = local._obs_user_labels
+}
+
+resource "google_monitoring_alert_policy" "serving_prediction_errors_high" {
+  for_each = local._obs_serving_enabled ? { "0" = true } : {}
+
+  project      = var.project_id
+  display_name = "${var.project}-vertex-prediction-errors"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Online prediction error rate above ${local._obs_thresholds["prediction_error_rate"]}/s"
+    condition_threshold {
+      filter          = "metric.type=\"aiplatform.googleapis.com/prediction/online/error_count\" AND resource.type=\"aiplatform.googleapis.com/Endpoint\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local._obs_thresholds["prediction_error_rate"]
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_RATE"
       }
     }
   }

--- a/gcp/vertex_ai/outputs.tf
+++ b/gcp/vertex_ai/outputs.tf
@@ -35,3 +35,16 @@ output "deployed_index_id" {
   value       = var.enable_vector_search ? google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id : null
   description = "The deployed-index ID binding the index to the endpoint (null when Vector Search is disabled)"
 }
+
+# --- Model serving (#768) ---------------------------------------------------
+# Null when var.enable_serving is false (the endpoint is not created).
+
+output "endpoint_id" {
+  value       = var.enable_serving ? google_vertex_ai_endpoint.serving[0].id : null
+  description = "The resource ID of the Vertex AI serving endpoint (null when serving is disabled)"
+}
+
+output "endpoint_name" {
+  value       = var.enable_serving ? google_vertex_ai_endpoint.serving[0].name : null
+  description = "The numeric resource name of the Vertex AI serving endpoint (null when serving is disabled)"
+}

--- a/gcp/vertex_ai/outputs.tf
+++ b/gcp/vertex_ai/outputs.tf
@@ -37,14 +37,30 @@ output "deployed_index_id" {
 }
 
 # --- Model serving (#768) ---------------------------------------------------
-# Null when var.enable_serving is false (the endpoint is not created).
+# Null when var.enable_serving is false (no endpoint is created).
+#
+# The bare endpoint and the Model Garden deployment are mutually exclusive (see
+# main.tf): exactly one exists when serving is on. The outputs return whichever
+# one that is, so they never point at an empty shell:
+#   - bare endpoint path (no model named): google_vertex_ai_endpoint.serving
+#   - model-garden path (model named):     google_vertex_ai_endpoint_with_model_garden_deployment.model_garden
+#       .id       -> full resource name projects/<p>/locations/<l>/endpoints/<e>
+#       .endpoint -> the bare endpoint ID segment (matches the bare endpoint's .name)
 
 output "endpoint_id" {
-  value       = var.enable_serving ? google_vertex_ai_endpoint.serving[0].id : null
-  description = "The resource ID of the Vertex AI serving endpoint (null when serving is disabled)"
+  value = (
+    local.model_garden_enabled ? google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].id :
+    local.bare_endpoint_enabled ? google_vertex_ai_endpoint.serving[0].id :
+    null
+  )
+  description = "The full resource name of the Vertex AI serving endpoint — the Model Garden deployment's own endpoint when a model is deployed, otherwise the bare endpoint (null when serving is disabled)"
 }
 
 output "endpoint_name" {
-  value       = var.enable_serving ? google_vertex_ai_endpoint.serving[0].name : null
-  description = "The numeric resource name of the Vertex AI serving endpoint (null when serving is disabled)"
+  value = (
+    local.model_garden_enabled ? google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].endpoint :
+    local.bare_endpoint_enabled ? google_vertex_ai_endpoint.serving[0].name :
+    null
+  )
+  description = "The numeric endpoint ID segment of the Vertex AI serving endpoint — the Model Garden deployment's endpoint when a model is deployed, otherwise the bare endpoint (null when serving is disabled)"
 }

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -412,10 +412,15 @@ run "serving" {
   }
 
   # endpoint_id output is sourced from the bare endpoint on the no-model path
-  # (the model-garden deployment is absent here).
+  # (the model-garden deployment is absent here). The endpoint's .id is a
+  # provider-computed composite (projects/<p>/locations/<l>/endpoints/<e>) that
+  # is unknown at plan, so we can only assert the output is wired and non-null
+  # here — the bare-vs-model SOURCE is pinned by the endpoint_name assert above
+  # (== "2676412545", the bare endpoint's deterministic name) and by the
+  # model_garden run asserting model_garden[0].endpoint on the model path.
   assert {
-    condition     = output.endpoint_id == google_vertex_ai_endpoint.serving[0].id
-    error_message = "endpoint_id output must surface the bare serving endpoint's resource name on the no-model path."
+    condition     = output.endpoint_id != null
+    error_message = "endpoint_id output must be non-null on the no-model serving path (sourced from the bare serving endpoint)."
   }
 
   # Vector Search resources are untouched by the serving flag.

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -314,6 +314,269 @@ run "alert_policy_absent_when_vector_search_off" {
 }
 
 # -----------------------------------------------------------------------------
+# Model serving (#768): endpoint + Model Garden deployment, gated on
+# enable_serving. The dataset and Vector Search resources stay untouched.
+# -----------------------------------------------------------------------------
+
+run "serving_off_by_default" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+
+  # Serving is off by default -> no endpoint, no model-garden deployment.
+  assert {
+    condition     = length(google_vertex_ai_endpoint.serving) == 0
+    error_message = "serving endpoint must NOT be created when enable_serving is false (default)."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_endpoint_with_model_garden_deployment.model_garden) == 0
+    error_message = "model-garden deployment must NOT be created when enable_serving is false (default)."
+  }
+
+  # And no serving alarms.
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_latency_high) == 0
+    error_message = "serving prediction-latency alarm must be absent when serving is off."
+  }
+
+  # Serving outputs are null when serving is off (guards the [0]-index-on-empty
+  # short-circuit in outputs.tf).
+  assert {
+    condition     = output.endpoint_id == null
+    error_message = "endpoint_id output must be null when serving is disabled."
+  }
+
+  assert {
+    condition     = output.endpoint_name == null
+    error_message = "endpoint_name output must be null when serving is disabled."
+  }
+}
+
+run "serving" {
+  command = plan
+
+  variables {
+    project        = "test"
+    project_id     = "test-project"
+    enable_serving = true
+    # No model named -> a bare endpoint, no model-garden deployment.
+  }
+
+  # Exactly one bare serving endpoint, no model-garden deployment.
+  assert {
+    condition     = length(google_vertex_ai_endpoint.serving) == 1
+    error_message = "enable_serving=true must create exactly one serving endpoint."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_endpoint_with_model_garden_deployment.model_garden) == 0
+    error_message = "no model named -> no model-garden deployment (bare endpoint path)."
+  }
+
+  # Endpoint name is the deterministic NUMERIC id the API requires (no leading
+  # zeros, <=10 digits). Asserting the exact literal pins the sha256-derived
+  # name against a mutation of the derivation:
+  # parseint(substr(sha256("test"),0,8),16) = 2676412545.
+  assert {
+    condition     = google_vertex_ai_endpoint.serving[0].name == "2676412545"
+    error_message = "endpoint name must be the deterministic numeric id derived from sha256(var.project)."
+  }
+
+  assert {
+    condition     = can(regex("^[1-9][0-9]{0,9}$", google_vertex_ai_endpoint.serving[0].name))
+    error_message = "endpoint name must be numeric, no leading zeros, <=10 digits (the API constraint)."
+  }
+
+  # Display name carries the var.project prefix (name-prefix scoping).
+  assert {
+    condition     = google_vertex_ai_endpoint.serving[0].display_name == "test-serving-endpoint"
+    error_message = "endpoint display_name must be var.project-prefixed."
+  }
+
+  # location (the required field) is fed from var.region — pin the flow-through
+  # so a swap to the wrong source is caught.
+  assert {
+    condition     = google_vertex_ai_endpoint.serving[0].location == "us-central1"
+    error_message = "endpoint location must be fed from var.region (default us-central1)."
+  }
+
+  # endpoint_name output mirrors the resource name on the serving path (and is
+  # null on the off path — see serving_off_by_default-adjacent coverage).
+  assert {
+    condition     = output.endpoint_name == "2676412545"
+    error_message = "endpoint_name output must surface the numeric endpoint name when serving is on."
+  }
+
+  # Vector Search resources are untouched by the serving flag.
+  assert {
+    condition     = length(google_vertex_ai_index.this) == 0
+    error_message = "enable_serving must not create Vector Search resources (orthogonal flags)."
+  }
+
+  # Dataset still composes.
+  assert {
+    condition     = google_vertex_ai_dataset.dataset.display_name == "main-dataset"
+    error_message = "dataset must still be created when only serving is enabled."
+  }
+}
+
+run "model_garden" {
+  command = plan
+
+  variables {
+    project            = "test"
+    project_id         = "test-project"
+    enable_serving     = true
+    model_garden_model = "publishers/google/models/gemma3@gemma-3-1b-it"
+    # model_garden_accept_eula left at its FALSE default on purpose: asserting
+    # accept_eula == false below pins the variable->attribute edge in the
+    # direction a hardcoded `accept_eula = true` would otherwise survive. The
+    # EULA-true flow-through is exercised in model_garden_with_accelerator.
+  }
+
+  # Both the bare endpoint AND the model-garden deployment compose.
+  assert {
+    condition     = length(google_vertex_ai_endpoint.serving) == 1
+    error_message = "model-garden path still creates the bare serving endpoint."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_endpoint_with_model_garden_deployment.model_garden) == 1
+    error_message = "enable_serving + model_garden_model must create exactly one model-garden deployment."
+  }
+
+  # The publisher model name flows through verbatim.
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].publisher_model_name == "publishers/google/models/gemma3@gemma-3-1b-it"
+    error_message = "model_garden_model must reach publisher_model_name verbatim."
+  }
+
+  # EULA default (false) reaches model_config.accept_eula. Catches a hardcoded
+  # `accept_eula = true` (consent must not be silently granted).
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].model_config[0].accept_eula == false
+    error_message = "model_garden_accept_eula default (false) must reach model_config.accept_eula — EULA consent must not be hardcoded."
+  }
+
+  # CPU-only default: machine_type set, accelerator fields null.
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].deploy_config[0].dedicated_resources[0].machine_spec[0].machine_type == "n1-standard-4"
+    error_message = "serving_machine_type default (n1-standard-4) must reach machine_spec.machine_type."
+  }
+
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].deploy_config[0].dedicated_resources[0].machine_spec[0].accelerator_type == null
+    error_message = "CPU-only default must leave machine_spec.accelerator_type null (no GPU quota demanded)."
+  }
+
+  # Generous create timeout for the long-running model deploy.
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].timeouts.create == "60m"
+    error_message = "model-garden deployment must carry a generous create timeout (deploys run 30+ min)."
+  }
+}
+
+run "model_garden_with_accelerator" {
+  command = plan
+
+  variables {
+    project                   = "test"
+    project_id                = "test-project"
+    enable_serving            = true
+    model_garden_model        = "publishers/google/models/llama3-2@llama-3.2-1b"
+    model_garden_accept_eula  = true
+    serving_machine_type      = "g2-standard-16"
+    serving_accelerator_type  = "NVIDIA_L4"
+    serving_accelerator_count = 1
+  }
+
+  # GPU path: accelerator type + count flow through to machine_spec.
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].deploy_config[0].dedicated_resources[0].machine_spec[0].accelerator_type == "NVIDIA_L4"
+    error_message = "serving_accelerator_type must reach machine_spec.accelerator_type when set."
+  }
+
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].deploy_config[0].dedicated_resources[0].machine_spec[0].accelerator_count == 1
+    error_message = "serving_accelerator_count must reach machine_spec.accelerator_count when an accelerator type is set."
+  }
+
+  # EULA acceptance flows through when set true (the catch-the-hardcoded-false
+  # direction, paired with the accept_eula == false assert in run "model_garden").
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].model_config[0].accept_eula == true
+    error_message = "model_garden_accept_eula=true must reach model_config.accept_eula."
+  }
+}
+
+run "serving_alarms_emitted_when_serving_and_observability_on" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_serving       = true
+    enable_observability = true
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_latency_high) == 1
+    error_message = "prediction-latency alarm must be emitted when serving AND observability are both on."
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_errors_high) == 1
+    error_message = "prediction-error alarm must be emitted when serving AND observability are both on."
+  }
+
+  # Filters must carry the metric.types verified against Google's official list
+  # and registered in the pkg/observability vertexai catalog.
+  assert {
+    condition = strcontains(
+      google_monitoring_alert_policy.serving_prediction_latency_high["0"].conditions[0].condition_threshold[0].filter,
+      "metric.type=\"aiplatform.googleapis.com/prediction/online/prediction_latencies\""
+    )
+    error_message = "latency alarm filter must reference prediction/online/prediction_latencies."
+  }
+
+  assert {
+    condition = strcontains(
+      google_monitoring_alert_policy.serving_prediction_errors_high["0"].conditions[0].condition_threshold[0].filter,
+      "metric.type=\"aiplatform.googleapis.com/prediction/online/error_count\""
+    )
+    error_message = "error alarm filter must reference prediction/online/error_count."
+  }
+}
+
+run "serving_alarms_absent_when_serving_off" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_serving       = false
+    enable_observability = true
+    # Vector Search on so observability is clearly active for the vector alarm,
+    # proving the serving alarms gate on enable_serving specifically.
+    enable_vector_search = true
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_latency_high) == 0
+    error_message = "serving alarms must gate on enable_serving, not enable_vector_search."
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_errors_high) == 0
+    error_message = "serving error alarm must be absent when serving is off."
+  }
+}
+
+# -----------------------------------------------------------------------------
 # Negative cases: validation blocks must reject misconfigurations at plan time.
 # -----------------------------------------------------------------------------
 
@@ -405,4 +668,78 @@ run "rejects_max_replicas_below_min" {
   # The cross-variable invariant is a resource precondition, not a variable
   # validation, so the failure surfaces on the deployed-index resource.
   expect_failures = [google_vertex_ai_index_endpoint_deployed_index.this]
+}
+
+run "rejects_bad_model_garden_format" {
+  command = plan
+
+  variables {
+    project        = "test"
+    project_id     = "test-project"
+    enable_serving = true
+    # Bare model name, not the publishers/.../models/...@version form.
+    model_garden_model = "gemma-3-1b-it"
+  }
+
+  expect_failures = [var.model_garden_model]
+}
+
+run "rejects_model_garden_missing_version" {
+  command = plan
+
+  variables {
+    project        = "test"
+    project_id     = "test-project"
+    enable_serving = true
+    # Missing the @<version> suffix the API requires.
+    model_garden_model = "publishers/google/models/gemma3"
+  }
+
+  expect_failures = [var.model_garden_model]
+}
+
+run "rejects_serving_max_replicas_below_min" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_serving       = true
+    model_garden_model   = "publishers/google/models/gemma3@gemma-3-1b-it"
+    serving_min_replicas = 3
+    serving_max_replicas = 1 # ceiling below floor
+  }
+
+  # Cross-variable invariant is a precondition on the deployment resource.
+  expect_failures = [google_vertex_ai_endpoint_with_model_garden_deployment.model_garden]
+}
+
+run "rejects_accelerator_type_without_count" {
+  command = plan
+
+  variables {
+    project                  = "test"
+    project_id               = "test-project"
+    enable_serving           = true
+    model_garden_model       = "publishers/google/models/gemma3@gemma-3-1b-it"
+    serving_accelerator_type = "NVIDIA_L4"
+    # count left at its 0 default -> half-configured GPU request.
+  }
+
+  expect_failures = [google_vertex_ai_endpoint_with_model_garden_deployment.model_garden]
+}
+
+run "rejects_accelerator_count_without_type" {
+  command = plan
+
+  variables {
+    project                   = "test"
+    project_id                = "test-project"
+    enable_serving            = true
+    model_garden_model        = "publishers/google/models/gemma3@gemma-3-1b-it"
+    serving_accelerator_count = 2
+    # type left null -> half-configured GPU request.
+  }
+
+  expect_failures = [google_vertex_ai_endpoint_with_model_garden_deployment.model_garden]
 }

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -404,11 +404,18 @@ run "serving" {
     error_message = "endpoint location must be fed from var.region (default us-central1)."
   }
 
-  # endpoint_name output mirrors the resource name on the serving path (and is
-  # null on the off path — see serving_off_by_default-adjacent coverage).
+  # endpoint_name output mirrors the resource name on the bare-serving path (and
+  # is null on the off path — see serving_off_by_default-adjacent coverage).
   assert {
     condition     = output.endpoint_name == "2676412545"
-    error_message = "endpoint_name output must surface the numeric endpoint name when serving is on."
+    error_message = "endpoint_name output must surface the numeric endpoint name when serving is on (bare path)."
+  }
+
+  # endpoint_id output is sourced from the bare endpoint on the no-model path
+  # (the model-garden deployment is absent here).
+  assert {
+    condition     = output.endpoint_id == google_vertex_ai_endpoint.serving[0].id
+    error_message = "endpoint_id output must surface the bare serving endpoint's resource name on the no-model path."
   }
 
   # Vector Search resources are untouched by the serving flag.
@@ -438,15 +445,33 @@ run "model_garden" {
     # EULA-true flow-through is exercised in model_garden_with_accelerator.
   }
 
-  # Both the bare endpoint AND the model-garden deployment compose.
+  # Mutually exclusive (#768 review): when a Model Garden model is named, the
+  # model_garden resource owns its own endpoint, so the BARE endpoint is NOT
+  # created. Otherwise the bare endpoint would sit empty and the outputs would
+  # point at the empty shell.
   assert {
-    condition     = length(google_vertex_ai_endpoint.serving) == 1
-    error_message = "model-garden path still creates the bare serving endpoint."
+    condition     = length(google_vertex_ai_endpoint.serving) == 0
+    error_message = "model-garden path must NOT create the bare serving endpoint (the deployment owns its own endpoint; they are mutually exclusive)."
   }
 
   assert {
     condition     = length(google_vertex_ai_endpoint_with_model_garden_deployment.model_garden) == 1
     error_message = "enable_serving + model_garden_model must create exactly one model-garden deployment."
+  }
+
+  # The serving outputs surface the Model Garden deployment's OWN endpoint, not
+  # the (absent) bare endpoint — this is the #768-review bug fix. endpoint_id is
+  # the deployment's full resource name; endpoint_name is its numeric endpoint
+  # ID segment. The mock provider supplies computed values, so assert they are
+  # non-null and sourced from the deployment rather than a literal.
+  assert {
+    condition     = output.endpoint_id == google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].id
+    error_message = "endpoint_id output must surface the Model Garden deployment's own endpoint resource name, not the absent bare endpoint."
+  }
+
+  assert {
+    condition     = output.endpoint_name == google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].endpoint
+    error_message = "endpoint_name output must surface the Model Garden deployment's endpoint ID segment, not the absent bare endpoint."
   }
 
   # The publisher model name flows through verbatim.

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -169,3 +169,91 @@ variable "deployed_index_max_replicas" {
     error_message = "deployed_index_max_replicas must be greater than 0."
   }
 }
+
+# --- Model serving (Endpoint + Model Garden) --------------------------------
+# Issue #768. Independent of Vector Search: enable_serving gates a
+# google_vertex_ai_endpoint, and (optionally) a one-shot Model Garden open-model
+# deployment onto its own managed endpoint. The dataset and Vector Search
+# resources are untouched by these flags.
+
+variable "enable_serving" {
+  description = "When true, provision a Vertex AI serving endpoint (google_vertex_ai_endpoint). With model_garden_model also set, additionally deploy that open model from Model Garden onto a managed endpoint. The dataset and Vector Search resources are unaffected by this flag."
+  type        = bool
+  default     = false
+}
+
+variable "model_garden_model" {
+  description = "Model Garden publisher model to deploy when enable_serving is true. Format: publishers/<publisher>/models/<model>@<version> (e.g. publishers/google/models/gemma3@gemma-3-1b-it). Null provisions a bare endpoint with no model deployed (attach a model out-of-band)."
+  type        = string
+  default     = null
+
+  validation {
+    # Mirror the provider's documented publisher_model_name format
+    # publishers/{publisher}/models/{publisher_model}@{version_id}. Reject a
+    # bare model name or a Hugging Face id here so a malformed value fails at
+    # plan time rather than ~30min into a live model deploy.
+    condition     = var.model_garden_model == null ? true : can(regex("^publishers/[^/]+/models/[^/@]+@[^/@]+$", var.model_garden_model))
+    error_message = "model_garden_model must be null or match publishers/<publisher>/models/<model>@<version> (e.g. publishers/google/models/gemma3@gemma-3-1b-it)."
+  }
+}
+
+variable "model_garden_accept_eula" {
+  description = "Whether the operator accepts the model's End User License Agreement (EULA / ToS). Many Model Garden open models (Gemma, Llama) require this to be true before they will deploy. Surfaced as model_config.accept_eula on the deployment."
+  type        = bool
+  default     = false
+}
+
+variable "serving_machine_type" {
+  description = "Compute Engine machine type for the Model Garden deployment's dedicated serving resources. Defaults to a CPU-only machine (n1-standard-4); pick a GPU-capable type (e.g. g2-standard-16) when pairing with an accelerator."
+  type        = string
+  default     = "n1-standard-4"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]*-[a-z0-9-]+$", var.serving_machine_type))
+    error_message = "serving_machine_type must be a Compute Engine machine type (e.g. n1-standard-4, g2-standard-16)."
+  }
+}
+
+variable "serving_accelerator_type" {
+  description = "GPU/TPU accelerator type for the Model Garden deployment (e.g. NVIDIA_L4, NVIDIA_TESLA_T4). Null = CPU-only serving (the default). Must be paired with serving_accelerator_count > 0."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.serving_accelerator_type == null ? true : can(regex("^[A-Z][A-Z0-9_]+$", var.serving_accelerator_type))
+    error_message = "serving_accelerator_type must be null or an uppercase accelerator enum (e.g. NVIDIA_L4)."
+  }
+}
+
+variable "serving_accelerator_count" {
+  description = "Number of accelerators to attach per serving replica. 0 (default) = CPU-only. Must be > 0 when serving_accelerator_type is set (enforced by a precondition on the deployment)."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.serving_accelerator_count >= 0
+    error_message = "serving_accelerator_count must be >= 0."
+  }
+}
+
+variable "serving_min_replicas" {
+  description = "Minimum serving replicas for the Model Garden deployment's dedicated resources."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.serving_min_replicas > 0
+    error_message = "serving_min_replicas must be greater than 0."
+  }
+}
+
+variable "serving_max_replicas" {
+  description = "Maximum serving replicas (autoscaling ceiling) for the Model Garden deployment. Must be >= serving_min_replicas (enforced by a precondition on the deployment)."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.serving_max_replicas > 0
+    error_message = "serving_max_replicas must be greater than 0."
+  }
+}

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1045,6 +1045,12 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.GCPVertexAI.ModelGardenModel != "" {
 				vals["model_garden_model"] = cfg.GCPVertexAI.ModelGardenModel
 			}
+			// EULA acceptance for EULA-gated open models (Gemma/Llama). Only
+			// emit when the caller explicitly set it so the preset's
+			// explicit-consent default (false) wins when left unset.
+			if cfg.GCPVertexAI.ModelGardenAcceptEULA != nil {
+				vals["model_garden_accept_eula"] = *cfg.GCPVertexAI.ModelGardenAcceptEULA
+			}
 		}
 
 	case KeyGCPPubSub:

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1034,6 +1034,17 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.GCPVertexAI.IndexDimensions > 0 {
 				vals["index_dimensions"] = cfg.GCPVertexAI.IndexDimensions
 			}
+			// Serving (#768): orthogonal to Vector Search. enable_serving
+			// gates the endpoint; model_garden_model (when set) drives the
+			// Model Garden deployment. Same partial-config discipline: only
+			// emit a field the caller populated so the preset defaults
+			// (enable_serving=false, no model) win when left unset.
+			if cfg.GCPVertexAI.EnableServing != nil {
+				vals["enable_serving"] = *cfg.GCPVertexAI.EnableServing
+			}
+			if cfg.GCPVertexAI.ModelGardenModel != "" {
+				vals["model_garden_model"] = cfg.GCPVertexAI.ModelGardenModel
+			}
 		}
 
 	case KeyGCPPubSub:

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -250,9 +250,11 @@ func kitchenSinkConfig() *Config {
 		Versioning   *bool  `json:"versioning,omitempty"`
 	}{StorageClass: "STANDARD", Versioning: &t}
 	cfg.GCPVertexAI = &struct {
-		EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
-		IndexDimensions    int   `json:"indexDimensions,omitempty"`
-	}{EnableVectorSearch: &t, IndexDimensions: 768}
+		EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+		IndexDimensions    int    `json:"indexDimensions,omitempty"`
+		EnableServing      *bool  `json:"enableServing,omitempty"`
+		ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+	}{EnableVectorSearch: &t, IndexDimensions: 768, EnableServing: &t, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
 	cfg.GCPPubSub = &struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	}{MessageRetentionDuration: "604800s"}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -250,11 +250,12 @@ func kitchenSinkConfig() *Config {
 		Versioning   *bool  `json:"versioning,omitempty"`
 	}{StorageClass: "STANDARD", Versioning: &t}
 	cfg.GCPVertexAI = &struct {
-		EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-		IndexDimensions    int    `json:"indexDimensions,omitempty"`
-		EnableServing      *bool  `json:"enableServing,omitempty"`
-		ModelGardenModel   string `json:"modelGardenModel,omitempty"`
-	}{EnableVectorSearch: &t, IndexDimensions: 768, EnableServing: &t, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
+		EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+		IndexDimensions       int    `json:"indexDimensions,omitempty"`
+		EnableServing         *bool  `json:"enableServing,omitempty"`
+		ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+		ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
+	}{EnableVectorSearch: &t, IndexDimensions: 768, EnableServing: &t, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it", ModelGardenAcceptEULA: &t}
 	cfg.GCPPubSub = &struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	}{MessageRetentionDuration: "604800s"}

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -374,15 +374,19 @@ type Config struct {
 	// EnableServing (#768) gates a serving endpoint; ModelGardenModel, when
 	// set alongside EnableServing, deploys that open Model Garden model
 	// (publishers/<pub>/models/<model>@<version>) onto a managed endpoint.
+	// ModelGardenAcceptEULA records the operator's acceptance of the model's
+	// EULA/ToS; EULA-gated open models (Gemma, Llama) will not deploy unless it
+	// is true. It defaults to the preset's explicit-consent false when unset.
 	// Vector Search and serving are orthogonal flags.
 	//
 	// Every field is partial-config: the mapper only emits a field the caller
 	// actually populated so the preset's own defaults win when left unset.
 	GCPVertexAI *struct {
-		EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-		IndexDimensions    int    `json:"indexDimensions,omitempty"`
-		EnableServing      *bool  `json:"enableServing,omitempty"`
-		ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+		EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+		IndexDimensions       int    `json:"indexDimensions,omitempty"`
+		EnableServing         *bool  `json:"enableServing,omitempty"`
+		ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+		ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 	} `json:"gcp_vertex_ai,omitempty"`
 
 	GCPPubSub *struct {

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -363,16 +363,26 @@ type Config struct {
 		Versioning   *bool  `json:"versioning,omitempty"`
 	} `json:"gcp_gcs,omitempty"`
 
-	// GCPVertexAI carries the caller-supplied Vertex AI configuration (#764).
+	// GCPVertexAI carries the caller-supplied Vertex AI configuration (#764,
+	// #768).
+	//
 	// EnableVectorSearch gates the Vector Search resources (index + endpoint +
 	// deployed index) in the gcp/vertex_ai preset; the dataset is always
 	// created. IndexDimensions is the embedding dimensionality of the Vector
-	// Search index (immutable — changing it forces destroy/recreate). Both are
-	// partial-config: the mapper only emits a field the caller actually
-	// populated so the preset's own defaults win when left unset.
+	// Search index (immutable — changing it forces destroy/recreate).
+	//
+	// EnableServing (#768) gates a serving endpoint; ModelGardenModel, when
+	// set alongside EnableServing, deploys that open Model Garden model
+	// (publishers/<pub>/models/<model>@<version>) onto a managed endpoint.
+	// Vector Search and serving are orthogonal flags.
+	//
+	// Every field is partial-config: the mapper only emits a field the caller
+	// actually populated so the preset's own defaults win when left unset.
 	GCPVertexAI *struct {
-		EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
-		IndexDimensions    int   `json:"indexDimensions,omitempty"`
+		EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+		IndexDimensions    int    `json:"indexDimensions,omitempty"`
+		EnableServing      *bool  `json:"enableServing,omitempty"`
+		ModelGardenModel   string `json:"modelGardenModel,omitempty"`
 	} `json:"gcp_vertex_ai,omitempty"`
 
 	GCPPubSub *struct {

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -39,27 +39,40 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		assert.False(t, hasEnable, "nil GCPVertexAI must not emit enable_vector_search")
 		_, hasDims := vals["index_dimensions"]
 		assert.False(t, hasDims, "nil GCPVertexAI must not emit index_dimensions")
+		_, hasServing := vals["enable_serving"]
+		assert.False(t, hasServing, "nil GCPVertexAI must not emit enable_serving")
+		_, hasModel := vals["model_garden_model"]
+		assert.False(t, hasModel, "nil GCPVertexAI must not emit model_garden_model")
 	})
 
 	t.Run("EnableVectorSearch=true flows through", func(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int   `json:"indexDimensions,omitempty"`
+			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int    `json:"indexDimensions,omitempty"`
+			EnableServing      *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
 		}{EnableVectorSearch: &tr, IndexDimensions: 1536}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
 		assert.Equal(t, true, vals["enable_vector_search"])
 		assert.Equal(t, 1536, vals["index_dimensions"])
+		// Serving fields untouched here -> not emitted (preset defaults win).
+		_, hasServing := vals["enable_serving"]
+		assert.False(t, hasServing, "unset EnableServing must not emit enable_serving")
+		_, hasModel := vals["model_garden_model"]
+		assert.False(t, hasModel, "unset ModelGardenModel must not emit model_garden_model")
 	})
 
 	t.Run("EnableVectorSearch=false flows through, zero dimensions omitted", func(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int   `json:"indexDimensions,omitempty"`
+			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int    `json:"indexDimensions,omitempty"`
+			EnableServing      *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
 		}{EnableVectorSearch: &fa}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
@@ -68,6 +81,42 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		// preset's own default (768) applies rather than an invalid 0.
 		_, hasDims := vals["index_dimensions"]
 		assert.False(t, hasDims, "zero IndexDimensions must be omitted so the preset default wins")
+	})
+
+	t.Run("EnableServing + ModelGardenModel flow through (#768)", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		cfg.GCPVertexAI = &struct {
+			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int    `json:"indexDimensions,omitempty"`
+			EnableServing      *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["enable_serving"])
+		assert.Equal(t, "publishers/google/models/gemma3@gemma-3-1b-it", vals["model_garden_model"])
+		// Vector Search fields untouched -> not emitted (orthogonal flags).
+		_, hasVS := vals["enable_vector_search"]
+		assert.False(t, hasVS, "unset EnableVectorSearch must not emit enable_vector_search when only serving is set")
+	})
+
+	t.Run("EnableServing=false flows through, empty model omitted (#768)", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		cfg.GCPVertexAI = &struct {
+			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int    `json:"indexDimensions,omitempty"`
+			EnableServing      *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+		}{EnableServing: &fa}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["enable_serving"])
+		// Empty ModelGardenModel must NOT be emitted so the preset default
+		// (null -> bare endpoint) wins rather than an invalid empty string.
+		_, hasModel := vals["model_garden_model"]
+		assert.False(t, hasModel, "empty ModelGardenModel must be omitted so the preset default wins")
 	})
 }
 

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -49,10 +49,11 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int    `json:"indexDimensions,omitempty"`
-			EnableServing      *bool  `json:"enableServing,omitempty"`
-			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 		}{EnableVectorSearch: &tr, IndexDimensions: 1536}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
@@ -69,10 +70,11 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int    `json:"indexDimensions,omitempty"`
-			EnableServing      *bool  `json:"enableServing,omitempty"`
-			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 		}{EnableVectorSearch: &fa}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
@@ -87,10 +89,11 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int    `json:"indexDimensions,omitempty"`
-			EnableServing      *bool  `json:"enableServing,omitempty"`
-			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
@@ -101,14 +104,61 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		assert.False(t, hasVS, "unset EnableVectorSearch must not emit enable_vector_search when only serving is set")
 	})
 
+	t.Run("ModelGardenAcceptEULA flows through only when set (#768 review)", func(t *testing.T) {
+		t.Parallel()
+
+		// Set true -> emitted (EULA-gated Gemma/Llama need it).
+		cfgYes := &Config{}
+		cfgYes.GCPVertexAI = &struct {
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
+		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it", ModelGardenAcceptEULA: &tr}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfgYes, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["model_garden_accept_eula"], "ModelGardenAcceptEULA=true must reach model_garden_accept_eula")
+
+		// Set false -> still emitted (explicit non-consent is a real choice the
+		// caller made; partial-config keys on nil, not on the zero value).
+		cfgNo := &Config{}
+		cfgNo.GCPVertexAI = &struct {
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
+		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it", ModelGardenAcceptEULA: &fa}
+		vals, err = m.BuildModuleValues(KeyGCPVertexAI, nil, cfgNo, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["model_garden_accept_eula"], "explicit ModelGardenAcceptEULA=false must reach model_garden_accept_eula")
+
+		// Unset (nil) -> NOT emitted so the preset's explicit-consent default
+		// (false) wins rather than a config-supplied value.
+		cfgUnset := &Config{}
+		cfgUnset.GCPVertexAI = &struct {
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
+		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
+		vals, err = m.BuildModuleValues(KeyGCPVertexAI, nil, cfgUnset, "demo", "us-central1")
+		require.NoError(t, err)
+		_, hasEULA := vals["model_garden_accept_eula"]
+		assert.False(t, hasEULA, "unset ModelGardenAcceptEULA must not emit model_garden_accept_eula (preset default wins)")
+	})
+
 	t.Run("EnableServing=false flows through, empty model omitted (#768)", func(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int    `json:"indexDimensions,omitempty"`
-			EnableServing      *bool  `json:"enableServing,omitempty"`
-			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 		}{EnableServing: &fa}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -694,7 +694,17 @@ var alarmedGCPMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyGCPLoadbalancer:   {Module: "gcp/loadbalancer", Metrics: []string{"loadbalancing.googleapis.com/https/backend_latencies"}},
 	composer.KeyGCPMemorystore:    {Module: "gcp/memorystore", Metrics: []string{"redis.googleapis.com/stats/cpu_utilization"}},
 	composer.KeyGCPPubSub:         {Module: "gcp/pubsub", Metrics: []string{"pubsub.googleapis.com/subscription/num_undelivered_messages"}},
-	composer.KeyGCPVertexAI:       {Module: "gcp/vertex_ai", Metrics: []string{"aiplatform.googleapis.com/matching_engine/query/latencies"}},
+	// Vector Search query latency (#764) plus the two serving alarms (#768):
+	// online-prediction latency and error_count, both already in the vertexai
+	// catalog above. All three have google_monitoring_alert_policy resources in
+	// gcp/vertex_ai/observability.tf (the for_each gates suppress the serving
+	// pair when enable_serving=false and the vector alarm when
+	// enable_vector_search=false, but the metric.type strings still match).
+	composer.KeyGCPVertexAI: {Module: "gcp/vertex_ai", Metrics: []string{
+		"aiplatform.googleapis.com/matching_engine/query/latencies",
+		"aiplatform.googleapis.com/prediction/online/prediction_latencies",
+		"aiplatform.googleapis.com/prediction/online/error_count",
+	}},
 }
 
 // AlarmedAWSMetrics returns a defensive copy of the AWS authority entry

--- a/tests/lint-labelless-name-prefix.sh
+++ b/tests/lint-labelless-name-prefix.sh
@@ -131,6 +131,14 @@ EXEMPT_LABELLESS_GCP=(
   # dashboard_json carries operator-defined display labels. Project-
   # scoped via API parent (`projects/<id>`).
   google_monitoring_dashboard
+  # google_vertex_ai_endpoint_with_model_garden_deployment — a one-shot
+  # Model Garden deploy keyed by publisher_model_name + location; it has
+  # NO name/display_name/account_id field to carry var.project (the
+  # managed endpoint it creates is named server-side). The sibling bare
+  # google_vertex_ai_endpoint.serving DOES carry the var.project prefix.
+  # Inspector attribution flows through the project-scoped Vertex API
+  # path (`projects/<id>/locations/<loc>/endpoints`).
+  google_vertex_ai_endpoint_with_model_garden_deployment
 )
 
 # Build regex patterns from the arrays.


### PR DESCRIPTION
Closes #768. Part of #756.

- google_vertex_ai_endpoint + google_vertex_ai_endpoint_with_model_garden_deployment gated on enable_serving; dataset + vector-search slices unchanged
- Config.GCPVertexAI: EnableServing + ModelGardenModel (partial-config)
- Verification: CI runs the full tftest matrix + go suite (local heavy checks skipped per operator request — laptop thermal limits); implementation agent ran targeted tests green before commit
- Live GCP validation deferred (no GCP creds session yet); EULA/quota are operator concerns
- External QC (Codex) to follow on the PR diff