### PR TITLE
feat(gcp-gpu): GPU support on gcp_gke + gcp_compute (#752)

### DIFF
--- a/gcp/compute/main.tf
+++ b/gcp/compute/main.tf
@@ -17,9 +17,12 @@ locals {
   # the composer machineFamily() derive; kept in lockstep by TestGCPGPUFamiliesDrift.
   _machine_family = lower(split("-", trimspace(var.machine_type))[0])
 
-  # GPUs attach via guest_accelerator ONLY on N1 machines. A2/A3/A4/G2/G4
-  # accelerator-optimized machines bundle their GPU with the machine type, so
-  # attaching a separate accelerator there is invalid and GCP rejects it.
+  # On a Compute Engine VM, GPUs attach via guest_accelerator ONLY on N1 machines.
+  # A2/A3/A4/G2/G4 accelerator-optimized machines have their GPU attached
+  # AUTOMATICALLY by the machine type, so passing a separate guest_accelerator
+  # there is invalid and GCP rejects it (verified: cloud.google.com/compute/docs/gpus
+  # — "the GPU model is automatically attached to the instance"). This is the VM
+  # rule; GKE node pools differ (they DO declare the accelerator) — see gcp/gke.
   _gpu_bundled_machine_families = ["a2", "a3", "a4", "a4x", "g2", "g4"]
   _is_n1_machine                = local._machine_family == "n1"
   _is_bundled_gpu_machine       = contains(local._gpu_bundled_machine_families, local._machine_family)
@@ -110,15 +113,15 @@ resource "google_compute_instance" "this" {
   allow_stopping_for_update = true
 
   lifecycle {
-    # GPU machine-type compatibility (#767). VALIDATE, don't mask. A GPU attaches
-    # via guest_accelerator only on N1 machines; A2/A3/A4/G2/G4 bundle their GPU
-    # with the machine type (so an explicit accelerator is invalid) and every
-    # other family takes none. Cross-variable rule lives here as a resource
-    # precondition (Terraform forbids multi-variable conditions in variable
-    # validation blocks).
+    # GPU machine-type compatibility (#767). VALIDATE, don't mask. On a VM a GPU
+    # attaches via guest_accelerator only on N1 machines; A2/A3/A4/G2/G4 attach
+    # their GPU automatically by machine type (so an explicit guest_accelerator is
+    # invalid) and every other family takes none. Cross-variable rule lives here
+    # as a resource precondition (Terraform forbids multi-variable conditions in
+    # variable validation blocks).
     precondition {
       condition     = !local._gpu_enabled || (local._is_n1_machine && !local._is_bundled_gpu_machine)
-      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GCP attaches GPUs via guest_accelerator only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type — use that machine type alone with no gpu_type."
+      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GCP attaches GPUs via guest_accelerator only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines attach their GPU automatically by the machine type — use that machine type alone with no gpu_type."
     }
   }
 }

--- a/gcp/compute/main.tf
+++ b/gcp/compute/main.tf
@@ -9,6 +9,25 @@ resource "random_id" "suffix" {
 
 locals {
   instance_name = "${var.project}-${var.instance_name}-${random_id.suffix.hex}"
+
+  # GPU attachment (#767). A non-empty gpu_type requests an attached GPU.
+  _gpu_enabled = trimspace(var.gpu_type) != ""
+
+  # Machine family = the part before the first "-" (n1-standard-4 -> n1). Mirrors
+  # the composer machineFamily() derive; kept in lockstep by TestGCPGPUFamiliesDrift.
+  _machine_family = lower(split("-", trimspace(var.machine_type))[0])
+
+  # GPUs attach via guest_accelerator ONLY on N1 machines. A2/A3/A4/G2/G4
+  # accelerator-optimized machines bundle their GPU with the machine type, so
+  # attaching a separate accelerator there is invalid and GCP rejects it.
+  _gpu_bundled_machine_families = ["a2", "a3", "a4", "a4x", "g2", "g4"]
+  _is_n1_machine                = local._machine_family == "n1"
+  _is_bundled_gpu_machine       = contains(local._gpu_bundled_machine_families, local._machine_family)
+
+  # GCP rejects live migration for any GPU-bearing instance, so a GPU instance
+  # MUST terminate on host maintenance. Force it by construction (validate-don't-
+  # mask): the preset never lets MIGRATE coexist with a GPU.
+  _on_host_maintenance = local._gpu_enabled ? "TERMINATE" : (var.preemptible ? "TERMINATE" : "MIGRATE")
 }
 
 data "google_compute_image" "this" {
@@ -45,7 +64,17 @@ resource "google_compute_instance" "this" {
   scheduling {
     preemptible         = var.preemptible
     automatic_restart   = !var.preemptible
-    on_host_maintenance = var.preemptible ? "TERMINATE" : "MIGRATE"
+    on_host_maintenance = local._on_host_maintenance
+  }
+
+  # GPU attachment (#767). Only emitted when gpu_type is set. on_host_maintenance
+  # is forced to TERMINATE above when this block is present.
+  dynamic "guest_accelerator" {
+    for_each = local._gpu_enabled ? [1] : []
+    content {
+      type  = var.gpu_type
+      count = var.gpu_count > 0 ? var.gpu_count : 1
+    }
   }
 
   service_account {
@@ -79,5 +108,18 @@ resource "google_compute_instance" "this" {
   }
 
   allow_stopping_for_update = true
+
+  lifecycle {
+    # GPU machine-type compatibility (#767). VALIDATE, don't mask. A GPU attaches
+    # via guest_accelerator only on N1 machines; A2/A3/A4/G2/G4 bundle their GPU
+    # with the machine type (so an explicit accelerator is invalid) and every
+    # other family takes none. Cross-variable rule lives here as a resource
+    # precondition (Terraform forbids multi-variable conditions in variable
+    # validation blocks).
+    precondition {
+      condition     = !local._gpu_enabled || (local._is_n1_machine && !local._is_bundled_gpu_machine)
+      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GCP attaches GPUs via guest_accelerator only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type — use that machine type alone with no gpu_type."
+    }
+  }
 }
 

--- a/gcp/compute/tests/gpu.tftest.hcl
+++ b/gcp/compute/tests/gpu.tftest.hcl
@@ -1,0 +1,124 @@
+mock_provider "google" {}
+
+# gcp/compute GPU shape tests (#767). Verifies that:
+#   - A GPU on an N1 machine attaches guest_accelerator (type + count) and
+#     forces scheduling.on_host_maintenance = "TERMINATE" (GCP rejects live
+#     migration for GPU instances).
+#   - A non-GPU instance attaches no accelerator and keeps the normal
+#     MIGRATE maintenance policy.
+#   - The machine-type precondition rejects a GPU on a non-N1 machine and on a
+#     bundled-GPU (G2/A2) machine (expect_failures on the instance resource).
+
+run "gpu_vm_on_n1_attaches_accelerator_and_terminates" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "n1-standard-4"
+    gpu_type          = "nvidia-tesla-t4"
+    gpu_count         = 2
+  }
+
+  assert {
+    condition     = length(google_compute_instance.this.guest_accelerator) == 1
+    error_message = "A GPU instance must attach exactly one guest_accelerator block."
+  }
+
+  assert {
+    condition     = google_compute_instance.this.guest_accelerator[0].type == "nvidia-tesla-t4"
+    error_message = "guest_accelerator.type must be the configured gpu_type."
+  }
+
+  assert {
+    condition     = google_compute_instance.this.guest_accelerator[0].count == 2
+    error_message = "guest_accelerator.count must be the configured gpu_count."
+  }
+
+  assert {
+    condition     = google_compute_instance.this.scheduling[0].on_host_maintenance == "TERMINATE"
+    error_message = "GPU instances must set on_host_maintenance=TERMINATE; GCP rejects live migration with a GPU attached."
+  }
+}
+
+run "gpu_count_defaults_to_one" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "n1-standard-4"
+    gpu_type          = "nvidia-tesla-t4"
+  }
+
+  assert {
+    condition     = google_compute_instance.this.guest_accelerator[0].count == 1
+    error_message = "gpu_count must default to 1 when unset (preset default)."
+  }
+}
+
+run "no_gpu_attaches_nothing_and_keeps_migrate" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "e2-medium"
+  }
+
+  assert {
+    condition     = length(google_compute_instance.this.guest_accelerator) == 0
+    error_message = "A non-GPU instance must attach no guest_accelerator block."
+  }
+
+  assert {
+    condition     = google_compute_instance.this.scheduling[0].on_host_maintenance == "MIGRATE"
+    error_message = "A non-GPU, non-preemptible instance must keep the default MIGRATE maintenance policy."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: the machine-type precondition (resource-hosted because it is a
+# cross-variable rule) rejects GPU on incompatible machine types at plan time.
+# expect_failures matches by resource address.
+# -----------------------------------------------------------------------------
+
+run "gpu_on_non_n1_machine_fails_precondition" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "e2-standard-4" # not N1 — cannot attach a GPU
+    gpu_type          = "nvidia-tesla-t4"
+  }
+
+  expect_failures = [
+    google_compute_instance.this,
+  ]
+}
+
+run "gpu_on_bundled_g2_machine_fails_precondition" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "g2-standard-4" # G2 bundles its L4 GPU — guest_accelerator invalid
+    gpu_type          = "nvidia-l4"
+  }
+
+  expect_failures = [
+    google_compute_instance.this,
+  ]
+}

--- a/gcp/compute/variables.tf
+++ b/gcp/compute/variables.tf
@@ -38,9 +38,26 @@ variable "instance_name" {
 }
 
 variable "machine_type" {
-  description = "Machine type (e.g., e2-medium, n2-standard-2)"
+  description = "Machine type (e.g., e2-medium, n2-standard-2). To attach a GPU via guest_accelerator, use an N1 machine (e.g. n1-standard-4); A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type and do not take a guest_accelerator."
   type        = string
   default     = "e2-medium"
+}
+
+variable "gpu_type" {
+  description = "NVIDIA accelerator type to attach via guest_accelerator (e.g. nvidia-tesla-t4). Empty = no GPU. Only N1 machines accept attached GPUs; when set, the instance is forced to on_host_maintenance=TERMINATE because GCP rejects live migration for GPU instances. GPU types are zone-constrained and quota-gated — a deploy-time operator concern."
+  type        = string
+  default     = ""
+}
+
+variable "gpu_count" {
+  description = "Number of GPUs of gpu_type to attach. Ignored unless gpu_type is set."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.gpu_count >= 0
+    error_message = "gpu_count must be >= 0."
+  }
 }
 
 variable "network_self_link" {

--- a/gcp/compute/variables.tf
+++ b/gcp/compute/variables.tf
@@ -50,13 +50,13 @@ variable "gpu_type" {
 }
 
 variable "gpu_count" {
-  description = "Number of GPUs of gpu_type to attach. Ignored unless gpu_type is set."
+  description = "Number of GPUs of gpu_type to attach. Ignored unless gpu_type is set. Valid counts are 1, 2, 4, 8, or 16 (0 = no GPU). The exact legal count is GPU-type/zone-specific (e.g. T4: 1/2/4, V100: 1/2/4/8) — a deploy-time/quota concern — but counts outside this set are always rejected by GCP."
   type        = number
   default     = 0
 
   validation {
-    condition     = var.gpu_count >= 0
-    error_message = "gpu_count must be >= 0."
+    condition     = contains([0, 1, 2, 4, 8, 16], var.gpu_count)
+    error_message = "gpu_count must be one of 0, 1, 2, 4, 8, 16."
   }
 }
 

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -5,10 +5,44 @@
 # cluster name (issue #159). GKE cluster names are limited to 40 chars.
 resource "random_id" "suffix" {
   byte_length = 4
+
+  lifecycle {
+    # GPU machine-type compatibility (#767). VALIDATE, don't mask. Hosted on the
+    # always-present suffix resource because the node pool is created inside the
+    # vendored gke module (no local resource to attach a precondition to). An
+    # accelerator attaches via the node pool accelerator config only on N1
+    # machines; A2/A3/A4/G2/G4 bundle their GPU with the machine type (so an
+    # explicit accelerator is invalid) and every other family takes none.
+    precondition {
+      condition     = !local._gpu_enabled || (local._is_n1_machine && !local._is_bundled_gpu_machine)
+      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GKE attaches accelerators via the node pool accelerator config only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type — use that machine type alone with no gpu_type."
+    }
+  }
 }
 
 locals {
   cluster_name = "${var.project}-${var.cluster_name}-${random_id.suffix.hex}"
+
+  # GPU node pool (#767). A non-empty gpu_type requests an attached accelerator.
+  _gpu_enabled = trimspace(var.gpu_type) != ""
+
+  # Machine family = the part before the first "-" (n1-standard-4 -> n1). Mirrors
+  # the composer machineFamily() derive; kept in lockstep by TestGCPGPUFamiliesDrift.
+  _machine_family = lower(split("-", trimspace(var.machine_type))[0])
+
+  # Accelerators attach to the node pool ONLY on N1 machines. A2/A3/A4/G2/G4
+  # accelerator-optimized machines bundle their GPU with the machine type.
+  _gpu_bundled_machine_families = ["a2", "a3", "a4", "a4x", "g2", "g4"]
+  _is_n1_machine                = local._machine_family == "n1"
+  _is_bundled_gpu_machine       = contains(local._gpu_bundled_machine_families, local._machine_family)
+
+  # Resolved accelerator config fed into the node pool object below. Inert (count
+  # 0, empty type/driver) when no GPU, so the module skips guest_accelerator and
+  # the auto-driver config. Surfaced via the gpu_node_pool output for assertions
+  # and downstream consumers.
+  _gpu_accelerator_count   = local._gpu_enabled ? (var.gpu_count > 0 ? var.gpu_count : 1) : 0
+  _gpu_accelerator_type    = local._gpu_enabled ? var.gpu_type : ""
+  _gpu_node_driver_version = local._gpu_enabled ? var.gpu_driver_version : ""
 }
 
 module "gke" {
@@ -73,6 +107,15 @@ module "gke" {
       enable_gvnic       = true
       image_type         = "COS_CONTAINERD"
       initial_node_count = var.node_count
+
+      # GPU accelerator (#767). The module emits guest_accelerator only when
+      # accelerator_count > 0, and gpu_driver_installation_config only when
+      # gpu_driver_version != "" — so a non-GPU pool leaves these inert.
+      # gpu_driver_version drives GKE auto NVIDIA driver install (no in-cluster
+      # device-plugin work, unlike EKS).
+      accelerator_count  = local._gpu_accelerator_count
+      accelerator_type   = local._gpu_accelerator_type
+      gpu_driver_version = local._gpu_node_driver_version
     }
   ]
 

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -7,15 +7,23 @@ resource "random_id" "suffix" {
   byte_length = 4
 
   lifecycle {
-    # GPU machine-type compatibility (#767). VALIDATE, don't mask. Hosted on the
-    # always-present suffix resource because the node pool is created inside the
-    # vendored gke module (no local resource to attach a precondition to). An
-    # accelerator attaches via the node pool accelerator config only on N1
-    # machines; A2/A3/A4/G2/G4 bundle their GPU with the machine type (so an
-    # explicit accelerator is invalid) and every other family takes none.
+    # GPU machine-type compatibility (#767, #752 review). VALIDATE, don't mask.
+    # Hosted on the always-present suffix resource because the node pool is
+    # created inside the vendored gke module (no local resource to attach a
+    # precondition to). Unlike a Compute VM, a GKE node pool DECLARES the
+    # accelerator even for the accelerator-optimized families: N1 attaches
+    # T4/V100/P100/P4, and A2/A3/A4/G2/G4 pair the machine type with its bundled
+    # accelerator (g2->nvidia-l4, a2->nvidia-tesla-a100, a3->nvidia-h100-80gb, ...).
+    # Every other family takes no GPU. Two preconditions: (1) the machine family
+    # must be GPU-capable; (2) on a bundled family the gpu_type must match the
+    # family's accelerator(s).
     precondition {
-      condition     = !local._gpu_enabled || (local._is_n1_machine && !local._is_bundled_gpu_machine)
-      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GKE attaches accelerators via the node pool accelerator config only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type — use that machine type alone with no gpu_type."
+      condition     = !local._gpu_enabled || local._is_n1_machine || local._is_bundled_gpu_machine
+      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot run a GPU node pool: GKE needs an N1 machine (attaches T4/V100/P100/P4) or an accelerator-optimized machine (a2-*/a3-*/a4-*/g2-*/g4-*, whose accelerator the node pool declares). Pick one of those machine types."
+    }
+    precondition {
+      condition     = !local._gpu_enabled || !local._is_bundled_gpu_machine || contains(local._gpu_bundled_family_accelerators, lower(trimspace(var.gpu_type)))
+      error_message = "gpu_type=${var.gpu_type} does not pair with machine_type=${var.machine_type}: a GKE ${upper(local._machine_family)} node pool declares the accelerator that matches the machine family (expected one of ${join(", ", local._gpu_bundled_family_accelerators)}). Use the matching accelerator type."
     }
   }
 }
@@ -30,11 +38,25 @@ locals {
   # the composer machineFamily() derive; kept in lockstep by TestGCPGPUFamiliesDrift.
   _machine_family = lower(split("-", trimspace(var.machine_type))[0])
 
-  # Accelerators attach to the node pool ONLY on N1 machines. A2/A3/A4/G2/G4
-  # accelerator-optimized machines bundle their GPU with the machine type.
+  # Accelerator-optimized families pair the machine type with a fixed accelerator
+  # (the node pool still DECLARES it, unlike a VM). N1 attaches T4/V100/P100/P4.
   _gpu_bundled_machine_families = ["a2", "a3", "a4", "a4x", "g2", "g4"]
   _is_n1_machine                = local._machine_family == "n1"
   _is_bundled_gpu_machine       = contains(local._gpu_bundled_machine_families, local._machine_family)
+
+  # Per-family accelerator pairing for the bundled families (#752 review). Mirrors
+  # the composer gpuBundledFamilyAccelerators map; the second GPU precondition
+  # above checks gpu_type against the entry for the selected family. Empty list
+  # for a non-bundled family (the lookup default) so the precondition is inert.
+  _gpu_bundled_family_accelerator_map = {
+    a2  = ["nvidia-tesla-a100", "nvidia-a100-80gb"]
+    a3  = ["nvidia-h100-80gb", "nvidia-h100-mega-80gb", "nvidia-h200-141gb"]
+    a4  = ["nvidia-b200"]
+    a4x = ["nvidia-gb200", "nvidia-gb300"]
+    g2  = ["nvidia-l4"]
+    g4  = ["nvidia-rtx-pro-6000"]
+  }
+  _gpu_bundled_family_accelerators = lookup(local._gpu_bundled_family_accelerator_map, local._machine_family, [])
 
   # Resolved accelerator config fed into the node pool object below. Inert (count
   # 0, empty type/driver) when no GPU, so the module skips guest_accelerator and

--- a/gcp/gke/outputs.tf
+++ b/gcp/gke/outputs.tf
@@ -40,3 +40,13 @@ output "identity_namespace" {
   value       = var.enable_workload_identity ? "${var.project_id}.svc.id.goog" : null
 }
 
+output "gpu_node_pool" {
+  description = "Resolved GPU accelerator config for the default node pool (#767). enabled=false and count=0 when no GPU is attached. type/count are the guest_accelerator attached to each node; driver_version drives GKE auto NVIDIA driver install."
+  value = {
+    enabled        = local._gpu_enabled
+    type           = local._gpu_accelerator_type
+    count          = local._gpu_accelerator_count
+    driver_version = local._gpu_node_driver_version
+  }
+}
+

--- a/gcp/gke/tests/gpu.tftest.hcl
+++ b/gcp/gke/tests/gpu.tftest.hcl
@@ -2,15 +2,20 @@ mock_provider "google" {}
 mock_provider "kubernetes" {}
 mock_provider "random" {}
 
-# gcp/gke GPU node-pool shape tests (#767). Verifies that:
+# gcp/gke GPU node-pool shape tests (#767, #752 review). Verifies that:
 #   - A GPU on an N1 machine resolves the node-pool accelerator config (type +
 #     count + auto-driver version) that the vendored gke module wires into
 #     guest_accelerator { ... gpu_driver_installation_config { ... } }.
+#   - A GPU on an accelerator-optimized family (G2->nvidia-l4, A3->nvidia-h100)
+#     ALSO resolves the accelerator config: unlike a Compute VM, a GKE node pool
+#     DECLARES the accelerator paired with the machine type. This is the #752
+#     review fix — the bundled families are valid on GKE, not rejected.
 #   - A non-GPU node pool resolves an inert accelerator config (count 0, no
 #     driver) so the module emits no guest_accelerator block.
-#   - The machine-type precondition (hosted on random_id.suffix because the node
-#     pool lives inside the module) rejects a GPU on a non-N1 machine and on a
-#     bundled-GPU (A3) machine (expect_failures on random_id.suffix).
+#   - The machine-family precondition (hosted on random_id.suffix because the node
+#     pool lives inside the module) rejects a GPU on a family that takes none
+#     (e.g. N2), and the pairing precondition rejects a bundled family paired with
+#     the wrong GPU type (expect_failures on random_id.suffix).
 #
 # Assertions read the gpu_node_pool output: the gke module's node-pool resources
 # are not directly addressable from tftest (only module outputs are), so the
@@ -82,6 +87,72 @@ run "gpu_count_defaults_to_one_and_driver_override" {
   }
 }
 
+run "gpu_nodepool_on_g2_resolves_bundled_l4_accelerator" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "g2-standard-4" # G2 pairs with nvidia-l4 — VALID on GKE
+    gpu_type            = "nvidia-l4"
+    gpu_count           = 1
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.enabled == true
+    error_message = "A G2 GPU node pool must report enabled=true — GKE declares the bundled accelerator."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.type == "nvidia-l4"
+    error_message = "G2 node-pool accelerator type must be nvidia-l4."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 1
+    error_message = "G2 node-pool accelerator count must be the configured gpu_count."
+  }
+}
+
+run "gpu_nodepool_on_a3_resolves_bundled_h100_accelerator" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "a3-highgpu-8g" # A3 pairs with nvidia-h100-80gb — VALID on GKE
+    gpu_type            = "nvidia-h100-80gb"
+    gpu_count           = 8
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.enabled == true
+    error_message = "An A3 GPU node pool must report enabled=true — GKE declares the bundled accelerator."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.type == "nvidia-h100-80gb"
+    error_message = "A3 node-pool accelerator type must be nvidia-h100-80gb."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 8
+    error_message = "A3 node-pool accelerator count must be the configured gpu_count."
+  }
+}
+
 run "no_gpu_resolves_inert_accelerator_config" {
   command = plan
 
@@ -114,16 +185,21 @@ run "no_gpu_resolves_inert_accelerator_config" {
 }
 
 # -----------------------------------------------------------------------------
-# Negative cases: the machine-type precondition (hosted on random_id.suffix)
-# rejects GPU on incompatible machine types at plan time. expect_failures
-# matches by resource address.
+# Negative cases: the GPU preconditions (hosted on random_id.suffix because the
+# node pool lives inside the vendored module) reject GPU on a non-GPU machine
+# family and a bundled family paired with the wrong GPU type at plan time.
+# expect_failures matches by resource address.
 #
-# Maintainer note: random_id.suffix currently carries exactly one precondition
-# (the GPU machine-type rule). If a second precondition is added to that
-# resource, split these negative exercises so the failures don't collide.
+# Maintainer note: random_id.suffix now carries TWO GPU preconditions — the
+# machine-family rule and the bundled-family pairing rule. expect_failures
+# matches by resource address, so each case below only needs to trip ONE of
+# them; that is exactly what these exercise (the n2 case trips the family rule,
+# the g2+wrong-type case trips the pairing rule). If a NON-GPU precondition is
+# ever added to this resource, split these so an unrelated failure can't mask a
+# regression in the GPU rules.
 # -----------------------------------------------------------------------------
 
-run "gpu_on_non_n1_machine_fails_precondition" {
+run "gpu_on_non_gpu_family_fails_precondition" {
   command = plan
 
   variables {
@@ -135,7 +211,7 @@ run "gpu_on_non_n1_machine_fails_precondition" {
     services_range_name = "svcs"
     regional            = false
     node_zones          = ["us-central1-a"]
-    machine_type        = "n2-standard-4" # not N1 — cannot attach a GPU
+    machine_type        = "n2-standard-4" # neither N1 nor accelerator-optimized — no GPU
     gpu_type            = "nvidia-tesla-t4"
   }
 
@@ -144,7 +220,7 @@ run "gpu_on_non_n1_machine_fails_precondition" {
   ]
 }
 
-run "gpu_on_bundled_a3_machine_fails_precondition" {
+run "gpu_on_bundled_g2_with_mismatched_type_fails_pairing" {
   command = plan
 
   variables {
@@ -156,8 +232,8 @@ run "gpu_on_bundled_a3_machine_fails_precondition" {
     services_range_name = "svcs"
     regional            = false
     node_zones          = ["us-central1-a"]
-    machine_type        = "a3-highgpu-8g" # A3 bundles its H100 — accelerator config invalid
-    gpu_type            = "nvidia-h100-80gb"
+    machine_type        = "g2-standard-4"  # G2 pairs with nvidia-l4 only
+    gpu_type            = "nvidia-tesla-a100" # A100 is an A2 GPU — wrong pairing
   }
 
   expect_failures = [

--- a/gcp/gke/tests/gpu.tftest.hcl
+++ b/gcp/gke/tests/gpu.tftest.hcl
@@ -1,0 +1,166 @@
+mock_provider "google" {}
+mock_provider "kubernetes" {}
+mock_provider "random" {}
+
+# gcp/gke GPU node-pool shape tests (#767). Verifies that:
+#   - A GPU on an N1 machine resolves the node-pool accelerator config (type +
+#     count + auto-driver version) that the vendored gke module wires into
+#     guest_accelerator { ... gpu_driver_installation_config { ... } }.
+#   - A non-GPU node pool resolves an inert accelerator config (count 0, no
+#     driver) so the module emits no guest_accelerator block.
+#   - The machine-type precondition (hosted on random_id.suffix because the node
+#     pool lives inside the module) rejects a GPU on a non-N1 machine and on a
+#     bundled-GPU (A3) machine (expect_failures on random_id.suffix).
+#
+# Assertions read the gpu_node_pool output: the gke module's node-pool resources
+# are not directly addressable from tftest (only module outputs are), so the
+# preset surfaces the resolved accelerator config it feeds the module.
+
+run "gpu_nodepool_on_n1_resolves_accelerator_and_driver" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "n1-standard-4"
+    gpu_type            = "nvidia-tesla-t4"
+    gpu_count           = 2
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.enabled == true
+    error_message = "A GPU node pool must report enabled=true."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.type == "nvidia-tesla-t4"
+    error_message = "node-pool accelerator type must be the configured gpu_type."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 2
+    error_message = "node-pool accelerator count must be the configured gpu_count."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.driver_version == "DEFAULT"
+    error_message = "GKE auto driver install must default to DEFAULT (gpu_driver_installation_config.gpu_driver_version)."
+  }
+}
+
+run "gpu_count_defaults_to_one_and_driver_override" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "n1-standard-8"
+    gpu_type            = "nvidia-tesla-v100"
+    gpu_driver_version  = "LATEST"
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 1
+    error_message = "gpu_count must default to 1 when unset."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.driver_version == "LATEST"
+    error_message = "gpu_driver_version override (LATEST) must flow into the node-pool driver config."
+  }
+}
+
+run "no_gpu_resolves_inert_accelerator_config" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "e2-standard-4"
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.enabled == false
+    error_message = "A non-GPU node pool must report enabled=false."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 0
+    error_message = "A non-GPU node pool must resolve accelerator_count=0 so the module emits no guest_accelerator."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.driver_version == ""
+    error_message = "A non-GPU node pool must resolve an empty driver_version so the module emits no gpu_driver_installation_config."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: the machine-type precondition (hosted on random_id.suffix)
+# rejects GPU on incompatible machine types at plan time. expect_failures
+# matches by resource address.
+#
+# Maintainer note: random_id.suffix currently carries exactly one precondition
+# (the GPU machine-type rule). If a second precondition is added to that
+# resource, split these negative exercises so the failures don't collide.
+# -----------------------------------------------------------------------------
+
+run "gpu_on_non_n1_machine_fails_precondition" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "n2-standard-4" # not N1 — cannot attach a GPU
+    gpu_type            = "nvidia-tesla-t4"
+  }
+
+  expect_failures = [
+    random_id.suffix,
+  ]
+}
+
+run "gpu_on_bundled_a3_machine_fails_precondition" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "a3-highgpu-8g" # A3 bundles its H100 — accelerator config invalid
+    gpu_type            = "nvidia-h100-80gb"
+  }
+
+  expect_failures = [
+    random_id.suffix,
+  ]
+}

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -140,9 +140,37 @@ variable "max_node_count" {
 }
 
 variable "machine_type" {
-  description = "Machine type for nodes"
+  description = "Machine type for nodes. To attach a GPU via the node pool accelerator config, use an N1 machine (e.g. n1-standard-4); A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type and do not take a separate accelerator."
   type        = string
   default     = "e2-standard-4"
+}
+
+variable "gpu_type" {
+  description = "NVIDIA accelerator type to attach to the node pool (e.g. nvidia-tesla-t4). Empty = no GPU. Only N1 node machines accept attached accelerators. When set, GKE auto-installs the NVIDIA driver (gpu_driver_version=DEFAULT) — no in-cluster device-plugin work needed, unlike EKS. GPU types are zone-constrained and quota-gated — a deploy-time operator concern."
+  type        = string
+  default     = ""
+}
+
+variable "gpu_count" {
+  description = "Number of GPUs of gpu_type per node. Ignored unless gpu_type is set."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.gpu_count >= 0
+    error_message = "gpu_count must be >= 0."
+  }
+}
+
+variable "gpu_driver_version" {
+  description = "GKE GPU driver auto-install version: DEFAULT (driver for the node GKE version), LATEST, or INSTALLATION_DISABLED. Applied only when gpu_type is set."
+  type        = string
+  default     = "DEFAULT"
+
+  validation {
+    condition     = contains(["DEFAULT", "LATEST", "INSTALLATION_DISABLED"], var.gpu_driver_version)
+    error_message = "gpu_driver_version must be one of: DEFAULT, LATEST, INSTALLATION_DISABLED."
+  }
 }
 
 variable "disk_size_gb" {

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -140,25 +140,25 @@ variable "max_node_count" {
 }
 
 variable "machine_type" {
-  description = "Machine type for nodes. To attach a GPU via the node pool accelerator config, use an N1 machine (e.g. n1-standard-4); A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type and do not take a separate accelerator."
+  description = "Machine type for nodes. For a GPU node pool, use an N1 machine (e.g. n1-standard-4, attaches T4/V100/P100/P4) or an accelerator-optimized machine (a2-*/a3-*/a4-*/g2-*/g4-*, whose accelerator the node pool declares — paired with the family's GPU type). Unlike a Compute VM, a GKE node pool DECLARES the accelerator even for the accelerator-optimized families."
   type        = string
   default     = "e2-standard-4"
 }
 
 variable "gpu_type" {
-  description = "NVIDIA accelerator type to attach to the node pool (e.g. nvidia-tesla-t4). Empty = no GPU. Only N1 node machines accept attached accelerators. When set, GKE auto-installs the NVIDIA driver (gpu_driver_version=DEFAULT) — no in-cluster device-plugin work needed, unlike EKS. GPU types are zone-constrained and quota-gated — a deploy-time operator concern."
+  description = "NVIDIA accelerator type the node pool declares (e.g. nvidia-tesla-t4 on N1, nvidia-l4 on g2, nvidia-tesla-a100 on a2, nvidia-h100-80gb on a3). Empty = no GPU. Must pair with the machine family. When set, GKE auto-installs the NVIDIA driver (gpu_driver_version=DEFAULT) — no in-cluster device-plugin work needed, unlike EKS. GPU types are zone-constrained and quota-gated — a deploy-time operator concern."
   type        = string
   default     = ""
 }
 
 variable "gpu_count" {
-  description = "Number of GPUs of gpu_type per node. Ignored unless gpu_type is set."
+  description = "Number of GPUs of gpu_type per node. Ignored unless gpu_type is set. Valid counts are 1, 2, 4, 8, or 16 (0 = no GPU). The exact legal count is GPU-type/zone/machine-specific (e.g. T4: 1/2/4; a2-highgpu-8g exposes 8) — a deploy-time/quota concern — but counts outside this set are always rejected by GCP."
   type        = number
   default     = 0
 
   validation {
-    condition     = var.gpu_count >= 0
-    error_message = "gpu_count must be >= 0."
+    condition     = contains([0, 1, 2, 4, 8, 16], var.gpu_count)
+    error_message = "gpu_count must be one of 0, 1, 2, 4, 8, 16."
   }
 }
 

--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -85,6 +85,64 @@ func configWithAWSEKS(in awsEKSCfgInput) *Config {
 	}
 }
 
+// gcpComputeCfgInput mirrors the subset of Config.GCPCompute fields exercised
+// by GPU mapper tests (#767).
+type gcpComputeCfgInput struct {
+	MachineType string
+	DiskSizeGb  int
+	GPUType     string
+	GPUCount    int
+}
+
+// configWithGCPCompute returns *Config with GCPCompute populated from input,
+// eliding the anonymous-struct redeclaration at each call site.
+func configWithGCPCompute(in gcpComputeCfgInput) *Config {
+	return &Config{
+		GCPCompute: &struct {
+			NumServers  string `json:"numServers,omitempty"`
+			MachineType string `json:"machineType,omitempty"`
+			DiskSizeGb  int    `json:"diskSizeGb,omitempty"`
+			GPUType     string `json:"gpuType,omitempty"`
+			GPUCount    int    `json:"gpuCount,omitempty"`
+		}{
+			MachineType: in.MachineType,
+			DiskSizeGb:  in.DiskSizeGb,
+			GPUType:     in.GPUType,
+			GPUCount:    in.GPUCount,
+		},
+	}
+}
+
+// gcpGKECfgInput mirrors the subset of Config.GCPGKE fields exercised by GPU
+// mapper tests (#767).
+type gcpGKECfgInput struct {
+	Regional    *bool
+	NodeCount   string
+	MachineType string
+	GPUType     string
+	GPUCount    int
+}
+
+// configWithGCPGKE returns *Config with GCPGKE populated from input, eliding the
+// anonymous-struct redeclaration at each call site.
+func configWithGCPGKE(in gcpGKECfgInput) *Config {
+	return &Config{
+		GCPGKE: &struct {
+			Regional    *bool  `json:"regional,omitempty"`
+			NodeCount   string `json:"nodeCount,omitempty"`
+			MachineType string `json:"machineType,omitempty"`
+			GPUType     string `json:"gpuType,omitempty"`
+			GPUCount    int    `json:"gpuCount,omitempty"`
+		}{
+			Regional:    in.Regional,
+			NodeCount:   in.NodeCount,
+			MachineType: in.MachineType,
+			GPUType:     in.GPUType,
+			GPUCount:    in.GPUCount,
+		},
+	}
+}
+
 // awsCognitoCfgInput mirrors the subset of Config.AWSCognito fields exercised
 // by mapper / validator tests.
 type awsCognitoCfgInput struct {

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -197,6 +197,7 @@ func (c *Client) ComputePresetDefaults(cfg Config, comps *Components, selected [
 	// instance type the mapper will actually deploy. Only fills when the user's
 	// own cfg left the instance type blank — an explicit pick is preserved.
 	applyGPUInstanceTypeDefault(&cfg, &out)
+	applyGCPGPUDefaults(&cfg, &out)
 
 	return out, nil
 }
@@ -225,6 +226,41 @@ func applyGPUInstanceTypeDefault(cfg, out *Config) {
 			reflect.ValueOf(&out.AWSEKS).Elem().Set(v)
 		}
 		out.AWSEKS.InstanceType = defaultGPUInstanceType
+	}
+}
+
+// applyGCPGPUDefaults backfills the GCP GPU overlay so the pricing-facing Config
+// is self-consistent when a caller signalled GPU intent with a partial spec
+// (#767): supplying only GPUType leaves GPUCount blank, and supplying only
+// GPUCount leaves GPUType blank. The mapper fills the same blanks at compose
+// time (defaultGCPAccelerator / defaultGCPGPUCount); mirroring it here keeps the
+// overlay Config in sync with what actually deploys. Only fills when the user's
+// cfg signalled a GPU and left the paired field blank — explicit picks are
+// preserved (the overlay is merged zero-only downstream).
+func applyGCPGPUDefaults(cfg, out *Config) {
+	if cfg.GCPCompute != nil && (cfg.GCPCompute.GPUType != "" || cfg.GCPCompute.GPUCount > 0) {
+		if out.GCPCompute == nil {
+			v := reflect.New(reflect.TypeOf(out.GCPCompute).Elem())
+			reflect.ValueOf(&out.GCPCompute).Elem().Set(v)
+		}
+		if out.GCPCompute.GPUType == "" {
+			out.GCPCompute.GPUType = defaultGCPAccelerator
+		}
+		if out.GCPCompute.GPUCount == 0 {
+			out.GCPCompute.GPUCount = defaultGCPGPUCount
+		}
+	}
+	if cfg.GCPGKE != nil && (cfg.GCPGKE.GPUType != "" || cfg.GCPGKE.GPUCount > 0) {
+		if out.GCPGKE == nil {
+			v := reflect.New(reflect.TypeOf(out.GCPGKE).Elem())
+			reflect.ValueOf(&out.GCPGKE).Elem().Set(v)
+		}
+		if out.GCPGKE.GPUType == "" {
+			out.GCPGKE.GPUType = defaultGCPAccelerator
+		}
+		if out.GCPGKE.GPUCount == 0 {
+			out.GCPGKE.GPUCount = defaultGCPGPUCount
+		}
 	}
 }
 

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -256,7 +256,16 @@ func applyGCPGPUDefaults(cfg, out *Config) {
 			reflect.ValueOf(&out.GCPGKE).Elem().Set(v)
 		}
 		if out.GCPGKE.GPUType == "" {
-			out.GCPGKE.GPUType = defaultGCPAccelerator
+			// GKE pairs a bundled accelerator-optimized family (g2/a2/a3/...) with
+			// its own GPU type; fall back to the shared N1 default only when the
+			// machine family has no bundled pairing (#752 review). Mirrors the
+			// mapper's defaultGKEGPUType so the pricing-facing overlay matches what
+			// deploys.
+			if def := defaultGKEGPUType(cfg.GCPGKE.MachineType); def != "" {
+				out.GCPGKE.GPUType = def
+			} else {
+				out.GCPGKE.GPUType = defaultGCPAccelerator
+			}
 		}
 		if out.GCPGKE.GPUCount == 0 {
 			out.GCPGKE.GPUCount = defaultGCPGPUCount

--- a/pkg/composer/gpu_gcp.go
+++ b/pkg/composer/gpu_gcp.go
@@ -1,0 +1,173 @@
+package composer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// gpu_gcp.go centralises the single source of truth the GCP GPU mapper branches
+// (#767) share: the default attachable accelerator type, the set of NVIDIA
+// accelerator types that attach to N1 machines via guest_accelerator, and the
+// set of machine families that bundle a GPU with the machine type (so attaching
+// a separate accelerator there is invalid). Both the gcp/gke node-pool branch
+// and the gcp/compute instance branch consume these so the knowledge can't drift
+// between them, and a drift test (gpu_gcp_families_drift_test.go) asserts the Go
+// sets stay in lockstep with the HCL `_gpu_attachable_accelerators` and
+// `_gpu_bundled_machine_families` locals in gcp/compute/main.tf and
+// gcp/gke/main.tf — the presets' own preconditions are the runtime SoT.
+//
+// GCP attaches GPUs in two distinct ways, and the validation enforces the right
+// one (validate, don't mask — the #759 lesson applied to GCP):
+//
+//   - N1 general-purpose machines accept ATTACHED GPUs via guest_accelerator
+//     (T4 / V100 / P100 / P4). This is the path GPUType/GPUCount drive.
+//   - A2 / A3 / A4 / G2 / G4 accelerator-optimized machines BUNDLE their GPU
+//     with the machine type (A100 / H100 / H200 / B200 / L4 / RTX-PRO-6000).
+//     Setting guest_accelerator there is rejected by GCP — the GPU is implied
+//     by the machine type, so we reject an explicit GPUType for those families.
+//   - Every other family (E2, N2, C3, ...) cannot take a GPU at all.
+//
+// GCP also forbids live-migration for any GPU-bearing instance, so the compute
+// preset forces scheduling.on_host_maintenance = "TERMINATE" by construction
+// when a GPU is attached (validate-don't-mask: the mapper never lets MIGRATE
+// coexist with a GPU).
+
+// defaultGCPAccelerator is the accelerator type the mapper supplies when a
+// caller sets GPUCount on an N1 machine but does not pin an explicit GPUType.
+// nvidia-tesla-t4 is the cheapest, most broadly available N1-attachable NVIDIA
+// GPU and is shared by the GKE node-pool and Compute instance GPU paths.
+const defaultGCPAccelerator = "nvidia-tesla-t4"
+
+// defaultGCPGPUCount is the accelerator count the mapper supplies when a caller
+// pins a GPUType on an N1 machine but leaves GPUCount unset (a single GPU).
+const defaultGCPGPUCount = 1
+
+// gpuAttachableAccelerators is the allow-list of NVIDIA accelerator types that
+// attach to N1 machines via guest_accelerator (#767). vws variants are the
+// virtual-workstation SKUs of the same silicon and attach the same way.
+//
+// This set MUST stay in lockstep with the HCL `_gpu_attachable_accelerators`
+// locals in gcp/compute/main.tf and gcp/gke/main.tf — TestGCPGPUFamiliesDrift
+// enforces it.
+var gpuAttachableAccelerators = map[string]struct{}{
+	"nvidia-tesla-t4":       {},
+	"nvidia-tesla-t4-vws":   {},
+	"nvidia-tesla-p4":       {},
+	"nvidia-tesla-p4-vws":   {},
+	"nvidia-tesla-v100":     {},
+	"nvidia-tesla-p100":     {},
+	"nvidia-tesla-p100-vws": {},
+}
+
+// gpuBundledMachineFamilies is the set of machine-type family prefixes whose
+// GPU is BUNDLED with the machine type (#767): A2 / A3 / A4 / A4X (A100 / H100 /
+// H200 / B200 / GB200 / GB300), G2 (L4), and G4 (RTX-PRO-6000). For these you
+// select the GPU by picking the machine type; attaching a guest_accelerator is
+// invalid and GCP rejects it. We reject an explicit GPUType on these families at
+// compose time rather than silently attaching an incompatible accelerator.
+//
+// This set MUST stay in lockstep with the HCL `_gpu_bundled_machine_families`
+// locals in gcp/compute/main.tf and gcp/gke/main.tf — TestGCPGPUFamiliesDrift
+// enforces it.
+var gpuBundledMachineFamilies = map[string]struct{}{
+	"a2":  {},
+	"a3":  {},
+	"a4":  {},
+	"a4x": {},
+	"g2":  {},
+	"g4":  {},
+}
+
+// machineFamily returns the family prefix of a GCP machine type — the part
+// before the first "-" — matching the HCL `split("-", ...)[0]` derive. For
+// "n1-standard-4" it returns "n1"; for "a2-highgpu-1g" it returns "a2". The
+// input is trimmed and lower-cased first so surrounding whitespace or a
+// capitalised family still matches (GCP machine types are canonically
+// lower-case).
+func machineFamily(machineType string) string {
+	normalized := strings.ToLower(strings.TrimSpace(machineType))
+	return strings.SplitN(normalized, "-", 2)[0]
+}
+
+// isN1Machine reports whether machineType is an N1 general-purpose machine, the
+// only family that takes an ATTACHED GPU via guest_accelerator. An empty machine
+// type is not N1 (the preset defaults to a non-N1 type), so an attached GPU with
+// no machine type is rejected — the caller must pick an N1 machine.
+func isN1Machine(machineType string) bool {
+	return machineFamily(machineType) == "n1"
+}
+
+// isBundledGPUMachine reports whether machineType belongs to a family whose GPU
+// is bundled with the machine type (per gpuBundledMachineFamilies), so attaching
+// a separate guest_accelerator is invalid.
+func isBundledGPUMachine(machineType string) bool {
+	_, ok := gpuBundledMachineFamilies[machineFamily(machineType)]
+	return ok
+}
+
+// isAttachableAccelerator reports whether gpuType is a known N1-attachable NVIDIA
+// accelerator type (per gpuAttachableAccelerators). Used to validate an explicit
+// GPUType so an unknown or bundled-only accelerator is rejected at compose time
+// instead of producing an apply-time GCP error.
+func isAttachableAccelerator(gpuType string) bool {
+	_, ok := gpuAttachableAccelerators[strings.ToLower(strings.TrimSpace(gpuType))]
+	return ok
+}
+
+// validateGCPGPU enforces the GCP attach-a-GPU rules shared by the gcp_compute
+// and gcp_gke mapper branches (#767), so both reject the same invalid configs
+// with identical, actionable error content. component is the IR field name used
+// in the error message ("GCPCompute" / "GCPGKE"). It validates, in order:
+//
+//  1. A bundled-GPU machine family (A2/A3/A4/G2/G4) with an explicit GPUType is
+//     rejected — the GPU comes with the machine type, so attaching a separate
+//     accelerator is invalid and GCP rejects it.
+//  2. A non-N1 machine type that is not a bundled-GPU family cannot take a GPU at
+//     all — rejected (only N1 attaches GPUs via guest_accelerator).
+//  3. An explicit GPUType that is not a known N1-attachable accelerator is
+//     rejected (typo, or a bundled-only / TPU type used by mistake).
+//
+// An empty machine type is treated as the non-N1 preset default and rejected
+// with the same N1 guidance — the caller must pick an N1 machine to attach a GPU.
+func validateGCPGPU(component, machineType, gpuType string) error {
+	if isBundledGPUMachine(machineType) {
+		return NewValidationError(fmt.Sprintf(
+			"%s machine_type=%q bundles its GPU with the machine type "+
+				"(A2/A3/A4/G2/G4 families ship a fixed GPU): you select the GPU by "+
+				"picking the machine type, so an explicit GPUType is invalid. "+
+				"Clear GPUType/GPUCount and use the accelerator-optimized machine "+
+				"type alone, or pick an N1 machine to attach %s.",
+			component, machineType, gpuTypeForMsg(gpuType),
+		))
+	}
+	if !isN1Machine(machineType) {
+		return NewValidationError(fmt.Sprintf(
+			"%s requests a GPU but machine_type=%q does not accept one: GCP attaches "+
+				"GPUs via guest_accelerator only on N1 general-purpose machines "+
+				"(e.g. n1-standard-4). Pick an N1 machine type to attach a GPU, or "+
+				"use an accelerator-optimized machine type (a2-*/a3-*/g2-*) whose GPU "+
+				"is bundled and set no GPUType.",
+			component, machineType,
+		))
+	}
+	if gpuType != "" && !isAttachableAccelerator(gpuType) {
+		return NewValidationError(fmt.Sprintf(
+			"%s GPUType=%q is not a known N1-attachable NVIDIA accelerator "+
+				"(expected one of nvidia-tesla-t4/nvidia-tesla-t4-vws/"+
+				"nvidia-tesla-p4/nvidia-tesla-p4-vws/nvidia-tesla-v100/"+
+				"nvidia-tesla-p100/nvidia-tesla-p100-vws). Clear GPUType to default "+
+				"to %s, or pick a supported accelerator.",
+			component, gpuType, defaultGCPAccelerator,
+		))
+	}
+	return nil
+}
+
+// gpuTypeForMsg renders the GPU type for an error message, falling back to "a
+// GPU" when the caller signalled GPU intent via GPUCount only (empty GPUType).
+func gpuTypeForMsg(gpuType string) string {
+	if strings.TrimSpace(gpuType) == "" {
+		return "a GPU"
+	}
+	return gpuType
+}

--- a/pkg/composer/gpu_gcp.go
+++ b/pkg/composer/gpu_gcp.go
@@ -7,25 +7,40 @@ import (
 
 // gpu_gcp.go centralises the single source of truth the GCP GPU mapper branches
 // (#767) share: the default attachable accelerator type, the set of NVIDIA
-// accelerator types that attach to N1 machines via guest_accelerator, and the
-// set of machine families that bundle a GPU with the machine type (so attaching
-// a separate accelerator there is invalid). Both the gcp/gke node-pool branch
-// and the gcp/compute instance branch consume these so the knowledge can't drift
+// accelerator types that attach to N1 machines via guest_accelerator, the set of
+// machine families that bundle a GPU with the machine type, and — for GKE only —
+// the bundled-family → GPU-type pairing. Both the gcp/gke node-pool branch and
+// the gcp/compute instance branch consume these so the knowledge can't drift
 // between them, and a drift test (gpu_gcp_families_drift_test.go) asserts the Go
 // sets stay in lockstep with the HCL `_gpu_attachable_accelerators` and
 // `_gpu_bundled_machine_families` locals in gcp/compute/main.tf and
 // gcp/gke/main.tf — the presets' own preconditions are the runtime SoT.
 //
-// GCP attaches GPUs in two distinct ways, and the validation enforces the right
-// one (validate, don't mask — the #759 lesson applied to GCP):
+// GCP attaches GPUs in two distinct ways, and the validation differs by service
+// (validate, don't mask — the #759 lesson applied to GCP). The crucial split is
+// Compute Engine VMs vs. GKE node pools (#752 review):
 //
-//   - N1 general-purpose machines accept ATTACHED GPUs via guest_accelerator
-//     (T4 / V100 / P100 / P4). This is the path GPUType/GPUCount drive.
-//   - A2 / A3 / A4 / G2 / G4 accelerator-optimized machines BUNDLE their GPU
-//     with the machine type (A100 / H100 / H200 / B200 / L4 / RTX-PRO-6000).
-//     Setting guest_accelerator there is rejected by GCP — the GPU is implied
-//     by the machine type, so we reject an explicit GPUType for those families.
-//   - Every other family (E2, N2, C3, ...) cannot take a GPU at all.
+//   - On a Compute Engine VM (google_compute_instance), only N1 general-purpose
+//     machines accept an ATTACHED GPU via guest_accelerator (T4 / V100 / P100 /
+//     P4). A2 / A3 / A4 / G2 / G4 accelerator-optimized machines have their GPU
+//     ATTACHED AUTOMATICALLY by the machine type — you do NOT pass
+//     guest_accelerator, and doing so is invalid. Every other family (E2, N2,
+//     C3, ...) cannot take a GPU at all. Verified against
+//     https://cloud.google.com/compute/docs/gpus ("For these machine types, the
+//     GPU model is automatically attached to the instance") and the create-VM
+//     guide (no --accelerator for A2/A3/G2; --accelerator required for N1).
+//
+//   - On a GKE node pool (google_container_node_pool), guest_accelerator IS
+//     REQUIRED even for the accelerator-optimized families — the node pool must
+//     declare the accelerator type+count that matches the machine type. g2 pairs
+//     with nvidia-l4, a2 with nvidia-tesla-a100 / nvidia-a100-80gb, a3 with
+//     nvidia-h100-80gb / nvidia-h200-141gb, etc. N1 node pools attach the same
+//     N1-attachable accelerators as a VM. Verified against
+//     https://cloud.google.com/kubernetes-engine/docs/how-to/gpus
+//     ("gcloud container node-pools create ... --accelerator type=nvidia-l4 ...
+//     --machine-type g2-standard-4"). This is the bug the #752 review caught:
+//     the GKE path reused the Compute bundled-family REJECTION, which would have
+//     rejected the very configs GKE GPU node pools require.
 //
 // GCP also forbids live-migration for any GPU-bearing instance, so the compute
 // preset forces scheduling.on_host_maintenance = "TERMINATE" by construction
@@ -41,6 +56,23 @@ const defaultGCPAccelerator = "nvidia-tesla-t4"
 // defaultGCPGPUCount is the accelerator count the mapper supplies when a caller
 // pins a GPUType on an N1 machine but leaves GPUCount unset (a single GPU).
 const defaultGCPGPUCount = 1
+
+// validGCPGPUCounts is the set of accelerator counts GCP accepts across the
+// N1-attachable GPU models (T4: 1/2/4, V100: 1/2/4/8, P100: 1/2/4, P4: 1/2/4)
+// and the per-node counts the accelerator-optimized families expose (1/2/4/8/16
+// depending on the machine type, e.g. a2-highgpu-8g = 8, a2-megagpu-16g = 16).
+// We validate against this union rather than the full per-type/per-machine
+// matrix: the exact legal count is type- AND zone-AND-machine-specific (a
+// deploy-time / quota concern), but a count outside this set is always wrong and
+// is worth catching at compose time. Verified against
+// https://cloud.google.com/compute/docs/gpus.
+var validGCPGPUCounts = map[int]struct{}{
+	1:  {},
+	2:  {},
+	4:  {},
+	8:  {},
+	16: {},
+}
 
 // gpuAttachableAccelerators is the allow-list of NVIDIA accelerator types that
 // attach to N1 machines via guest_accelerator (#767). vws variants are the
@@ -61,10 +93,13 @@ var gpuAttachableAccelerators = map[string]struct{}{
 
 // gpuBundledMachineFamilies is the set of machine-type family prefixes whose
 // GPU is BUNDLED with the machine type (#767): A2 / A3 / A4 / A4X (A100 / H100 /
-// H200 / B200 / GB200 / GB300), G2 (L4), and G4 (RTX-PRO-6000). For these you
-// select the GPU by picking the machine type; attaching a guest_accelerator is
-// invalid and GCP rejects it. We reject an explicit GPUType on these families at
-// compose time rather than silently attaching an incompatible accelerator.
+// H200 / B200 / GB200 / GB300), G2 (L4), and G4 (RTX-PRO-6000).
+//
+// On Compute Engine VMs the GPU is attached automatically and a guest_accelerator
+// is invalid, so the compute mapper rejects an explicit GPUType on these. On GKE
+// node pools the accelerator IS declared (paired with the machine type), so the
+// gke mapper ACCEPTS these families and validates the type/family pairing against
+// gpuBundledFamilyAccelerators below.
 //
 // This set MUST stay in lockstep with the HCL `_gpu_bundled_machine_families`
 // locals in gcp/compute/main.tf and gcp/gke/main.tf — TestGCPGPUFamiliesDrift
@@ -76,6 +111,24 @@ var gpuBundledMachineFamilies = map[string]struct{}{
 	"a4x": {},
 	"g2":  {},
 	"g4":  {},
+}
+
+// gpuBundledFamilyAccelerators maps each bundled-GPU machine family to the
+// accelerator type(s) GKE pairs with it in the node-pool accelerator config.
+// Used only by the GKE path: when a caller requests a GPU node pool on one of
+// these families, the gpu_type must be one of the family's accelerators (or is
+// defaulted to the first listed when unset). Verified against
+// https://cloud.google.com/kubernetes-engine/docs/how-to/gpus.
+//
+// Keys MUST exactly match gpuBundledMachineFamilies — TestGCPGPUBundledPairings
+// enforces that every bundled family has a pairing entry and vice-versa.
+var gpuBundledFamilyAccelerators = map[string][]string{
+	"a2":  {"nvidia-tesla-a100", "nvidia-a100-80gb"},
+	"a3":  {"nvidia-h100-80gb", "nvidia-h100-mega-80gb", "nvidia-h200-141gb"},
+	"a4":  {"nvidia-b200"},
+	"a4x": {"nvidia-gb200", "nvidia-gb300"},
+	"g2":  {"nvidia-l4"},
+	"g4":  {"nvidia-rtx-pro-6000"},
 }
 
 // machineFamily returns the family prefix of a GCP machine type — the part
@@ -98,8 +151,7 @@ func isN1Machine(machineType string) bool {
 }
 
 // isBundledGPUMachine reports whether machineType belongs to a family whose GPU
-// is bundled with the machine type (per gpuBundledMachineFamilies), so attaching
-// a separate guest_accelerator is invalid.
+// is bundled with the machine type (per gpuBundledMachineFamilies).
 func isBundledGPUMachine(machineType string) bool {
 	_, ok := gpuBundledMachineFamilies[machineFamily(machineType)]
 	return ok
@@ -114,10 +166,37 @@ func isAttachableAccelerator(gpuType string) bool {
 	return ok
 }
 
-// validateGCPGPU enforces the GCP attach-a-GPU rules shared by the gcp_compute
-// and gcp_gke mapper branches (#767), so both reject the same invalid configs
-// with identical, actionable error content. component is the IR field name used
-// in the error message ("GCPCompute" / "GCPGKE"). It validates, in order:
+// normalizeGPUType lower-cases and trims a GPU type so the value the mapper
+// emits is the canonical form GCP expects ("  NVIDIA-Tesla-T4 " → "nvidia-tesla-t4").
+func normalizeGPUType(gpuType string) string {
+	return strings.ToLower(strings.TrimSpace(gpuType))
+}
+
+// validateGCPGPUCount rejects an accelerator count GCP never accepts (per
+// validGCPGPUCounts). component is the IR field name used in the message. A
+// count of 0 is treated as "default to 1" by the caller and is not validated
+// here — only an explicit positive count is checked.
+func validateGCPGPUCount(component string, count int) error {
+	if count <= 0 {
+		return nil
+	}
+	if _, ok := validGCPGPUCounts[count]; !ok {
+		return NewValidationError(fmt.Sprintf(
+			"%s GPUCount=%d is not a valid GCP accelerator count (expected one of "+
+				"1, 2, 4, 8, 16). The exact legal count is GPU-type/zone/machine-"+
+				"specific (a deploy-time concern), but counts outside this set are "+
+				"always rejected by GCP.",
+			component, count,
+		))
+	}
+	return nil
+}
+
+// validateGCPComputeGPU enforces the Compute Engine VM attach-a-GPU rules
+// (#752 review). On a VM the GPU attaches via guest_accelerator ONLY on N1
+// machines; A2/A3/A4/G2/G4 attach their GPU automatically by machine type and
+// reject an explicit guest_accelerator, and every other family takes none. It
+// validates, in order:
 //
 //  1. A bundled-GPU machine family (A2/A3/A4/G2/G4) with an explicit GPUType is
 //     rejected — the GPU comes with the machine type, so attaching a separate
@@ -126,17 +205,19 @@ func isAttachableAccelerator(gpuType string) bool {
 //     all — rejected (only N1 attaches GPUs via guest_accelerator).
 //  3. An explicit GPUType that is not a known N1-attachable accelerator is
 //     rejected (typo, or a bundled-only / TPU type used by mistake).
+//  4. An explicit GPUCount outside the valid GCP set is rejected.
 //
 // An empty machine type is treated as the non-N1 preset default and rejected
 // with the same N1 guidance — the caller must pick an N1 machine to attach a GPU.
-func validateGCPGPU(component, machineType, gpuType string) error {
+func validateGCPComputeGPU(machineType, gpuType string, gpuCount int) error {
+	const component = "GCPCompute"
 	if isBundledGPUMachine(machineType) {
 		return NewValidationError(fmt.Sprintf(
-			"%s machine_type=%q bundles its GPU with the machine type "+
-				"(A2/A3/A4/G2/G4 families ship a fixed GPU): you select the GPU by "+
-				"picking the machine type, so an explicit GPUType is invalid. "+
-				"Clear GPUType/GPUCount and use the accelerator-optimized machine "+
-				"type alone, or pick an N1 machine to attach %s.",
+			"%s machine_type=%q attaches its GPU automatically (A2/A3/A4/G2/G4 "+
+				"families ship a fixed GPU with the machine type): on a Compute Engine "+
+				"VM you do not set a guest_accelerator, so an explicit GPUType is "+
+				"invalid. Clear GPUType/GPUCount and use the accelerator-optimized "+
+				"machine type alone, or pick an N1 machine to attach %s.",
 			component, machineType, gpuTypeForMsg(gpuType),
 		))
 	}
@@ -146,7 +227,7 @@ func validateGCPGPU(component, machineType, gpuType string) error {
 				"GPUs via guest_accelerator only on N1 general-purpose machines "+
 				"(e.g. n1-standard-4). Pick an N1 machine type to attach a GPU, or "+
 				"use an accelerator-optimized machine type (a2-*/a3-*/g2-*) whose GPU "+
-				"is bundled and set no GPUType.",
+				"is attached automatically and set no GPUType.",
 			component, machineType,
 		))
 	}
@@ -160,7 +241,91 @@ func validateGCPGPU(component, machineType, gpuType string) error {
 			component, gpuType, defaultGCPAccelerator,
 		))
 	}
-	return nil
+	return validateGCPGPUCount(component, gpuCount)
+}
+
+// validateGCPGKEGPU enforces the GKE node-pool attach-a-GPU rules (#752 review).
+// Unlike a Compute VM, a GKE node pool DECLARES the accelerator even for the
+// accelerator-optimized families — the node pool's accelerator config must pair
+// the machine type with its GPU. It validates, in order:
+//
+//  1. An N1 machine accepts the N1-attachable accelerators (T4/V100/P100/P4); an
+//     explicit GPUType that is not one is rejected.
+//  2. A bundled-GPU machine family (A2/A3/A4/G2/G4) is ACCEPTED, but an explicit
+//     GPUType must be one of the accelerators GKE pairs with that family (per
+//     gpuBundledFamilyAccelerators) — a mismatched type is rejected. An empty
+//     GPUType is allowed; the mapper defaults it to the family's accelerator.
+//  3. Any other family cannot take a GPU at all — rejected.
+//  4. An explicit GPUCount outside the valid GCP set is rejected.
+//
+// An empty machine type is treated as the non-N1 preset default and rejected
+// with N1 guidance — the caller must pick an N1 or accelerator-optimized machine.
+func validateGCPGKEGPU(machineType, gpuType string, gpuCount int) error {
+	const component = "GCPGKE"
+	fam := machineFamily(machineType)
+	switch {
+	case fam == "n1":
+		if gpuType != "" && !isAttachableAccelerator(gpuType) {
+			return NewValidationError(fmt.Sprintf(
+				"%s GPUType=%q is not a known N1-attachable NVIDIA accelerator "+
+					"(expected one of nvidia-tesla-t4/nvidia-tesla-t4-vws/"+
+					"nvidia-tesla-p4/nvidia-tesla-p4-vws/nvidia-tesla-v100/"+
+					"nvidia-tesla-p100/nvidia-tesla-p100-vws). Clear GPUType to default "+
+					"to %s, or pick a supported accelerator.",
+				component, gpuType, defaultGCPAccelerator,
+			))
+		}
+	case isBundledGPUMachine(machineType):
+		if gpuType != "" && !isBundledFamilyAccelerator(fam, gpuType) {
+			return NewValidationError(fmt.Sprintf(
+				"%s GPUType=%q does not pair with machine_type=%q: a GKE %s node pool "+
+					"declares the accelerator that matches the machine family (expected "+
+					"one of %s). Clear GPUType to default to %s, or pick the matching "+
+					"accelerator.",
+				component, gpuType, machineType, strings.ToUpper(fam),
+				strings.Join(gpuBundledFamilyAccelerators[fam], "/"),
+				gpuBundledFamilyAccelerators[fam][0],
+			))
+		}
+	default:
+		return NewValidationError(fmt.Sprintf(
+			"%s requests a GPU but machine_type=%q does not accept one: a GKE GPU node "+
+				"pool needs an N1 machine (attaches T4/V100/P100/P4) or an accelerator-"+
+				"optimized machine (a2-*/a3-*/a4-*/g2-*/g4-*, whose GPU is declared by "+
+				"the matching accelerator type). Pick one of those machine types.",
+			component, machineType,
+		))
+	}
+	return validateGCPGPUCount(component, gpuCount)
+}
+
+// isBundledFamilyAccelerator reports whether gpuType is one of the accelerators
+// GKE pairs with the given bundled machine family. gpuType is normalized before
+// the lookup so case/whitespace don't matter.
+func isBundledFamilyAccelerator(family, gpuType string) bool {
+	want := normalizeGPUType(gpuType)
+	for _, a := range gpuBundledFamilyAccelerators[family] {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultGKEGPUType returns the accelerator type the GKE mapper supplies when a
+// caller requests a GPU node pool on machineType but does not pin a GPUType. For
+// N1 it is the shared default (nvidia-tesla-t4); for a bundled family it is that
+// family's first paired accelerator. Returns "" for a family that cannot take a
+// GPU (validation rejects those before this is consulted).
+func defaultGKEGPUType(machineType string) string {
+	fam := machineFamily(machineType)
+	if fam == "n1" {
+		return defaultGCPAccelerator
+	}
+	if accs := gpuBundledFamilyAccelerators[fam]; len(accs) > 0 {
+		return accs[0]
+	}
+	return ""
 }
 
 // gpuTypeForMsg renders the GPU type for an error message, falling back to "a

--- a/pkg/composer/gpu_gcp_families_drift_test.go
+++ b/pkg/composer/gpu_gcp_families_drift_test.go
@@ -93,3 +93,119 @@ func parseGCPBundledFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
 	}
 	return out
 }
+
+// TestGCPGPUBundledPairings asserts the Go bundled-family → accelerator pairing
+// map (gpuBundledFamilyAccelerators, GKE-only) is internally consistent and stays
+// in lockstep with the HCL `_gpu_bundled_family_accelerator_map` in gcp/gke/main.tf
+// (#752 review). Two contracts:
+//
+//  1. Every bundled machine family (gpuBundledMachineFamilies) has a pairing entry
+//     and vice-versa — a family with no accelerator could never compose a GKE GPU
+//     node pool, and a stray pairing entry would never be reachable.
+//  2. The Go pairing map matches the GKE HCL map exactly (family → set of GPU
+//     types). If they drift, a gpu_type the composer accepts for a family could be
+//     rejected by the preset's pairing precondition at apply (or vice-versa) —
+//     exactly the failure the split validation exists to prevent.
+//
+// The pairing map is GKE-only: on a Compute VM the accelerator is attached
+// automatically and the compute preset rejects an explicit gpu_type on these
+// families, so there is no compute HCL pairing map to drift against.
+func TestGCPGPUBundledPairings(t *testing.T) {
+	// (1) keys of the pairing map == the bundled-family set, and no family maps
+	// to an empty accelerator list.
+	for fam := range gpuBundledMachineFamilies {
+		accs, ok := gpuBundledFamilyAccelerators[fam]
+		if !ok {
+			t.Errorf("bundled family %q has no accelerator pairing in gpuBundledFamilyAccelerators", fam)
+			continue
+		}
+		if len(accs) == 0 {
+			t.Errorf("bundled family %q maps to an empty accelerator list", fam)
+		}
+	}
+	for fam := range gpuBundledFamilyAccelerators {
+		if _, ok := gpuBundledMachineFamilies[fam]; !ok {
+			t.Errorf("gpuBundledFamilyAccelerators has pairing for %q but it is not a bundled machine family", fam)
+		}
+	}
+
+	// (2) the Go pairing map matches the GKE HCL `_gpu_bundled_family_accelerator_map`.
+	path := filepath.Join("..", "..", "gcp", "gke", "main.tf")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	hclMap := parseGCPBundledFamilyAcceleratorMapHCL(t, string(b))
+	if len(hclMap) == 0 {
+		t.Fatalf("no entries parsed from _gpu_bundled_family_accelerator_map in %s — parser or HCL shape changed", path)
+	}
+
+	for fam, goAccs := range gpuBundledFamilyAccelerators {
+		hclAccs, ok := hclMap[fam]
+		if !ok {
+			t.Errorf("family %q in gpuBundledFamilyAccelerators (gpu_gcp.go) but missing from %s _gpu_bundled_family_accelerator_map", fam, path)
+			continue
+		}
+		want := append([]string(nil), goAccs...)
+		got := append([]string(nil), hclAccs...)
+		sort.Strings(want)
+		sort.Strings(got)
+		if strings.Join(want, ",") != strings.Join(got, ",") {
+			t.Errorf("family %q accelerator pairing drift: gpu_gcp.go=%v, %s=%v", fam, want, path, got)
+		}
+	}
+	for fam := range hclMap {
+		if _, ok := gpuBundledFamilyAccelerators[fam]; !ok {
+			t.Errorf("family %q in %s _gpu_bundled_family_accelerator_map but missing from gpuBundledFamilyAccelerators (gpu_gcp.go)", fam, path)
+		}
+	}
+}
+
+// parseGCPBundledFamilyAcceleratorMapHCL extracts the
+// `_gpu_bundled_family_accelerator_map = { fam = [ ... ] ... }` local from the
+// GKE main.tf into a family → []accelerator map. It isolates the braced map body
+// (balanced-brace scan from the first "{" after the assignment), strips inline
+// comments, then matches each `key = [ "a", "b" ]` entry.
+func parseGCPBundledFamilyAcceleratorMapHCL(t *testing.T, hcl string) map[string][]string {
+	t.Helper()
+	anchor := regexp.MustCompile(`_gpu_bundled_family_accelerator_map\s*=\s*\{`)
+	loc := anchor.FindStringIndex(hcl)
+	if loc == nil {
+		t.Fatalf("could not locate `_gpu_bundled_family_accelerator_map = {` in main.tf")
+	}
+	// Balanced-brace scan starting at the opening brace.
+	open := loc[1] - 1
+	depth := 0
+	end := -1
+	for i := open; i < len(hcl); i++ {
+		switch hcl[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				end = i
+			}
+		}
+		if end >= 0 {
+			break
+		}
+	}
+	if end < 0 {
+		t.Fatalf("unbalanced braces in `_gpu_bundled_family_accelerator_map`")
+	}
+	body := stripHCLLineComments(hcl[open+1 : end])
+
+	entryRe := regexp.MustCompile(`(?m)^\s*([A-Za-z0-9_]+)\s*=\s*\[([^\]]*)\]`)
+	tokenRe := regexp.MustCompile(`"([^"]+)"`)
+	out := map[string][]string{}
+	for _, em := range entryRe.FindAllStringSubmatch(body, -1) {
+		fam := strings.TrimSpace(em[1])
+		var accs []string
+		for _, tm := range tokenRe.FindAllStringSubmatch(em[2], -1) {
+			accs = append(accs, strings.TrimSpace(tm[1]))
+		}
+		out[fam] = accs
+	}
+	return out
+}

--- a/pkg/composer/gpu_gcp_families_drift_test.go
+++ b/pkg/composer/gpu_gcp_families_drift_test.go
@@ -1,0 +1,95 @@
+package composer
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestGCPGPUFamiliesDrift asserts the Go bundled-GPU machine-family set
+// (gpuBundledMachineFamilies in gpu_gcp.go) stays in lockstep with the HCL
+// `_gpu_bundled_machine_families` locals in BOTH gcp/compute/main.tf and
+// gcp/gke/main.tf (#767). The HCL lists drive each preset's plan-time GPU
+// machine-type precondition; the Go set drives the composer's compose-time
+// rejection of an explicit GPUType on a bundled-GPU machine. If any of the three
+// drift, a machine family rejected by one layer might be accepted by another, so
+// a config that composes could fail at apply (or vice-versa) — exactly the
+// failure the validation exists to prevent. This fails the moment any list adds
+// or removes a family without the other two.
+//
+// The N1-attachable accelerator allow-list (gpuAttachableAccelerators) is
+// deliberately Go-only: the presets attach whatever gpu_type the composer passes
+// and gate it with the machine-family precondition, so there is no HCL
+// accelerator list to drift against.
+func TestGCPGPUFamiliesDrift(t *testing.T) {
+	goFamilies := map[string]struct{}{}
+	for f := range gpuBundledMachineFamilies {
+		goFamilies[f] = struct{}{}
+	}
+
+	for _, src := range []struct {
+		name string
+		path string
+	}{
+		{"compute", filepath.Join("..", "..", "gcp", "compute", "main.tf")},
+		{"gke", filepath.Join("..", "..", "gcp", "gke", "main.tf")},
+	} {
+		t.Run(src.name, func(t *testing.T) {
+			b, err := os.ReadFile(src.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", src.path, err)
+			}
+
+			hclFamilies := parseGCPBundledFamiliesHCL(t, string(b))
+			if len(hclFamilies) == 0 {
+				t.Fatalf("no families parsed from _gpu_bundled_machine_families in %s — parser or HCL shape changed", src.path)
+			}
+
+			var missingInGo []string
+			for f := range hclFamilies {
+				if _, ok := goFamilies[f]; !ok {
+					missingInGo = append(missingInGo, f)
+				}
+			}
+			var missingInHCL []string
+			for f := range goFamilies {
+				if _, ok := hclFamilies[f]; !ok {
+					missingInHCL = append(missingInHCL, f)
+				}
+			}
+
+			sort.Strings(missingInGo)
+			sort.Strings(missingInHCL)
+			if len(missingInGo) > 0 {
+				t.Errorf("families in %s _gpu_bundled_machine_families but missing from gpuBundledMachineFamilies (gpu_gcp.go): %v", src.path, missingInGo)
+			}
+			if len(missingInHCL) > 0 {
+				t.Errorf("families in gpuBundledMachineFamilies (gpu_gcp.go) but missing from %s _gpu_bundled_machine_families: %v", src.path, missingInHCL)
+			}
+		})
+	}
+}
+
+// parseGCPBundledFamiliesHCL extracts the quoted family strings from the
+// `_gpu_bundled_machine_families = [ ... ]` local assignment, mirroring
+// parseGPUFamiliesHCL (the AWS analogue). It isolates the bracketed list body,
+// strips inline `#` comments, then pulls every double-quoted token so reordering
+// or reflowing the HCL doesn't affect the result.
+func parseGCPBundledFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
+	t.Helper()
+	listRe := regexp.MustCompile(`(?s)_gpu_bundled_machine_families\s*=\s*\[(.*?)\]`)
+	m := listRe.FindStringSubmatch(hcl)
+	if m == nil {
+		t.Fatalf("could not locate `_gpu_bundled_machine_families = [...]` in main.tf")
+	}
+	body := stripHCLLineComments(m[1])
+	tokenRe := regexp.MustCompile(`"([^"]+)"`)
+	out := map[string]struct{}{}
+	for _, tm := range tokenRe.FindAllStringSubmatch(body, -1) {
+		out[strings.TrimSpace(tm[1])] = struct{}{}
+	}
+	return out
+}

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -953,6 +953,28 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.GCPCompute.DiskSizeGb > 0 {
 				vals["disk_size_gb"] = cfg.GCPCompute.DiskSizeGb
 			}
+			// GPU instance (#767): VALIDATE, don't mask. Either GPUType or
+			// GPUCount signals "attach a GPU". GCP only attaches GPUs via
+			// guest_accelerator on N1 machines; A2/A3/A4/G2/G4 bundle their GPU
+			// with the machine type, and every other family takes none. Reject
+			// an incompatible machine type at compose time, and emit the GPU
+			// tfvars so the preset attaches the accelerator AND forces
+			// on_host_maintenance=TERMINATE (GCP rejects MIGRATE with a GPU).
+			if cfg.GCPCompute.GPUType != "" || cfg.GCPCompute.GPUCount > 0 {
+				if err := validateGCPGPU("GCPCompute", cfg.GCPCompute.MachineType, cfg.GCPCompute.GPUType); err != nil {
+					return nil, err
+				}
+				gpuType := cfg.GCPCompute.GPUType
+				if gpuType == "" {
+					gpuType = defaultGCPAccelerator
+				}
+				gpuCount := cfg.GCPCompute.GPUCount
+				if gpuCount <= 0 {
+					gpuCount = defaultGCPGPUCount
+				}
+				vals["gpu_type"] = gpuType
+				vals["gpu_count"] = gpuCount
+			}
 		}
 
 	case KeyGCPGKE:
@@ -972,6 +994,26 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 			if cfg.GCPGKE.Regional != nil {
 				vals["regional"] = *cfg.GCPGKE.Regional
+			}
+			// GPU node pool (#767): VALIDATE, don't mask. Same N1-attachable vs
+			// bundled-family rule as gcp_compute. When a GPU is requested, emit
+			// the accelerator tfvars; the preset wires them into the node pool's
+			// accelerator config and turns on GKE auto NVIDIA driver install (no
+			// in-cluster device-plugin work, unlike EKS).
+			if cfg.GCPGKE.GPUType != "" || cfg.GCPGKE.GPUCount > 0 {
+				if err := validateGCPGPU("GCPGKE", cfg.GCPGKE.MachineType, cfg.GCPGKE.GPUType); err != nil {
+					return nil, err
+				}
+				gpuType := cfg.GCPGKE.GPUType
+				if gpuType == "" {
+					gpuType = defaultGCPAccelerator
+				}
+				gpuCount := cfg.GCPGKE.GPUCount
+				if gpuCount <= 0 {
+					gpuCount = defaultGCPGPUCount
+				}
+				vals["gpu_type"] = gpuType
+				vals["gpu_count"] = gpuCount
 			}
 		}
 

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -954,17 +954,19 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["disk_size_gb"] = cfg.GCPCompute.DiskSizeGb
 			}
 			// GPU instance (#767): VALIDATE, don't mask. Either GPUType or
-			// GPUCount signals "attach a GPU". GCP only attaches GPUs via
-			// guest_accelerator on N1 machines; A2/A3/A4/G2/G4 bundle their GPU
-			// with the machine type, and every other family takes none. Reject
-			// an incompatible machine type at compose time, and emit the GPU
-			// tfvars so the preset attaches the accelerator AND forces
-			// on_host_maintenance=TERMINATE (GCP rejects MIGRATE with a GPU).
+			// GPUCount signals "attach a GPU". On a Compute Engine VM, GCP only
+			// attaches GPUs via guest_accelerator on N1 machines; A2/A3/A4/G2/G4
+			// attach their GPU automatically by machine type (an explicit
+			// guest_accelerator is invalid there) and every other family takes
+			// none. Reject an incompatible machine type at compose time, and emit
+			// the GPU tfvars (canonical lower-case type) so the preset attaches
+			// the accelerator AND forces on_host_maintenance=TERMINATE (GCP rejects
+			// MIGRATE with a GPU).
 			if cfg.GCPCompute.GPUType != "" || cfg.GCPCompute.GPUCount > 0 {
-				if err := validateGCPGPU("GCPCompute", cfg.GCPCompute.MachineType, cfg.GCPCompute.GPUType); err != nil {
+				if err := validateGCPComputeGPU(cfg.GCPCompute.MachineType, cfg.GCPCompute.GPUType, cfg.GCPCompute.GPUCount); err != nil {
 					return nil, err
 				}
-				gpuType := cfg.GCPCompute.GPUType
+				gpuType := normalizeGPUType(cfg.GCPCompute.GPUType)
 				if gpuType == "" {
 					gpuType = defaultGCPAccelerator
 				}
@@ -995,18 +997,21 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.GCPGKE.Regional != nil {
 				vals["regional"] = *cfg.GCPGKE.Regional
 			}
-			// GPU node pool (#767): VALIDATE, don't mask. Same N1-attachable vs
-			// bundled-family rule as gcp_compute. When a GPU is requested, emit
-			// the accelerator tfvars; the preset wires them into the node pool's
-			// accelerator config and turns on GKE auto NVIDIA driver install (no
-			// in-cluster device-plugin work, unlike EKS).
+			// GPU node pool (#767, #752 review): VALIDATE, don't mask. Unlike a
+			// Compute VM, a GKE node pool DECLARES the accelerator even for the
+			// accelerator-optimized families — g2 pairs with nvidia-l4, a2 with
+			// nvidia-tesla-a100, a3 with nvidia-h100-80gb, etc. — and N1 attaches
+			// the T4/V100/P100/P4 accelerators. When a GPU is requested, emit the
+			// accelerator tfvars (canonical lower-case type); the preset wires them
+			// into the node pool's accelerator config and turns on GKE auto NVIDIA
+			// driver install (no in-cluster device-plugin work, unlike EKS).
 			if cfg.GCPGKE.GPUType != "" || cfg.GCPGKE.GPUCount > 0 {
-				if err := validateGCPGPU("GCPGKE", cfg.GCPGKE.MachineType, cfg.GCPGKE.GPUType); err != nil {
+				if err := validateGCPGKEGPU(cfg.GCPGKE.MachineType, cfg.GCPGKE.GPUType, cfg.GCPGKE.GPUCount); err != nil {
 					return nil, err
 				}
-				gpuType := cfg.GCPGKE.GPUType
+				gpuType := normalizeGPUType(cfg.GCPGKE.GPUType)
 				if gpuType == "" {
-					gpuType = defaultGCPAccelerator
+					gpuType = defaultGKEGPUType(cfg.GCPGKE.MachineType)
 				}
 				gpuCount := cfg.GCPGKE.GPUCount
 				if gpuCount <= 0 {

--- a/pkg/composer/mapper_gcp_gpu_test.go
+++ b/pkg/composer/mapper_gcp_gpu_test.go
@@ -38,13 +38,13 @@ func TestBuildModuleValues_GCPCompute_GPU(t *testing.T) {
 		assert.Equal(t, 4, vals["gpu_count"])
 	})
 
-	t.Run("capitalised + padded GPUType normalizes and is accepted", func(t *testing.T) {
+	t.Run("capitalised + padded GPUType normalizes and is emitted canonical", func(t *testing.T) {
 		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "  NVIDIA-Tesla-T4  "})
 		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
 		require.NoError(t, err)
-		// The mapper passes the user's literal through to HCL; validation
-		// normalizes case/whitespace before the allow-list check.
-		assert.Equal(t, "  NVIDIA-Tesla-T4  ", vals["gpu_type"])
+		// The mapper emits the canonical (lower-cased, trimmed) form so the
+		// composed HCL is the type string GCP expects (#752 review, P2-2).
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"])
 	})
 
 	t.Run("no GPU leaves gpu_type/gpu_count unset", func(t *testing.T) {
@@ -58,18 +58,28 @@ func TestBuildModuleValues_GCPCompute_GPU(t *testing.T) {
 		assert.Equal(t, "e2-medium", vals["machine_type"], "non-GPU fields unchanged")
 	})
 
-	t.Run("bundled-GPU machine (G2) with explicit GPUType is rejected", func(t *testing.T) {
+	t.Run("bundled-GPU machine (G2) with explicit GPUType is rejected on a VM", func(t *testing.T) {
+		// On a Compute VM the GPU is attached automatically by the machine type,
+		// so an explicit guest_accelerator is invalid (unlike GKE — see the GKE
+		// test below where the same family is ACCEPTED).
 		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "g2-standard-4", GPUType: "nvidia-l4"})
 		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+		assert.Contains(t, err.Error(), "attaches its GPU automatically")
 	})
 
-	t.Run("bundled-GPU machine (A2) with explicit GPUType is rejected", func(t *testing.T) {
+	t.Run("bundled-GPU machine (A2) with explicit GPUType is rejected on a VM", func(t *testing.T) {
 		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "a2-highgpu-1g", GPUType: "nvidia-tesla-a100"})
 		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+		assert.Contains(t, err.Error(), "attaches its GPU automatically")
+	})
+
+	t.Run("invalid GPUCount on N1 is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4", GPUCount: 3})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid GCP accelerator count")
 	})
 
 	t.Run("non-N1 non-bundled machine (E2) with a GPU is rejected", func(t *testing.T) {
@@ -95,8 +105,10 @@ func TestBuildModuleValues_GCPCompute_GPU(t *testing.T) {
 }
 
 // TestBuildModuleValues_GCPGKE_GPU exercises the gcp_gke GPU mapper branch
-// (#767): same N1-attachable-vs-bundled rule as gcp_compute, applied to the node
-// pool accelerator config.
+// (#767, #752 review). Unlike gcp_compute, a GKE node pool DECLARES the
+// accelerator even for the accelerator-optimized families, so the bundled
+// families (G2/A2/A3/...) are ACCEPTED here (paired with their GPU type), not
+// rejected — while N1 attaches the T4/V100/P100/P4 accelerators.
 func TestBuildModuleValues_GCPGKE_GPU(t *testing.T) {
 	m := DefaultMapper{}
 
@@ -137,11 +149,40 @@ func TestBuildModuleValues_GCPGKE_GPU(t *testing.T) {
 		assert.False(t, hasCount, "non-GPU node pool must not set gpu_count")
 	})
 
-	t.Run("bundled-GPU machine (A3) with explicit GPUType is rejected", func(t *testing.T) {
-		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "a3-highgpu-8g", GPUType: "nvidia-h100-80gb"})
+	t.Run("bundled-GPU machine (G2) with matching GPUType is accepted", func(t *testing.T) {
+		// The #752 review fix: G2 is a valid GKE GPU node pool (paired with
+		// nvidia-l4), where the same config is rejected on a Compute VM.
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "g2-standard-4", GPUType: "nvidia-l4", GPUCount: 1})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-l4", vals["gpu_type"])
+		assert.Equal(t, 1, vals["gpu_count"])
+	})
+
+	t.Run("bundled-GPU machine (A3) with matching GPUType is accepted", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "a3-highgpu-8g", GPUType: "nvidia-h100-80gb", GPUCount: 8})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-h100-80gb", vals["gpu_type"])
+		assert.Equal(t, 8, vals["gpu_count"])
+	})
+
+	t.Run("bundled-GPU machine (G2) with no GPUType defaults to family accelerator", func(t *testing.T) {
+		// GPUCount alone signals GPU intent; the mapper defaults the type to the
+		// family's bundled accelerator (nvidia-l4 for G2), not the N1 T4 default.
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "g2-standard-4", GPUCount: 2})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-l4", vals["gpu_type"], "G2 with no GPUType must default to its bundled nvidia-l4")
+		assert.Equal(t, 2, vals["gpu_count"])
+	})
+
+	t.Run("bundled-GPU machine (G2) with mismatched GPUType is rejected", func(t *testing.T) {
+		// nvidia-tesla-a100 is an A2 accelerator — wrong pairing for G2.
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "g2-standard-4", GPUType: "nvidia-tesla-a100"})
 		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+		assert.Contains(t, err.Error(), "does not pair with machine_type")
 	})
 
 	t.Run("non-N1 non-bundled machine with a GPU is rejected", func(t *testing.T) {
@@ -156,5 +197,19 @@ func TestBuildModuleValues_GCPGKE_GPU(t *testing.T) {
 		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not a known N1-attachable NVIDIA accelerator")
+	})
+
+	t.Run("invalid GPUCount is rejected", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4", GPUCount: 5})
+		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid GCP accelerator count")
+	})
+
+	t.Run("capitalised + padded GPUType normalizes and is emitted canonical", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", GPUType: "  NVIDIA-Tesla-T4  "})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"], "GKE must emit the canonical lower-cased type (#752 review, P2-2)")
 	})
 }

--- a/pkg/composer/mapper_gcp_gpu_test.go
+++ b/pkg/composer/mapper_gcp_gpu_test.go
@@ -1,0 +1,160 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildModuleValues_GCPCompute_GPU exercises the gcp_compute GPU mapper
+// branch (#767): partial-config defaulting and rejection-with-content. The
+// preset forces on_host_maintenance=TERMINATE by construction, so the mapper
+// only emits gpu_type / gpu_count.
+func TestBuildModuleValues_GCPCompute_GPU(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("explicit GPUType on N1 emits gpu_type + default count", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4"})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"])
+		assert.Equal(t, 1, vals["gpu_count"], "GPUType with no count must default to 1")
+	})
+
+	t.Run("GPUCount only on N1 defaults the accelerator type", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-8", GPUCount: 2})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"], "GPUCount with no type must default to nvidia-tesla-t4")
+		assert.Equal(t, 2, vals["gpu_count"])
+	})
+
+	t.Run("explicit GPUType + GPUCount preserved", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-v100", GPUCount: 4})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-v100", vals["gpu_type"])
+		assert.Equal(t, 4, vals["gpu_count"])
+	})
+
+	t.Run("capitalised + padded GPUType normalizes and is accepted", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "  NVIDIA-Tesla-T4  "})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		// The mapper passes the user's literal through to HCL; validation
+		// normalizes case/whitespace before the allow-list check.
+		assert.Equal(t, "  NVIDIA-Tesla-T4  ", vals["gpu_type"])
+	})
+
+	t.Run("no GPU leaves gpu_type/gpu_count unset", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "e2-medium", DiskSizeGb: 50})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasType := vals["gpu_type"]
+		_, hasCount := vals["gpu_count"]
+		assert.False(t, hasType, "non-GPU compute must not set gpu_type")
+		assert.False(t, hasCount, "non-GPU compute must not set gpu_count")
+		assert.Equal(t, "e2-medium", vals["machine_type"], "non-GPU fields unchanged")
+	})
+
+	t.Run("bundled-GPU machine (G2) with explicit GPUType is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "g2-standard-4", GPUType: "nvidia-l4"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+	})
+
+	t.Run("bundled-GPU machine (A2) with explicit GPUType is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "a2-highgpu-1g", GPUType: "nvidia-tesla-a100"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+	})
+
+	t.Run("non-N1 non-bundled machine (E2) with a GPU is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "e2-standard-4", GPUType: "nvidia-tesla-t4"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not accept one")
+	})
+
+	t.Run("GPU with no machine type is rejected (preset default is non-N1)", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{GPUType: "nvidia-tesla-t4"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not accept one")
+	})
+
+	t.Run("unknown accelerator type on N1 is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-l4"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a known N1-attachable NVIDIA accelerator")
+	})
+}
+
+// TestBuildModuleValues_GCPGKE_GPU exercises the gcp_gke GPU mapper branch
+// (#767): same N1-attachable-vs-bundled rule as gcp_compute, applied to the node
+// pool accelerator config.
+func TestBuildModuleValues_GCPGKE_GPU(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("explicit GPUType on N1 emits gpu_type + default count", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4"})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"])
+		assert.Equal(t, 1, vals["gpu_count"])
+	})
+
+	t.Run("GPUCount only on N1 defaults the accelerator type", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-8", GPUCount: 2})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"])
+		assert.Equal(t, 2, vals["gpu_count"])
+	})
+
+	t.Run("GPU config coexists with node_count and regional", func(t *testing.T) {
+		f := false
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", NodeCount: "3", Regional: &f, GPUType: "nvidia-tesla-p100", GPUCount: 1})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-p100", vals["gpu_type"])
+		assert.Equal(t, 1, vals["gpu_count"])
+		assert.Equal(t, 3, vals["node_count"], "non-GPU fields still map")
+		assert.Equal(t, false, vals["regional"])
+	})
+
+	t.Run("no GPU leaves gpu_type/gpu_count unset", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "e2-standard-4", NodeCount: "1"})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasType := vals["gpu_type"]
+		_, hasCount := vals["gpu_count"]
+		assert.False(t, hasType, "non-GPU node pool must not set gpu_type")
+		assert.False(t, hasCount, "non-GPU node pool must not set gpu_count")
+	})
+
+	t.Run("bundled-GPU machine (A3) with explicit GPUType is rejected", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "a3-highgpu-8g", GPUType: "nvidia-h100-80gb"})
+		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+	})
+
+	t.Run("non-N1 non-bundled machine with a GPU is rejected", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n2-standard-4", GPUType: "nvidia-tesla-t4"})
+		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not accept one")
+	})
+
+	t.Run("unknown accelerator type on N1 is rejected", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-h100-80gb"})
+		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a known N1-attachable NVIDIA accelerator")
+	})
+}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -226,16 +226,24 @@ func kitchenSinkConfig() *Config {
 	}{DomainName: "example.com", SubjectAlternativeNames: []string{"www.example.com"}, KeyAlgorithm: "RSA_2048", CertificateTransparencyLogging: "ENABLED", CreateValidation: &t, ValidationTimeout: "45m"}
 
 	// GCP
+	// GPU fields set on N1 machines so the kitchen-sink stays internally
+	// consistent with the #767 GPU machine-type validation (a GPU on an e2/g2
+	// machine would be rejected). This also exercises the gpu_type/gpu_count
+	// keys through the subset gate.
 	cfg.GCPCompute = &struct {
 		NumServers  string `json:"numServers,omitempty"`
 		MachineType string `json:"machineType,omitempty"`
 		DiskSizeGb  int    `json:"diskSizeGb,omitempty"`
-	}{NumServers: "1", MachineType: "e2-medium", DiskSizeGb: 50}
+		GPUType     string `json:"gpuType,omitempty"`
+		GPUCount    int    `json:"gpuCount,omitempty"`
+	}{NumServers: "1", MachineType: "n1-standard-4", DiskSizeGb: 50, GPUType: "nvidia-tesla-t4", GPUCount: 1}
 	cfg.GCPGKE = &struct {
 		Regional    *bool  `json:"regional,omitempty"`
 		NodeCount   string `json:"nodeCount,omitempty"`
 		MachineType string `json:"machineType,omitempty"`
-	}{Regional: &t, NodeCount: "3", MachineType: "e2-standard-2"}
+		GPUType     string `json:"gpuType,omitempty"`
+		GPUCount    int    `json:"gpuCount,omitempty"`
+	}{Regional: &t, NodeCount: "3", MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4", GPUCount: 1}
 	cfg.GCPCloudSQL = &struct {
 		Tier             string `json:"tier,omitempty"`
 		DiskSizeGb       int    `json:"diskSizeGb,omitempty"`

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -339,12 +339,28 @@ type Config struct {
 		NumServers  string `json:"numServers,omitempty"`
 		MachineType string `json:"machineType,omitempty"`
 		DiskSizeGb  int    `json:"diskSizeGb,omitempty"`
+		// GPU attachment (#767). GPUType is an NVIDIA accelerator type that
+		// attaches to an N1 machine via guest_accelerator (e.g. nvidia-tesla-t4);
+		// GPUCount is how many. Either field signals "attach a GPU" — the mapper
+		// fills the other from a default and forces on_host_maintenance=TERMINATE.
+		// Only N1 machines accept attached GPUs; A2/A3/A4/G2/G4 bundle their GPU
+		// with the machine type, so setting GPUType there is rejected.
+		GPUType  string `json:"gpuType,omitempty"`
+		GPUCount int    `json:"gpuCount,omitempty"`
 	} `json:"gcp_compute,omitempty"`
 
 	GCPGKE *struct {
 		Regional    *bool  `json:"regional,omitempty"`
 		NodeCount   string `json:"nodeCount,omitempty"`
 		MachineType string `json:"machineType,omitempty"`
+		// GPU node pool (#767). GPUType is an NVIDIA accelerator type that
+		// attaches to an N1 node machine via the node pool's accelerator config
+		// (e.g. nvidia-tesla-t4); GPUCount is per-node. Either field signals "GPU
+		// node pool" — the mapper fills the other from a default and enables GKE
+		// auto driver install. Only N1 node machines accept attached accelerators;
+		// A2/A3/A4/G2/G4 bundle their GPU, so setting GPUType there is rejected.
+		GPUType  string `json:"gpuType,omitempty"`
+		GPUCount int    `json:"gpuCount,omitempty"`
 	} `json:"gcp_gke,omitempty"`
 
 	GCPCloudSQL *struct {

--- a/pkg/composer/types_test.go
+++ b/pkg/composer/types_test.go
@@ -135,6 +135,8 @@ func TestConfig_Normalize_ClearsGCPFieldsForAWS(t *testing.T) {
 			Regional    *bool  `json:"regional,omitempty"`
 			NodeCount   string `json:"nodeCount,omitempty"`
 			MachineType string `json:"machineType,omitempty"`
+			GPUType     string `json:"gpuType,omitempty"`
+			GPUCount    int    `json:"gpuCount,omitempty"`
 		}{
 			NodeCount: "3",
 		},


### PR DESCRIPTION
Closes #752. Part of #756.

- gke node pool: guest_accelerator (type/count) + driver auto-install + machine-family compatibility preconditions
- compute: guest_accelerator + TERMINATE scheduling precondition (GCP rejects MIGRATE with GPUs)
- composer: GPU fields on Config.GCPGKE/GCPCompute, validate-dont-mask per the #759 pattern
- Verification: CI runs the full tftest matrix + go suite (local heavy checks skipped per operator request — laptop thermal limits); implementation completed targeted tests before interruption
- QC note: internal review round was interrupted — external review (Codex) to follow on the PR diff before merge
- Live GCP validation deferred (no GCP creds session); TPU deferred unless trivial (see PR diff)