### PR TITLE
feat(agent_engine): new gcp_agent_engine component — Vertex AI Agent Engine (#769)

### DIFF
--- a/gcp/agent_engine/main.tf
+++ b/gcp/agent_engine/main.tf
@@ -1,0 +1,119 @@
+# GCP Vertex AI Agent Engine (Reasoning Engine) — issue #769.
+#
+# The managed runtime for ADK / custom agents on Vertex AI. GCP counterpart of
+# aws_bedrock_agent (#762). A single google_vertex_ai_reasoning_engine is the
+# whole preset surface — there is no separate alias / action-group machinery as
+# on Bedrock; the deployable unit is the engine + its packaged artifact spec.
+#
+# Packaged artifact is app-layer (the "Gotcha" in #769):
+#   The engine runs a packaged Python object (a pickled agent) that the
+#   application build stages into a GCS bucket — typically the wired staging
+#   bucket — as `spec.package_spec.pickle_object_gcs_uri`. This preset does NOT
+#   build or upload that artifact; it only VALIDATES that the reference is
+#   present. The provider marks pickle_object_gcs_uri as OPTIONAL (a source-code
+#   / container deploy is the alternative), so a bare engine with no artifact
+#   would plan clean and then fail opaquely at apply / first-invocation. The
+#   preset closes that hole with a fail-loud precondition: package_artifact_uri
+#   MUST be a gs:// URI, surfaced at plan time rather than as a runtime 400.
+#
+# Networking: PUBLIC by default. The Reasoning Engine reaches private resources
+# only via a PSC-Interface network attachment (spec.deployment_spec.
+# psc_interface_config) that gcp/vpc does not provision today — so, like
+# gcp/vertex_ai's private endpoint, that path is deliberately out of scope here
+# and the default composed engine is public. No VPC is a hard dependency.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      # google_vertex_ai_reasoning_engine landed in the hashicorp/google
+      # provider at v7.6.0 (verified absent in 7.5.0, present in 7.6.0). The
+      # composed root provider pin is supplied by the caller / composer; this
+      # floor documents the minimum the resource type requires.
+      version = ">= 7.6"
+    }
+  }
+}
+
+locals {
+  # Default the engine's display name to the stack prefix so a bare compose
+  # still produces a uniquely-named, attributable engine. var.display_name
+  # overrides for a human-friendly label.
+  engine_display_name = var.display_name == null ? "${var.project}-agent-engine" : var.display_name
+}
+
+# The Reasoning Engine. Unconditional (no count / for_each gate) so the preset
+# always produces plan-time infrastructure — TestEveryPresetHasUnconditional
+# Resource and the all-gated-preset guard (#253) both require this.
+resource "google_vertex_ai_reasoning_engine" "this" {
+  project      = var.project_id
+  region       = var.region
+  display_name = local.engine_display_name
+  description  = "InsideOut Vertex AI Agent Engine for ${var.project}."
+
+  spec {
+    # The packaged agent artifact (app-layer). pickle_object_gcs_uri is the
+    # pickled Python object; requirements / dependency files are optional
+    # companions. The preset only wires the references through — it never
+    # builds them.
+    package_spec {
+      pickle_object_gcs_uri    = var.package_artifact_uri
+      requirements_gcs_uri     = var.requirements_uri
+      dependency_files_gcs_uri = var.dependency_files_uri
+      python_version           = var.python_version
+    }
+  }
+
+  # CMEK: encrypt the engine and all its sub-resources with a caller-supplied
+  # Cloud KMS key when set. Null disables CMEK (Google-managed encryption).
+  dynamic "encryption_spec" {
+    for_each = var.encryption_kms_key_name == null ? [] : [var.encryption_kms_key_name]
+    content {
+      kms_key_name = encryption_spec.value
+    }
+  }
+
+  # google_vertex_ai_reasoning_engine is not yet in this repo's typed import
+  # registry (it requires google provider 7.6+; the schema/codegen pin is
+  # 6.10), so it is intentionally absent from the LABEL_CAPABLE_GCP lint
+  # allowlists. Setting labels here is still correct and propagates the Project
+  # identity to the inspector; name-prefix scoping (display_name carries
+  # var.project) is the attribution path the labelless-name-prefix lint checks.
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+
+  lifecycle {
+    # Fail-loud guard: the engine needs a packaged artifact to be useful, but
+    # the provider leaves pickle_object_gcs_uri optional (source-code/container
+    # deploys are the alternative this preset does not surface). Without this
+    # precondition a missing artifact plans clean and then fails opaquely at
+    # apply / first invocation. A per-variable validation can only see its own
+    # variable; this lives on the resource so the failure is attributed to the
+    # engine that needs it.
+    precondition {
+      condition     = var.package_artifact_uri != null && can(regex("^gs://", var.package_artifact_uri))
+      error_message = "package_artifact_uri must be a gs:// URI pointing at the packaged agent object (e.g. gs://<staging-bucket>/agent_engine/agent.pkl). The artifact is built and uploaded by the application layer; this preset only validates the reference."
+    }
+
+    # Cross-variable invariant: when both the staging bucket and the artifact
+    # URI are wired, the artifact must live UNDER that bucket. Catches a stale
+    # / mismatched artifact URI pointing at a different bucket than the one the
+    # stack provisions. Skipped when staging_bucket is null (standalone preview
+    # with a caller-supplied absolute artifact URI). The package_artifact_uri
+    # null-guard keeps this precondition from erroring on a null argument to
+    # startswith — the missing-artifact case is already reported by the
+    # precondition above, and Terraform evaluates every precondition.
+    precondition {
+      condition = var.staging_bucket == null || var.package_artifact_uri == null || (
+        startswith(var.package_artifact_uri, "${trimsuffix(var.staging_bucket, "/")}/")
+      )
+      error_message = "package_artifact_uri must live under staging_bucket. Got artifact=\"${coalesce(var.package_artifact_uri, "<null>")}\" staging_bucket=\"${coalesce(var.staging_bucket, "<null>")}\". Stage the packaged object inside the wired bucket, or clear staging_bucket to use an absolute artifact URI."
+    }
+  }
+}

--- a/gcp/agent_engine/observability.tf
+++ b/gcp/agent_engine/observability.tf
@@ -1,0 +1,44 @@
+# observability.tf — issue #204 / #769
+#
+# Declares the standard per-component observability wiring surface
+# (enable_observability + notification_channels + severity/threshold knobs) so
+# the contract matches the other GCP presets and any future Cloud Monitoring
+# wiring binds cleanly.
+#
+# NO alert policy is emitted yet. Vertex AI Agent Engine (Reasoning Engine) has
+# no catalog-registered Cloud Monitoring metric in this repo — emitting a
+# google_monitoring_alert_policy against an unverified metric type would page on
+# a filter that never matches (or worse, silently never fires). Per the #769
+# guard "no alarms unless catalog-registered", this stays var-only until a
+# verified Reasoning Engine serving metric is added to the catalog. The preset
+# is therefore intentionally NOT listed in PricingDependencies[gcp_cloud_
+# monitoring] (no emitter to wire), mirroring gcp/vertex_ai's dataset-only path.
+
+variable "enable_observability" {
+  description = "When true, emit per-component Cloud Monitoring alert policies (issue #204). No-op today — the Reasoning Engine has no catalog-registered metric yet."
+  type        = bool
+  default     = true
+}
+
+variable "notification_channels" {
+  description = "Cloud Monitoring notification channel names alert policies would page. Unused until a Reasoning Engine alarm is catalog-registered."
+  type        = list(string)
+  default     = []
+}
+
+variable "alarm_severity" {
+  description = "Severity tag that would be attached to alert policies."
+  type        = string
+  default     = "warning"
+
+  validation {
+    condition     = contains(["critical", "warning", "info"], var.alarm_severity)
+    error_message = "alarm_severity must be one of critical|warning|info."
+  }
+}
+
+variable "alarm_threshold_overrides" {
+  description = "Per-metric numeric threshold overrides for future alert policies."
+  type        = map(number)
+  default     = {}
+}

--- a/gcp/agent_engine/outputs.tf
+++ b/gcp/agent_engine/outputs.tf
@@ -1,0 +1,19 @@
+output "reasoning_engine_id" {
+  description = "The resource ID of the Vertex AI Reasoning Engine."
+  value       = google_vertex_ai_reasoning_engine.this.id
+}
+
+output "reasoning_engine_name" {
+  description = "The full generated resource name of the Reasoning Engine (projects/<project>/locations/<region>/reasoningEngines/<id>)."
+  value       = google_vertex_ai_reasoning_engine.this.name
+}
+
+output "reasoning_engine_display_name" {
+  description = "The display name of the Reasoning Engine."
+  value       = google_vertex_ai_reasoning_engine.this.display_name
+}
+
+output "region" {
+  description = "The region the Reasoning Engine is deployed in."
+  value       = google_vertex_ai_reasoning_engine.this.region
+}

--- a/gcp/agent_engine/tests/shape.tftest.hcl
+++ b/gcp/agent_engine/tests/shape.tftest.hcl
@@ -1,0 +1,277 @@
+mock_provider "google" {}
+
+# Issue #769 (gcp/agent_engine — Vertex AI Agent Engine / Reasoning Engine)
+# shape tests. Verifies that:
+#   - A valid artifact URI composes exactly one reasoning engine, flows the
+#     packaged-artifact spec through, defaults the display name to the project
+#     prefix, and carries the project label.
+#   - The fail-loud precondition rejects a missing / non-gs:// artifact URI at
+#     plan time (the artifact is app-layer; the preset validates the reference).
+#   - The cross-variable staging_bucket-membership precondition rejects an
+#     artifact that lives outside the wired staging bucket.
+#   - Optional knobs (requirements/dependency URIs, python_version, CMEK,
+#     display_name override) flow through, and the validations reject obvious
+#     misconfigurations at plan time.
+#
+# Reader note: a run whose resource PRECONDITION fails (e.g. the missing- or
+# outside-bucket-artifact cases) aborts the file, so any run listed AFTER it
+# reports `skip`, not `pass`. The expect_failures runs are grouped last so this
+# ordering never masks a positive-path assertion — but if you see `skip`s
+# trailing a red run, the first hard failure above is the cause to read.
+
+run "defaults_compose_engine" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent_engine/agent.pkl"
+  }
+
+  # Display name defaults to the project-prefixed form (name-prefix scoping —
+  # the labelless-name-prefix attribution path for this label-less-in-registry
+  # resource). The engine is unconditional (no count/for_each), so it is
+  # referenced directly; a clean plan IS the "exactly one composes" assertion.
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.display_name == "test-agent-engine"
+    error_message = "display_name must default to \"<project>-agent-engine\"."
+  }
+
+  # Project is pinned to the real GCP project ID (#287 project-split).
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.project == "test-project"
+    error_message = "engine must pin project = var.project_id."
+  }
+
+  # The packaged artifact URI reaches spec.package_spec.pickle_object_gcs_uri.
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.spec[0].package_spec[0].pickle_object_gcs_uri == "gs://test-bucket/agent_engine/agent.pkl"
+    error_message = "package_artifact_uri must reach spec.package_spec.pickle_object_gcs_uri."
+  }
+
+  # The project label carries var.project (inspector grouping), not project_id.
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.labels["project"] == "test"
+    error_message = "engine must carry the project = var.project label."
+  }
+
+  # CMEK off by default -> no encryption_spec block.
+  assert {
+    condition     = length(google_vertex_ai_reasoning_engine.this.encryption_spec) == 0
+    error_message = "encryption_spec must be absent when no CMEK key is supplied."
+  }
+}
+
+run "display_name_override" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent_engine/agent.pkl"
+    display_name         = "my-custom-agent"
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.display_name == "my-custom-agent"
+    error_message = "display_name override must win over the project-prefixed default."
+  }
+}
+
+run "staging_bucket_membership_ok_trailing_slash" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    # Staging bucket carries a TRAILING SLASH and the artifact lives under it.
+    # This exercises the membership precondition's trimsuffix(staging_bucket,
+    # "/") normalization specifically: without the trimsuffix the prefix would
+    # be "gs://test-bucket//" and this valid artifact would be wrongly
+    # rejected. A clean plan here is the assertion (the precondition holds);
+    # the region passthrough is asserted as a concrete membership-branch marker
+    # distinct from the URI flow-through covered in defaults_compose_engine.
+    staging_bucket       = "gs://test-bucket/"
+    package_artifact_uri = "gs://test-bucket/agent_engine/agent.pkl"
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.region == "us-central1"
+    error_message = "engine must compose (membership precondition holds) when staging_bucket has a trailing slash and the artifact lives under it."
+  }
+}
+
+run "optional_spec_fields_flow_through" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent_engine/agent.pkl"
+    requirements_uri     = "gs://test-bucket/agent_engine/requirements.txt"
+    dependency_files_uri = "gs://test-bucket/agent_engine/deps.tar.gz"
+    python_version       = "3.12"
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.spec[0].package_spec[0].requirements_gcs_uri == "gs://test-bucket/agent_engine/requirements.txt"
+    error_message = "requirements_uri must reach spec.package_spec.requirements_gcs_uri."
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.spec[0].package_spec[0].dependency_files_gcs_uri == "gs://test-bucket/agent_engine/deps.tar.gz"
+    error_message = "dependency_files_uri must reach spec.package_spec.dependency_files_gcs_uri."
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.spec[0].package_spec[0].python_version == "3.12"
+    error_message = "python_version must reach spec.package_spec.python_version."
+  }
+}
+
+run "cmek_encryption_spec_emitted" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    package_artifact_uri    = "gs://test-bucket/agent_engine/agent.pkl"
+    encryption_kms_key_name = "projects/test-project/locations/us-central1/keyRings/kr/cryptoKeys/ck"
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_reasoning_engine.this.encryption_spec) == 1
+    error_message = "encryption_spec must be emitted when a CMEK key is supplied."
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.encryption_spec[0].kms_key_name == "projects/test-project/locations/us-central1/keyRings/kr/cryptoKeys/ck"
+    error_message = "CMEK key must flow through to encryption_spec.kms_key_name."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Fail-loud: the packaged-artifact reference is mandatory even though the
+# provider leaves pickle_object_gcs_uri optional.
+# -----------------------------------------------------------------------------
+
+run "rejects_missing_artifact_uri" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    # package_artifact_uri left at its null default — the resource precondition
+    # must fail loudly at plan time.
+  }
+
+  expect_failures = [google_vertex_ai_reasoning_engine.this]
+}
+
+run "rejects_non_gcs_artifact_uri" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "s3://wrong/scheme/agent.pkl"
+  }
+
+  # Variable-level validation rejects the non-gs:// scheme first.
+  expect_failures = [var.package_artifact_uri]
+}
+
+run "rejects_artifact_outside_staging_bucket" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    # Artifact in a DIFFERENT bucket than the wired staging bucket — the
+    # cross-variable membership precondition must fail.
+    staging_bucket       = "gs://stack-bucket"
+    package_artifact_uri = "gs://some-other-bucket/agent.pkl"
+  }
+
+  expect_failures = [google_vertex_ai_reasoning_engine.this]
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: variable validations reject obvious misconfigurations.
+# -----------------------------------------------------------------------------
+
+run "rejects_invalid_python_version" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+    python_version       = "2.7"
+  }
+
+  expect_failures = [var.python_version]
+}
+
+run "rejects_non_gcs_requirements_uri" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+    requirements_uri     = "https://example.com/requirements.txt"
+  }
+
+  expect_failures = [var.requirements_uri]
+}
+
+run "rejects_non_gcs_staging_bucket" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+    staging_bucket       = "test-bucket"
+  }
+
+  expect_failures = [var.staging_bucket]
+}
+
+run "rejects_empty_project" {
+  command = plan
+
+  variables {
+    project              = ""
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+  }
+
+  expect_failures = [var.project]
+}
+
+run "rejects_invalid_project_id" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "BadProjectID"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+  }
+
+  expect_failures = [var.project_id]
+}
+
+run "rejects_invalid_alarm_severity" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+    alarm_severity       = "fatal"
+  }
+
+  expect_failures = [var.alarm_severity]
+}

--- a/gcp/agent_engine/variables.tf
+++ b/gcp/agent_engine/variables.tf
@@ -1,0 +1,102 @@
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+variable "region" {
+  description = "GCP region for the Reasoning Engine (e.g. us-central1)."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "display_name" {
+  description = "Display name of the Reasoning Engine. Null defaults to \"<project>-agent-engine\" so a bare compose still produces a uniquely-named, attributable engine."
+  type        = string
+  default     = null
+}
+
+variable "package_artifact_uri" {
+  description = "GCS URI (gs://<bucket>/<path>) of the packaged agent object the engine runs — the pickled Python object built and uploaded by the APPLICATION layer (this preset never builds it). Required: a fail-loud precondition rejects a null/non-gs:// value at plan time. When staging_bucket is wired, the artifact must live under it."
+  type        = string
+  default     = null
+
+  # Shape is validated here; presence + bucket-membership are cross-variable
+  # invariants enforced by preconditions on the engine resource (a per-variable
+  # validation can only see its own variable, and "must be set" is clearer as a
+  # resource precondition that names the engine that needs it).
+  validation {
+    condition     = var.package_artifact_uri == null ? true : can(regex("^gs://", var.package_artifact_uri))
+    error_message = "package_artifact_uri must be a gs:// URI."
+  }
+}
+
+variable "staging_bucket" {
+  description = "GCS bucket URL (gs://<bucket>) the application stages the packaged artifact into. Wired from gcp/gcs.bucket_url in a full stack. Null on a standalone preview where the caller supplies an absolute package_artifact_uri. When set, package_artifact_uri must live under it (enforced by a precondition)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.staging_bucket == null ? true : can(regex("^gs://", var.staging_bucket))
+    error_message = "staging_bucket must be a gs:// URI."
+  }
+}
+
+variable "requirements_uri" {
+  description = "Optional GCS URI (gs://<bucket>/requirements.txt) of the Python requirements file the engine installs alongside the packaged artifact. Null omits it — the engine uses only its bundled dependencies."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.requirements_uri == null ? true : can(regex("^gs://", var.requirements_uri))
+    error_message = "requirements_uri must be a gs:// URI."
+  }
+}
+
+variable "dependency_files_uri" {
+  description = "Optional GCS URI (gs://<bucket>/dependencies.tar.gz) of extra dependency files (tar.gz) the engine unpacks alongside the packaged artifact. Null omits it."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.dependency_files_uri == null ? true : can(regex("^gs://", var.dependency_files_uri))
+    error_message = "dependency_files_uri must be a gs:// URI."
+  }
+}
+
+variable "python_version" {
+  description = "Python runtime version for the packaged agent. Supported: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13. Null lets the provider default (3.10) win."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.python_version == null ? true : contains(["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"], var.python_version)
+    error_message = "python_version must be one of: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13."
+  }
+}
+
+variable "encryption_kms_key_name" {
+  description = "Fully-qualified Cloud KMS CMEK (projects/<p>/locations/<l>/keyRings/<k>/cryptoKeys/<c>) to encrypt the engine and its sub-resources. Null disables CMEK (Google-managed encryption). The key must be in the same region as the engine."
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Resource labels merged with the standard { project = var.project } identity label."
+  type        = map(string)
+  default     = {}
+}

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -138,6 +138,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.GCPSecretManager)
 	case KeyGCPVertexAI:
 		return boolPtrTrue(c.GCPVertexAI)
+	case KeyGCPAgentEngine:
+		return boolPtrTrue(c.GCPAgentEngine)
 	case KeyGCPPubSub:
 		return boolPtrTrue(c.GCPPubSub)
 	case KeyGCPCloudLogging:
@@ -306,7 +308,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
-		KeyGCPVertexAI,
+		KeyGCPVertexAI, KeyGCPAgentEngine,
 		KeyGCPPubSub, KeyGCPCloudLogging,
 		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
 		KeyGCPCloudDNS, KeyGCPGitHubActions, KeyGCPCloudDeploy:

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -90,6 +90,7 @@ const (
 	KeyGCPCloudDeploy      ComponentKey = "gcp_cloud_deploy"
 	KeyGCPFirestore        ComponentKey = "gcp_firestore"
 	KeyGCPVertexAI         ComponentKey = "gcp_vertex_ai"
+	KeyGCPAgentEngine      ComponentKey = "gcp_agent_engine"
 	KeyGCPCloudArmor       ComponentKey = "gcp_cloud_armor"
 	KeyGCPAPIGateway       ComponentKey = "gcp_api_gateway"
 	KeyGCPBackups          ComponentKey = "gcp_backups"
@@ -166,6 +167,13 @@ var ComposeOrder = []ComponentKey{
 	KeyAWSBedrockAgent,
 	KeyAWSSageMaker,
 	KeyGCPVertexAI,
+	// Agent Engine (#769) composes after KeyGCPVertexAI and KeyGCPGCS (GCS is
+	// far earlier, ~:124) so its DefaultWiring case can read gcp/gcs's
+	// bucket_url output to wire the staging bucket when GCS is also selected.
+	// No hard ImplicitDependency: a bare engine composes standalone with a
+	// caller-supplied artifact URI (public by default; PSC-private networking
+	// is out of scope until gcp/vpc provisions a network attachment).
+	KeyGCPAgentEngine,
 	// App Runner (#598 row 2). Independent of EKS/ECS/Lambda compute
 	// keys — App Runner is a peer managed-container service (Cloud Run
 	// analog), not a downstream consumer of them. Position adjacent to
@@ -256,6 +264,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyGCPCloudKMS:         "gcp/kms",
 	KeyGCPSecretManager:    "gcp/secret_manager",
 	KeyGCPVertexAI:         "gcp/vertex_ai",
+	KeyGCPAgentEngine:      "gcp/agent_engine",
 	KeyGCPPubSub:           "gcp/pubsub",
 	KeyGCPCloudLogging:     "gcp/cloud_logging",
 	KeyGCPCloudMonitoring:  "gcp/cloud_monitoring",
@@ -476,6 +485,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyGCPPubSub:               "pubsub",
 	KeyGCPCloudMonitoring:      "cloud_monitoring",
 	KeyGCPVertexAI:             "vertex_ai",
+	KeyGCPAgentEngine:          "agent_engine",
 	KeyGCPCloudBuild:           "cloud_build",
 	KeyGCPFirestore:            "firestore",
 	KeyGCPCloudArmor:           "cloud_armor",
@@ -583,6 +593,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyAWSVPC,
 	KeyAWSWAF,
 	// GCP
+	KeyGCPAgentEngine,
 	KeyGCPAPIGateway,
 	KeyGCPBackups,
 	KeyGCPBastion,
@@ -1255,6 +1266,18 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		if selected[KeyGCPGCS] {
 			wi.RawHCL["contents_delta_uri"] = "\"${" + WireRef(KeyGCPGCS, "bucket_url") + "}/vertex-index/\""
 			wi.Names = append(wi.Names, "contents_delta_uri")
+		}
+
+	case KeyGCPAgentEngine:
+		// Agent Engine (#769). When GCS is selected, wire the bucket as the
+		// staging bucket the application stages the packaged agent artifact
+		// into. bucket_url is the gs://<bucket> root — the engine's preset
+		// validates that the artifact URI (app-layer, supplied separately)
+		// lives under this bucket. The artifact itself is NOT wired here: it is
+		// built and uploaded by the application layer, not by the composer.
+		if selected[KeyGCPGCS] {
+			wi.RawHCL["staging_bucket"] = WireRef(KeyGCPGCS, "bucket_url")
+			wi.Names = append(wi.Names, "staging_bucket")
 		}
 	}
 

--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -63,6 +63,9 @@ var GCPServices = map[ComponentKey][]GCPService{
 	KeyGCPCloudBuild:       {{Name: "cloudbuild.googleapis.com", Title: "Cloud Build"}},
 	KeyGCPFirestore:        {{Name: "firestore.googleapis.com", Title: "Cloud Firestore"}},
 	KeyGCPVertexAI:         {{Name: "aiplatform.googleapis.com", Title: "Vertex AI"}},
+	// Agent Engine / Reasoning Engine is the same Vertex AI plane as datasets +
+	// vector search, so it rides on aiplatform.googleapis.com (#769).
+	KeyGCPAgentEngine: {{Name: "aiplatform.googleapis.com", Title: "Vertex AI"}},
 	KeyGCPAPIGateway: {
 		{Name: "apigateway.googleapis.com", Title: "API Gateway"},
 		// API Gateway plane requires both Service Control (request

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -217,6 +217,7 @@ var GCPIAMPermissions = map[ComponentKey][]string{
 	KeyGCPCloudBuild:       {"cloudbuild.builds.create"},
 	KeyGCPFirestore:        {"datastore.databases.create"},
 	KeyGCPVertexAI:         {"aiplatform.endpoints.create"},
+	KeyGCPAgentEngine:      {"aiplatform.reasoningEngines.create"},
 	KeyGCPAPIGateway:       {"apigateway.gateways.create"},
 	KeyGCPBackups:          {"backupdr.managementServers.create"},
 	// Cloud DNS (#593). managedZones.create + resourceRecordSets.create

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1036,6 +1036,19 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyGCPAgentEngine:
+		// Vertex AI Agent Engine (#769). Partial-config: only emit a field the
+		// caller actually populated so the preset's own defaults win when left
+		// unset (display_name defaults to "<project>-agent-engine"). The
+		// packaged-artifact URI is app-layer (supplied via package_artifact_uri
+		// directly, not modeled in Config), and staging_bucket is wired by
+		// DefaultWiring from gcp/gcs — neither is emitted here.
+		if cfg != nil && cfg.GCPAgentEngine != nil {
+			if strings.TrimSpace(cfg.GCPAgentEngine.DisplayName) != "" {
+				vals["display_name"] = strings.TrimSpace(cfg.GCPAgentEngine.DisplayName)
+			}
+		}
+
 	case KeyGCPPubSub:
 		vals["topic_name"] = "events"
 		if cfg != nil && cfg.GCPPubSub != nil {

--- a/pkg/composer/mapper_required_test.go
+++ b/pkg/composer/mapper_required_test.go
@@ -149,6 +149,7 @@ func kitchenSinkComponents() *Components {
 		GCPCloudKMS:         &t,
 		GCPSecretManager:    &t,
 		GCPVertexAI:         &t,
+		GCPAgentEngine:      &t,
 		GCPPubSub:           &t,
 		GCPCloudLogging:     &t,
 		GCPCloudMonitoring:  &t,

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -145,6 +145,7 @@ type PricingData struct {
 		GCPCloudKMS         *PricingItem       `json:"gcp_cloud_kms,omitempty"`
 		GCPSecretManager    *PricingItem       `json:"gcp_secret_manager,omitempty"`
 		GCPVertexAI         *PricingItem       `json:"gcp_vertex_ai,omitempty"`
+		GCPAgentEngine      *PricingItem       `json:"gcp_agent_engine,omitempty"`
 		GCPPubSub           *PricingItem       `json:"gcp_pubsub,omitempty"`
 		GCPCloudLogging     *PricingItem       `json:"gcp_cloud_logging,omitempty"`
 		GCPCloudMonitoring  *PricingItem       `json:"gcp_cloud_monitoring,omitempty"`
@@ -409,6 +410,7 @@ func (p *PricingData) Normalize() {
 		c.GCPCloudKMS = nil
 		c.GCPSecretManager = nil
 		c.GCPVertexAI = nil
+		c.GCPAgentEngine = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudMonitoring = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -74,6 +74,7 @@ type Components struct {
 	GCPCloudKMS         *bool  `json:"gcp_cloud_kms,omitempty"`
 	GCPSecretManager    *bool  `json:"gcp_secret_manager,omitempty"`
 	GCPVertexAI         *bool  `json:"gcp_vertex_ai,omitempty"`
+	GCPAgentEngine      *bool  `json:"gcp_agent_engine,omitempty"`
 	GCPPubSub           *bool  `json:"gcp_pubsub,omitempty"`
 	GCPCloudLogging     *bool  `json:"gcp_cloud_logging,omitempty"`
 	GCPCloudMonitoring  *bool  `json:"gcp_cloud_monitoring,omitempty"`
@@ -375,6 +376,18 @@ type Config struct {
 		IndexDimensions    int   `json:"indexDimensions,omitempty"`
 	} `json:"gcp_vertex_ai,omitempty"`
 
+	// GCPAgentEngine carries the caller-supplied Vertex AI Agent Engine
+	// configuration (#769). DisplayName overrides the preset's project-prefixed
+	// default for the Reasoning Engine. The packaged-artifact URI / staging
+	// bucket are not modeled here: the artifact is built by the application
+	// layer and its URI is supplied directly to the preset, and staging_bucket
+	// is wired by DefaultWiring from gcp/gcs. Partial-config: the mapper only
+	// emits a field the caller actually populated so the preset's own defaults
+	// win when left unset.
+	GCPAgentEngine *struct {
+		DisplayName string `json:"displayName,omitempty"`
+	} `json:"gcp_agent_engine,omitempty"`
+
 	GCPPubSub *struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	} `json:"gcp_pubsub,omitempty"`
@@ -646,6 +659,7 @@ func (c *Components) Normalize() {
 		c.GCPCloudKMS = nil
 		c.GCPSecretManager = nil
 		c.GCPVertexAI = nil
+		c.GCPAgentEngine = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudMonitoring = nil
@@ -747,7 +761,7 @@ func (c *Config) Normalize() {
 	}
 	switch c.Cloud {
 	case "AWS":
-		// Clear every GCP sub-config (15 fields — keep in sync with the
+		// Clear every GCP sub-config (18 fields — keep in sync with the
 		// GCPConfiguration section of the Config struct).
 		c.GCPCompute = nil
 		c.GCPGKE = nil
@@ -755,6 +769,7 @@ func (c *Config) Normalize() {
 		c.GCPMemorystore = nil
 		c.GCPGCS = nil
 		c.GCPVertexAI = nil
+		c.GCPAgentEngine = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudRun = nil


### PR DESCRIPTION
## What

Adds the `gcp_agent_engine` composer component — Vertex AI Agent Engine (Reasoning Engine), the GCP counterpart of `aws_bedrock_agent` (#762). The managed runtime for ADK / custom agents on Vertex AI.

Closes #769
Part of #756

## Preset `gcp/agent_engine/`

- `google_vertex_ai_reasoning_engine`, unconditional so the preset always plans infrastructure. Attribute shapes verified against the live provider schema (`spec.package_spec.{pickle_object_gcs_uri, requirements_gcs_uri, dependency_files_gcs_uri, python_version}`, `encryption_spec.kms_key_name`).
- Fail-loud precondition: the packaged-artifact GCS URI is mandatory even though the provider leaves `pickle_object_gcs_uri` optional. The artifact is app-layer — the preset validates the reference, never builds it. A second precondition enforces that the artifact lives under the wired staging bucket (null-safe).
- `project = var.project_id` (#287 pin), `labels` carry `var.project`, `display_name` is `var.project`-prefixed for name-prefix attribution.
- `staging_bucket` wired from `gcp/gcs.bucket_url` via `DefaultWiring` when GCS is selected; the artifact URI stays app-supplied.
- `tests/shape.tftest.hcl`: 14 mock-provider cases — attribute-level asserts plus `expect_failures` for both artifact preconditions and the variable validations.

## Composer registration

New key `KeyGCPAgentEngine` registered at the canonical spots, at parity with `KeyGCPVertexAI`:

- `contracts.go` — const, `ComposeOrder` (after VertexAI + GCS), `ModulePath`, `PresetKeyMap`, `AllComponentKeys`, `DefaultWiring` (WireRef only)
- `types.go` — `Components.GCPAgentEngine` + `Config.GCPAgentEngine` sub-struct + both `Normalize` clears
- `mapper.go` — partial-config case + kitchenSink fixture
- `pricing.go` — `PricingData.Components.GCPAgentEngine` + Normalize clear
- `gcp_services.go` — `aiplatform.googleapis.com`
- `iam_actions.go` — `aiplatform.reasoningEngines.create`
- `coherence.go` — `ComponentSelected` case + `isOrphanStrippableKey`

## Provider-version note

`google_vertex_ai_reasoning_engine` landed in the `hashicorp/google` provider at **v7.6.0** (verified absent in 7.5.0, present in 7.6.0). This repo's schema / import-codegen pin is **6.10**, so the resource is **deploy-only** and correctly stays out of `SUPPORTED_RESOURCES.md` and the import matrix. The preset pins `>= 7.6` and the tftest uses a mock provider. `make verify-supported-resources` / `verify-gen` are green (no codegen drift).

## QC

- `terraform test` (gcp/agent_engine): 14/14 pass against the real provider schema.
- Full `go test ./pkg/composer/`: green; all named invariant gates pass (services / IAM / pricing / unconditional-resource / required-var / mapper-subset / label-lint drift / coherence orphan-strip).
- Lint scripts green: `lint-gcp-project-pin`, `lint-project-label`, `lint-labelless-name-prefix`, `validate-as-child`, `go vet`, `gofmt`, `terraform fmt`.
- 2 diff-finder reviews + 1 qa mutation review run; all P0/P1 fixed (a stale field-count comment corrected; one tftest strengthened to a mutation-killing `trimsuffix` edge case).