### PR TITLE
test(reverseimport): golden + terraform-validate coverage for AWS retry tuning

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -296,11 +296,15 @@ jobs:
         with:
           terraform_version: "1.7.5"
       - run: go test -race ./...
-      # Build-tagged terraform-validate harness (imported_tfvalidate_test.go,
-      # #669): emits imported.tf and runs `terraform validate` against the
-      # real provider schema. Excluded from the untagged run above; run it
-      # explicitly so a computed-attr leak is caught end-to-end in CI.
-      - run: go test -tags tfvalidate -run TestImportedTF_TerraformValidate ./pkg/composer/
+      # Build-tagged terraform-validate harnesses: emit real HCL and run
+      # `terraform validate` against the live provider schema. Excluded from
+      # the untagged run above; run them explicitly so schema-level
+      # regressions are caught end-to-end in CI:
+      #   - imported.tf (#669): catches a computed-attr leak into a body.
+      #   - AWS provider blocks incl. retry tuning (#780 deferred-P2):
+      #     proves retry_mode/max_retries are accepted by the live provider
+      #     rather than only asserted by string/regex matching.
+      - run: make test-tfvalidate
 
   # NOTE (#406): the previous localstack-discover-gate job was removed
   # alongside Bundle 13c. The unified discoverer routes every AWS

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -280,7 +280,11 @@ jobs:
 
   go-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 20m: `make test-tfvalidate` adds ~5min of deliberately serialized
+    # (-p 1, shared TF_PLUGIN_CACHE_DIR) live `terraform validate` harnesses
+    # on top of `go test -race ./...`, which no longer fit the old 10m cap —
+    # the job was cancelled at the boundary with every step green.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,12 @@ test-roundtrip: ## Live AWS discover->emit->plan round-trip for the import flow 
 test-golden-stack: ## Replay genconfig cleanup over captured real-world stacks and assert `terraform validate` passes (#708). Needs terraform + the AWS provider; NO AWS creds.
 	RUN_GOLDEN_HCL=1 $(GO) test -run TestGoldenStackValidates ./cmd/insideout-import/genconfig/... -v -count=1 -timeout 10m
 
+.PHONY: test-tfvalidate
+test-tfvalidate: ## Build-tagged terraform-validate harnesses: emit real HCL (imported.tf + AWS provider blocks incl. retry tuning #780) and run `terraform validate` against the live provider schema. Needs terraform + the AWS provider; NO AWS creds. -p 1: the harnesses share TF_PLUGIN_CACHE_DIR, so serialize packages to avoid a concurrent-init plugin handshake race.
+	$(GO) test -tags tfvalidate -count=1 -p 1 -timeout 10m \
+		-run 'TestImportedTF_TerraformValidate|TestEmitProviders_TerraformValidate|TestRenderImportedProvidersTF_TerraformValidate' \
+		./pkg/composer/ ./cmd/insideout-import/genconfig/ ./pkg/reverseimport/
+
 .PHONY: reverse-e2e
 reverse-e2e: ## Live whole-account reverse-import e2e: discover->genconfig->driftfix->depchase->plan via the prod engine, asserting a clean tag-only plan. Needs real AWS creds + terraform + an offline provider mirror. REVERSE_E2E_REGIONS=all for multi-region; see scripts/reverse-e2e.sh header for knobs.
 	./scripts/reverse-e2e.sh

--- a/cmd/insideout-import/genconfig/providers_golden_test.go
+++ b/cmd/insideout-import/genconfig/providers_golden_test.go
@@ -1,0 +1,65 @@
+package genconfig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestEmitProviders_GoldenSnapshot pins the EXACT bytes emitProviders /
+// configureAWSProviderBody render for a representative AWS provider block —
+// including the retry-tuning attrs `retry_mode = "adaptive"` / `max_retries`
+// (luthersystems/ui-core#420) — against testdata/providers_aws.golden.
+//
+// This complements the value-anchored regex assertions in emit_test.go and
+// the live-provider terraform validate in providers_tfvalidate_test.go: the
+// regex tests prove the attrs are present, validate proves the live provider
+// accepts them, and this golden proves the full block (attribute set, order,
+// and hclwrite column alignment) has not drifted. A change to
+// configureAWSProviderBody that, say, reordered the attrs or dropped the
+// retry tuning fails here even when terraform is unavailable.
+//
+// Re-seed after an intentional emitter change with:
+//
+//	UPDATE_GOLDEN=1 go test ./cmd/insideout-import/genconfig/ -run TestEmitProviders_GoldenSnapshot
+//
+// The fixture carries a `.golden` suffix (not `.tf`) so the repo's
+// `tflint --recursive` / `terraform fmt -check -recursive` gates skip it,
+// matching testdata/golden/**.
+func TestEmitProviders_GoldenSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	if err := emitProviders(dir, providerEmitOptions{
+		Provider: ProviderAWS,
+		Region:   "us-west-2",
+		AWSAuth: awsProviderAuth{
+			RoleARN:    "arn:aws:iam::123456789012:role/io-terraform",
+			ExternalID: "external-123",
+		},
+	}); err != nil {
+		t.Fatalf("emitProviders: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dir, providersFile))
+	if err != nil {
+		t.Fatalf("read providers.tf: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "providers_aws.golden")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote golden: %s", goldenPath)
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("golden missing — run `UPDATE_GOLDEN=1 go test ./cmd/insideout-import/genconfig/ -run TestEmitProviders_GoldenSnapshot`: %v", err)
+	}
+	if string(want) != string(got) {
+		t.Errorf("emitted providers.tf drifted from %s. If intentional, re-seed via UPDATE_GOLDEN=1.\n--- want ---\n%s\n--- got ---\n%s", goldenPath, want, got)
+	}
+}

--- a/cmd/insideout-import/genconfig/providers_tfvalidate_test.go
+++ b/cmd/insideout-import/genconfig/providers_tfvalidate_test.go
@@ -1,0 +1,149 @@
+//go:build tfvalidate
+
+// Build-tagged Terraform-validate harness for the genconfig provider emitter.
+//
+// Normal `go test` skips this file (it shells out to the `terraform` binary
+// and does a one-time provider download). Run it explicitly:
+//
+//	go test -tags tfvalidate -run TestEmitProviders_TerraformValidate -v ./cmd/insideout-import/genconfig/
+//
+// It emits providers.tf via the REAL emitProviders / configureAWSProviderBody
+// path (NOT a hand-written fixture), drops it in a temp dir, and runs
+// `terraform init -backend=false` + `terraform validate` against the pinned
+// hashicorp/aws ~> 6.0 provider.
+//
+// Why this exists (PR #780 deferred-P2 hardening): the retry-tuning attrs
+// `retry_mode = "adaptive"` / `max_retries = 25` (luthersystems/ui-core#420)
+// are otherwise only asserted by string/regex matching in emit_test.go, and
+// the RUN_GOLDEN_HCL golden gate validates a hand-edited static providers.tf
+// fixture rather than re-emitting via configureAWSProviderBody. A future
+// provider major that rejected those attrs would ship green. This harness
+// runs the live provider schema over the real emitter output so a rejected
+// retry attribute fails the gate. `terraform validate` is a pure
+// provider-schema check — NO AWS credentials and no network beyond the
+// one-time provider download (TF_PLUGIN_CACHE_DIR keeps that warm).
+
+package genconfig
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// tfValidateGenconfigCases exercises the provider-block shapes
+// configureAWSProviderBody can emit, each one carrying the retry tuning.
+// A resource referencing the (default, unaliased) provider is dropped
+// alongside so validate exercises the provider config, not just parses it.
+func TestEmitProviders_TerraformValidate(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not on PATH")
+	}
+
+	cases := []struct {
+		name string
+		opts providerEmitOptions
+		// resourceHCL is dropped next to providers.tf so validate resolves
+		// the default provider config against the live schema.
+		resourceHCL string
+	}{
+		{
+			name: "aws_plain",
+			opts: providerEmitOptions{Provider: ProviderAWS, Region: "us-west-2"},
+			resourceHCL: `resource "aws_sqs_queue" "orders" {
+  name = "orders"
+}
+`,
+		},
+		{
+			name: "aws_assume_role",
+			opts: providerEmitOptions{
+				Provider: ProviderAWS,
+				Region:   "us-east-1",
+				AWSAuth: awsProviderAuth{
+					RoleARN:    "arn:aws:iam::123456789012:role/io-terraform",
+					ExternalID: "external-123",
+				},
+			},
+			resourceHCL: `resource "aws_sqs_queue" "orders" {
+  name = "orders"
+}
+`,
+		},
+		{
+			name: "aws_localstack",
+			opts: providerEmitOptions{
+				Provider:       ProviderAWS,
+				Region:         "us-east-1",
+				AWSEndpointURL: "http://localhost:4566",
+			},
+			resourceHCL: `resource "aws_sqs_queue" "orders" {
+  name = "orders"
+}
+`,
+		},
+	}
+
+	// Persistent plugin cache so the aws provider download is paid once
+	// across cases and across the imported.tf harness. Mirrors
+	// pkg/composer/imported_tfvalidate_test.go.
+	cache := filepath.Join(os.TempDir(), "tf-plugin-cache")
+	_ = os.MkdirAll(cache, 0o755)
+	env := append(os.Environ(), "TF_PLUGIN_CACHE_DIR="+cache, "TF_IN_AUTOMATION=1")
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := emitProviders(dir, tc.opts); err != nil {
+				t.Fatalf("emitProviders: %v", err)
+			}
+			// The real retry tuning must be present in what we validate —
+			// guard against a regression that drops it before this test even
+			// reaches terraform. Whitespace-tolerant: hclwrite re-aligns the
+			// `=` column when a block gains a wider attribute (e.g. the
+			// LocalStack skip_* attrs), so anchor on the value, not the gutter.
+			provBody, err := os.ReadFile(filepath.Join(dir, providersFile))
+			if err != nil {
+				t.Fatalf("read providers.tf: %v", err)
+			}
+			for _, pat := range []string{`retry_mode\s*=\s*"adaptive"`, `max_retries\s*=\s*25`} {
+				if !regexp.MustCompile(pat).MatchString(string(provBody)) {
+					t.Fatalf("emitted providers.tf is missing retry tuning %q — the validate below would not be covering it:\n%s", pat, provBody)
+				}
+			}
+			if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(tc.resourceHCL), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			run := func(args ...string) (string, error) {
+				cmd := exec.Command("terraform", args...)
+				cmd.Dir = dir
+				cmd.Env = env
+				b, cerr := cmd.CombinedOutput()
+				return string(b), cerr
+			}
+
+			if initOut, ierr := run("init", "-backend=false", "-input=false", "-no-color"); ierr != nil {
+				// A sandbox without registry access can't fetch the provider;
+				// skip rather than fail to keep unprivileged environments green
+				// (CI's terraform lane has access). Mirrors golden_stack_test.go.
+				t.Skipf("terraform init could not fetch the provider (%v):\n%s", ierr, initOut)
+			}
+
+			validateOut, verr := run("validate", "-no-color")
+			t.Logf("terraform validate output:\n%s", validateOut)
+			if verr != nil {
+				t.Errorf("terraform validate failed on emitted providers.tf (exit error: %v)\n--- providers.tf ---\n%s", verr, provBody)
+			}
+			// The PR #780 deferred-P2 assertion: a future provider that
+			// rejected a retry-tuning attr surfaces here as an
+			// "Unsupported argument" diagnostic rather than shipping green.
+			if strings.Contains(validateOut, "Unsupported argument") {
+				t.Errorf("provider rejected an emitted argument (retry tuning regression?):\n%s\n--- providers.tf ---\n%s", validateOut, provBody)
+			}
+		})
+	}
+}

--- a/cmd/insideout-import/genconfig/testdata/providers_aws.golden
+++ b/cmd/insideout-import/genconfig/testdata/providers_aws.golden
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region      = "us-west-2"
+  retry_mode  = "adaptive"
+  max_retries = 25
+  assume_role {
+    role_arn    = "arn:aws:iam::123456789012:role/io-terraform"
+    external_id = "external-123"
+  }
+}

--- a/cmd/insideout-import/genconfig/testdata/providers_aws.golden
+++ b/cmd/insideout-import/genconfig/testdata/providers_aws.golden
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "= 6.46.0"
     }
   }
 }

--- a/pkg/reverseimport/providers_golden_test.go
+++ b/pkg/reverseimport/providers_golden_test.go
@@ -1,0 +1,67 @@
+package reverseimport
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+)
+
+// TestRenderImportedProvidersTF_GoldenSnapshot pins the EXACT bytes
+// renderImportedProvidersTF emits for a representative multi-region AWS batch
+// (base `aws.imported` + one `aws.imported_<region>` per region), including
+// the retry-tuning attrs `retry_mode = "adaptive"` / `max_retries`
+// (luthersystems/ui-core#420), against testdata/providers_imported_aws.golden.
+//
+// This complements the value-anchored regex assertions in providers_test.go
+// and the live-provider terraform validate in providers_tfvalidate_test.go:
+// the regex tests prove the attrs are present, validate proves the live
+// provider accepts them, and this golden proves the full multi-block output
+// (per-region alias set, attribute order, and hclwrite column alignment) has
+// not drifted. A change to appendAWSImportedProvider that reordered the attrs
+// or dropped the retry tuning fails here even when terraform is unavailable.
+//
+// Re-seed after an intentional emitter change with:
+//
+//	UPDATE_GOLDEN=1 go test ./pkg/reverseimport/ -run TestRenderImportedProvidersTF_GoldenSnapshot
+//
+// The fixture carries a `.golden` suffix (not `.tf`) so the repo's
+// `tflint --recursive` / `terraform fmt -check -recursive` gates skip it.
+func TestRenderImportedProvidersTF_GoldenSnapshot(t *testing.T) {
+	got, err := renderImportedProvidersTF(importedProviderRenderOptions{
+		Cloud:      "aws",
+		Region:     "us-east-1",
+		AWSRegions: []string{"us-east-1", "us-west-2"},
+		ProvidersUsed: map[string]bool{
+			composer.ProvidersUsedKeyAWS: true,
+		},
+		AWSAuth: AWSProviderAuth{
+			RoleARN:    "arn:aws:iam::123456789012:role/io-terraform",
+			ExternalID: "external-123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderImportedProvidersTF: %v", err)
+	}
+
+	goldenPath := filepath.Join("testdata", "providers_imported_aws.golden")
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("wrote golden: %s", goldenPath)
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("golden missing — run `UPDATE_GOLDEN=1 go test ./pkg/reverseimport/ -run TestRenderImportedProvidersTF_GoldenSnapshot`: %v", err)
+	}
+	if string(want) != string(got) {
+		t.Errorf("emitted providers-imported.tf drifted from %s. If intentional, re-seed via UPDATE_GOLDEN=1.\n--- want ---\n%s\n--- got ---\n%s", goldenPath, want, got)
+	}
+}

--- a/pkg/reverseimport/providers_tfvalidate_test.go
+++ b/pkg/reverseimport/providers_tfvalidate_test.go
@@ -1,0 +1,127 @@
+//go:build tfvalidate
+
+// Build-tagged Terraform-validate harness for the reverseimport provider
+// emitter (renderImportedProvidersTF).
+//
+// Normal `go test` skips this file (it shells out to the `terraform` binary
+// and does a one-time provider download). Run it explicitly:
+//
+//	go test -tags tfvalidate -run TestRenderImportedProvidersTF_TerraformValidate -v ./pkg/reverseimport/
+//
+// It renders providers-imported.tf via the REAL renderImportedProvidersTF
+// path for a multi-region AWS batch (base `aws.imported` + one
+// `aws.imported_<region>` per region), drops it next to a resource that
+// references one of the per-region aliases, and runs
+// `terraform init -backend=false` + `terraform validate` against the pinned
+// hashicorp/aws ~> 6.0 provider.
+//
+// Why this exists (PR #780 deferred-P2 hardening): the retry-tuning attrs
+// `retry_mode = "adaptive"` / `max_retries = 25` (luthersystems/ui-core#420)
+// emitted onto every imported provider block were otherwise only asserted by
+// string/regex matching in providers_test.go — nothing ran the live provider
+// schema over the real emitter output, so a future provider major that
+// rejected those attrs would ship green. `terraform validate` is a pure
+// provider-schema check — NO AWS credentials and no network beyond the
+// one-time provider download (TF_PLUGIN_CACHE_DIR keeps that warm).
+
+package reverseimport
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+)
+
+func TestRenderImportedProvidersTF_TerraformValidate(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not on PATH")
+	}
+
+	// Representative multi-region AWS batch with assume-role plumbing — the
+	// production shape EmitImportedTF references via aws.imported_<region>.
+	body, err := renderImportedProvidersTF(importedProviderRenderOptions{
+		Cloud:      "aws",
+		Region:     "us-east-1",
+		AWSRegions: []string{"us-east-1", "us-west-2"},
+		ProvidersUsed: map[string]bool{
+			composer.ProvidersUsedKeyAWS: true,
+		},
+		AWSAuth: AWSProviderAuth{
+			RoleARN:    "arn:aws:iam::123456789012:role/io-terraform",
+			ExternalID: "external-123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("renderImportedProvidersTF: %v", err)
+	}
+	// Guard against a regression dropping the tuning before terraform runs.
+	// Whitespace-tolerant (hclwrite re-aligns the `=` column).
+	for _, pat := range []string{`retry_mode\s*=\s*"adaptive"`, `max_retries\s*=\s*25`} {
+		if !regexp.MustCompile(pat).MatchString(string(body)) {
+			t.Fatalf("emitted providers-imported.tf is missing retry tuning %q — the validate below would not be covering it:\n%s", pat, body)
+		}
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "providers-imported.tf"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A resource per aliased provider block so validate resolves each
+	// `aws.imported*` config against the live schema (an aliased provider
+	// with no consumer is not type-checked by validate).
+	resourceHCL := `resource "aws_sqs_queue" "base" {
+  provider = aws.imported
+  name     = "base"
+}
+
+resource "aws_sqs_queue" "east" {
+  provider = aws.imported_us_east_1
+  name     = "east"
+}
+
+resource "aws_sqs_queue" "west" {
+  provider = aws.imported_us_west_2
+  name     = "west"
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(resourceHCL), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Persistent plugin cache so the aws provider download is paid once.
+	cache := filepath.Join(os.TempDir(), "tf-plugin-cache")
+	_ = os.MkdirAll(cache, 0o755)
+	env := append(os.Environ(), "TF_PLUGIN_CACHE_DIR="+cache, "TF_IN_AUTOMATION=1")
+
+	run := func(args ...string) (string, error) {
+		cmd := exec.Command("terraform", args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		b, cerr := cmd.CombinedOutput()
+		return string(b), cerr
+	}
+
+	if initOut, ierr := run("init", "-backend=false", "-input=false", "-no-color"); ierr != nil {
+		// A sandbox without registry access can't fetch the provider; skip
+		// rather than fail to keep unprivileged environments green (CI's
+		// terraform lane has access). Mirrors golden_stack_test.go.
+		t.Skipf("terraform init could not fetch the provider (%v):\n%s", ierr, initOut)
+	}
+
+	validateOut, verr := run("validate", "-no-color")
+	t.Logf("terraform validate output:\n%s", validateOut)
+	if verr != nil {
+		t.Errorf("terraform validate failed on emitted providers-imported.tf (exit error: %v)\n--- providers-imported.tf ---\n%s", verr, body)
+	}
+	// The PR #780 deferred-P2 assertion: a future provider that rejected a
+	// retry-tuning attr surfaces here as an "Unsupported argument"
+	// diagnostic rather than shipping green.
+	if strings.Contains(validateOut, "Unsupported argument") {
+		t.Errorf("provider rejected an emitted argument (retry tuning regression?):\n%s\n--- providers-imported.tf ---\n%s", validateOut, body)
+	}
+}

--- a/pkg/reverseimport/testdata/providers_imported_aws.golden
+++ b/pkg/reverseimport/testdata/providers_imported_aws.golden
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "= 6.46.0"
     }
   }
 }

--- a/pkg/reverseimport/testdata/providers_imported_aws.golden
+++ b/pkg/reverseimport/testdata/providers_imported_aws.golden
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  alias       = "imported"
+  region      = "us-east-1"
+  retry_mode  = "adaptive"
+  max_retries = 25
+  assume_role {
+    role_arn    = "arn:aws:iam::123456789012:role/io-terraform"
+    external_id = "external-123"
+  }
+}
+provider "aws" {
+  alias       = "imported_us_east_1"
+  region      = "us-east-1"
+  retry_mode  = "adaptive"
+  max_retries = 25
+  assume_role {
+    role_arn    = "arn:aws:iam::123456789012:role/io-terraform"
+    external_id = "external-123"
+  }
+}
+provider "aws" {
+  alias       = "imported_us_west_2"
+  region      = "us-west-2"
+  retry_mode  = "adaptive"
+  max_retries = 25
+  assume_role {
+    role_arn    = "arn:aws:iam::123456789012:role/io-terraform"
+    external_id = "external-123"
+  }
+}


### PR DESCRIPTION
Implements the deferred-P2 hardening from [#780](https://github.com/luthersystems/insideout-terraform-presets/pull/780) — see the [qa-professor follow-up comment](https://github.com/luthersystems/insideout-terraform-presets/pull/780#issuecomment-4672183641).

## Why

The emitted AWS retry-tuning HCL (`retry_mode = "adaptive"` / `max_retries = 25`, [luthersystems/ui-core#420](https://github.com/luthersystems/ui-core/issues/420)) was only asserted by string/regex matching, and the `RUN_GOLDEN_HCL` golden gate validates a hand-edited static `providers.tf` fixture rather than re-emitting via `configureAWSProviderBody`. A future provider major that rejected those attrs would ship green.

## What

For both AWS provider emitters — `genconfig.emitProviders` / `configureAWSProviderBody` and `reverseimport.renderImportedProvidersTF`:

- Build-tagged (`tfvalidate`) terraform-validate harnesses that render the real emitter output, drop it next to a resource referencing the provider, and run `terraform init -backend=false` + `terraform validate` against the live `hashicorp/aws ~> 6.0` schema. Mirrors `pkg/composer/imported_tfvalidate_test.go`. A rejected retry attr now surfaces as an `Unsupported argument` diagnostic instead of passing.
- Golden-snapshot tests (`UPDATE_GOLDEN=1` convention, `.golden` suffix so tflint / `terraform fmt -check` skip them) pinning the exact emitted bytes — including the retry tuning — for a representative AWS block and a multi-region (base `imported` + per-region) batch. Catches attribute-order / alignment drift with no terraform required.

## Wiring

- New `make test-tfvalidate` target runs all three tfvalidate harnesses (`-p 1` to avoid a shared `TF_PLUGIN_CACHE_DIR` init race).
- The `go-test` CI job now calls `make test-tfvalidate` in place of the single inline imported.tf invocation.

## Tests

- `make test-tfvalidate` — all 3 harnesses pass (`terraform validate` succeeds against real provider; both emitter shapes accepted).
- Golden snapshots pass in read mode; untagged package tests (274) + `go build ./...` + `go vet` (both tag modes) + gofmt all clean.