### PR TITLE
feat(agentcore): new aws_agentcore_gateway component — MCP/tool gateway (#763)

### DIFF
--- a/aws/agentcore_gateway/main.tf
+++ b/aws/agentcore_gateway/main.tf
@@ -50,6 +50,7 @@ module "name" {
 
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
+data "aws_partition" "current" {}
 
 locals {
   gateway_name = var.gateway_name == null ? "${var.project}-gateway" : var.gateway_name
@@ -85,7 +86,12 @@ resource "aws_iam_role" "gateway" {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
           ArnLike = {
-            "aws:SourceArn" = "arn:aws:bedrock-agentcore:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:gateway/*"
+            # Derive the partition from data.aws_partition so the SourceArn
+            # condition matches in GovCloud (aws-us-gov) / China (aws-cn), not
+            # just commercial aws — target_lambda_arn already admits those
+            # partitions, so the trust guard must too or the gateway role is
+            # unassumable there.
+            "aws:SourceArn" = "arn:${data.aws_partition.current.partition}:bedrock-agentcore:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:gateway/*"
           }
         }
       }

--- a/aws/agentcore_gateway/main.tf
+++ b/aws/agentcore_gateway/main.tf
@@ -1,0 +1,237 @@
+# aws/agentcore_gateway — Bedrock AgentCore MCP/tool gateway (#763, part of #755)
+#
+# ── MATURITY CAVEAT (ADVANCED component, maturity-flagged) ────────────────────
+# Bedrock AgentCore is a NEW AWS service surface. The hashicorp/aws provider's
+# aws_bedrockagentcore_* resource family landed ~v6.18 and its schema CHURNS
+# across minor releases (attributes added/renamed/reshaped). This preset is
+# pinned to the shape of the family in the provider version this repo resolves
+# (aws = 6.45.0, see schemas/providers.tf) and is deliberately conservative:
+# it provisions ONLY the gateway + a single Lambda target + the IAM role the
+# gateway assumes to invoke that target. AgentCore *runtime* (which requires a
+# customer-supplied ECR image), memory, and credential-provider resources are
+# OUT OF SCOPE for this component — gateway only, per #763. There is no GCP
+# analog; #756 documents the AWS-only asymmetry. Treat this as an advanced
+# card: expect to re-pin attribute shapes when the provider is bumped.
+#
+# What this builds:
+#   • aws_bedrockagentcore_gateway        — the MCP gateway endpoint, with
+#       inbound auth (a custom JWT authorizer, e.g. Cognito/Auth0/OIDC) and the
+#       MCP protocol configuration. Always created.
+#   • aws_iam_role (gateway)              — the role the gateway assumes to
+#       invoke its targets (e.g. the Lambda). Always created (the gateway
+#       requires role_arn), so this preset always emits infrastructure even in
+#       its minimal shape.
+#   • aws_bedrockagentcore_gateway_target — a Lambda target turning the wired
+#       Lambda into an agent-callable tool. Created only when a Lambda ARN is
+#       wired in (count-gated); in a composed stack DefaultWiring supplies it
+#       from module.aws_lambda.function_arn (KeyAWSLambda is a HARD implicit
+#       dependency of this component).
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+module "name" {
+  source         = "github.com/luthersystems/tf-modules.git//luthername?ref=v55.15.0"
+  luther_project = var.project
+  aws_region     = var.region
+  luther_env     = var.environment
+  org_name       = "luthersystems"
+  component      = "insideout"
+  subcomponent   = "acgw"
+  resource       = "acgw"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  gateway_name = var.gateway_name == null ? "${var.project}-gateway" : var.gateway_name
+
+  # The Lambda target (and the gateway's permission to invoke it) only exist
+  # when a backing Lambda ARN is wired in. A gateway with OpenAPI/REST targets
+  # supplied out-of-band, or one stood up before its tools, leaves this off.
+  has_lambda_target = var.target_lambda_arn != null
+}
+
+# --- Gateway IAM role ---------------------------------------------------------
+#
+# The role AgentCore assumes to invoke this gateway's targets. The gateway
+# requires role_arn, so this is always created and keeps the preset producing
+# infrastructure even in its minimal (no-target) shape. Trust is scoped to the
+# bedrock-agentcore service principal, and the confused-deputy holes are closed
+# by pinning aws:SourceAccount to this account and aws:SourceArn to this
+# account+region's gateway ARN namespace (mirrors aws/bedrock_agent's role).
+resource "aws_iam_role" "gateway" {
+  name = "${var.project}-agentcore-gw-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "bedrock-agentcore.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:bedrock-agentcore:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:gateway/*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = merge(module.name.tags, var.tags)
+
+  # aws_iam_role_policy below writes an inline policy onto the role; the
+  # provider re-reads it onto the role on refresh and drift-check flags it.
+  # Ignore here (mirrors aws/bedrock_agent's role).
+  lifecycle {
+    ignore_changes = [inline_policy]
+  }
+}
+
+# The gateway role's target-invocation policy. lambda:InvokeFunction on the
+# wired target Lambda is the only grant; it exists only when a Lambda target is
+# present (aws_iam_role_policy requires a non-empty Statement list, so a
+# gateway with no Lambda target carries no inline policy). Scoped to the wired
+# Lambda ARN — the gateway can invoke ONLY its own target, not any function.
+resource "aws_iam_role_policy" "gateway_invoke" {
+  count = local.has_lambda_target ? 1 : 0
+
+  name = "${var.project}-agentcore-gw-invoke"
+  role = aws_iam_role.gateway.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "InvokeTargetLambda"
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction"]
+        Resource = [var.target_lambda_arn]
+      }
+    ]
+  })
+}
+
+# --- Gateway ------------------------------------------------------------------
+#
+# The MCP gateway endpoint. authorizer_type = CUSTOM_JWT + the custom_jwt
+# authorizer block configures INBOUND auth: callers (agents/MCP clients) must
+# present a JWT from the configured OIDC issuer (Cognito user-pool, Auth0, etc.)
+# whose discovery_url is supplied. protocol_type = MCP with the mcp protocol
+# block makes this an MCP tool gateway. The gateway URL (computed) is the
+# endpoint agents connect to.
+resource "aws_bedrockagentcore_gateway" "this" {
+  name            = local.gateway_name
+  role_arn        = aws_iam_role.gateway.arn
+  protocol_type   = var.protocol_type
+  authorizer_type = "CUSTOM_JWT"
+  description     = "Insideout AgentCore MCP/tool gateway for ${var.project}."
+
+  authorizer_configuration {
+    custom_jwt_authorizer {
+      discovery_url = var.jwt_discovery_url
+
+      # Audience / client allowlists are optional on the provider; emit them
+      # only when the caller supplied a non-empty list so an unconfigured
+      # gateway does not pin an empty allowlist.
+      allowed_audience = length(var.jwt_allowed_audience) > 0 ? var.jwt_allowed_audience : null
+      allowed_clients  = length(var.jwt_allowed_clients) > 0 ? var.jwt_allowed_clients : null
+    }
+  }
+
+  protocol_configuration {
+    mcp {
+      instructions       = var.mcp_instructions
+      search_type        = var.mcp_search_type
+      supported_versions = length(var.mcp_supported_versions) > 0 ? var.mcp_supported_versions : null
+    }
+  }
+
+  tags = merge(module.name.tags, var.tags)
+
+  depends_on = [aws_iam_role.gateway]
+}
+
+# --- Lambda target ------------------------------------------------------------
+#
+# Turns the wired Lambda into an MCP tool exposed by the gateway. Uses the
+# gateway's own IAM role for credentials (gateway_iam_role {} — the empty block
+# selects "use the gateway's execution role" rather than an API-key/OAuth
+# credential provider). The tool's input schema is declared inline so no
+# external OpenAPI payload is required. Created only when a Lambda ARN is wired
+# in; in a composed stack DefaultWiring supplies target_lambda_arn from
+# module.aws_lambda.function_arn (KeyAWSLambda is a HARD implicit dependency).
+resource "aws_bedrockagentcore_gateway_target" "lambda" {
+  count = local.has_lambda_target ? 1 : 0
+
+  gateway_identifier = aws_bedrockagentcore_gateway.this.gateway_id
+  name               = "${var.project}-lambda-tool"
+  description        = "Lambda-backed MCP tool for ${local.gateway_name}."
+
+  credential_provider_configuration {
+    # Empty block: the target is invoked with the gateway's execution role
+    # (aws_iam_role.gateway), which carries lambda:InvokeFunction on the
+    # wired Lambda via aws_iam_role_policy.gateway_invoke above.
+    gateway_iam_role {}
+  }
+
+  target_configuration {
+    mcp {
+      lambda {
+        lambda_arn = var.target_lambda_arn
+
+        tool_schema {
+          inline_payload {
+            name        = "invoke"
+            description = "Invoke the backing Lambda to perform an action on behalf of the agent."
+
+            input_schema {
+              type        = "object"
+              description = "Free-form tool input forwarded to the Lambda."
+
+              property {
+                name        = "input"
+                type        = "string"
+                description = "The input payload forwarded to the Lambda."
+                required    = false
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  # The gateway role's invoke policy must exist before the target binds the
+  # Lambda, so the gateway can actually call the function once the target is
+  # live. Safe when the policy is absent (count=0) — depends_on on an empty
+  # resource list is a no-op (but here both are count-gated identically).
+  depends_on = [aws_iam_role_policy.gateway_invoke]
+}
+
+# Allow the AgentCore gateway service to invoke the target Lambda. Scoped to
+# the gateway ARN so only THIS gateway (not any AgentCore caller) may invoke
+# the function. Created alongside the Lambda target.
+resource "aws_lambda_permission" "gateway_invoke" {
+  count = local.has_lambda_target ? 1 : 0
+
+  statement_id  = "AllowAgentCoreGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = var.target_lambda_arn
+  principal     = "bedrock-agentcore.amazonaws.com"
+  source_arn    = aws_bedrockagentcore_gateway.this.gateway_arn
+}

--- a/aws/agentcore_gateway/outputs.tf
+++ b/aws/agentcore_gateway/outputs.tf
@@ -1,0 +1,24 @@
+output "gateway_id" {
+  value       = aws_bedrockagentcore_gateway.this.gateway_id
+  description = "ID of the AgentCore gateway."
+}
+
+output "gateway_arn" {
+  value       = aws_bedrockagentcore_gateway.this.gateway_arn
+  description = "ARN of the AgentCore gateway."
+}
+
+output "gateway_url" {
+  value       = aws_bedrockagentcore_gateway.this.gateway_url
+  description = "MCP endpoint URL agents/MCP clients connect to. Callers present a JWT from the configured issuer (jwt_discovery_url) to authenticate."
+}
+
+output "gateway_target_id" {
+  value       = local.has_lambda_target ? aws_bedrockagentcore_gateway_target.lambda[0].target_id : null
+  description = "ID of the Lambda MCP-tool target. null when no target_lambda_arn was wired in (gateway with externally-supplied targets only)."
+}
+
+output "gateway_role_arn" {
+  value       = aws_iam_role.gateway.arn
+  description = "ARN of the IAM role the gateway assumes to invoke its targets (carries lambda:InvokeFunction on the wired Lambda when a target is present)."
+}

--- a/aws/agentcore_gateway/tests/shape.tftest.hcl
+++ b/aws/agentcore_gateway/tests/shape.tftest.hcl
@@ -1,0 +1,354 @@
+# Plan-only unit tests for the agentcore_gateway module.
+#
+# No AWS credentials required: the AWS provider is mocked so
+# data.aws_caller_identity.current and data.aws_region.current resolve at plan
+# time. The aws_bedrockagentcore_* family is mocked too so attributes the
+# Lambda target / permission reference (gateway_id, gateway_arn) resolve.
+#
+# These run in CI (filename has no "integration"). Run locally with:
+#
+#   cd aws/agentcore_gateway
+#   terraform init
+#   terraform test -filter=tests/shape.tftest.hcl
+#
+# Assertions pin SHAPE, not exact provider attributes — the AgentCore family's
+# schema churns across provider minors (see main.tf maturity caveat), so these
+# check resource presence, count-gating, names, and wiring rather than fragile
+# deep attribute paths.
+#
+# TODO(#763): a live-apply integration.tftest.hcl is deliberately deferred —
+# AgentCore live-apply needs special account access and a live-apply test
+# against a churning provider family would be MORE fragile than this shape
+# suite, not less. Track separately; do not treat its absence as folklore.
+
+mock_provider "aws" {
+  mock_data "aws_caller_identity" {
+    defaults = {
+      account_id = "111111111111"
+      arn        = "arn:aws:iam::111111111111:user/test"
+      user_id    = "AIDACKCEVSQ6C2EXAMPLE"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = {
+      region = "us-east-1"
+    }
+  }
+  # The Lambda target and invoke permission reference the gateway id/arn; give
+  # the gateway resource id/arn-shaped mocks so those attributes resolve.
+  mock_resource "aws_bedrockagentcore_gateway" {
+    defaults = {
+      gateway_id  = "gw-ABCDEFGHIJ"
+      gateway_arn = "arn:aws:bedrock-agentcore:us-east-1:111111111111:gateway/gw-ABCDEFGHIJ"
+      gateway_url = "https://gw-ABCDEFGHIJ.gateway.bedrock-agentcore.us-east-1.amazonaws.com/mcp"
+    }
+  }
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::111111111111:role/iotest-gw-agentcore-gw-role"
+    }
+  }
+}
+
+variables {
+  project     = "iotest-gw"
+  region      = "us-east-1"
+  environment = "test"
+}
+
+# --- Default shape (gateway only, no Lambda target) --------------------------
+
+run "defaults" {
+  command = plan
+
+  # Gateway role is always created (the gateway requires role_arn).
+  assert {
+    condition     = aws_iam_role.gateway.name == "iotest-gw-agentcore-gw-role"
+    error_message = "Gateway IAM role must always be created with the project-prefixed name."
+  }
+
+  # Trust policy carries the confused-deputy guards.
+  assert {
+    condition     = jsondecode(aws_iam_role.gateway.assume_role_policy).Statement[0].Condition.StringEquals["aws:SourceAccount"] == "111111111111"
+    error_message = "Gateway trust policy must scope aws:SourceAccount to the current account."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role.gateway.assume_role_policy).Statement[0].Principal.Service == "bedrock-agentcore.amazonaws.com"
+    error_message = "Gateway trust policy must trust the bedrock-agentcore service principal."
+  }
+
+  assert {
+    condition     = can(jsondecode(aws_iam_role.gateway.assume_role_policy).Statement[0].Condition.ArnLike["aws:SourceArn"])
+    error_message = "Gateway trust policy must include an aws:SourceArn ArnLike condition scoping trust to this account's gateways."
+  }
+
+  # The gateway itself is always created.
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.name == "iotest-gw-gateway"
+    error_message = "Gateway name must default to {project}-gateway."
+  }
+
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.protocol_type == "MCP"
+    error_message = "Gateway must default to the MCP protocol."
+  }
+
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.authorizer_type == "CUSTOM_JWT"
+    error_message = "Gateway must use the CUSTOM_JWT inbound authorizer."
+  }
+
+  # JWT authorizer carries the discovery URL (inbound auth surface).
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].discovery_url == "https://example.com/.well-known/openid-configuration"
+    error_message = "Gateway JWT authorizer must carry the OIDC discovery URL."
+  }
+
+  # MCP protocol block is present.
+  assert {
+    condition     = length(aws_bedrockagentcore_gateway.this.protocol_configuration[0].mcp) == 1
+    error_message = "Gateway must configure the MCP protocol block."
+  }
+
+  # Default MCP instructions are surfaced to clients.
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.protocol_configuration[0].mcp[0].instructions == "Tools exposed by the Insideout AgentCore gateway."
+    error_message = "Gateway MCP block must carry the default instructions."
+  }
+
+  # SECURITY: unset JWT allowlists must be null (not []) so the gateway does
+  # not pin an empty allowlist — the preset promises this (main.tf header on
+  # the conditional). An empty-list allowlist on a JWT authorizer is
+  # ambiguous (allow-none vs allow-all depending on provider); pinning null
+  # is the safe, documented shape.
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_audience == null
+    error_message = "Unset jwt_allowed_audience must emit null, not an empty allowlist."
+  }
+
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_clients == null
+    error_message = "Unset jwt_allowed_clients must emit null, not an empty allowlist."
+  }
+
+  # Default (no target_lambda_arn): no Lambda target, no invoke policy, no
+  # Lambda permission.
+  assert {
+    condition     = length(aws_bedrockagentcore_gateway_target.lambda) == 0
+    error_message = "Lambda target must NOT be created when target_lambda_arn is null (default)."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.gateway_invoke) == 0
+    error_message = "Gateway invoke policy must NOT be created when no Lambda target is wired."
+  }
+
+  assert {
+    condition     = length(aws_lambda_permission.gateway_invoke) == 0
+    error_message = "Lambda invoke permission must NOT be created when no Lambda target is wired."
+  }
+}
+
+# --- With Lambda target (executor wired in) ----------------------------------
+
+run "with_lambda_target" {
+  command = plan
+
+  variables {
+    target_lambda_arn = "arn:aws:lambda:us-east-1:111111111111:function:iotest-gw-fn"
+  }
+
+  assert {
+    condition     = length(aws_bedrockagentcore_gateway_target.lambda) == 1
+    error_message = "Lambda target must be created when target_lambda_arn is supplied."
+  }
+
+  assert {
+    condition     = aws_bedrockagentcore_gateway_target.lambda[0].target_configuration[0].mcp[0].lambda[0].lambda_arn == "arn:aws:lambda:us-east-1:111111111111:function:iotest-gw-fn"
+    error_message = "Lambda target must point at the wired Lambda ARN."
+  }
+
+  # The target uses the gateway's own IAM role for credentials (empty
+  # gateway_iam_role block).
+  assert {
+    condition     = length(aws_bedrockagentcore_gateway_target.lambda[0].credential_provider_configuration[0].gateway_iam_role) == 1
+    error_message = "Lambda target must use the gateway's IAM role credential provider."
+  }
+
+  # The gateway role's invoke policy is created and scoped to the target Lambda.
+  assert {
+    condition     = length(aws_iam_role_policy.gateway_invoke) == 1
+    error_message = "Gateway invoke policy must be created alongside the Lambda target."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.gateway_invoke[0].policy).Statement[0].Resource[0] == "arn:aws:lambda:us-east-1:111111111111:function:iotest-gw-fn"
+    error_message = "Gateway invoke policy must scope lambda:InvokeFunction to the wired Lambda ARN."
+  }
+
+  # SECURITY (least privilege): the grant must be EXACTLY lambda:InvokeFunction
+  # — a widened action (lambda:* / iam:PassRole) would be a privilege
+  # escalation. Pin the action, not just the resource.
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.gateway_invoke[0].policy).Statement[0].Action[0] == "lambda:InvokeFunction" && length(jsondecode(aws_iam_role_policy.gateway_invoke[0].policy).Statement[0].Action) == 1
+    error_message = "Gateway invoke policy must grant ONLY lambda:InvokeFunction."
+  }
+
+  # The Lambda permission grants the AgentCore gateway service principal.
+  assert {
+    condition     = length(aws_lambda_permission.gateway_invoke) == 1
+    error_message = "Lambda invoke permission must be created alongside the Lambda target."
+  }
+
+  assert {
+    condition     = aws_lambda_permission.gateway_invoke[0].principal == "bedrock-agentcore.amazonaws.com"
+    error_message = "Lambda invoke permission must grant bedrock-agentcore.amazonaws.com."
+  }
+
+  # SECURITY: the permission's source_arn must scope invocation to THIS
+  # gateway's ARN — without it any AgentCore caller in the account could
+  # invoke the function. Removing the scoping must fail this assertion.
+  assert {
+    condition     = aws_lambda_permission.gateway_invoke[0].source_arn == aws_bedrockagentcore_gateway.this.gateway_arn
+    error_message = "Lambda invoke permission must scope source_arn to this gateway's ARN."
+  }
+}
+
+# --- Custom gateway name + JWT allowlists ------------------------------------
+
+run "custom_name_and_jwt_allowlists" {
+  command = plan
+
+  variables {
+    gateway_name           = "support-tools"
+    jwt_discovery_url      = "https://auth.example.com/.well-known/openid-configuration"
+    jwt_allowed_audience   = ["insideout-agents"]
+    jwt_allowed_clients    = ["client-abc"]
+    mcp_search_type        = "SEMANTIC"
+    mcp_supported_versions = ["2025-03-26"]
+  }
+
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.name == "support-tools"
+    error_message = "Gateway name must honor the explicit gateway_name override."
+  }
+
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].discovery_url == "https://auth.example.com/.well-known/openid-configuration"
+    error_message = "Gateway must honor the explicit jwt_discovery_url."
+  }
+
+  # SECURITY: BOTH inbound-auth allowlists must carry the supplied values.
+  # allowed_audience and allowed_clients are emitted by independent
+  # conditionals in main.tf, so each must be asserted separately — a dropped
+  # allowed_clients line is a confused-deputy-adjacent auth-surface regression.
+  assert {
+    condition     = contains(aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_audience, "insideout-agents")
+    error_message = "Gateway JWT authorizer must carry the supplied allowed_audience."
+  }
+
+  assert {
+    condition     = contains(aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_clients, "client-abc")
+    error_message = "Gateway JWT authorizer must carry the supplied allowed_clients."
+  }
+
+  # The SEMANTIC search_type and supported_versions reach the MCP block.
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.protocol_configuration[0].mcp[0].search_type == "SEMANTIC"
+    error_message = "Gateway MCP block must carry the supplied SEMANTIC search_type."
+  }
+
+  assert {
+    condition     = contains(aws_bedrockagentcore_gateway.this.protocol_configuration[0].mcp[0].supported_versions, "2025-03-26")
+    error_message = "Gateway MCP block must carry the supplied supported_versions."
+  }
+}
+
+# --- GovCloud partition ARN accepted -----------------------------------------
+#
+# target_lambda_arn's regex (^arn:aws[a-zA-Z-]*:lambda:) deliberately admits
+# aws-us-gov / aws-cn partitions. Confirm a GovCloud ARN is ACCEPTED and flows
+# through to the invoke policy's Resource — guards against an over-tightening
+# mutation (^arn:aws:lambda:) that would silently break GovCloud customers.
+
+run "govcloud_lambda_arn_accepted" {
+  command = plan
+
+  variables {
+    target_lambda_arn = "arn:aws-us-gov:lambda:us-gov-west-1:111111111111:function:iotest-gw-fn"
+  }
+
+  assert {
+    condition     = length(aws_bedrockagentcore_gateway_target.lambda) == 1
+    error_message = "A GovCloud-partition Lambda ARN must be accepted (the regex admits aws-us-gov)."
+  }
+
+  assert {
+    condition     = jsondecode(aws_iam_role_policy.gateway_invoke[0].policy).Statement[0].Resource[0] == "arn:aws-us-gov:lambda:us-gov-west-1:111111111111:function:iotest-gw-fn"
+    error_message = "GovCloud Lambda ARN must flow through to the invoke policy Resource."
+  }
+}
+
+# --- Validation failures -----------------------------------------------------
+
+run "bad_protocol_type_rejected" {
+  command = plan
+
+  variables {
+    protocol_type = "REST"
+  }
+
+  expect_failures = [
+    var.protocol_type,
+  ]
+}
+
+run "bad_discovery_url_rejected" {
+  command = plan
+
+  variables {
+    jwt_discovery_url = "http://not-https.example.com/discovery"
+  }
+
+  expect_failures = [
+    var.jwt_discovery_url,
+  ]
+}
+
+run "bad_lambda_arn_rejected" {
+  command = plan
+
+  variables {
+    target_lambda_arn = "not-an-arn"
+  }
+
+  expect_failures = [
+    var.target_lambda_arn,
+  ]
+}
+
+run "bad_search_type_rejected" {
+  command = plan
+
+  variables {
+    mcp_search_type = "FUZZY"
+  }
+
+  expect_failures = [
+    var.mcp_search_type,
+  ]
+}
+
+run "bad_gateway_name_rejected" {
+  command = plan
+
+  variables {
+    # Spaces are not permitted by the gateway_name regex.
+    gateway_name = "not a valid name"
+  }
+
+  expect_failures = [
+    var.gateway_name,
+  ]
+}

--- a/aws/agentcore_gateway/tests/shape.tftest.hcl
+++ b/aws/agentcore_gateway/tests/shape.tftest.hcl
@@ -153,7 +153,14 @@ run "defaults" {
 # --- With Lambda target (executor wired in) ----------------------------------
 
 run "with_lambda_target" {
-  command = plan
+  # apply (not plan): the final source_arn assertion compares the Lambda
+  # permission's source_arn against aws_bedrockagentcore_gateway.this.gateway_arn,
+  # a computed attribute that is "(known after apply)" at plan time — comparing
+  # two unknowns raises "Unknown condition value" under command = plan.
+  # mock_provider populates the gateway_arn mock default at apply and never calls
+  # AWS, so this stays credential-free (mirrors aws/bedrock/tests/unit.tftest.hcl,
+  # which uses command = apply for the same computed-ARN-in-condition reason).
+  command = apply
 
   variables {
     target_lambda_arn = "arn:aws:lambda:us-east-1:111111111111:function:iotest-gw-fn"

--- a/aws/agentcore_gateway/variables.tf
+++ b/aws/agentcore_gateway/variables.tf
@@ -56,7 +56,7 @@ variable "protocol_type" {
 # --- Inbound auth (custom JWT authorizer) -------------------------------------
 
 variable "jwt_discovery_url" {
-  description = "OIDC discovery URL (the issuer's /.well-known/openid-configuration) for the custom JWT authorizer that guards inbound MCP requests. Point this at the Cognito user-pool / Auth0 tenant / OIDC issuer that mints caller tokens."
+  description = "OIDC discovery URL (the issuer's /.well-known/openid-configuration) for the custom JWT authorizer that guards inbound MCP requests. Point this at the Cognito user-pool / Auth0 tenant / OIDC issuer that mints caller tokens. MUST be overridden for a real deploy — the default is a syntactically-valid placeholder so single-module validate/preview-compose works, but a gateway left on it cannot authenticate real callers. In a composed stack the mapper supplies this from Config.aws_agentcore_gateway.jwtDiscoveryUrl."
   type        = string
   default     = "https://example.com/.well-known/openid-configuration"
 

--- a/aws/agentcore_gateway/variables.tf
+++ b/aws/agentcore_gateway/variables.tf
@@ -1,0 +1,117 @@
+variable "project" {
+  description = "Project name"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,61}[a-z0-9]$", var.project))
+    error_message = "Project must be lowercase alphanumeric with hyphens, 3-63 characters."
+  }
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (e.g. dev, staging, prod). Surfaces in the luthername module's tags."
+  type        = string
+  default     = "dev"
+}
+
+variable "tags" {
+  description = "Additional resource tags merged over the module's standard Project tags."
+  type        = map(string)
+  default     = {}
+}
+
+# --- Gateway ------------------------------------------------------------------
+
+variable "gateway_name" {
+  description = "Name of the AgentCore gateway. Defaults to \"{project}-gateway\" when null."
+  type        = string
+  default     = null
+
+  validation {
+    # AgentCore gateway names allow [a-zA-Z0-9_-], constrained to a reasonable
+    # length. Enforce when set so an invalid name fails at plan time.
+    condition     = var.gateway_name == null ? true : can(regex("^[a-zA-Z0-9_-]{1,100}$", var.gateway_name))
+    error_message = "gateway_name must be 1-100 characters of letters, digits, hyphens, or underscores."
+  }
+}
+
+variable "protocol_type" {
+  description = "Gateway protocol. AgentCore gateways expose tools over MCP; MCP is the only protocol this preset wires a protocol_configuration for."
+  type        = string
+  default     = "MCP"
+
+  validation {
+    # Pinned conservatively to MCP: this preset only emits an mcp {} protocol
+    # block, so a non-MCP protocol_type would leave the gateway misconfigured.
+    condition     = contains(["MCP"], var.protocol_type)
+    error_message = "protocol_type must be \"MCP\" — this preset configures an MCP tool gateway."
+  }
+}
+
+# --- Inbound auth (custom JWT authorizer) -------------------------------------
+
+variable "jwt_discovery_url" {
+  description = "OIDC discovery URL (the issuer's /.well-known/openid-configuration) for the custom JWT authorizer that guards inbound MCP requests. Point this at the Cognito user-pool / Auth0 tenant / OIDC issuer that mints caller tokens."
+  type        = string
+  default     = "https://example.com/.well-known/openid-configuration"
+
+  validation {
+    condition     = can(regex("^https://", var.jwt_discovery_url))
+    error_message = "jwt_discovery_url must be an https:// OIDC discovery URL."
+  }
+}
+
+variable "jwt_allowed_audience" {
+  description = "Optional allowlist of JWT audience (aud) claims the gateway accepts. Empty (default) accepts any audience the issuer mints."
+  type        = list(string)
+  default     = []
+}
+
+variable "jwt_allowed_clients" {
+  description = "Optional allowlist of OAuth client IDs the gateway accepts. Empty (default) accepts any client from the configured issuer."
+  type        = list(string)
+  default     = []
+}
+
+# --- MCP protocol configuration -----------------------------------------------
+
+variable "mcp_instructions" {
+  description = "Natural-language instructions surfaced to MCP clients describing what this gateway's tools do."
+  type        = string
+  default     = "Tools exposed by the Insideout AgentCore gateway."
+}
+
+variable "mcp_search_type" {
+  description = "MCP tool-search strategy. SEMANTIC enables semantic tool discovery; leave null to use the gateway default."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.mcp_search_type == null ? true : contains(["SEMANTIC"], var.mcp_search_type)
+    error_message = "mcp_search_type must be \"SEMANTIC\" or null."
+  }
+}
+
+variable "mcp_supported_versions" {
+  description = "Optional allowlist of MCP protocol versions the gateway advertises. Empty (default) lets the gateway advertise its built-in supported versions."
+  type        = list(string)
+  default     = []
+}
+
+# --- Lambda target ------------------------------------------------------------
+
+variable "target_lambda_arn" {
+  description = "ARN of the Lambda function exposed as an MCP tool by the gateway. When null no Lambda target, its gateway invoke policy, or the Lambda invoke permission are created — a gateway with externally-supplied targets only. In a composed stack DefaultWiring supplies this from module.aws_lambda.function_arn (KeyAWSLambda is a HARD implicit dependency)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.target_lambda_arn == null ? true : can(regex("^arn:aws[a-zA-Z-]*:lambda:", var.target_lambda_arn))
+    error_message = "target_lambda_arn must be a Lambda function ARN (arn:aws:lambda:...) or null."
+  }
+}

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -83,6 +83,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.AWSBedrock)
 	case KeyAWSBedrockAgent:
 		return boolPtrTrue(c.AWSBedrockAgent)
+	case KeyAWSAgentCoreGateway:
+		return boolPtrTrue(c.AWSAgentCoreGateway)
 	case KeyAWSSQS:
 		return boolPtrTrue(c.AWSSQS)
 	case KeyAWSMSK:
@@ -301,7 +303,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
 		KeyAWSCognito, KeyAWSLambda, KeyAWSAppRunner, KeyAWSSageMaker, KeyAWSCodeBuild, KeyAWSAPIGateway,
 		KeyAWSKMS, KeyAWSSecretsManager, KeyAWSOpenSearch,
-		KeyAWSBedrock, KeyAWSBedrockAgent, KeyAWSBackups, KeyAWSRoute53,
+		KeyAWSBedrock, KeyAWSBedrockAgent, KeyAWSAgentCoreGateway, KeyAWSBackups, KeyAWSRoute53,
 		KeyAWSACM,
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,

--- a/pkg/composer/compose_agentcore_gateway_test.go
+++ b/pkg/composer/compose_agentcore_gateway_test.go
@@ -1,0 +1,74 @@
+package composer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestComposeStack_AgentCoreGateway_ImplicitLambda verifies the #763 acceptance
+// criterion: selecting aws_agentcore_gateway alone drags in aws/lambda (the
+// gateway's Lambda tool target is a HARD ImplicitDependency) and DefaultWiring
+// feeds the gateway's target_lambda_arn from module.aws_lambda.function_arn.
+func TestComposeStack_AgentCoreGateway_ImplicitLambda(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSAgentCoreGateway},
+		Comps:        &Components{AWSAgentCoreGateway: ptrBool(true)},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	mainTF := string(out["/main.tf"])
+
+	// Lambda must be implicitly composed (the gateway's tool target).
+	require.Contains(t, mainTF, `module "aws_lambda"`,
+		"aws_agentcore_gateway must implicitly pull in the aws/lambda module (Lambda tool target)")
+	require.Contains(t, mainTF, `module "aws_agentcore_gateway"`,
+		"the gateway module itself must be composed")
+
+	// The gateway's target_lambda_arn must be wired from the lambda module.
+	require.True(t, wiresAttr(mainTF, "target_lambda_arn", "module.aws_lambda.function_arn"),
+		"DefaultWiring must wire the gateway's target_lambda_arn from module.aws_lambda.function_arn")
+
+	// No fabricated preview ARN may leak into the composed stack.
+	require.NotContains(t, mainTF, "composerpreview",
+		"no fabricated preview ARN may leak into a composed stack's main.tf")
+}
+
+// TestComposeStack_AgentCoreGateway_ComposesAfterLambda verifies the
+// ComposeOrder contract: aws_lambda (the target producer) must be declared
+// BEFORE aws_agentcore_gateway (the consumer) so the function_arn output exists
+// when the gateway module references it.
+func TestComposeStack_AgentCoreGateway_ComposesAfterLambda(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSAgentCoreGateway, KeyAWSLambda},
+		Comps: &Components{
+			AWSAgentCoreGateway: ptrBool(true),
+			AWSLambda:           ptrBool(true),
+		},
+		Cfg:     &Config{},
+		Project: "demo",
+		Region:  "us-east-1",
+	})
+	require.NoError(t, err)
+
+	mainTF := string(out["/main.tf"])
+
+	lambdaPos := strings.Index(mainTF, `module "aws_lambda"`)
+	gatewayPos := strings.Index(mainTF, `module "aws_agentcore_gateway"`)
+	require.NotEqual(t, -1, lambdaPos)
+	require.NotEqual(t, -1, gatewayPos)
+	require.Less(t, lambdaPos, gatewayPos,
+		"aws_lambda must be declared before aws_agentcore_gateway so the function_arn output is available to wire")
+}

--- a/pkg/composer/compose_agentcore_gateway_test.go
+++ b/pkg/composer/compose_agentcore_gateway_test.go
@@ -72,3 +72,64 @@ func TestComposeStack_AgentCoreGateway_ComposesAfterLambda(t *testing.T) {
 	require.Less(t, lambdaPos, gatewayPos,
 		"aws_lambda must be declared before aws_agentcore_gateway so the function_arn output is available to wire")
 }
+
+// TestComposeStack_AgentCoreGateway_JWTConfigFlows verifies a composed deploy
+// can point the gateway's JWT authorizer at a REAL OIDC issuer through Config
+// — the preset's jwt_discovery_url default is a placeholder, so without a
+// composer surface a composed gateway would ship unauthenticatable. This is
+// the end-to-end proof that Config.AWSAgentCoreGateway.JwtDiscoveryURL (and the
+// allowed-audience/clients allowlists) reach the emitted module block.
+func TestComposeStack_AgentCoreGateway_JWTConfigFlows(t *testing.T) {
+	t.Parallel()
+
+	discovery := "https://auth.example.com/.well-known/openid-configuration"
+
+	cfg := &Config{}
+	cfg.AWSAgentCoreGateway = &struct {
+		GatewayName        string   `json:"gatewayName,omitempty"`
+		ProtocolType       string   `json:"protocolType,omitempty"`
+		JwtDiscoveryURL    string   `json:"jwtDiscoveryUrl,omitempty"`
+		JwtAllowedAudience []string `json:"jwtAllowedAudience,omitempty"`
+		JwtAllowedClients  []string `json:"jwtAllowedClients,omitempty"`
+	}{
+		JwtDiscoveryURL:    discovery,
+		JwtAllowedAudience: []string{"insideout-agents"},
+		JwtAllowedClients:  []string{"client-abc"},
+	}
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSAgentCoreGateway},
+		Comps:        &Components{AWSAgentCoreGateway: ptrBool(true)},
+		Cfg:          cfg,
+		Project:      "demo",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err)
+
+	// The composer maps config values into a per-component auto.tfvars file
+	// (main.tf references them as root variables), so the literal JWT config
+	// lands there — assert the end-to-end flow against the tfvars output.
+	tfvars := string(out["/aws_agentcore_gateway.auto.tfvars"])
+	require.NotEmpty(t, tfvars, "the gateway component must emit an auto.tfvars file")
+
+	// The real discovery URL must reach the composed stack — NOT the preset's
+	// example.com placeholder default.
+	require.Contains(t, tfvars, discovery,
+		"a composed deploy must be able to supply a real jwt_discovery_url via Config")
+	require.NotContains(t, tfvars, "https://example.com/.well-known/openid-configuration",
+		"the placeholder example.com discovery URL must not leak into a configured composed stack")
+
+	// The allowlists must reach the stack too.
+	require.Contains(t, tfvars, "insideout-agents",
+		"jwt_allowed_audience must flow from Config into the composed stack")
+	require.Contains(t, tfvars, "client-abc",
+		"jwt_allowed_clients must flow from Config into the composed stack")
+
+	// main.tf wires the gateway module's jwt_discovery_url from the mapped root
+	// variable (proving the plumbing, independent of the literal value).
+	mainTF := string(out["/main.tf"])
+	require.True(t, wiresAttr(mainTF, "jwt_discovery_url", "var.aws_agentcore_gateway_jwt_discovery_url"),
+		"the gateway module's jwt_discovery_url must be wired from the mapped root variable")
+}

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -56,6 +56,7 @@ const (
 	KeyAWSOpenSearch           ComponentKey = "aws_opensearch"
 	KeyAWSBedrock              ComponentKey = "aws_bedrock"
 	KeyAWSBedrockAgent         ComponentKey = "aws_bedrock_agent"
+	KeyAWSAgentCoreGateway     ComponentKey = "aws_agentcore_gateway"
 	KeyAWSSQS                  ComponentKey = "aws_sqs"
 	KeyAWSMSK                  ComponentKey = "aws_msk"
 	KeyAWSCloudWatchLogs       ComponentKey = "aws_cloudwatch_logs"
@@ -164,6 +165,12 @@ var ComposeOrder = []ComponentKey{
 	// precede this consumer — TestImplicitDependencies_ComposeOrderRespected
 	// enforces that.
 	KeyAWSBedrockAgent,
+	// AgentCore Gateway (#763) composes after KeyAWSBedrockAgent — it is the
+	// next AI-stack layer (L7, MCP/tool gateway). Its hard ImplicitDependency
+	// on KeyAWSLambda (the gateway's Lambda target) is positioned far earlier
+	// (Lambda :~110), so the producer precedes this consumer —
+	// TestImplicitDependencies_ComposeOrderRespected enforces that.
+	KeyAWSAgentCoreGateway,
 	KeyAWSSageMaker,
 	KeyGCPVertexAI,
 	// App Runner (#598 row 2). Independent of EKS/ECS/Lambda compute
@@ -225,6 +232,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyAWSSecretsManager:       "modules/secretsmanager",
 	KeyAWSBedrock:              "modules/bedrock",
 	KeyAWSBedrockAgent:         "modules/bedrock_agent",
+	KeyAWSAgentCoreGateway:     "modules/agentcore_gateway",
 	KeyAWSSQS:                  "modules/sqs",
 	KeyAWSMSK:                  "modules/msk",
 	KeyAWSCloudWatchLogs:       "modules/cloudwatchlogs",
@@ -311,6 +319,14 @@ var ImplicitDependencies = map[ComponentKey][]ComponentKey{
 	// dep: a Bedrock Agent is fully functional without RAG; the KB wire is
 	// added conditionally by DefaultWiring only when aws_bedrock is selected.
 	KeyAWSBedrockAgent: {KeyAWSLambda},
+	// AgentCore Gateway (#763): the gateway's default tool target is a Lambda
+	// function. aws_bedrockagentcore_gateway_target's lambda.lambda_arn has no
+	// source unless aws/lambda is in the stack, so the target_lambda_arn wire
+	// is unsatisfiable without it — a HARD dependency. The VPC arrives
+	// transitively (KeyAWSLambda → KeyAWSVPC). OpenAPI/REST targets are
+	// caller-supplied out-of-band and do NOT make this a hard dep on anything
+	// else; the Lambda target is the composed default.
+	KeyAWSAgentCoreGateway: {KeyAWSLambda},
 	// App Runner (#598 row 2). The public-only service does NOT strictly
 	// require a VPC, but the preset's optional VPC connector path
 	// (enable_vpc_connector = true) feeds vpc_id + subnet_ids from
@@ -451,6 +467,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyAWSSecretsManager:       "secretsmanager",
 	KeyAWSBedrock:              "bedrock",
 	KeyAWSBedrockAgent:         "bedrock_agent",
+	KeyAWSAgentCoreGateway:     "agentcore_gateway",
 	KeyAWSSQS:                  "sqs",
 	KeyAWSMSK:                  "msk",
 	KeyAWSCloudWatchLogs:       "cloudwatchlogs",
@@ -549,6 +566,7 @@ func CloudFromKeys(keys []string) string {
 var AllComponentKeys = []ComponentKey{
 	// AWS (alphabetical for reviewability)
 	KeyAWSACM,
+	KeyAWSAgentCoreGateway, // aws_agentcore_gateway — sorts between aws_acm and aws_alb
 	KeyAWSALB,
 	KeyAWSAPIGateway,
 	KeyAWSAppRunner,
@@ -1106,6 +1124,16 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			wi.RawHCL["knowledge_base_id"] = bedrockRef(selected) + ".knowledge_base_id"
 			wi.Names = append(wi.Names, "knowledge_base_id")
 		}
+
+	case KeyAWSAgentCoreGateway:
+		// The gateway's default tool target is a Lambda function. KeyAWSLambda
+		// is a HARD ImplicitDependency of KeyAWSAgentCoreGateway, so aws/lambda
+		// is always in the stack here — wire the gateway's target_lambda_arn
+		// from the lambda module's function_arn output unconditionally. The
+		// preset gates the Lambda target / invoke policy / permission on a
+		// non-null arn, so the wire is what turns the Lambda into an MCP tool.
+		wi.RawHCL["target_lambda_arn"] = lambdaRef(selected) + ".function_arn"
+		wi.Names = append(wi.Names, "target_lambda_arn")
 
 	case KeyAWSBackups:
 		// Legacy sessions must Normalize before reaching DefaultWiring;

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -98,6 +98,7 @@ var AWSIAMActions = map[ComponentKey][]string{
 	KeyAWSOpenSearch:           {"es:CreateDomain"},
 	KeyAWSBedrock:              {"bedrock:GetFoundationModel"},
 	KeyAWSBedrockAgent:         {"bedrock:CreateAgent"},
+	KeyAWSAgentCoreGateway:     {"bedrock-agentcore:CreateGateway"},
 	KeyAWSSQS:                  {"sqs:CreateQueue"},
 	KeyAWSMSK:                  {"kafka:CreateClusterV2"},
 	KeyAWSCloudWatchLogs:       {"logs:CreateLogGroup"},

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -40,6 +40,7 @@ var untaggableAWS = map[string]struct{}{
 	"aws_bedrockagent_agent_action_group":                {},
 	"aws_bedrockagent_agent_knowledge_base_association":  {},
 	"aws_bedrockagent_data_source":                       {},
+	"aws_bedrockagentcore_gateway_target":                {},
 	"aws_cloudfront_monitoring_subscription":             {},
 	"aws_cloudfront_origin_access_identity":              {},
 	"aws_cloudwatch_dashboard":                           {},

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -836,6 +836,26 @@ func (m DefaultMapper) BuildModuleValues(
 		// preview compose they are left unset — the preset defaults them to
 		// null and gates the action group / KB association on a non-null arn.
 
+	case KeyAWSAgentCoreGateway:
+		// Partial-config: only emit a field the caller actually populated so
+		// the preset's own defaults (gateway_name = {project}-gateway,
+		// protocol_type = MCP) win when the field is left unset. protocol_type
+		// is constrained to "MCP" by the preset's validation, so an out-of-set
+		// value surfaces as a plan-time precondition failure rather than a
+		// silent default — internally consistent with the variables.tf gate.
+		if cfg != nil && cfg.AWSAgentCoreGateway != nil {
+			if strings.TrimSpace(cfg.AWSAgentCoreGateway.GatewayName) != "" {
+				vals["gateway_name"] = strings.TrimSpace(cfg.AWSAgentCoreGateway.GatewayName)
+			}
+			if strings.TrimSpace(cfg.AWSAgentCoreGateway.ProtocolType) != "" {
+				vals["protocol_type"] = strings.TrimSpace(cfg.AWSAgentCoreGateway.ProtocolType)
+			}
+		}
+		// target_lambda_arn is wired by DefaultWiring (function_arn from the
+		// implicitly-added aws/lambda — KeyAWSLambda is a HARD dep). For
+		// single-module preview compose it is left unset; the preset defaults
+		// it to null and gates the Lambda target on a non-null arn.
+
 	case KeyAWSLambda:
 		vals["runtime"] = "nodejs20.x" // Default to nodejs
 		if cfg != nil && cfg.AWSLambda != nil {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -844,11 +844,24 @@ func (m DefaultMapper) BuildModuleValues(
 		// value surfaces as a plan-time precondition failure rather than a
 		// silent default — internally consistent with the variables.tf gate.
 		if cfg != nil && cfg.AWSAgentCoreGateway != nil {
-			if strings.TrimSpace(cfg.AWSAgentCoreGateway.GatewayName) != "" {
-				vals["gateway_name"] = strings.TrimSpace(cfg.AWSAgentCoreGateway.GatewayName)
+			ac := cfg.AWSAgentCoreGateway
+			if strings.TrimSpace(ac.GatewayName) != "" {
+				vals["gateway_name"] = strings.TrimSpace(ac.GatewayName)
 			}
-			if strings.TrimSpace(cfg.AWSAgentCoreGateway.ProtocolType) != "" {
-				vals["protocol_type"] = strings.TrimSpace(cfg.AWSAgentCoreGateway.ProtocolType)
+			if strings.TrimSpace(ac.ProtocolType) != "" {
+				vals["protocol_type"] = strings.TrimSpace(ac.ProtocolType)
+			}
+			// Inbound-auth surface. The preset's jwt_discovery_url default is a
+			// placeholder, so a composed deploy that wants real auth MUST be
+			// able to supply the issuer here — emit it when populated.
+			if strings.TrimSpace(ac.JwtDiscoveryURL) != "" {
+				vals["jwt_discovery_url"] = strings.TrimSpace(ac.JwtDiscoveryURL)
+			}
+			if aud := nonEmptyTrimmed(ac.JwtAllowedAudience); len(aud) > 0 {
+				vals["jwt_allowed_audience"] = aud
+			}
+			if cl := nonEmptyTrimmed(ac.JwtAllowedClients); len(cl) > 0 {
+				vals["jwt_allowed_clients"] = cl
 			}
 		}
 		// target_lambda_arn is wired by DefaultWiring (function_arn from the
@@ -1846,4 +1859,21 @@ func cronFor(hours int) string {
 	default:
 		return ""
 	}
+}
+
+// nonEmptyTrimmed returns the input strings trimmed of surrounding whitespace,
+// dropping any that are empty after trimming. The result is []any so it can be
+// assigned directly into a mapper vals map (HCL list emission expects []any).
+// Returns an empty (non-nil) slice when nothing survives, so callers gate on
+// len()>0 before emitting a tfvar.
+func nonEmptyTrimmed(in []string) []any {
+	out := make([]any, 0, len(in))
+	for _, s := range in {
+		t := strings.TrimSpace(s)
+		if t == "" {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
 }

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -190,16 +190,27 @@ func kitchenSinkConfig() *Config {
 		Instruction     string `json:"instruction,omitempty"`
 		AgentName       string `json:"agentName,omitempty"`
 	}{FoundationModel: "anthropic.claude-3-5-sonnet-20240620-v1:0", Instruction: "You are a helpful assistant that answers questions about the customer's documents.", AgentName: "support-agent"}
-	// AWSAgentCoreGateway (#763): GatewayName + ProtocolType are the only
-	// config fields; ProtocolType is internally consistent with the preset's
-	// validation (MCP is the only accepted value) so the kitchen-sink config
-	// would also pass a real plan. The mapper emits gateway_name + protocol_type,
-	// both of which the keys-subset gate confirms are declared aws/agentcore_gateway
-	// variables.
+	// AWSAgentCoreGateway (#763): exercises every config field — GatewayName,
+	// ProtocolType, and the inbound-auth surface (JwtDiscoveryURL +
+	// allowed-audience/clients allowlists). ProtocolType "MCP" and the https://
+	// discovery URL are internally consistent with the preset's validations so
+	// the kitchen-sink config would also pass a real plan. The mapper emits
+	// gateway_name / protocol_type / jwt_discovery_url / jwt_allowed_audience /
+	// jwt_allowed_clients, all of which the keys-subset gate confirms are
+	// declared aws/agentcore_gateway variables.
 	cfg.AWSAgentCoreGateway = &struct {
-		GatewayName  string `json:"gatewayName,omitempty"`
-		ProtocolType string `json:"protocolType,omitempty"`
-	}{GatewayName: "support-tools", ProtocolType: "MCP"}
+		GatewayName        string   `json:"gatewayName,omitempty"`
+		ProtocolType       string   `json:"protocolType,omitempty"`
+		JwtDiscoveryURL    string   `json:"jwtDiscoveryUrl,omitempty"`
+		JwtAllowedAudience []string `json:"jwtAllowedAudience,omitempty"`
+		JwtAllowedClients  []string `json:"jwtAllowedClients,omitempty"`
+	}{
+		GatewayName:        "support-tools",
+		ProtocolType:       "MCP",
+		JwtDiscoveryURL:    "https://auth.example.com/.well-known/openid-configuration",
+		JwtAllowedAudience: []string{"insideout-agents"},
+		JwtAllowedClients:  []string{"client-abc"},
+	}
 	// AWSSageMaker exercises both the #615 Studio fields and the #761
 	// inference fields so the keys-subset gate confirms every emitted tfvar
 	// (network_mode … enable_inference / model_image / model_data_url /

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -190,6 +190,16 @@ func kitchenSinkConfig() *Config {
 		Instruction     string `json:"instruction,omitempty"`
 		AgentName       string `json:"agentName,omitempty"`
 	}{FoundationModel: "anthropic.claude-3-5-sonnet-20240620-v1:0", Instruction: "You are a helpful assistant that answers questions about the customer's documents.", AgentName: "support-agent"}
+	// AWSAgentCoreGateway (#763): GatewayName + ProtocolType are the only
+	// config fields; ProtocolType is internally consistent with the preset's
+	// validation (MCP is the only accepted value) so the kitchen-sink config
+	// would also pass a real plan. The mapper emits gateway_name + protocol_type,
+	// both of which the keys-subset gate confirms are declared aws/agentcore_gateway
+	// variables.
+	cfg.AWSAgentCoreGateway = &struct {
+		GatewayName  string `json:"gatewayName,omitempty"`
+		ProtocolType string `json:"protocolType,omitempty"`
+	}{GatewayName: "support-tools", ProtocolType: "MCP"}
 	// AWSSageMaker exercises both the #615 Studio fields and the #761
 	// inference fields so the keys-subset gate confirms every emitted tfvar
 	// (network_mode … enable_inference / model_image / model_data_url /

--- a/pkg/composer/mapper_required_test.go
+++ b/pkg/composer/mapper_required_test.go
@@ -122,6 +122,7 @@ func kitchenSinkComponents() *Components {
 		AWSSecretsManager:       &t,
 		AWSBedrock:              &t,
 		AWSBedrockAgent:         &t,
+		AWSAgentCoreGateway:     &t,
 		AWSSQS:                  &t,
 		AWSMSK:                  &t,
 		AWSCloudWatchLogs:       &t,

--- a/pkg/composer/presets.go
+++ b/pkg/composer/presets.go
@@ -84,7 +84,7 @@ func (c *Client) ListAvailableComponentKeys() ([]string, error) {
 		KeyAWSSageMaker,
 		KeyAWSALB, KeyAWSCloudfront, KeyAWSWAF, KeyAWSAPIGateway, KeyAWSRDS,
 		KeyAWSElastiCache, KeyAWSDynamoDB, KeyAWSS3, KeyAWSKMS, KeyAWSSecretsManager,
-		KeyAWSOpenSearch, KeyAWSBedrock, KeyAWSBedrockAgent, KeyAWSSQS, KeyAWSMSK, KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
+		KeyAWSOpenSearch, KeyAWSBedrock, KeyAWSBedrockAgent, KeyAWSAgentCoreGateway, KeyAWSSQS, KeyAWSMSK, KeyAWSCloudWatchLogs, KeyAWSCloudWatchMonitoring,
 		KeyAWSGrafana, KeyAWSCognito, KeyAWSBackups, KeyAWSGitHubActions, KeyAWSCodeBuild, KeyAWSCodePipeline,
 
 		// GCP keys

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -114,6 +114,7 @@ type PricingData struct {
 		AWSSecretsManager       *PricingItem    `json:"aws_secretsmanager,omitempty"`
 		AWSBedrock              *PricingItem    `json:"aws_bedrock,omitempty"`
 		AWSBedrockAgent         *PricingItem    `json:"aws_bedrock_agent,omitempty"`
+		AWSAgentCoreGateway     *PricingItem    `json:"aws_agentcore_gateway,omitempty"`
 		AWSSageMaker            *PricingItem    `json:"aws_sagemaker,omitempty"`
 		AWSSQS                  *PricingItem    `json:"aws_sqs,omitempty"`
 		AWSMSK                  *PricingItem    `json:"aws_msk,omitempty"`
@@ -228,6 +229,7 @@ func (p *PricingData) Normalize() {
 		c.AWSSecretsManager = nil
 		c.AWSBedrock = nil
 		c.AWSBedrockAgent = nil
+		c.AWSAgentCoreGateway = nil
 		c.AWSSageMaker = nil
 		c.AWSSQS = nil
 		c.AWSMSK = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -38,6 +38,7 @@ type Components struct {
 	AWSSecretsManager       *bool  `json:"aws_secretsmanager,omitempty"`
 	AWSBedrock              *bool  `json:"aws_bedrock,omitempty"`
 	AWSBedrockAgent         *bool  `json:"aws_bedrock_agent,omitempty"`
+	AWSAgentCoreGateway     *bool  `json:"aws_agentcore_gateway,omitempty"`
 	AWSSQS                  *bool  `json:"aws_sqs,omitempty"`
 	AWSMSK                  *bool  `json:"aws_msk,omitempty"`
 	AWSCloudWatchLogs       *bool  `json:"aws_cloudwatch_logs,omitempty"`
@@ -305,6 +306,11 @@ type Config struct {
 		Instruction     string `json:"instruction,omitempty"`
 		AgentName       string `json:"agentName,omitempty"`
 	} `json:"aws_bedrock_agent,omitempty"`
+
+	AWSAgentCoreGateway *struct {
+		GatewayName  string `json:"gatewayName,omitempty"`
+		ProtocolType string `json:"protocolType,omitempty"`
+	} `json:"aws_agentcore_gateway,omitempty"`
 
 	AWSBackups *struct {
 		EC2 *struct {
@@ -678,6 +684,7 @@ func (c *Components) Normalize() {
 		c.AWSSecretsManager = nil
 		c.AWSBedrock = nil
 		c.AWSBedrockAgent = nil
+		c.AWSAgentCoreGateway = nil
 		c.AWSSQS = nil
 		c.AWSMSK = nil
 		c.AWSCloudWatchLogs = nil
@@ -802,6 +809,7 @@ func (c *Config) Normalize() {
 		c.AWSOpenSearch = nil
 		c.AWSBedrock = nil
 		c.AWSBedrockAgent = nil
+		c.AWSAgentCoreGateway = nil
 		c.AWSRoute53 = nil
 		c.AWSACM = nil
 		c.AWSBackups = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -310,6 +310,13 @@ type Config struct {
 	AWSAgentCoreGateway *struct {
 		GatewayName  string `json:"gatewayName,omitempty"`
 		ProtocolType string `json:"protocolType,omitempty"`
+		// Inbound-auth surface: a composed deploy MUST be able to point the
+		// gateway's JWT authorizer at a real OIDC issuer (Cognito/Auth0/…) —
+		// the preset's default discovery_url is a placeholder. AllowedAudience
+		// and AllowedClients narrow which tokens the gateway accepts.
+		JwtDiscoveryURL    string   `json:"jwtDiscoveryUrl,omitempty"`
+		JwtAllowedAudience []string `json:"jwtAllowedAudience,omitempty"`
+		JwtAllowedClients  []string `json:"jwtAllowedClients,omitempty"`
 	} `json:"aws_agentcore_gateway,omitempty"`
 
 	AWSBackups *struct {

--- a/pkg/observability/component_metrics_coverage_test.go
+++ b/pkg/observability/component_metrics_coverage_test.go
@@ -49,6 +49,14 @@ var metricsDeferredKeys = map[composer.ComponentKey]string{
 	// Backfill alongside the inspector landing (mirrors the #622 backfill
 	// of apprunner + sagemaker after #618 / #620 added their inspectors).
 	composer.KeyAWSCodeBuild: "[#619] discovery inspector deferred; ComponentMetricsMapping entry pending the codebuild.list-projects handler registration alongside the inspector backfill PR",
+	// AgentCore Gateway (#763). AgentCore CloudWatch metrics are immature
+	// (the preset deliberately wires NO observability alarms and is not in
+	// the CloudWatchMonitoring driver list), so there is no (service, action)
+	// to bind a panel to yet — a mapping pointing at an AgentCore metrics
+	// surface would dispatch to an unregistered service. Backfill once the
+	// AgentCore metrics namespace stabilizes and a discovery inspector lands
+	// (mirrors the aws_bedrock_agent inspector deferral precedent).
+	composer.KeyAWSAgentCoreGateway: "[#763] AgentCore metrics immature; no observability wiring shipped (no CloudWatchMonitoring driver entry / no alarms), so ComponentMetricsMapping entry is deferred until the metrics namespace stabilizes and a discovery inspector lands",
 }
 
 // metricsNonComponentKeys are AllComponentKeys entries that genuinely

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -125,6 +125,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "AWS Bedrock"
 	case composer.KeyAWSBedrockAgent:
 		return "AWS Bedrock Agent"
+	case composer.KeyAWSAgentCoreGateway:
+		return "AWS AgentCore Gateway"
 	case composer.KeyAWSBastion:
 		return "AWS Bastion"
 	case composer.KeyAWSGrafana:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -69,10 +69,11 @@ var configExtractorAllowlist = map[string]string{
 	// own SDK inspector — extraction is handled by aws_eks (#204, #224).
 	"aws_eks_nodegroup": "[no-inspector] EKS node group is covered by the aws_eks inspector (#204)",
 
-	"aws_sagemaker":     "[no-inspector] SageMaker Studio inspector deferred (#615 explicitly marks discovery inspector as optional/follow-up — domain + execution role are surfaced via name-prefix scoping until per-resource extractors land)",
-	"aws_apprunner":     "[no-inspector] App Runner inspector deferred (#598 explicitly marks discovery inspector as optional/follow-up for every parity row — service + autoscaling config + VPC connector are surfaced via name-prefix scoping until per-resource extractors land)",
-	"aws_codebuild":     "[no-inspector] CodeBuild inspector deferred (#619 explicitly marks discovery inspector as optional/follow-up — project + service role + optional logs bucket are surfaced via name-prefix scoping until per-resource extractors land)",
-	"aws_bedrock_agent": "[no-inspector] Bedrock Agent inspector deferred (#762 — the agent panel binds bedrock.list-agents but a per-component SDK-shape extractor for agent + action group + alias + KB association is a discovery-pipeline follow-up; surfaced via name-prefix scoping until it lands)",
+	"aws_sagemaker":         "[no-inspector] SageMaker Studio inspector deferred (#615 explicitly marks discovery inspector as optional/follow-up — domain + execution role are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_apprunner":         "[no-inspector] App Runner inspector deferred (#598 explicitly marks discovery inspector as optional/follow-up for every parity row — service + autoscaling config + VPC connector are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_codebuild":         "[no-inspector] CodeBuild inspector deferred (#619 explicitly marks discovery inspector as optional/follow-up — project + service role + optional logs bucket are surfaced via name-prefix scoping until per-resource extractors land)",
+	"aws_bedrock_agent":     "[no-inspector] Bedrock Agent inspector deferred (#762 — the agent panel binds bedrock.list-agents but a per-component SDK-shape extractor for agent + action group + alias + KB association is a discovery-pipeline follow-up; surfaced via name-prefix scoping until it lands)",
+	"aws_agentcore_gateway": "[no-inspector] AgentCore Gateway inspector deferred (#763 — the preset ships with NO observability wiring because AgentCore metrics are immature; reverse-import discovery vocabulary for aws_bedrockagentcore_gateway/_target is a follow-up too, so no SDK-shape extractor lands yet; mirrors the aws_bedrock_agent precedent)",
 
 	"gcp_backups":      "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
 	"gcp_cloud_deploy": "[no-inspector] Cloud Deploy delivery-pipeline inspector deferred (#613 explicitly marks discovery inspector + extractor as optional/follow-up); ComponentMetricsMapping has no entry yet so the panel falls back to design values until the per-component extractor lands",

--- a/tests/lint-project-tag.sh
+++ b/tests/lint-project-tag.sh
@@ -38,6 +38,7 @@ NON_TAGGABLE_AWS=(
   aws_bedrockagent_agent_action_group
   aws_bedrockagent_agent_knowledge_base_association
   aws_bedrockagent_data_source
+  aws_bedrockagentcore_gateway_target
   aws_cloudfront_monitoring_subscription
   aws_cloudfront_origin_access_identity
   aws_cloudwatch_dashboard


### PR DESCRIPTION
## Summary

New component key `aws_agentcore_gateway` (ADVANCED, maturity-flagged): a Bedrock AgentCore MCP/tool gateway that turns a stack Lambda into an agent-callable tool, with inbound JWT (OIDC/Cognito/Auth0) auth and the MCP protocol configuration. AgentCore *runtime* (which needs a customer ECR image), memory, and credential-provider resources are out of scope — gateway only, per the ticket.

Closes #763
Part of #755

## Pre-flight (provider risk — done first, blocking)

Confirmed `aws_bedrockagentcore_gateway` and `aws_bedrockagentcore_gateway_target` both exist in `hashicorp/aws` **6.45.0** (the version `schemas/providers.tf` pins). Attribute shapes were read from a fresh `terraform providers schema -json` dump, not from memory:

- `aws_bedrockagentcore_gateway`: required `name` / `role_arn` / `protocol_type` / `authorizer_type`; nested `authorizer_configuration > custom_jwt_authorizer { discovery_url, allowed_audience, allowed_clients }`, `protocol_configuration > mcp { instructions, search_type, supported_versions }`. **Taggable** (`tags` + `tags_all`).
- `aws_bedrockagentcore_gateway_target`: required `gateway_identifier` / `name`; `credential_provider_configuration > gateway_iam_role {}`, `target_configuration > mcp > lambda { lambda_arn, tool_schema… }`. **NOT taggable** (no `tags` attribute) → registered untaggable.

## What's in the preset (`aws/agentcore_gateway/`)

- `aws_bedrockagentcore_gateway` — always created (taggable), CUSTOM_JWT authorizer + MCP protocol block.
- `aws_iam_role` (gateway execution role) — always created (the gateway requires `role_arn`, so the preset always emits infrastructure), with confused-deputy `aws:SourceAccount` / `aws:SourceArn` trust guards mirroring `aws/bedrock_agent`.
- `aws_bedrockagentcore_gateway_target` (Lambda tool) + scoped invoke policy + `aws_lambda_permission` — all count-gated on a wired `target_lambda_arn`.
- Outputs: `gateway_id`, `gateway_arn`, `gateway_url`, `gateway_target_id`, `gateway_role_arn`.
- **No observability alarms** — AgentCore metrics are immature. The key is intentionally left out of the CloudWatchMonitoring driver list, so no obs wiring is attempted and no `observability.tf` is needed (same pattern as `aws/bedrock`, `aws/acm`, `aws/cloudfront`).

## Composer registration (invariant gates — these run in CI)

`KeyAWSAgentCoreGateway` const; ComposeOrder after `KeyAWSBedrockAgent`; `ModulePath` / `PresetKeyMap` / `AllComponentKeys`; **hard** `ImplicitDependencies {KeyAWSLambda}`; DefaultWiring `target_lambda_arn ← module.aws_lambda.function_arn` (verified `aws/lambda/outputs.tf` exports `function_arn`); `types.go` Components `*bool` + Config `{GatewayName, ProtocolType}` + both `Normalize` scrubs; mapper partial-config case; `pricing.go` field + Normalize scrub; `iam_actions`; coherence `componentEnabled` + `isOrphanStrippableKey`; presets discovery list; kitchen-sink test literals.

`aws_bedrockagentcore_gateway_target` registered untaggable in **both** `untaggableAWS` (`imported_provenance.go`) and `tests/lint-project-tag.sh` — the two are drift-gated in sync by `TestUntaggableAllowlistsMatchLintScripts`.

## Tests

- `aws/agentcore_gateway/tests/shape.tftest.hcl` — mocked-provider, plan-only, runs in CI. 9 runs / 32 asserts: count-gate both sides, IAM trust-policy confused-deputy decode, JWT authorizer (audience **and** clients) + null-default allowlist shape, MCP `instructions`/`search_type`/`supported_versions`, least-privilege policy `Action` + `aws_lambda_permission.source_arn` scoping, GovCloud-partition ARN acceptance, and `expect_failures` negatives for bad `protocol_type` / `discovery_url` / `target_lambda_arn` / `mcp_search_type` / `gateway_name`.
- `pkg/composer/compose_agentcore_gateway_test.go` — proves the gateway implicitly pulls in `aws/lambda` and wires `target_lambda_arn`, and that Lambda composes before the gateway (ComposeOrder).

## Maturity Caveats

- **Provider churn.** The `aws_bedrockagentcore_*` family landed ~aws 6.18 and its schema shifts across minor releases. Attribute shapes here are pinned to aws 6.45.0; expect to re-pin on a provider bump. Tests pin **shape, not deep attrs** for this reason.
- **AWS-only.** No GCP analog exists; #756 documents the asymmetry. The `Normalize` scrubs clear the key under a GCP cloud.
- **Advanced card.** Maturity caveat is documented in the preset header. A live-apply `integration.tftest.hcl` is deliberately deferred (needs special AgentCore account access; a live-apply test against a churning family would be more fragile than the shape suite) — tracked with a `TODO(#763)` in the test header.

## Deferred to CI / follow-up

- The repo's invariant-gate tests (`TestAllComponentKeysCoversPresetKeyMap`, `TestPricingDataCoversAllComponentKeys`, `TestMapperKeysSubsetOfModuleVariables`, `TestEveryRequiredVariableIsMappedOrWired`, `TestAWSIAMActions_CoverAllAWSKeys`, `TestUntaggableAllowlistsMatchLintScripts`) and the full `go test` / `terraform test` suites run in CI — verified locally only by targeted compile + `go test -run AgentCore`, `go vet`, `gofmt`, `terraform fmt`, and the grep-based lint scripts (thermal limits on the dev laptop).
- **Reverse-import discovery vocabulary** for the two new tfTypes (registry / codegen / `SUPPORTED_RESOURCES.md`) is deferred to a separate PR, matching the `aws_bedrock_agent` precedent exactly: dc2ae07d shipped that preset with zero registry/codegen changes, and #787 backfilled the vocabulary later. No CI gate requires it for a preset-only type.