### PR TITLE
fix(import): pin providers to mars-baked versions, mark service-managed resources un-importable, @region S3 import IDs

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer.go
@@ -128,8 +128,17 @@ type cloudControlConfig struct {
 	NameHintFromProperties  func(identifier string, props map[string]any) string
 	NativeIDsFromProperties func(identifier string, props map[string]any) map[string]string
 	TagsFromProperties      func(props map[string]any) map[string]string
-	ParentLister            func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
-	SDKLister               func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
+	// ServiceManagedByFromProperties, when non-nil, extracts the service
+	// owner of a service-managed instance from its Cloud Control properties
+	// (e.g. an EventBridge rule's ManagedBy = "autoscaling.amazonaws.com").
+	// A non-empty return stamps Identity.ServiceManagedBy so the importability
+	// classifier (imported.UnimportableReason → ReasonServiceManaged, #785)
+	// greys the instance out and the composer's provenance injector skips it.
+	// Return "" for customer-owned instances. Generic: any type whose service
+	// owns some instances on the customer's behalf can wire this hook.
+	ServiceManagedByFromProperties func(props map[string]any) string
+	ParentLister                   func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
+	SDKLister                      func(ctx context.Context, awsCfg aws.Config, region string, args DiscoverArgs) ([]string, error)
 	// SkipIdentifier, when non-nil, is consulted for every identifier
 	// returned by ListResources / SDKLister: returning true drops that
 	// identifier before the GetResource fan-out (and short-circuits
@@ -600,6 +609,9 @@ func (d *cloudControlDiscoverer) Discover(ctx context.Context, args DiscoverArgs
 				native,
 				f.tags,
 			)
+			if d.cfg.ServiceManagedByFromProperties != nil {
+				ir.Identity.ServiceManagedBy = d.cfg.ServiceManagedByFromProperties(f.props)
+			}
 			if d.cfg.PostDiscover != nil {
 				if perr := d.cfg.PostDiscover(ctx, d.awsCfg, region, &ir); perr != nil {
 					// Soft-fail: the resource is still emitted with whatever
@@ -687,6 +699,9 @@ func (d *cloudControlDiscoverer) DiscoverByID(ctx context.Context, id, region, a
 		native,
 		tags,
 	)
+	if d.cfg.ServiceManagedByFromProperties != nil {
+		ir.Identity.ServiceManagedBy = d.cfg.ServiceManagedByFromProperties(props)
+	}
 	if d.cfg.PostDiscover != nil {
 		// Soft-fail to match the bulk Discover path: a follow-up SDK miss
 		// on a single dep-chased resource still returns the IR with

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_discoverer_test.go
@@ -249,6 +249,50 @@ func TestCloudControlDiscover_HappyPath(t *testing.T) {
 	}
 }
 
+// TestCloudControlDiscover_ServiceManagedByLandsOnIdentity proves the
+// ServiceManagedByFromProperties hook (#785) flows end-to-end: a resource
+// whose properties carry the managed-by marker emits an ImportedResource
+// with Identity.ServiceManagedBy populated, so the importability classifier
+// can grey it out. A resource without the marker leaves the field empty.
+func TestCloudControlDiscover_ServiceManagedByLandsOnIdentity(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCloudControlClient{
+		listPages: []cloudcontrol.ListResourcesOutput{
+			listPage("", "managed-rule", "customer-rule"),
+		},
+		propsByIdentifier: map[string]map[string]any{
+			"managed-rule":  {"Name": "managed-rule", "ManagedBy": "autoscaling.amazonaws.com"},
+			"customer-rule": {"Name": "customer-rule"},
+		},
+	}
+	cfg := testConfig()
+	cfg.ServiceManagedByFromProperties = func(props map[string]any) string {
+		return extractString(props, "ManagedBy")
+	}
+	d := &cloudControlDiscoverer{
+		cfg:            cfg,
+		new:            func(_ string) cloudControlClient { return fake },
+		maxConcurrency: DefaultMaxConcurrency,
+	}
+	got, err := d.Discover(context.Background(), DiscoverArgs{
+		Regions:   []string{"us-east-1"},
+		AccountID: "123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]imported.ImportedResource{}
+	for _, ir := range got {
+		byID[ir.Identity.ImportID] = ir
+	}
+	if got := byID["managed-rule"].Identity.ServiceManagedBy; got != "autoscaling.amazonaws.com" {
+		t.Errorf("managed-rule ServiceManagedBy=%q, want autoscaling.amazonaws.com", got)
+	}
+	if got := byID["customer-rule"].Identity.ServiceManagedBy; got != "" {
+		t.Errorf("customer-rule ServiceManagedBy=%q, want empty", got)
+	}
+}
+
 // TestCloudControlDiscover_PaginatesUntilNoToken pins that pagination
 // continues until a page returns no NextToken. A regression that drops
 // the paginator loop (or only reads the first page) would only see

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -234,6 +234,26 @@ func TestCloudWatchEventRuleConfig(t *testing.T) {
 	if native["arn"] != props["Arn"] {
 		t.Errorf("NativeIDs arn: got %q, want %q", native["arn"], props["Arn"])
 	}
+
+	// Service-managed marker (#785): AWS-managed rules (AutoScalingManagedRule,
+	// etc.) carry a ManagedBy property. The discoverer must surface it so the
+	// importability classifier greys them out — tag/PutRule/DeleteRule all fail
+	// with ManagedRuleException on a managed rule.
+	if cfg.ServiceManagedByFromProperties == nil {
+		t.Fatal("aws_cloudwatch_event_rule: ServiceManagedByFromProperties must be set to capture managed rules")
+	}
+	managedProps := map[string]any{
+		"Name":      "AutoScalingManagedRule",
+		"Arn":       "arn:aws:events:us-east-1:111111111111:rule/AutoScalingManagedRule",
+		"ManagedBy": "autoscaling.amazonaws.com",
+	}
+	if got := cfg.ServiceManagedByFromProperties(managedProps); got != "autoscaling.amazonaws.com" {
+		t.Errorf("ServiceManagedBy (managed rule): got %q, want autoscaling.amazonaws.com", got)
+	}
+	// A customer rule has no ManagedBy → empty marker → importable.
+	if got := cfg.ServiceManagedByFromProperties(props); got != "" {
+		t.Errorf("ServiceManagedBy (customer rule): got %q, want empty", got)
+	}
 }
 
 // TestKMSKeyConfig pins the per-type extractors for aws_kms_key, focused

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -332,6 +332,16 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		NameHintFromProperties:  nameOrIdentifier("Name"),
 		NativeIDsFromProperties: arnUnderKey("Arn"),
 		TagsFromProperties:      tagsFromKey("Tags"),
+		// Surface the AWS-managed marker so the importability classifier
+		// (imported.UnimportableReason → ReasonServiceManaged, #785) greys
+		// out service-managed rules (AutoScalingManagedRule, etc.) instead
+		// of offering them. AWS rejects tag / PutRule / DeleteRule on any
+		// rule with ManagedBy set (ManagedRuleException), so the rule cannot
+		// be managed by Terraform at all. Absent-safe: a customer rule has no
+		// ManagedBy → empty marker → importable.
+		ServiceManagedByFromProperties: func(props map[string]any) string {
+			return extractString(props, "ManagedBy")
+		},
 	},
 
 	// =====================================================================

--- a/cmd/insideout-import/genconfig/emit.go
+++ b/cmd/insideout-import/genconfig/emit.go
@@ -93,7 +93,8 @@ type providerEmitOptions struct {
 // unaliased — see emitImports for why.
 //
 // On AWS (provider == ProviderAWS):
-//   - required_providers entry for hashicorp/aws ~> 6.0
+//   - required_providers entry for hashicorp/aws exact-pinned via
+//     imported.BaseProviderPin (mars-cache-aligned, #786)
 //   - provider "aws" { region = ... }
 //   - When awsEndpointURL is non-empty (LocalStack CI gate #272),
 //     emits the LocalStack attribute set + endpoints {} map.
@@ -101,7 +102,8 @@ type providerEmitOptions struct {
 //     readback runs through the project Terraform role.
 //
 // On GCP (provider == ProviderGCP):
-//   - required_providers entry for hashicorp/google ~> 5.0
+//   - required_providers entry for hashicorp/google exact-pinned via
+//     imported.BaseProviderPin (mars-cache-aligned, #786)
 //   - provider "google" { project = gcpProjectID; region = ... } (region
 //     omitted when empty so project-global stacks don't emit a stray
 //     attribute the provider would warn on).
@@ -121,7 +123,7 @@ func emitProviders(dir string, opts providerEmitOptions) error {
 	case ProviderGCP:
 		rp.Body().SetAttributeValue("google", cty.ObjectVal(map[string]cty.Value{
 			"source":  cty.StringVal("hashicorp/google"),
-			"version": cty.StringVal("~> 5.0"),
+			"version": cty.StringVal(imported.BaseProviderPin("gcp", "google")),
 		}))
 		prov := body.AppendNewBlock("provider", []string{"google"})
 		prov.Body().SetAttributeValue("project", cty.StringVal(opts.GCPProjectID))
@@ -131,7 +133,7 @@ func emitProviders(dir string, opts providerEmitOptions) error {
 	default: // ProviderAWS
 		rp.Body().SetAttributeValue("aws", cty.ObjectVal(map[string]cty.Value{
 			"source":  cty.StringVal("hashicorp/aws"),
-			"version": cty.StringVal("~> 6.0"),
+			"version": cty.StringVal(imported.BaseProviderPin("aws", "aws")),
 		}))
 		// Single default (unaliased) provider for this region. Each region
 		// in a multi-region import gets its own genconfig pass / workdir
@@ -187,7 +189,7 @@ const awsProviderMaxRetries = 25
 // concurrent Describe/Get reads from the raised parallelism is smoothed back
 // toward the account's real API budget rather than surfacing as a hard
 // ThrottlingException. Both attributes are top-level provider arguments
-// supported by the pinned hashicorp/aws ~> 6.0 provider (retry_mode has been
+// supported by the exact-pinned hashicorp/aws provider (retry_mode has been
 // a provider argument since v5.32; max_retries since the SDKv2 migration).
 func appendAWSRetryTuning(b *hclwrite.Body) {
 	b.SetAttributeValue("retry_mode", cty.StringVal("adaptive"))

--- a/cmd/insideout-import/genconfig/emit_test.go
+++ b/cmd/insideout-import/genconfig/emit_test.go
@@ -128,11 +128,17 @@ func TestEmitProviders_HappyPath(t *testing.T) {
 	for _, want := range []string{
 		"required_providers",
 		`source  = "hashicorp/aws"`,
-		`version = "~> 6.0"`,
+		// Exact pin aligned with the mars provider-mirror bake so the
+		// genconfig readback hits the cache (#786) — sourced from the same
+		// single source of truth as the composed-archive emitter.
+		`version = "` + imported.BaseProviderPin("aws", "aws") + `"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("providers.tf missing %q\n--- got ---\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, `version = "~> 6.0"`) {
+		t.Errorf("genconfig providers.tf must not emit the open ~> 6.0 range\n--- got ---\n%s", got)
 	}
 	// hclwrite aligns the `=` columns across the provider block, so match the
 	// region + retry-tuning attrs value-anchored (the retry attrs widen the
@@ -299,13 +305,18 @@ func TestEmitProviders_GCPHappyPath(t *testing.T) {
 	// patterns rather than alignment-dependent literals.
 	for _, pat := range []string{
 		`source\s*=\s*"hashicorp/google"`,
-		`version\s*=\s*"~> 5\.0"`,
+		// Exact pin aligned with the mars provider-mirror bake (#786),
+		// regexp-escaped from the single source of truth.
+		`version\s*=\s*"` + regexp.QuoteMeta(imported.BaseProviderPin("gcp", "google")) + `"`,
 		`project\s*=\s*"real-proj-12345"`,
 		`region\s*=\s*"us-central1"`,
 	} {
 		if !regexp.MustCompile(pat).MatchString(got) {
 			t.Errorf("providers.tf missing pattern %q\n--- got ---\n%s", pat, got)
 		}
+	}
+	if strings.Contains(got, `version = "~> 5.0"`) {
+		t.Errorf("genconfig GCP providers.tf must not emit the open ~> 5.0 range\n--- got ---\n%s", got)
 	}
 	// AWS-flavored attributes must NOT appear in a GCP block.
 	bannedPatterns := []string{

--- a/cmd/insideout-import/genconfig/testdata/golden/dario/providers.tf.golden
+++ b/cmd/insideout-import/genconfig/testdata/golden/dario/providers.tf.golden
@@ -7,8 +7,9 @@ terraform {
       # reads the live provider schema and `terraform validate` enforces the
       # live provider's rules, so a floating `~> 6.0` lets a newer provider
       # (different schema / validation) fail the gate for reasons unrelated to
-      # the fixups under test. Re-pin when the fixture is re-captured.
-      version = "6.43.0"
+      # the fixups under test. Re-pin when the fixture is re-captured. Aligned
+      # with the mars-baked / composer-emitted exact pin (#786).
+      version = "6.46.0"
     }
   }
 }

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -950,7 +950,7 @@ func generateProvidersFiles(in providersTFInput) providersTFFiles {
 		// blowing up the workflow tar with a fresh provider binary
 		// every plan. Bump both this pin AND the mars bake together.
 		// See luthersystems/mars/Dockerfile `GOOGLE_PROVIDER_VERSION`.
-		required["google"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google", VersionConstraints: []string{"= 6.10.0"}}
+		required["google"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google", VersionConstraints: []string{imported.BaseProviderPin("gcp", "google")}}
 		// google-beta is part of every GCP stack's provider set so the
 		// `google-beta.imported` alias block below always resolves —
 		// even when the current compose's Imported list is empty but
@@ -958,8 +958,16 @@ func generateProvidersFiles(in providersTFInput) providersTFFiles {
 		// google-beta only ships with GCP-cloud composes; the outer
 		// `switch cloud` keeps it out of AWS stacks. Mars bakes
 		// google-beta at the same version as google.
-		required["google-beta"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google-beta", VersionConstraints: []string{"= 6.10.0"}}
+		required["google-beta"] = &tfconfig.ProviderRequirement{Source: "hashicorp/google-beta", VersionConstraints: []string{imported.BaseProviderPin("gcp", "google-beta")}}
 		maps.Copy(required, discovered)
+		// Re-assert the exact pin AFTER the discovered union: every
+		// gcp/<module>/main.tf preset declares an open `version = ">= 5.0"`
+		// (or similar), which maps.Copy would otherwise let override the
+		// seed above — re-emitting the open range into the composed archive
+		// and defeating the cache-hit guarantee (#786). The discovered union
+		// still flows for every NON-base provider (random, time, …); only
+		// the cloud's base providers are forced back to the mars-baked pin.
+		pinBaseProviders(required, imported.BaseProviderPins("gcp"))
 
 		// default_labels is a safety net so every GCP resource in the
 		// rendered stack carries the session's project label, even if a
@@ -1075,8 +1083,17 @@ variable "aws_external_id" {
 		// for sess_v2_CnqUJ6NRJnLC on 2026-05-25 — see
 		// luthersystems/mars#171. Bump this AND the mars bake
 		// (`AWS_PROVIDER_VERSION` in mars/Dockerfile) together.
-		required["aws"] = &tfconfig.ProviderRequirement{Source: "hashicorp/aws", VersionConstraints: []string{"= 6.46.0"}}
+		required["aws"] = &tfconfig.ProviderRequirement{Source: "hashicorp/aws", VersionConstraints: []string{imported.BaseProviderPin("aws", "aws")}}
 		maps.Copy(required, discovered)
+		// Re-assert the exact pin AFTER the discovered union: every
+		// aws/<module>/main.tf preset declares an open `version = ">= 6.0"`,
+		// which maps.Copy would otherwise let override the seed above —
+		// re-emitting `>= 6.0` into the composed archive so terraform init
+		// resolves "newest at runtime", drifts ahead of the mars bake, and
+		// falls back to a direct registry download (the 6.49→6.50 breakage,
+		// #786). The discovered union still flows for every NON-base provider
+		// (random, time, opensearch, …); only aws is forced back to the pin.
+		pinBaseProviders(required, imported.BaseProviderPins("aws"))
 
 		var main strings.Builder
 		// awsVarDecls (the bootstrap_role / aws_external_id declarations)
@@ -1142,6 +1159,26 @@ variable "aws_external_id" {
 			Main:     []byte(main.String()),
 			Aliases:  aliases,
 			Imported: []byte(imp.String()),
+		}
+	}
+}
+
+// pinBaseProviders forces each provider named in pins back to its exact pinned
+// constraint on required, overwriting whatever the discovered child-module
+// union left there. Used after maps.Copy(required, discovered) so the cloud's
+// base providers keep the mars-cache-aligned exact pin while every other
+// discovered provider (random, time, opensearch, …) flows through unchanged.
+// Each entry's Source is preserved from the seed already present in required;
+// pins only overrides VersionConstraints. See #786.
+func pinBaseProviders(required map[string]*tfconfig.ProviderRequirement, pins map[string]string) {
+	for name, constraint := range pins {
+		source := "hashicorp/" + name
+		if existing := required[name]; existing != nil && existing.Source != "" {
+			source = existing.Source
+		}
+		required[name] = &tfconfig.ProviderRequirement{
+			Source:             source,
+			VersionConstraints: []string{constraint},
 		}
 	}
 }

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -354,6 +354,52 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 			"required_providers must have ≥3 entries")
 	})
 
+	t.Run("aws base provider stays exactly pinned despite a looser discovered constraint", func(t *testing.T) {
+		// Every aws/<module>/main.tf preset declares `version = ">= 6.0"`,
+		// which lands in Discovered["aws"]. The composed archive must NOT
+		// inherit that open range — it must keep the exact pin matching the
+		// mars provider-mirror bake (= 6.46.0) so terraform init hits the
+		// cache instead of resolving "newest at runtime" (#786).
+		withAWSDiscovered := map[string]*tfconfig.ProviderRequirement{
+			"aws":  {Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
+			"time": {Source: "hashicorp/time", VersionConstraints: []string{">= 0.9"}},
+		}
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:      "aws",
+			Region:     "us-east-1",
+			Selected:   map[ComponentKey]bool{},
+			Discovered: withAWSDiscovered,
+		}))
+		require.Contains(t, got, `version = "= 6.46.0"`,
+			"aws base provider must stay exactly pinned to the mars-baked version, not the discovered >= 6.0 range")
+		require.NotContains(t, got, `version = ">= 6.0"`,
+			"the open >= 6.0 range must never reach the composed archive")
+		require.Contains(t, got, "hashicorp/time",
+			"discovered non-base providers must still flow through")
+	})
+
+	t.Run("gcp base providers stay exactly pinned despite a looser discovered constraint", func(t *testing.T) {
+		withGCPDiscovered := map[string]*tfconfig.ProviderRequirement{
+			"google":      {Source: "hashicorp/google", VersionConstraints: []string{">= 5.16"}},
+			"google-beta": {Source: "hashicorp/google-beta", VersionConstraints: []string{">= 5.16"}},
+		}
+		got := string(generateProvidersTF(providersTFInput{
+			Cloud:        "gcp",
+			Region:       "us-central1",
+			GCPProjectID: "demo-project-12345",
+			Selected:     map[ComponentKey]bool{},
+			Discovered:   withGCPDiscovered,
+		}))
+		// Assert BOTH google and google-beta are pinned — a regression that
+		// pinned only `google` and let `google-beta` keep the discovered range
+		// would still leave one `= 6.10.0` present, so count ≥2 occurrences to
+		// catch a dropped google-beta pin specifically (#786).
+		require.GreaterOrEqual(t, strings.Count(got, `version = "= 6.10.0"`), 2,
+			"both google AND google-beta must stay exactly pinned to the mars-baked version")
+		require.NotContains(t, got, `version = ">= 5.16"`,
+			"the open >= 5.16 range must never reach the composed archive for either provider")
+	})
+
 	t.Run("aws with no discovery falls back to aws only", func(t *testing.T) {
 		got := string(generateProvidersTF(providersTFInput{
 			Cloud:      "aws",
@@ -564,6 +610,73 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 			"base aws provider block must be emitted")
 		require.Contains(t, got, `alias  = "imported"`,
 			"aws.imported alias block must be emitted unconditionally (#562)")
+	})
+}
+
+// TestPinBaseProviders covers the helper that re-asserts the exact base
+// provider pin after the discovered-provider union (#786) — the actual
+// mechanism that prevents an open `>= 6.0` from a preset reaching the archive.
+func TestPinBaseProviders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("overwrites the discovered version range with the exact pin", func(t *testing.T) {
+		required := map[string]*tfconfig.ProviderRequirement{
+			"aws": {Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
+		}
+		pinBaseProviders(required, map[string]string{"aws": "= 6.46.0"})
+		require.Equal(t, []string{"= 6.46.0"}, required["aws"].VersionConstraints,
+			"the open range must be replaced by the exact pin")
+		require.Equal(t, "hashicorp/aws", required["aws"].Source)
+	})
+
+	t.Run("preserves a non-default discovered Source when overwriting the version", func(t *testing.T) {
+		// A child module could legitimately declare the base provider from a
+		// mirror/registry override; pinBaseProviders must overwrite only the
+		// version, never the Source. A regression that hardcoded
+		// "hashicorp/"+name would drop the override and emit the wrong source.
+		required := map[string]*tfconfig.ProviderRequirement{
+			"aws": {Source: "registry.example.com/hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
+		}
+		pinBaseProviders(required, map[string]string{"aws": "= 6.46.0"})
+		require.Equal(t, "registry.example.com/hashicorp/aws", required["aws"].Source,
+			"a non-default Source must survive the version pin")
+		require.Equal(t, []string{"= 6.46.0"}, required["aws"].VersionConstraints)
+	})
+
+	t.Run("synthesizes hashicorp/<name> Source when the provider is absent", func(t *testing.T) {
+		required := map[string]*tfconfig.ProviderRequirement{}
+		pinBaseProviders(required, map[string]string{"google-beta": "= 6.10.0"})
+		require.NotNil(t, required["google-beta"])
+		require.Equal(t, "hashicorp/google-beta", required["google-beta"].Source)
+		require.Equal(t, []string{"= 6.10.0"}, required["google-beta"].VersionConstraints)
+	})
+
+	t.Run("leaves non-pinned discovered providers untouched", func(t *testing.T) {
+		required := map[string]*tfconfig.ProviderRequirement{
+			"aws":  {Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
+			"time": {Source: "hashicorp/time", VersionConstraints: []string{">= 0.9"}},
+		}
+		pinBaseProviders(required, map[string]string{"aws": "= 6.46.0"})
+		require.Equal(t, []string{">= 0.9"}, required["time"].VersionConstraints,
+			"a provider not named in the pin set must be left as-is")
+	})
+
+	t.Run("empty or nil pins is a no-op", func(t *testing.T) {
+		// The no-pins contract callers rely on for a cloud with no base pins:
+		// imported.BaseProviderPins("azure") returns nil, and the emitter then
+		// calls pinBaseProviders(required, nil). It must leave required exactly
+		// as the discovered union left it — never panic, never synthesize an
+		// entry.
+		base := map[string]*tfconfig.ProviderRequirement{
+			"aws": {Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
+		}
+		for _, pins := range []map[string]string{nil, {}} {
+			required := map[string]*tfconfig.ProviderRequirement{
+				"aws": {Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
+			}
+			pinBaseProviders(required, pins)
+			require.Equal(t, base, required, "no pins must leave required byte-for-byte unchanged")
+		}
 	})
 }
 

--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -1790,7 +1790,9 @@ func TestComposeStack_GCP_Provider(t *testing.T) {
 	// resource regardless of whether the preset wires labels itself.
 	//
 	// Requires google provider 5.16+ (default_labels was introduced there);
-	// generateProvidersTF pins the GCP required_providers to ">= 5.16".
+	// generateProvidersTF exact-pins the GCP required_providers to the
+	// mars-baked version (= 6.10.0, via imported.BaseProviderPin, #786), which
+	// is well past 5.16.
 	require.Contains(t, provStr, "default_labels",
 		"GCP provider block should declare default_labels as the project-label safety net (#215)")
 	require.Contains(t, provStr, "project    = var.project",

--- a/pkg/composer/imported/identity.go
+++ b/pkg/composer/imported/identity.go
@@ -113,6 +113,23 @@ type ResourceIdentity struct {
 	// rely on the nil-vs-empty distinction.
 	Tags map[string]string `json:"tags,omitempty"`
 
+	// ServiceManagedBy carries the cloud-side "managed by" principal for a
+	// resource that an AWS/GCP service owns on the customer's behalf, e.g.
+	// an EventBridge rule's ManagedBy ("autoscaling.amazonaws.com"). When
+	// non-empty the instance is service-managed and CANNOT be managed by
+	// Terraform: tag / create / delete operations are rejected by the
+	// provider (EventBridge ManagedRuleException, #785). This is a
+	// dedicated identity field rather than an Attrs/Tags entry so the
+	// signal survives the snapshot envelope round-trip and the
+	// schema-filter that drops computed-only attributes — the discoverer
+	// sets it from the type's ServiceManagedByFromProperties hook, and
+	// both the importability classifier (UnimportableReason →
+	// ReasonServiceManaged) and the composer provenance injector (skip +
+	// weak-lock) read it. Generic by design: any type that surfaces a
+	// service-owner marker can populate it. Empty for customer-owned
+	// resources.
+	ServiceManagedBy string `json:"service_managed_by,omitempty"`
+
 	// EnrichmentStatus reports whether the per-type enricher fully
 	// populated this resource's Attrs. Empty == not-yet-enriched (the
 	// discoverer hasn't run the enrich pass, or no enricher is

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -63,6 +63,16 @@ const (
 	// standalone aws_network_interface.
 	ReasonServiceManagedENI = "service_managed_eni"
 
+	// ReasonServiceManaged marks an instance that an AWS/GCP service owns on
+	// the customer's behalf, detected via a non-empty Identity.ServiceManagedBy
+	// marker (e.g. an EventBridge rule's ManagedBy =
+	// "autoscaling.amazonaws.com"). Terraform cannot manage these resources at
+	// all — tag, create, and delete operations are categorically rejected by
+	// the provider (EventBridge surfaces ManagedRuleException, #785). Generic
+	// across types: any discoverer that surfaces a service-owner marker routes
+	// the instance here.
+	ReasonServiceManaged = "service_managed"
+
 	// ReasonEphemeralLogStream marks an aws_cloudwatch_log_stream. Individual
 	// log streams are created automatically by their log group as events
 	// arrive and are continuously rotated — they are not declarative
@@ -130,6 +140,16 @@ func IsAWSManagedKMSKeyManager(keyManager string) bool {
 	return keyManager == awsManagedKMSKeyManager
 }
 
+// IsServiceManaged reports whether an identity carries a service-managed
+// marker (Identity.ServiceManagedBy is non-empty after trimming). A
+// service-managed instance is owned by an AWS/GCP service and cannot be
+// managed by Terraform. Generic across resource types; the discoverer
+// populates ServiceManagedBy from the per-type ServiceManagedByFromProperties
+// hook.
+func IsServiceManaged(id ResourceIdentity) bool {
+	return strings.TrimSpace(id.ServiceManagedBy) != ""
+}
+
 // IsServiceManagedENIInterfaceType reports whether an interface_type value
 // denotes an AWS-service-managed ENI (and therefore an un-importable one).
 // Forward-compatible: any interface_type AWS introduces for a managed ENI
@@ -175,6 +195,15 @@ func UnimportableReason(ir ImportedResource) string {
 		return ReasonInsideOutImported
 	}
 
+	// Service-managed instances are un-importable regardless of type: the
+	// owning service rejects tag/create/delete operations (EventBridge
+	// ManagedRuleException, #785). Checked here, before the type switch, so
+	// any type that surfaces a service-owner marker is covered without a
+	// per-type case.
+	if IsServiceManaged(ir.Identity) {
+		return ReasonServiceManaged
+	}
+
 	switch ir.Identity.Type {
 	case "aws_kms_alias":
 		if IsAWSManagedKMSAliasName(kmsAliasName(ir.Identity)) {
@@ -208,6 +237,8 @@ func ReasonDescription(reason string) string {
 		return "AWS-managed KMS key (KeyManager=AWS, e.g. the ACM default key) — cannot be imported into Terraform."
 	case ReasonServiceManagedENI:
 		return "Service-managed network interface (owned by its parent NAT gateway / VPC endpoint / load balancer) — cannot be imported as a standalone network interface."
+	case ReasonServiceManaged:
+		return "Service-managed resource (owned by an AWS/GCP service, e.g. an EventBridge ManagedBy rule) — tag, create, and delete operations are rejected by the provider, so it cannot be managed by Terraform."
 	case ReasonEphemeralLogStream:
 		return "Ephemeral CloudWatch log stream (auto-created and rotated by its log group) — not declarative infrastructure; manage the log group instead."
 	case ReasonInsideOutImported:

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -18,6 +18,7 @@ func TestReasonCodes_WireStable(t *testing.T) {
 	assert.Equal(t, "aws_managed_kms_alias", ReasonAWSManagedKMSAlias)
 	assert.Equal(t, "aws_managed_kms_key", ReasonAWSManagedKMSKey)
 	assert.Equal(t, "service_managed_eni", ReasonServiceManagedENI)
+	assert.Equal(t, "service_managed", ReasonServiceManaged)
 	assert.Equal(t, "ephemeral_log_stream", ReasonEphemeralLogStream)
 	assert.Equal(t, "insideout_imported", ReasonInsideOutImported)
 }
@@ -74,6 +75,43 @@ func TestUnimportableReason_KMSKey(t *testing.T) {
 		}}
 		assert.Equal(t, "", UnimportableReason(ir))
 	})
+}
+
+func TestUnimportableReason_ServiceManaged(t *testing.T) {
+	t.Parallel()
+	t.Run("EventBridge rule with ManagedBy is un-importable", func(t *testing.T) {
+		// AutoScalingManagedRule: AWS stamps ManagedBy; tag/PutRule/DeleteRule
+		// are all rejected (ManagedRuleException), so the rule cannot be managed
+		// by Terraform at all (#785).
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:             "aws_cloudwatch_event_rule",
+			NameHint:         "AutoScalingManagedRule",
+			ServiceManagedBy: "autoscaling.amazonaws.com",
+		}}
+		assert.Equal(t, ReasonServiceManaged, UnimportableReason(ir))
+	})
+	t.Run("rule without ManagedBy is importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:     "aws_cloudwatch_event_rule",
+			NameHint: "my-app-rule",
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
+	t.Run("marker is type-agnostic — any type with ServiceManagedBy is un-importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type:             "aws_some_future_type",
+			ServiceManagedBy: "service.amazonaws.com",
+		}}
+		assert.Equal(t, ReasonServiceManaged, UnimportableReason(ir))
+	})
+}
+
+func TestIsServiceManaged(t *testing.T) {
+	t.Parallel()
+	assert.True(t, IsServiceManaged(ResourceIdentity{ServiceManagedBy: "autoscaling.amazonaws.com"}))
+	assert.True(t, IsServiceManaged(ResourceIdentity{ServiceManagedBy: "  spaces-trimmed  "}))
+	assert.False(t, IsServiceManaged(ResourceIdentity{}))
+	assert.False(t, IsServiceManaged(ResourceIdentity{ServiceManagedBy: "   "}))
 }
 
 func TestIsServiceManagedENIInterfaceType(t *testing.T) {
@@ -257,6 +295,9 @@ func TestReasonDescription(t *testing.T) {
 	assert.Truef(t, strings.Contains(eni, "network interface"), "ENI description must mention network interface, got %q", eni)
 	insideOut := ReasonDescription(ReasonInsideOutImported)
 	assert.Truef(t, strings.Contains(insideOut, "InsideOut"), "InsideOut-imported description must mention InsideOut, got %q", insideOut)
+	svcManaged := ReasonDescription(ReasonServiceManaged)
+	assert.Truef(t, strings.Contains(svcManaged, "Service-managed"), "service-managed description must mention Service-managed, got %q", svcManaged)
+	assert.NotEqual(t, eni, svcManaged, "the ENI and generic service-managed descriptions must be distinct")
 	assert.NotEqual(t, kms, eni, "the two descriptions must be distinct (guards against swapped case bodies)")
 	assert.NotEqual(t, kms, kmsKey, "the KMS-alias and KMS-key descriptions must be distinct")
 	assert.NotEqual(t, insideOut, kms, "the InsideOut-imported and KMS-alias descriptions must be distinct")

--- a/pkg/composer/imported/importid/importid.go
+++ b/pkg/composer/imported/importid/importid.go
@@ -14,6 +14,13 @@ import (
 // resources Terraform's import block expects the remote ID to be suffixed with
 // "@<region>"; using the bare ID can make the provider search the wrong
 // regional endpoint and report a live object as missing.
+//
+// aws_s3_bucket is NOT exempt (the #676 bare-ID carve-out is gone): provider
+// v6.50.0 stopped resolving a bare bucket name across regions, so a bucket
+// living outside the provider's region fails import with "Cannot import
+// non-existent remote object". regionForImport prefers the enriched true
+// bucket region (Attrs/Attributes — see d4b01e0), so the suffix is reliable
+// even though discovery scans tag buckets by scan region (#1860).
 func ForResource(ir imported.ImportedResource) string {
 	id := strings.TrimSpace(ir.Identity.ImportID)
 	if id == "" {
@@ -31,9 +38,6 @@ func ForResource(ir imported.ImportedResource) string {
 }
 
 func needsAWSRegionSuffix(ir imported.ImportedResource, tfType string) bool {
-	if usesBareImportID(tfType) {
-		return false
-	}
 	cloud := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
 	if cloud != "" && cloud != "aws" {
 		return false
@@ -47,15 +51,6 @@ func needsAWSRegionSuffix(ir imported.ImportedResource, tfType string) bool {
 	}
 	field, ok := schema["region"]
 	return ok && field.Configurable()
-}
-
-func usesBareImportID(tfType string) bool {
-	switch tfType {
-	case "aws_s3_bucket":
-		return true
-	default:
-		return false
-	}
 }
 
 func terraformType(id imported.ResourceIdentity) string {

--- a/pkg/composer/imported/importid/importid_test.go
+++ b/pkg/composer/imported/importid/importid_test.go
@@ -33,7 +33,7 @@ func TestForResource_AppendsRegionForAWSRegionAwareResource(t *testing.T) {
 	}
 }
 
-func TestForResource_DoesNotAppendRegionForS3Bucket(t *testing.T) {
+func TestForResource_AppendsRegionForS3Bucket(t *testing.T) {
 	t.Parallel()
 	attrs, err := json.Marshal(&generated.AWSS3Bucket{
 		Bucket: generated.LiteralOf("io-uploads"),
@@ -44,16 +44,26 @@ func TestForResource_DoesNotAppendRegionForS3Bucket(t *testing.T) {
 	}
 	ir := imported.ImportedResource{
 		Identity: imported.ResourceIdentity{
-			Cloud:    "aws",
-			Type:     "aws_s3_bucket",
-			Address:  "aws_s3_bucket.io_uploads",
-			Region:   "us-west-2",
+			Cloud:   "aws",
+			Type:    "aws_s3_bucket",
+			Address: "aws_s3_bucket.io_uploads",
+			// Identity.Region is the STALE scan region (#1860): discovery tags
+			// buckets by the region it listed them from, which differs from
+			// the bucket's true home region. Diverge it from Attrs.Region so
+			// this test independently proves regionForImport prefers the
+			// enriched Attrs region — a regression that dropped the Attrs
+			// candidate would emit @us-east-1 (wrong) and fail here.
+			Region:   "us-east-1",
 			ImportID: "io-uploads",
 		},
 		Attrs: attrs,
 	}
 
-	if got, want := ForResource(ir), "io-uploads"; got != want {
+	// Provider v6.50.0 requires the @region suffix to import a bucket that
+	// lives outside the provider's configured region (bare names no longer
+	// resolve cross-region). The suffix MUST be the enriched true bucket
+	// region from Attrs (us-west-2), never the us-east-1 scan region.
+	if got, want := ForResource(ir), "io-uploads@us-west-2"; got != want {
 		t.Fatalf("ForResource() = %q, want %q", got, want)
 	}
 }

--- a/pkg/composer/imported/provider_pins.go
+++ b/pkg/composer/imported/provider_pins.go
@@ -1,0 +1,87 @@
+package imported
+
+import "strings"
+
+// Provider version pinning for composed / import Terraform archives (#786).
+//
+// Composed archives historically constrained hashicorp/aws to an open
+// `>= 6.0` range with no lock file, so every customer deploy resolved the
+// "newest available at run time". When HashiCorp shipped 6.50.0 mid-day the
+// same project flipped from green to red within an hour (the 6.49→6.50
+// cross-region S3 import breakage). To make deploys deterministic AND to hit
+// the Terraform provider plugin cache baked into the luthersystems/mars
+// container (a filesystem_mirror over an exact per-version directory), every
+// archive emitter pins the cloud's BASE provider to the SAME exact version
+// mars bakes — so `terraform init` symlinks from the mirror instead of
+// downloading.
+//
+// This map is the SINGLE SOURCE OF TRUTH for those base-provider pins. It is
+// consumed by:
+//   - pkg/composer (composed deploy archive /providers.tf),
+//   - pkg/reverseimport (reverse-import combined-stack providers.tf),
+//   - cmd/insideout-import/genconfig (generate-config readback stack).
+//
+// The versions MUST equal the luthersystems/mars provider-mirror bake
+// (mars/Dockerfile `AWS_PROVIDER_VERSION` / `GOOGLE_PROVIDER_VERSION`). As of
+// mars v0.123.0 that bake is aws 6.46.0 and google/google-beta 6.10.0. Bump
+// these AND the mars bake together; the cross-emitter drift guards
+// (TestBaseProviderPins_* and the per-emitter pin tests) fail if either side
+// drifts back to an open range. Note this is intentionally DISTINCT from
+// generated.AWSProviderVersion (the codegen schema version), which tracks
+// schemas/providers.tf and need not equal the runtime deploy pin.
+var baseProviderPins = map[string]map[string]string{
+	"aws": {
+		"aws": "= 6.46.0",
+	},
+	"gcp": {
+		"google":      "= 6.10.0",
+		"google-beta": "= 6.10.0",
+	},
+}
+
+// BaseProviderPin returns the exact version constraint (e.g. "= 6.46.0") this
+// repo pins for a cloud's base Terraform provider, matching the
+// luthersystems/mars provider-mirror bake so terraform init hits the cache.
+// cloud is "aws" or "gcp"; provider is the required_providers key ("aws",
+// "google", "google-beta"). Returns "" for an unknown cloud/provider pair so
+// callers fall back to whatever default they had — but every known base
+// provider is covered, so a "" return at a wired call site is a bug the
+// emitter tests catch.
+func BaseProviderPin(cloud, provider string) string {
+	return baseProviderPins[strings.ToLower(strings.TrimSpace(cloud))][strings.ToLower(strings.TrimSpace(provider))]
+}
+
+// BaseProviderPins returns a copy of the pin map for a cloud ("aws"/"gcp"),
+// so callers that re-assert every base provider after a discovered-provider
+// union (pkg/composer) can iterate without mutating the source of truth.
+// Returns nil for an unknown cloud.
+func BaseProviderPins(cloud string) map[string]string {
+	src := baseProviderPins[strings.ToLower(strings.TrimSpace(cloud))]
+	if src == nil {
+		return nil
+	}
+	out := make(map[string]string, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
+}
+
+// AllBaseProviderPins returns a flattened provider-name → exact-constraint map
+// across every cloud (aws, gcp), e.g. {"aws": "= 6.46.0", "google": "= 6.10.0",
+// "google-beta": "= 6.10.0"}. The composer's pre-init provider-conflict
+// validator seeds these into its constraint union so a preset pinning a range
+// incompatible with the exact emitted pin is caught before terraform init —
+// for EVERY base provider the emitter pins, including google-beta. Deriving the
+// seed from this accessor (rather than a hand-maintained copy) keeps the
+// validator faithful to the emitter by construction. Provider names are unique
+// across clouds today; if that ever changes this must key by cloud instead.
+func AllBaseProviderPins() map[string]string {
+	out := map[string]string{}
+	for _, byProvider := range baseProviderPins {
+		for name, constraint := range byProvider {
+			out[name] = constraint
+		}
+	}
+	return out
+}

--- a/pkg/composer/imported/provider_pins_test.go
+++ b/pkg/composer/imported/provider_pins_test.go
@@ -1,0 +1,77 @@
+package imported
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestBaseProviderPins_ExactAndMatchMars is the cross-repo drift guard for the
+// provider pins (#786). These literals MUST equal the versions baked into the
+// luthersystems/mars provider-mirror (mars/Dockerfile AWS_PROVIDER_VERSION /
+// GOOGLE_PROVIDER_VERSION); a change on either side without the other re-opens
+// the "deploy resolves newest at runtime" hazard (the 6.49→6.50 breakage). The
+// assertion reads the literal strings (not the symbol on both sides) so a
+// value edit surfaces here as a deliberate diff. Bump these AND the mars bake
+// together.
+func TestBaseProviderPins_ExactAndMatchMars(t *testing.T) {
+	t.Parallel()
+	// As of mars v0.123.0: aws 6.46.0, google/google-beta 6.10.0.
+	assert.Equal(t, "= 6.46.0", BaseProviderPin("aws", "aws"))
+	assert.Equal(t, "= 6.10.0", BaseProviderPin("gcp", "google"))
+	assert.Equal(t, "= 6.10.0", BaseProviderPin("gcp", "google-beta"))
+}
+
+// TestBaseProviderPins_AreExactNotRanges pins that every base-provider
+// constraint is an EXACT `=` pin, never an open range (>=, ~>) — an open
+// range would let terraform init resolve a newer provider at runtime and miss
+// the mars filesystem-mirror cache.
+func TestBaseProviderPins_AreExactNotRanges(t *testing.T) {
+	t.Parallel()
+	for _, cloud := range []string{"aws", "gcp"} {
+		for provider, constraint := range BaseProviderPins(cloud) {
+			assert.Truef(t, strings.HasPrefix(constraint, "= "),
+				"%s/%s pin %q must be an exact `=` constraint, not an open range", cloud, provider, constraint)
+			assert.NotContainsf(t, constraint, ">=", "%s/%s pin must not use >=", cloud, provider)
+			assert.NotContainsf(t, constraint, "~>", "%s/%s pin must not use ~>", cloud, provider)
+		}
+	}
+}
+
+// TestBaseProviderPin_UnknownReturnsEmpty pins the documented fallback for an
+// unknown cloud/provider pair.
+func TestBaseProviderPin_UnknownReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "", BaseProviderPin("azure", "azurerm"))
+	assert.Equal(t, "", BaseProviderPin("aws", "google"))
+	assert.Nil(t, BaseProviderPins("azure"))
+}
+
+// TestBaseProviderPins_ReturnsCopy pins that BaseProviderPins hands back a
+// copy, so a caller that re-asserts pins after a discovered-provider union
+// cannot mutate the source of truth.
+func TestBaseProviderPins_ReturnsCopy(t *testing.T) {
+	t.Parallel()
+	got := BaseProviderPins("aws")
+	got["aws"] = "= 9.9.9"
+	assert.Equal(t, "= 6.46.0", BaseProviderPin("aws", "aws"),
+		"mutating the returned map must not affect the source of truth")
+}
+
+// TestAllBaseProviderPins covers the flattened map the pre-init validator
+// seeds from — it MUST include every base provider the emitter pins, so a
+// preset pinning an incompatible range for any of them (notably google-beta)
+// is caught before terraform init.
+func TestAllBaseProviderPins(t *testing.T) {
+	t.Parallel()
+	all := AllBaseProviderPins()
+	assert.Equal(t, "= 6.46.0", all["aws"])
+	assert.Equal(t, "= 6.10.0", all["google"])
+	assert.Equal(t, "= 6.10.0", all["google-beta"],
+		"google-beta must be seeded — the emitter pins it, so the validator must too")
+	assert.Len(t, all, 3, "exactly the three base providers across aws+gcp")
+	// Returned map is a fresh copy; mutating it must not affect the source.
+	all["aws"] = "= 9.9.9"
+	assert.Equal(t, "= 6.46.0", AllBaseProviderPins()["aws"])
+}

--- a/pkg/composer/imported/snapshot_envelope_test.go
+++ b/pkg/composer/imported/snapshot_envelope_test.go
@@ -79,6 +79,20 @@ func TestSnapshotEnvelope_RoundTrip(t *testing.T) {
 			Tier:   TierImportedMissing,
 			Source: SourceInspector,
 		},
+		{
+			// Service-managed instance (#785): the ServiceManagedBy marker
+			// must survive the snapshot envelope so the composer's
+			// defense-in-depth can skip provenance injection.
+			Identity: ResourceIdentity{
+				Cloud:            "aws",
+				Type:             "aws_cloudwatch_event_rule",
+				Address:          "aws_cloudwatch_event_rule.autoscaling_managed_rule",
+				NameHint:         "AutoScalingManagedRule",
+				ServiceManagedBy: "autoscaling.amazonaws.com",
+			},
+			Tier:   TierImportedFlat,
+			Source: SourceImporter,
+		},
 	}
 
 	envelope := map[string]json.RawMessage{
@@ -123,7 +137,8 @@ func equalIdentity(a, b ResourceIdentity) bool {
 		a.ProviderSource != b.ProviderSource || a.ProviderVersion != b.ProviderVersion ||
 		a.SchemaVersion != b.SchemaVersion || a.AccountID != b.AccountID ||
 		a.ProjectID != b.ProjectID || a.Region != b.Region ||
-		a.Location != b.Location || a.ImportID != b.ImportID {
+		a.Location != b.Location || a.ImportID != b.ImportID ||
+		a.ServiceManagedBy != b.ServiceManagedBy {
 		return false
 	}
 	return mapsEqual(a.ProviderIdentity, b.ProviderIdentity) &&

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -91,7 +91,7 @@ func TestEmitImportedTF_TypedAWS(t *testing.T) {
 	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
 }
 
-func TestEmitImportedTF_S3ImportIDUsesBareBucketName(t *testing.T) {
+func TestEmitImportedTF_S3ImportIDCarriesBucketRegion(t *testing.T) {
 	t.Parallel()
 	attrs, err := json.Marshal(&generated.AWSS3Bucket{
 		Bucket: generated.LiteralOf("io-uploads"),
@@ -114,7 +114,9 @@ func TestEmitImportedTF_S3ImportIDUsesBareBucketName(t *testing.T) {
 	require.NotNil(t, out)
 	s := string(out)
 	assert.Contains(t, s, "to = aws_s3_bucket.io_uploads")
-	assert.Contains(t, s, `id = "io-uploads"`)
+	// The @region suffix must use the enriched true bucket region from
+	// Attrs (us-west-2), not Identity.Region (the us-east-1 scan region).
+	assert.Contains(t, s, `id = "io-uploads@us-west-2"`)
 	assert.True(t, hasAttr(t, s, "region", `"us-west-2"`), "region attr missing in:\n%s", s)
 	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
 	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -99,6 +99,19 @@ func taggable(ir imported.ImportedResource) (attr string, ok bool) {
 		return "", false
 	}
 
+	// Instance-level untaggability (#785): a resource whose type is normally
+	// taggable is still NOT taggable when the cloud marks it service-managed.
+	// AWS rejects every tag operation on a service-managed instance (an
+	// EventBridge ManagedBy rule fails with ManagedRuleException), so the
+	// injector must skip provenance and weak-lock it. This sits alongside the
+	// type-level untaggableAWS map but keys off the per-instance marker the
+	// discoverer captured, so it works for any type and any selection path —
+	// the composer's last line of defense even if classification let the
+	// instance through.
+	if imported.IsServiceManaged(ir.Identity) {
+		return "", false
+	}
+
 	if _, schema, registered := generated.Lookup(tfType); registered {
 		switch cloud {
 		case "aws":

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -111,6 +111,61 @@ func TestTaggable_AllowlistFallback(t *testing.T) {
 	assert.False(t, ok)
 }
 
+// TestTaggable_ServiceManagedInstance verifies the instance-level
+// untaggability override (#785): a resource whose type is normally taggable
+// (aws_cloudwatch_event_rule carries tags) must still be reported as
+// untaggable when its identity carries a service-managed marker, because
+// AWS rejects every tag operation on a service-managed rule.
+func TestTaggable_ServiceManagedInstance(t *testing.T) {
+	t.Parallel()
+	// Without the marker, an EventBridge rule is taggable.
+	plain := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_cloudwatch_event_rule"},
+	}
+	attr, ok := taggable(plain)
+	assert.True(t, ok, "plain EventBridge rule must be taggable")
+	assert.Equal(t, "tags", attr)
+
+	// With the marker, the same type is NOT taggable regardless of selection.
+	managed := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:            "aws",
+			Type:             "aws_cloudwatch_event_rule",
+			ServiceManagedBy: "autoscaling.amazonaws.com",
+		},
+	}
+	_, ok = taggable(managed)
+	assert.False(t, ok, "service-managed EventBridge rule must not be taggable")
+}
+
+// TestInjectProvenance_ServiceManagedSkipsAndWeakLocks is the composer
+// defense-in-depth for #785: even if a service-managed rule is selected and
+// reaches the composer, provenance injection must be skipped and the resource
+// weak-locked so no InsideOut* tags are stamped (apply would otherwise die
+// with ManagedRuleException).
+func TestInjectProvenance_ServiceManagedSkipsAndWeakLocks(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:            "aws",
+			Type:             "aws_cloudwatch_event_rule",
+			Address:          "aws_cloudwatch_event_rule.autoscaling_managed_rule",
+			ServiceManagedBy: "autoscaling.amazonaws.com",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"AutoScalingManagedRule"}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+	assert.True(t, ir.WeakLocked, "service-managed resource must be weak-locked")
+	assert.NotContains(t, s, "InsideOutImportProject", "no provenance tags may be stamped on a service-managed rule")
+	assert.NotContains(t, s, "merge(", "no tag merge may be injected on a service-managed rule")
+}
+
 // TestProvenanceKeysFor_AWS verifies provenanceKeysFor wiring (key set,
 // order, session omission). The literal values of the marker keys are
 // pinned in TestMarkerTagKeyValues_PinnedLiterals; here we use the

--- a/pkg/composer/validate_providers.go
+++ b/pkg/composer/validate_providers.go
@@ -6,26 +6,33 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-version"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
-// providerSeed represents the cloud-level required_provider entry that
+// providerSeeds represents the cloud-level required_provider entry that
 // generateProvidersTF stamps on every emitted root, regardless of what the
 // presets declare. ValidateProviderConstraints unions these into the
-// per-provider constraint set so a preset that pins (e.g.) `aws < 6.0`
-// surfaces as a conflict against the seed's `aws >= 6.0` instead of slipping
-// through to terraform init.
+// per-provider constraint set so a preset that pins (e.g.) `aws ~> 6.40`
+// surfaces as a conflict against the seed's exact `= 6.46.0` instead of
+// slipping through to terraform init.
 //
-// Mirror these constants on any change to the seeds in generateProvidersTF
-// (compose.go).
+// These mirror the EXACT pins generateProvidersTF emits (#786): the composed
+// root no longer ships an open `>= 6.0` range — it hard-pins the cloud's base
+// provider to the mars-baked version. Deriving the seeds from
+// imported.AllBaseProviderPins (the same source of truth the emitter uses)
+// keeps this validator faithful to the actual emitted constraint by
+// construction — so a preset pinning a different 6.x range is caught pre-init,
+// for EVERY base provider the emitter pins (aws, google, AND google-beta), and
+// the seed can never drift from the emitter. ValidateProviderConstraints only
+// layers a seed onto a provider some preset already declares, so seeding
+// google-beta is inert until a GCP preset pins it.
 //
 // The imported provider aliases (`aws.imported` / `google.imported`,
-// emitted by generateProvidersTF when ComposeStackOpts.Imported is
-// non-empty) share the same provider source/version as the default
-// alias; they introduce no new entry here.
-var providerSeeds = map[string]string{
-	"aws":    ">= 6.0",
-	"google": ">= 5.0",
-}
+// emitted by generateProvidersTF unconditionally per #562) share the same
+// provider source/version as the default alias; they introduce no new entry
+// here.
+var providerSeeds = imported.AllBaseProviderPins()
 
 // ValidateProviderConstraints unions the required_providers VersionConstraints
 // across every selected module's preset (plus the cloud-level seeds emitted

--- a/pkg/composer/validate_providers_test.go
+++ b/pkg/composer/validate_providers_test.go
@@ -106,16 +106,31 @@ func TestFindSatisfyingVersion_AcceptsCompatibleAndRejectsImpossible(t *testing.
 	require.False(t, findSatisfyingVersion(mustParse("< 5.0,>= 7.0")))
 }
 
-// TestProviderSeedsMirrorComposer locks the providerSeeds constant
-// against drift from generateProvidersTF's hardcoded versions. If a
-// future contributor bumps the cloud-base aws or google constraint
-// in compose.go, this test fails until they bump providerSeeds too.
-// Without this guard, ValidateProviderConstraints would silently
-// validate against a stale seed.
+// TestProviderSeedsMirrorComposer locks the providerSeeds constant against
+// drift from generateProvidersTF's emitted pins. The composed root exact-pins
+// the cloud's base provider to the mars-baked version (#786), so the seed used
+// for pre-init conflict detection must equal that exact pin — otherwise
+// ValidateProviderConstraints would validate against a looser constraint than
+// the archive actually ships and miss a preset that pins an incompatible 6.x
+// range. The seed is derived from imported.AllBaseProviderPins (the emitter's
+// source of truth), so a version bump there flows to both together.
 func TestProviderSeedsMirrorComposer(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, ">= 6.0", providerSeeds["aws"], "seed drift: providerSeeds[aws] must mirror generateProvidersTF")
-	require.Equal(t, ">= 5.0", providerSeeds["google"], "seed drift: providerSeeds[google] must mirror generateProvidersTF")
+	// providerSeeds is now derived from imported.AllBaseProviderPins (the same
+	// source of truth the emitter uses), so it cannot drift from the emitter by
+	// construction — no symbol-vs-symbol comparison is meaningful here (it would
+	// compare the map against a copy of itself). Instead pin the LITERAL emitted
+	// constraints: a value change is then a deliberate diff, and the
+	// imported-package guard (TestBaseProviderPins_ExactAndMatchMars) separately
+	// asserts these equal the mars bake.
+	require.Equal(t, "= 6.46.0", providerSeeds["aws"])
+	require.Equal(t, "= 6.10.0", providerSeeds["google"])
+	// google-beta MUST be seeded: the emitter pins it (pinBaseProviders
+	// re-asserts google-beta), so a GCP preset pinning an incompatible
+	// google-beta range must be caught pre-init too. A regression that dropped
+	// google-beta from the seed map fails here.
+	require.Equal(t, "= 6.10.0", providerSeeds["google-beta"])
+	require.Len(t, providerSeeds, 3, "seed must cover exactly the three pinned base providers")
 }
 
 // TestFindProviderConflicts_SeedParticipates exercises the seed-merge

--- a/pkg/reverseimport/providers.go
+++ b/pkg/reverseimport/providers.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 var localstackEndpointServices = []string{
@@ -52,12 +53,12 @@ func renderImportedProvidersTF(opts importedProviderRenderOptions) ([]byte, erro
 	case "gcp":
 		rp.Body().SetAttributeValue("google", cty.ObjectVal(map[string]cty.Value{
 			"source":  cty.StringVal("hashicorp/google"),
-			"version": cty.StringVal("~> 5.0"),
+			"version": cty.StringVal(imported.BaseProviderPin("gcp", "google")),
 		}))
 		if opts.ProvidersUsed[composer.ProvidersUsedKeyGCPBeta] {
 			rp.Body().SetAttributeValue("google-beta", cty.ObjectVal(map[string]cty.Value{
 				"source":  cty.StringVal("hashicorp/google-beta"),
-				"version": cty.StringVal("~> 5.0"),
+				"version": cty.StringVal(imported.BaseProviderPin("gcp", "google-beta")),
 			}))
 		}
 		prov := body.AppendNewBlock("provider", []string{"google"})
@@ -77,7 +78,7 @@ func renderImportedProvidersTF(opts importedProviderRenderOptions) ([]byte, erro
 	case "aws", "":
 		rp.Body().SetAttributeValue("aws", cty.ObjectVal(map[string]cty.Value{
 			"source":  cty.StringVal("hashicorp/aws"),
-			"version": cty.StringVal("~> 6.0"),
+			"version": cty.StringVal(imported.BaseProviderPin("aws", "aws")),
 		}))
 		// Base `aws.imported` block (region = primary). Always emitted:
 		// back-compat with single-region stacks and the region-less
@@ -135,7 +136,7 @@ const awsProviderMaxRetries = 25
 // degrades to throttle backoff instead of failures (luthersystems/ui-core
 // #420). Mirrors genconfig.appendAWSRetryTuning; see it for the adaptive-mode
 // rationale. Both attributes are top-level arguments of the pinned
-// hashicorp/aws ~> 6.0 provider.
+// hashicorp/aws provider (exact pin via imported.BaseProviderPin, #786).
 func appendAWSRetryTuning(body *hclwrite.Body) {
 	body.SetAttributeValue("retry_mode", cty.StringVal("adaptive"))
 	body.SetAttributeValue("max_retries", cty.NumberIntVal(awsProviderMaxRetries))

--- a/pkg/reverseimport/providers_test.go
+++ b/pkg/reverseimport/providers_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
 func TestRenderImportedProvidersTF_AWSAssumesProjectRole(t *testing.T) {
@@ -48,6 +49,61 @@ func TestRenderImportedProvidersTF_AWSAssumesProjectRole(t *testing.T) {
 			t.Fatalf("providers-imported.tf missing pattern %q:\n%s", pat, s)
 		}
 	}
+}
+
+// TestRenderImportedProvidersTF_ExactProviderPins pins that the reverse-import
+// combined stack constrains its providers to the EXACT mars-baked versions
+// (not an open `~> 6.0` / `~> 5.0` range) so terraform init in the mars
+// container symlinks from the filesystem mirror instead of downloading
+// "newest at runtime" (#786). The pins are sourced from
+// imported.BaseProviderPin so this emitter and the composed-archive emitter
+// never drift.
+func TestRenderImportedProvidersTF_ExactProviderPins(t *testing.T) {
+	t.Run("aws", func(t *testing.T) {
+		body, err := renderImportedProvidersTF(importedProviderRenderOptions{
+			Cloud:  "aws",
+			Region: "us-west-2",
+			ProvidersUsed: map[string]bool{
+				composer.ProvidersUsedKeyAWS: true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("renderImportedProvidersTF() error = %v", err)
+		}
+		s := string(body)
+		want := imported.BaseProviderPin("aws", "aws") // "= 6.46.0"
+		if !strings.Contains(s, `version = "`+want+`"`) {
+			t.Fatalf("aws provider must be exactly pinned to %q, got:\n%s", want, s)
+		}
+		if strings.Contains(s, `version = "~> 6.0"`) {
+			t.Fatalf("open ~> 6.0 range must not reach the imported stack:\n%s", s)
+		}
+	})
+	t.Run("gcp", func(t *testing.T) {
+		body, err := renderImportedProvidersTF(importedProviderRenderOptions{
+			Cloud:        "gcp",
+			Region:       "us-central1",
+			GCPProjectID: "demo-project",
+			ProvidersUsed: map[string]bool{
+				composer.ProvidersUsedKeyGCPBeta: true,
+			},
+		})
+		if err != nil {
+			t.Fatalf("renderImportedProvidersTF() error = %v", err)
+		}
+		s := string(body)
+		want := imported.BaseProviderPin("gcp", "google") // "= 6.10.0"
+		if !strings.Contains(s, `version = "`+want+`"`) {
+			t.Fatalf("google provider must be exactly pinned to %q, got:\n%s", want, s)
+		}
+		wantBeta := imported.BaseProviderPin("gcp", "google-beta")
+		if !strings.Contains(s, `version = "`+wantBeta+`"`) {
+			t.Fatalf("google-beta provider must be exactly pinned to %q, got:\n%s", wantBeta, s)
+		}
+		if strings.Contains(s, `version = "~> 5.0"`) {
+			t.Fatalf("open ~> 5.0 range must not reach the imported stack:\n%s", s)
+		}
+	})
 }
 
 // TestRenderImportedProvidersTF_MultiRegion pins that a multi-region batch


### PR DESCRIPTION
## Summary

Bundle of three import-path fixes, one commit each.

**`bcc3970` — suffix `aws_s3_bucket` import IDs with `@region`**
Provider v6.50.0 stopped resolving bare bucket names across regions: importing a bucket outside the provider's configured region failed with "Cannot import non-existent remote object" (live repro: reliable project b5bd0929 — 6.49 green vs 6.50 red one hour apart). Drops the #676 bare-ID carve-out for S3. The suffix prefers the enriched true bucket region (Attrs), so scan-region staleness (#1860) cannot mis-route it.

This commit is **textually identical** to the temp branch `fix/s3-region-import-id-on-784` (b98d32fe) that reliable currently pins. Once this PR merges, reliable's temp pin retires after a one-line reliable presets pin bump back to a tagged release.

**`765d603` — mark service-managed resources un-importable (Closes #785)**
Discovery offered the AWS-managed EventBridge rule `AutoScalingManagedRule` as importable; compose stamped provenance tags; apply died with `ManagedRuleException`. Tag/PutRule/DeleteRule are categorically forbidden on any rule with `ManagedBy` set. Fixed in layers, generic by design:
- `Identity.ServiceManagedBy` — a dedicated identity field that survives the snapshot envelope and the computed-attribute schema filter.
- A generic `ServiceManagedByFromProperties` discovery hook (wired for `aws_cloudwatch_event_rule`), threaded through `Discover` and `DiscoverByID`.
- `UnimportableReason` returns the new `ReasonServiceManaged`, routing the instance to unsupported.json.
- Composer defense-in-depth: `taggable()` reports a service-managed instance untaggable regardless of type, so provenance injection is skipped and the resource weak-locked even if a stale selection reaches the composer.

**`2e66d93` — pin providers to the mars-baked exact versions (Closes #786)**
Composed archives constrained `hashicorp/aws` to an open `>= 6.0` with no lock file, so every deploy resolved "newest at runtime" — the same mechanism that flipped projects red when 6.50.0 shipped. The composer's seed exact pin was clobbered by `maps.Copy(required, discovered)` because every preset declares `>= 6.0`.
- `imported.BaseProviderPin` / `BaseProviderPins` / `AllBaseProviderPins`: single source of truth in the leaf package, consumed by the composer, reverse-import, and genconfig emitters. Distinct from `generated.AWSProviderVersion` (codegen schema version).
- `compose.go`: re-assert the exact base-provider pin AFTER the discovered union so the preset `>= 6.0` can no longer override it; non-base discovered providers (random, time, opensearch, ...) still flow through.
- `validate_providers.go`: the pre-init conflict-detection seed is now derived from `AllBaseProviderPins`, so a preset pinning an incompatible 6.x range is caught pre-init rather than at terraform init.
- Pins match the mars v0.123.0 bake (aws 6.46.0, google/google-beta 6.10.0). Drift guards assert the literals are exact `=` pins matching mars; bump the pins and the mars bake together.

## Test plan
- [x] `go test ./pkg/composer/... -timeout=30m` — 1621 passed
- [x] `go test ./pkg/composer/imported/... ./pkg/composer/imported/importid/... ./pkg/reverseimport/... ./cmd/insideout-import/... -timeout=30m` — 3915 passed in 16 packages
- [x] Rebased onto latest origin/main (incl #782 region-aware enrich + same-session claims, and #763 agentcore gateway); no conflicts

## Review notes
- /review: no P0/P1/P2 code issues.
- qa-professor: PASS, no P0/P1. Two P2 test-strengthening drive-bys applied:
  - `TestForResource_AppendsRegionForS3Bucket` now diverges `Identity.Region` (scan region) from `Attrs.Region` (true region), so the unit test independently proves the Attrs-over-Identity precedence instead of leaning on its sibling emit test.
  - `TestPinBaseProviders` gained an empty/nil-pins no-op subtest covering the `BaseProviderPins("azure") == nil` caller contract.
- Deferred: none.