### PR TITLE
fix(observability): add list-endpoints action to AWS SageMaker inspector

### DIFF
--- a/pkg/observability/discovery/aws/live_probe_255_test.go
+++ b/pkg/observability/discovery/aws/live_probe_255_test.go
@@ -109,6 +109,12 @@ func TestLive255_AWSInspectorsJSONShape(t *testing.T) {
 		// a hosted_zone_id and is exercised separately below.
 		{"route53", "list-hosted-zones"},
 		{"acm", "list-certificates"},
+		// #797: SageMaker account-wide slice actions. list-endpoints is
+		// the new EndpointName-discovery surface; list-domains /
+		// list-user-profiles ride along since they share the #255 guard.
+		{"sagemaker", "list-domains"},
+		{"sagemaker", "list-user-profiles"},
+		{"sagemaker", "list-endpoints"},
 	} {
 		probes = append(probes, mk(pair[0], pair[1])...)
 	}

--- a/pkg/observability/discovery/aws/sagemaker.go
+++ b/pkg/observability/discovery/aws/sagemaker.go
@@ -1,7 +1,7 @@
 // AWS SageMaker inspector (issue #622).
 //
 // Provides panel-default discovery for the aws/sagemaker preset (#615,
-// composer wiring #618). Three list/describe actions plus the metrics
+// composer wiring #618). Four list/describe actions plus the metrics
 // passthrough:
 //
 //   - list-domains — ListDomains; returns []sagemakertypes.DomainDetails.
@@ -15,12 +15,19 @@
 //     []sagemakertypes.UserProfileDetails across every domain visible to
 //     the credentials. No required filter; callers post-scope by
 //     DomainId in the panel layer if needed.
+//   - list-endpoints — ListEndpoints; returns
+//     []sagemakertypes.EndpointSummary account-wide (#797). SageMaker
+//     CloudWatch metrics (AWS/SageMaker namespace) are dimensioned by
+//     EndpointName, so this is the action that lets metrics-discovery
+//     enumerate the EndpointName dimension values account-wide. No
+//     required filter.
 //   - get-metrics — routed to pkg/observability/metrics; AWS/SageMaker
 //     emits CloudWatch metrics that the metrics package owns.
 //
-// Issue #255 contract: list-domains and list-user-profiles both use
-// nilSliceToEmpty so empty AWS responses marshal as `[]` not `null`.
-// describe-domain returns a single object (no top-level slice to guard).
+// Issue #255 contract: list-domains, list-user-profiles, and
+// list-endpoints all use nilSliceToEmpty so empty AWS responses marshal
+// as `[]` not `null`. describe-domain returns a single object (no
+// top-level slice to guard).
 
 package aws
 
@@ -40,6 +47,7 @@ type sageMakerClient interface {
 	ListDomains(ctx context.Context, params *sagemaker.ListDomainsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListDomainsOutput, error)
 	DescribeDomain(ctx context.Context, params *sagemaker.DescribeDomainInput, optFns ...func(*sagemaker.Options)) (*sagemaker.DescribeDomainOutput, error)
 	ListUserProfiles(ctx context.Context, params *sagemaker.ListUserProfilesInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListUserProfilesOutput, error)
+	ListEndpoints(ctx context.Context, params *sagemaker.ListEndpointsInput, optFns ...func(*sagemaker.Options)) (*sagemaker.ListEndpointsOutput, error)
 }
 
 func inspectSageMaker(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
@@ -54,6 +62,8 @@ func inspectSageMaker(ctx context.Context, cfg aws.Config, action, filters strin
 		return describeSageMakerDomain(ctx, sagemaker.NewFromConfig(cfg), domainID)
 	case "list-user-profiles":
 		return listSageMakerUserProfiles(ctx, sagemaker.NewFromConfig(cfg))
+	case "list-endpoints":
+		return listSageMakerEndpoints(ctx, sagemaker.NewFromConfig(cfg))
 	case "get-metrics":
 		// SageMaker emits CloudWatch metrics under the AWS/SageMaker
 		// namespace; the metrics fetch path owns those. Route through
@@ -98,6 +108,22 @@ func listSageMakerUserProfiles(ctx context.Context, client sageMakerClient) ([]s
 		return nil, err
 	}
 	return nilSliceToEmpty(out.UserProfiles), nil
+}
+
+// listSageMakerEndpoints runs ListEndpoints account-wide and returns the
+// Endpoints slice with nil normalized to [] (#797). The EndpointSummary
+// entries carry EndpointName, the CloudWatch dimension the AWS/SageMaker
+// metrics namespace is keyed on, so this is the surface metrics-discovery
+// uses to enumerate dimension values account-wide. Pagination via
+// NextToken; current impl returns the first page (default 10 endpoints
+// per page — sufficient for most stacks). Multi-page fan-out is a
+// follow-up if needed.
+func listSageMakerEndpoints(ctx context.Context, client sageMakerClient) ([]sagemakertypes.EndpointSummary, error) {
+	out, err := client.ListEndpoints(ctx, &sagemaker.ListEndpointsInput{})
+	if err != nil {
+		return nil, err
+	}
+	return nilSliceToEmpty(out.Endpoints), nil
 }
 
 // sageMakerFilterDomainID parses the filters JSON envelope for a

--- a/pkg/observability/discovery/aws/sagemaker_test.go
+++ b/pkg/observability/discovery/aws/sagemaker_test.go
@@ -1,9 +1,10 @@
 // AWS SageMaker inspector tests (issue #622).
 //
-// Pins the #255 contract: empty list-domains / list-user-profiles
-// responses MUST marshal as JSON `[]`, never `null`. Also pins
-// describe-domain's required domain_id surface and the metrics-routing
-// arm.
+// Pins the #255 contract: empty list-domains / list-user-profiles /
+// list-endpoints responses MUST marshal as JSON `[]`, never `null`.
+// Also pins describe-domain's required domain_id surface and the
+// metrics-routing arm. list-endpoints (#797) is the account-wide
+// EndpointName discovery action for the AWS/SageMaker metrics namespace.
 
 package aws
 
@@ -25,6 +26,7 @@ type fakeSageMakerClient struct {
 	describeDomainOut   *sagemaker.DescribeDomainOutput
 	describeDomainIn    *sagemaker.DescribeDomainInput
 	listUserProfilesOut *sagemaker.ListUserProfilesOutput
+	listEndpointsOut    *sagemaker.ListEndpointsOutput
 	err                 error
 }
 
@@ -57,6 +59,16 @@ func (f *fakeSageMakerClient) ListUserProfiles(_ context.Context, _ *sagemaker.L
 		return &sagemaker.ListUserProfilesOutput{}, nil
 	}
 	return f.listUserProfilesOut, nil
+}
+
+func (f *fakeSageMakerClient) ListEndpoints(_ context.Context, _ *sagemaker.ListEndpointsInput, _ ...func(*sagemaker.Options)) (*sagemaker.ListEndpointsOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	if f.listEndpointsOut == nil {
+		return &sagemaker.ListEndpointsOutput{}, nil
+	}
+	return f.listEndpointsOut, nil
 }
 
 // TestListSageMakerDomains_EmptyResult — #255 contract: empty response
@@ -131,6 +143,54 @@ func TestListSageMakerUserProfiles_NonEmpty(t *testing.T) {
 	assert.Equal(t, "alice", aws.ToString(got[0].UserProfileName))
 }
 
+// TestListSageMakerEndpoints_EmptyResult — #255 contract (#797): an
+// empty endpoint list must marshal as JSON `[]`, never `null`, so the
+// downstream account-wide EndpointName discovery surface renders.
+func TestListSageMakerEndpoints_EmptyResult(t *testing.T) {
+	t.Parallel()
+	got, err := listSageMakerEndpoints(context.Background(), &fakeSageMakerClient{})
+	require.NoError(t, err)
+	require.NotNil(t, got, "#255: empty endpoint list must be non-nil")
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListSageMakerEndpoints_ExplicitEmptySliceNormalized(t *testing.T) {
+	t.Parallel()
+	client := &fakeSageMakerClient{listEndpointsOut: &sagemaker.ListEndpointsOutput{
+		Endpoints: []sagemakertypes.EndpointSummary{}, // explicitly empty
+	}}
+	got, err := listSageMakerEndpoints(context.Background(), client)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	b, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
+func TestListSageMakerEndpoints_NonEmpty(t *testing.T) {
+	t.Parallel()
+	client := &fakeSageMakerClient{
+		listEndpointsOut: &sagemaker.ListEndpointsOutput{
+			Endpoints: []sagemakertypes.EndpointSummary{
+				{EndpointName: aws.String("my-endpoint")},
+			},
+		},
+	}
+	got, err := listSageMakerEndpoints(context.Background(), client)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "my-endpoint", aws.ToString(got[0].EndpointName))
+}
+
+func TestListSageMakerEndpoints_APIError(t *testing.T) {
+	t.Parallel()
+	_, err := listSageMakerEndpoints(context.Background(), &fakeSageMakerClient{err: errors.New("AccessDenied")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDenied")
+}
+
 func TestDescribeSageMakerDomain_PassesID(t *testing.T) {
 	t.Parallel()
 	client := &fakeSageMakerClient{}
@@ -191,4 +251,22 @@ func TestInspectSageMaker_UnknownAction(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sagemaker")
 	assert.Contains(t, err.Error(), "no-such-action")
+}
+
+// TestInspectSageMaker_ListEndpointsRoutesToHandler — #797: the
+// list-endpoints arm must dispatch to the handler, not fall through to
+// unsupportedActionError. With an empty config the SDK call fails before
+// reaching AWS, so the contract we pin is "did NOT bounce off the switch
+// as an unsupported action" (mirrors the dispatcher drift gate). This
+// closes the gap that firstAction("sagemaker") leaves: it returns
+// list-domains, so TestInspectCoversAllAWSServices never exercises this
+// arm.
+func TestInspectSageMaker_ListEndpointsRoutesToHandler(t *testing.T) {
+	t.Parallel()
+	_, err := inspectSageMaker(context.Background(), aws.Config{Region: "us-east-1"}, "list-endpoints", "")
+	if err != nil {
+		assert.NotContains(t, err.Error(), "no-such-action")
+		assert.NotContains(t, err.Error(), "unsupported",
+			"list-endpoints must route to its handler, got unsupported-action error: %v", err)
+	}
 }

--- a/pkg/observability/inspect/testdata/render/aws_service_table.txt
+++ b/pkg/observability/inspect/testdata/render/aws_service_table.txt
@@ -24,7 +24,7 @@
 | rds | describe-db-instances, describe-db-clusters, get-metrics |
 | route53 | list-hosted-zones, list-resource-record-sets |
 | s3 | list-buckets, get-metrics |
-| sagemaker | list-domains, describe-domain, list-user-profiles, get-metrics |
+| sagemaker | list-domains, describe-domain, list-user-profiles, list-endpoints, get-metrics |
 | secretsmanager | list-secrets, get-metrics |
 | sqs | list-queues, get-metrics |
 | vpc | describe-nat-gateways, get-metrics |

--- a/pkg/observability/service_actions.go
+++ b/pkg/observability/service_actions.go
@@ -64,9 +64,12 @@ var AWSServiceActions = map[string][]string{
 	// top-level entity that holds user profiles + Studio apps.
 	// describe-domain fetches the full output for a given domain ID.
 	// list-user-profiles enumerates user profiles across visible domains.
+	// list-endpoints (#797) enumerates inference endpoints account-wide;
+	// EndpointName is the AWS/SageMaker CloudWatch dimension, so this is
+	// the action metrics-discovery uses to find dimension values.
 	// get-metrics routes to the metrics package for the AWS/SageMaker
 	// CloudWatch namespace.
-	"sagemaker": {"list-domains", "describe-domain", "list-user-profiles", "get-metrics"},
+	"sagemaker": {"list-domains", "describe-domain", "list-user-profiles", "list-endpoints", "get-metrics"},
 }
 
 // AWSServiceAliases maps caller-supplied aliases to canonical service


### PR DESCRIPTION
## Problem

The observability catalog ships a `sagemaker` AWSObs entry (namespace `AWS/SageMaker`, dimension `EndpointName`), but the inspect handler only exposed `list-domains`, `describe-domain`, `list-user-profiles`, and `get-metrics`. There was no action to list **endpoints**, so a consumer could not discover `EndpointName` dimension values account-wide. Downstream, reliable's metrics-discovery dispatch had to carry a marked sagemaker exemption (reliable#2076).

## Fix

Add a `list-endpoints` action to the SageMaker inspector:

- New `listSageMakerEndpoints` helper backed by SageMaker `ListEndpoints`, returning `[]sagemakertypes.EndpointSummary` (each entry carries `EndpointName`, the CloudWatch dimension).
- Slice normalized through `nilSliceToEmpty` so empty responses marshal as JSON `[]`, never `null` (the #255 contract).
- Registered the action in `AWSServiceActions["sagemaker"]` and the `sageMakerClient` interface + dispatch switch.
- Extended the #255 live probe (`live_probe_255_test.go`) with the three sagemaker slice actions.

Reliable can now add the dispatch row + Extract and drop the test exemption.

## Tests

- `TestListSageMakerEndpoints_{EmptyResult,ExplicitEmptySliceNormalized,NonEmpty,APIError}` — pins the #255 contract (`require.NotNil` + `json.Marshal` == `"[]"`), matching the sibling list-domains / list-user-profiles tests.
- `TestInspectSageMaker_ListEndpointsRoutesToHandler` — fails if the dispatch arm is removed (the existing `TestInspectCoversAllAWSServices` drift gate only exercises `list-domains`, so this closes that coverage gap). Verified by mutation: removing the switch arm turns this test red.
- Full suites green: `pkg/observability/discovery/aws` + `pkg/observability` (448 tests). `go vet -tags=integration` clean.

Closes #797