### PR TITLE
fix(test): derive tfvalidate AWS pin from emitter source of truth (#796)

### DIFF
--- a/pkg/composer/imported_tfvalidate_test.go
+++ b/pkg/composer/imported_tfvalidate_test.go
@@ -21,6 +21,7 @@
 package composer
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,15 +31,36 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
 
-// tfValidateProvidersHCL declares the aws.imported alias the emitted
-// resource blocks reference. The skip_*/static creds keep `terraform
-// validate` from ever touching AWS — validate is schema-only anyway, but
-// the explicit creds avoid an interactive prompt under -input=false.
-const tfValidateProvidersHCL = `terraform {
+// tfValidateProvidersHCL renders the providers.tf the harness drops next
+// to the emitted imported.tf. It declares the aws.imported alias the
+// emitted resource blocks reference; the skip_*/static creds keep
+// `terraform validate` from ever touching AWS — validate is schema-only
+// anyway, but the explicit creds avoid an interactive prompt under
+// -input=false.
+//
+// #796: the AWS version constraint is NOT hand-pinned here. It is sourced
+// from imported.BaseProviderPin("aws", "aws") — the SAME single source of
+// truth the real reverse-import emitter feeds into its providers.tf
+// (pkg/reverseimport/providers.go). Hand-pinning it (the pre-#796 `~> 5.0`)
+// let this harness validate the imported.tf codegen against a different AWS
+// provider major than production emits (`= 6.46.0`), because the shared
+// TF_PLUGIN_CACHE_DIR resolved each constraint to a different cached major.
+// A v6-only schema change to an imported resource body would therefore pass
+// the v5-pinned harness. Deriving the pin from BaseProviderPin closes that
+// schema-skew by construction: the harness can never validate against a
+// different provider version than the emitter ships.
+func tfValidateProvidersHCL(t *testing.T) string {
+	t.Helper()
+	pin := imported.BaseProviderPin("aws", "aws")
+	if strings.TrimSpace(pin) == "" {
+		t.Fatal(`imported.BaseProviderPin("aws", "aws") returned empty; ` +
+			"the harness has no canonical AWS provider pin to validate against")
+	}
+	return fmt.Sprintf(`terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = %q
     }
   }
 }
@@ -52,7 +74,54 @@ provider "aws" {
   skip_requesting_account_id  = true
   skip_metadata_api_check     = true
 }
-`
+`, pin)
+}
+
+// TestImportedTF_ProvidersFixtureMatchesEmitterPin is the #796 schema-skew
+// guard. It pins that the harness providers.tf validates the imported.tf
+// codegen against the SAME AWS provider version the real reverse-import
+// emitter ships — the canonical imported.BaseProviderPin("aws", "aws"),
+// also consumed by pkg/reverseimport/providers.go — and never against a
+// stale hand-pinned major. Pre-#796 the fixture hand-pinned `~> 5.0` while
+// production emitted `= 6.46.0`; this test fails on that skew. Unlike
+// TestImportedTF_TerraformValidate it needs no `terraform` binary, so it
+// runs everywhere the tfvalidate tag is built.
+func TestImportedTF_ProvidersFixtureMatchesEmitterPin(t *testing.T) {
+	pin := imported.BaseProviderPin("aws", "aws")
+	if strings.TrimSpace(pin) == "" {
+		t.Fatal(`imported.BaseProviderPin("aws", "aws") returned empty`)
+	}
+
+	// Anchor 1 — the canonical pin the emitter ships must target the AWS v6
+	// major, independent of the fixture. AWS preset modules require provider
+	// >= 6.0 (CLAUDE.md), so a harness that validates the imported.tf codegen
+	// against any other major reintroduces the #796 skew at the source. This
+	// fails if BaseProviderPin itself ever drifts off v6 — it is NOT a
+	// tautology against the fixture string.
+	if !strings.HasPrefix(strings.TrimLeft(pin, "=~> "), "6.") {
+		t.Fatalf("emitter AWS pin %q is not a v6 constraint; the imported.tf "+
+			"tfvalidate harness must validate against the v6 schema AWS presets "+
+			"require (#796)", pin)
+	}
+
+	// Anchor 2 — the rendered fixture must carry exactly that canonical pin,
+	// so the providers.tf this harness hands `terraform validate` is wired to
+	// the emitter source of truth and not a stale hand-pinned literal.
+	hcl := tfValidateProvidersHCL(t)
+	wantLine := fmt.Sprintf(`version = %q`, pin)
+	if !strings.Contains(hcl, wantLine) {
+		t.Errorf("harness providers.tf does not pin the canonical emitter AWS "+
+			"version (#796 schema-skew):\n  want line: %s\n--- providers.tf ---\n%s",
+			wantLine, hcl)
+	}
+
+	// Anchor 3 — tripwire for the retired v5 literal sneaking back into the
+	// static template body (the alias/creds block anchors 1-2 don't read,
+	// since they only inspect the interpolated pin) — the exact pre-#796 bug.
+	if strings.Contains(hcl, "~> 5") || strings.Contains(hcl, `"5.`) {
+		t.Errorf("harness providers.tf reintroduced a v5 AWS pin (#796 regression):\n%s", hcl)
+	}
+}
 
 func TestImportedTF_TerraformValidate(t *testing.T) {
 	tfBin, err := exec.LookPath("terraform")
@@ -94,7 +163,7 @@ func TestImportedTF_TerraformValidate(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	if werr := os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(tfValidateProvidersHCL), 0o644); werr != nil {
+	if werr := os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(tfValidateProvidersHCL(t)), 0o644); werr != nil {
 		t.Fatal(werr)
 	}
 	if werr := os.WriteFile(filepath.Join(dir, "imported.tf"), out, 0o644); werr != nil {


### PR DESCRIPTION
## Summary
- The imported.tf `terraform validate` harness hand-pinned its providers.tf fixture to `hashicorp/aws ~> 5.0`, while the real reverse-import emitter (`pkg/reverseimport/providers.go`) renders the AWS version from `imported.BaseProviderPin("aws", "aws")` = `= 6.46.0`. Because the shared `TF_PLUGIN_CACHE_DIR` resolves each constraint to a different cached major, the harness silently validated the codegen against the AWS **v5** schema while production emits **v6** — a v6-only schema change to an imported resource body would pass the v5-pinned harness undetected.
- Root-cause fix: source the harness fixture's AWS constraint from the same `imported.BaseProviderPin` the emitter consumes, so the harness can never validate against a different provider major than production ships. No new hardcoded number — it derives from the single source of truth.
- Adds `TestImportedTF_ProvidersFixtureMatchesEmitterPin`, a no-terraform drift guard with three independent anchors: (1) the canonical pin targets the v6 major (fails if `BaseProviderPin` itself drifts off v6), (2) the rendered fixture carries exactly that pin, (3) tripwire for a v5 literal sneaking back into the static template body.

## Why this is the right altitude
`pkg/composer` cannot import `pkg/reverseimport` (import cycle), so the harness can't assert against the live emitter output directly. Both sides instead pin to the shared `BaseProviderPin`: the reverse-import emitter is guarded by `pkg/reverseimport/providers_test.go` (asserts the emitter renders `= 6.46.0`), and this harness is now guarded to consume the same function. The skew is closed by construction.

## Test plan
- [x] Test-first: temporarily reverted the helper to hardcode `~> 5.0` and confirmed `TestImportedTF_ProvidersFixtureMatchesEmitterPin` fails (both the canonical-pin and v5-tripwire assertions fire); restored the fix and confirmed it passes.
- [x] `go test -tags tfvalidate -run TestImportedTF ./pkg/composer/` — both the new guard and the live `terraform validate` harness pass; `terraform init` now resolves the `6.46.0` provider from the plugin cache (was `5.100.0`).
- [x] `go test ./pkg/composer/...` (untagged) green; `go test ./pkg/composer/imported/... ./pkg/reverseimport/...` — 846 pass.
- [x] `go vet -tags tfvalidate ./pkg/composer/`, `gofmt`, `terraform fmt -check -recursive`, and the four static lint scripts all clean.

## Review notes
- /review (xhigh): no P0/P1/P2; addressed the one P2 (positive assertion was partially tautological) by adding the independent v6-major anchor. No deferrals.
- qa-professor: PASS, no blocking findings; applied the single P3 cosmetic comment tightening.

Closes #796