### PR TITLE
fix(composer): force EnableNATGateway on for stacks needing private subnets (default path)

### DIFF
--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -271,6 +271,27 @@ func configTagToKey(tag string) ComponentKey {
 // component derive is the rule that catches "VPC stays, but its NAT-related
 // sub-fields no longer have a justification."
 //
+// ASYMMETRY — derive only ACTS on the !needsPrivate case (it clears NAT). It
+// deliberately does NOT force EnableNATGateway=true for the needsPrivate case.
+// Three-way contract for EnableNATGateway on a needs-private stack:
+//
+//   - user-explicit false → preserved here, and the mapper fail-fast rejects it
+//     (mapper.go, KeyAWSVPC). Forcing true here would silently flip an explicit
+//     false to true AND suppress that intentional error — so we must not.
+//   - user-explicit true → preserved here; the mapper emits enable_nat_gateway
+//     =true.
+//   - user-unset (nil) → the needs-private default of true is injected upstream
+//     by ComputePresetDefaults' component-aware overlay
+//     (overrideNATGatewayDefaultForPrivateSubnets, #393), NOT here. That layer
+//     is zero-only, so it can only ever fill the user's nil field — it can
+//     never clobber an explicit value. By the time this derive re-runs after
+//     MergeConfigs the field is already &true and this function leaves it alone.
+//
+// In short: derive turns NAT OFF when nothing needs it; the preset-default
+// overlay turns NAT ON (by default, never over an explicit value) when
+// something does. Keeping the "on" decision in the overlay is what preserves
+// the user-explicit-false → fail-fast guarantee.
+//
 // Idempotent in-place mutation. Not a pure function in the strict sense
 // (it writes through *cfg); calling it twice on the same inputs is a
 // no-op on the second call.

--- a/pkg/composer/coherence_test.go
+++ b/pkg/composer/coherence_test.go
@@ -932,3 +932,83 @@ func TestCoherence_DefaultPathNAT_NoNeedsPrivateStaysOff(t *testing.T) {
 	assert.Equal(t, false, natVal,
 		"Public VPC with no consumers must keep NAT off in tfvars")
 }
+
+// TestCoherence_DefaultPathLambdaTimeoutUnit is the regression for the SECOND
+// instance of the composer self-contradiction class (same shape as the
+// #393/#805 NAT bug), surfaced by the class-level Guard B
+// (selfvalidation_test.go). A stack selecting aws_lambda built with DEFAULT
+// config (the user never authored AWSLambda.Timeout) used to:
+//
+//  1. get AWSLambda.Timeout="3" from the composer's OWN preset-default overlay
+//     — aws/lambda/variables.tf declares `timeout` as an HCL number (default
+//     3 seconds), and the zero-only overlay stringifies that to the bare
+//     integer "3"; then
+//  2. get rejected by the composer's OWN mapper validation
+//     (parseDurationToSeconds), which accepts only unit-suffixed durations
+//     ("3s"/"30s"/"15m") and fails fast on a bare integer.
+//
+// reliable would surface (2) as a red "Terraform Error" — exactly the NAT
+// symptom. The asymmetry: the IR enum default is "3s" (so the UI dodges it),
+// but ANY default-materialized stack with an empty Timeout hits the bare
+// integer.
+//
+// Pre-fix: this FAILS — BuildModuleValues returns the validation error.
+// Post-fix: overrideLambdaTimeoutUnitDefault normalises the overlay's own
+// bare-integer default to "3s", so the mapper emits timeout=3 and no error.
+func TestCoherence_DefaultPathLambdaTimeoutUnit(t *testing.T) {
+	t.Parallel()
+
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+	// Empty/default config: the user NEVER authored AWSLambda.Timeout. This is
+	// the default path the bug lives on.
+	cfg := &Config{Cloud: "AWS"}
+	selected := []ComponentKey{KeyAWSVPC, KeyAWSLambda}
+
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	require.NoError(t, New().ApplyPresetDefaults(cfg, comps, selected))
+	DeriveCrossComponentFields(comps, cfg)
+
+	require.NotNil(t, cfg.AWSLambda, "overlay must materialise the AWSLambda default block")
+	assert.Equal(t, "3s", cfg.AWSLambda.Timeout,
+		"the composer's own default timeout must be unit-suffixed (\"3s\"), not the "+
+			"bare HCL number (\"3\") its mapper rejects")
+
+	vals, err := DefaultMapper{}.BuildModuleValues(KeyAWSLambda, comps, cfg, "test", "us-east-1")
+	require.NoError(t, err,
+		"a default-config Lambda stack must NOT trip the composer's own Timeout "+
+			"fail-fast — the computed default must already be mapper-valid")
+	assert.Equal(t, 3, vals["timeout"], "mapper must emit timeout=3 (seconds) in tfvars")
+}
+
+// TestCoherence_DefaultPathLambdaTimeout_PreservesUserValue locks the
+// provenance guarantee for the Lambda-timeout fix: the overlay is zero-only, so
+// a user-explicit Timeout is never echoed into the overlay and therefore never
+// rewritten by overrideLambdaTimeoutUnitDefault. A user "120s" survives intact.
+func TestCoherence_DefaultPathLambdaTimeout_PreservesUserValue(t *testing.T) {
+	t.Parallel()
+
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSLambda: boolPtr(true)}
+	cfg := &Config{
+		Cloud: "AWS",
+		AWSLambda: &struct {
+			Runtime    string `json:"runtime,omitempty"`
+			MemorySize string `json:"memorySize,omitempty"`
+			Timeout    string `json:"timeout,omitempty"`
+		}{Timeout: "120s"},
+	}
+	selected := []ComponentKey{KeyAWSVPC, KeyAWSLambda}
+
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	require.NoError(t, New().ApplyPresetDefaults(cfg, comps, selected))
+	DeriveCrossComponentFields(comps, cfg)
+
+	require.NotNil(t, cfg.AWSLambda)
+	assert.Equal(t, "120s", cfg.AWSLambda.Timeout,
+		"a user-explicit Timeout must be preserved, never rewritten by the default normaliser")
+
+	vals, err := DefaultMapper{}.BuildModuleValues(KeyAWSLambda, comps, cfg, "test", "us-east-1")
+	require.NoError(t, err)
+	assert.Equal(t, 120, vals["timeout"], "mapper must emit the user's timeout (120s -> 120)")
+}

--- a/pkg/composer/coherence_test.go
+++ b/pkg/composer/coherence_test.go
@@ -767,3 +767,168 @@ func setPointerToBoolTrueByTag(c *Components, tag string) {
 		return
 	}
 }
+
+// runDefaultCoherenceThenMapNAT runs the EXACT coherence + preset-default
+// sequence reliable applies before composing a stack (strip → derive →
+// ComputePresetDefaults → MergeConfigs → derive), then runs the mapper's
+// KeyAWSVPC validation. It returns the resolved enable_nat_gateway tfvar value
+// (nil if the mapper did not emit one), the in-place-resolved cfg, and the
+// mapper error.
+//
+// It uses New() so the REAL embedded aws/vpc preset HCL defaults flow through —
+// in particular enable_nat_gateway's intentional false "backstop" (#393). This
+// is what reproduces the self-contradiction: the overlay injects the backstop
+// false into the user's nil EnableNATGateway, then the mapper rejects that very
+// value. A composer with a stubbed/empty preset FS would NOT reproduce it.
+func runDefaultCoherenceThenMapNAT(t *testing.T, comps *Components, cfg *Config, selected []ComponentKey) (any, *Config, error) {
+	t.Helper()
+	c := New()
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	overlay, err := c.ComputePresetDefaults(*cfg, comps, selected)
+	require.NoError(t, err)
+	MergeConfigs(cfg, &overlay)
+	DeriveCrossComponentFields(comps, cfg)
+	vals, mapErr := DefaultMapper{}.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+	if mapErr != nil {
+		return nil, cfg, mapErr
+	}
+	return vals["enable_nat_gateway"], cfg, nil
+}
+
+// TestCoherence_DefaultPathNATForNeedsPrivate_Issue393 is the HEADLINE
+// regression for the composer self-contradiction surfaced on staging session
+// sess_v2_ygVBb4cl1nJf (stack = aws_vpc + aws_rds + lambda + apigateway + s3 +
+// secretsmanager + bedrock + sqs + cognito + cloudwatch_logs + github_actions +
+// kms; default VPC config).
+//
+// A stack that has a VPC plus any component needing private subnets, built with
+// DEFAULT VPC config (the user never authored EnableNATGateway), used to:
+//  1. get AWSVPC.EnableNATGateway=false from the composer's OWN preset-default
+//     overlay (the aws/vpc HCL backstop, #393), then
+//  2. get rejected by the composer's OWN mapper validation with
+//     "AWSVPC.EnableNATGateway=false is incompatible with components that
+//     require private subnets ...".
+//
+// reliable surfaced (2) as a red "Terraform Error" button. The asymmetry: the
+// coherence derive only ACTS on the !needsPrivate case (clears NAT); for the
+// needsPrivate case it does nothing, so the overlay-injected false survives to
+// the mapper.
+//
+// Pre-fix: this FAILS — BuildModuleValues returns the validation error.
+// Post-fix: the COMPUTED default is component-aware, so the resolved
+// EnableNATGateway is true and no error is returned.
+func TestCoherence_DefaultPathNATForNeedsPrivate_Issue393(t *testing.T) {
+	t.Parallel()
+
+	comps := &Components{
+		Cloud:  "AWS",
+		AWSVPC: "Public VPC",
+		AWSRDS: boolPtr(true),
+	}
+	// Empty/default VPC config: the user NEVER authored EnableNATGateway. This
+	// is the default path the bug lives on.
+	cfg := &Config{Cloud: "AWS"}
+	selected := []ComponentKey{KeyAWSVPC, KeyAWSRDS}
+
+	natVal, resolved, err := runDefaultCoherenceThenMapNAT(t, comps, cfg, selected)
+	require.NoError(t, err,
+		"#393: a default-config VPC+RDS stack must NOT trip the composer's own "+
+			"EnableNATGateway=false fail-fast — the computed default must be NAT=true")
+	require.NotNil(t, resolved.AWSVPC, "AWSVPC sub-block must carry the derived NAT decision")
+	require.NotNil(t, resolved.AWSVPC.EnableNATGateway, "EnableNATGateway must be resolved, not left nil")
+	assert.True(t, *resolved.AWSVPC.EnableNATGateway,
+		"resolved EnableNATGateway must be true on a needs-private stack with default config")
+	assert.Equal(t, true, natVal, "mapper must emit enable_nat_gateway=true in tfvars")
+}
+
+// TestCoherence_DefaultPathNAT_AllNeedsPrivateComponents is the future-proofing
+// guard the user asked for: it sweeps the WHOLE needs-private component set
+// (EKS / ECS / RDS / ElastiCache / OpenSearch / EC2 node groups, plus a
+// combined stack) and asserts that, with a default VPC config, the
+// default+coherence+mapper path resolves NAT on and never trips the fail-fast.
+// Any new component added to stackNeedsPrivateSubnets should be added here too.
+func TestCoherence_DefaultPathNAT_AllNeedsPrivateComponents(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		comps    *Components
+		selected []ComponentKey
+	}{
+		{"EKS", &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSEKS: boolPtr(true)},
+			[]ComponentKey{KeyAWSVPC, KeyAWSEKS}},
+		{"ECS", &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSECS: boolPtr(true)},
+			[]ComponentKey{KeyAWSVPC, KeyAWSECS}},
+		{"RDS", &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSRDS: boolPtr(true)},
+			[]ComponentKey{KeyAWSVPC, KeyAWSRDS}},
+		{"ElastiCache", &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSElastiCache: boolPtr(true)},
+			[]ComponentKey{KeyAWSVPC, KeyAWSElastiCache}},
+		{"OpenSearch", &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSOpenSearch: boolPtr(true)},
+			[]ComponentKey{KeyAWSVPC, KeyAWSOpenSearch}},
+		{"EC2 node group", &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSEC2: "Intel"},
+			[]ComponentKey{KeyAWSVPC, KeyAWSEC2}},
+		{"EKS + RDS combined", &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSEKS: boolPtr(true), AWSRDS: boolPtr(true)},
+			[]ComponentKey{KeyAWSVPC, KeyAWSEKS, KeyAWSRDS}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{Cloud: "AWS"} // default VPC config
+			natVal, resolved, err := runDefaultCoherenceThenMapNAT(t, tc.comps, cfg, tc.selected)
+			require.NoError(t, err,
+				"#393: default-config stack with %s must not trip the EnableNATGateway=false fail-fast", tc.name)
+			require.NotNil(t, resolved.AWSVPC)
+			require.NotNil(t, resolved.AWSVPC.EnableNATGateway)
+			assert.True(t, *resolved.AWSVPC.EnableNATGateway,
+				"resolved EnableNATGateway must be true for %s", tc.name)
+			assert.Equal(t, true, natVal, "mapper must emit enable_nat_gateway=true for %s", tc.name)
+		})
+	}
+}
+
+// TestCoherence_DefaultPathNAT_PreservesExplicitFalse locks the intentional
+// guard: a user who EXPLICITLY sets EnableNATGateway=false on a needs-private
+// stack must STILL get the validation error. The fix is overlay-only and the
+// overlay is zero-only, so an explicit (non-nil) false is never echoed back nor
+// flipped — it reaches the mapper unchanged and fails fast.
+func TestCoherence_DefaultPathNAT_PreservesExplicitFalse(t *testing.T) {
+	t.Parallel()
+
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSEKS: boolPtr(true)}
+	cfg := cfgWithVPCSubBlock(nil, boolPtr(false), nil) // user-explicit NAT=false
+	selected := []ComponentKey{KeyAWSVPC, KeyAWSEKS}
+
+	_, _, err := runDefaultCoherenceThenMapNAT(t, comps, cfg, selected)
+	require.Error(t, err,
+		"user-explicit EnableNATGateway=false on a needs-private stack must STILL fail fast — "+
+			"the overlay-only fix must not suppress the intentional guard")
+	assert.Contains(t, err.Error(), "AWSVPC.EnableNATGateway=false is incompatible",
+		"must surface the specific #389/#393 fail-fast, not some other error path")
+}
+
+// TestCoherence_DefaultPathNAT_NoNeedsPrivateStaysOff is the negative case: a
+// stack with NO private-subnet-needing component (VPC + S3) must NOT get NAT
+// turned on by the fix. The component-aware default only applies to
+// needs-private stacks; here NAT ends nil/off and no error is raised.
+func TestCoherence_DefaultPathNAT_NoNeedsPrivateStaysOff(t *testing.T) {
+	t.Parallel()
+
+	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSS3: boolPtr(true)}
+	cfg := &Config{Cloud: "AWS"} // default VPC config
+	selected := []ComponentKey{KeyAWSVPC, KeyAWSS3}
+
+	natVal, resolved, err := runDefaultCoherenceThenMapNAT(t, comps, cfg, selected)
+	require.NoError(t, err, "a non-needs-private stack must compose cleanly")
+	// The final derive clears NAT fields (and possibly the whole AWSVPC block)
+	// on a stack that doesn't need private subnets.
+	if resolved.AWSVPC != nil {
+		assert.Nil(t, resolved.AWSVPC.EnableNATGateway,
+			"NAT must stay off (nil) on a stack with no private-subnet consumers")
+	}
+	// Public VPC with no consumers: the mapper emits enable_nat_gateway=false.
+	assert.Equal(t, false, natVal,
+		"Public VPC with no consumers must keep NAT off in tfvars")
+}

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"strconv"
 	"strings"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -210,6 +211,17 @@ func (c *Client) ComputePresetDefaults(cfg Config, comps *Components, selected [
 	// provenance-safe (it only rewrites the overlay's own zero-only default).
 	overrideNATGatewayDefaultForPrivateSubnets(&out, comps)
 
+	// Lambda-timeout default unit (same self-contradiction class as #393/#805,
+	// found by the class-level Guard B in selfvalidation_test.go).
+	// aws/lambda/variables.tf declares `timeout` as an HCL number (default 3
+	// seconds); the zero-only overlay stringifies that to the bare integer "3",
+	// but the mapper's strict duration parser (parseDurationToSeconds) accepts
+	// only unit-suffixed forms ("3s"/"30s"/"15m") and rejects a bare integer —
+	// so the composer's OWN default would trip its OWN validator. Normalise the
+	// overlay's own computed default to the "<N>s" form the mapper expects. See
+	// overrideLambdaTimeoutUnitDefault for why this is provenance-safe.
+	overrideLambdaTimeoutUnitDefault(&out)
+
 	return out, nil
 }
 
@@ -246,6 +258,47 @@ func overrideNATGatewayDefaultForPrivateSubnets(out *Config, comps *Components) 
 	}
 	enable := true
 	out.AWSVPC.EnableNATGateway = &enable
+}
+
+// overrideLambdaTimeoutUnitDefault makes the AWSLambda.Timeout preset default
+// mapper-valid. aws/lambda/variables.tf declares `timeout` as an HCL number
+// (default 3 seconds); overlayStructFromDefaults coerces that number into the
+// string Config.AWSLambda.Timeout field via fmt.Sprint, yielding the bare
+// integer "3". The mapper's strict duration parser (parseDurationToSeconds /
+// the validate registry's normalizeDurationSeconds) accepts only "<N>s" /
+// "<N>m" / "<N>h" and fails fast on a bare integer — so the composer's OWN
+// computed default trips its OWN validator. Rewrite the overlay's bare-integer
+// seconds default to the "<N>s" form. It mutates ONLY the overlay, never cfg.
+//
+// Provenance safety — this can never clobber a user-set value, by construction
+// (identical argument to overrideNATGatewayDefaultForPrivateSubnets):
+//
+//   - overlayStructFromDefaults is zero-only, so out.AWSLambda.Timeout is
+//     non-empty ONLY when the user left cfg.AWSLambda.Timeout blank. A non-empty
+//     overlay value therefore already PROVES the user didn't author it, and
+//     rewriting the composer's own "3" → "3s" is exactly "the computed default,
+//     spelled the way the mapper accepts."
+//   - A user-explicit Timeout (e.g. "30s") is never echoed into the overlay, so
+//     it is never seen here; the later zero-only MergeConfigs never touches the
+//     user's field and it reaches the mapper unchanged.
+//   - Only a BARE integer is rewritten. A value that is already unit-suffixed
+//     (or otherwise non-integer) is left untouched for the mapper to judge — we
+//     normalise the seconds-as-number default, we don't invent or relax format.
+func overrideLambdaTimeoutUnitDefault(out *Config) {
+	if out.AWSLambda == nil {
+		return
+	}
+	t := strings.TrimSpace(out.AWSLambda.Timeout)
+	if t == "" {
+		return
+	}
+	// strconv.Atoi succeeds only for a bare integer — exactly the shape the
+	// number→string coercion produces from the HCL default. "30s" fails here
+	// and is left alone.
+	if _, err := strconv.Atoi(t); err != nil {
+		return
+	}
+	out.AWSLambda.Timeout = t + "s"
 }
 
 // applyGPUInstanceTypeDefault overlays defaultGPUInstanceType onto the EC2/EKS

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -198,7 +198,54 @@ func (c *Client) ComputePresetDefaults(cfg Config, comps *Components, selected [
 	// own cfg left the instance type blank — an explicit pick is preserved.
 	applyGPUInstanceTypeDefault(&cfg, &out)
 
+	// NAT-gateway default for needs-private stacks (#393, reliable "Terraform
+	// Error" regression). The aws/vpc preset's enable_nat_gateway HCL default is
+	// false — an intentional backstop so a stale-true value can't wedge a
+	// Public-VPC-only stack. But that backstop is the WRONG default for a stack
+	// that DOES need private subnets: the zero-only overlay would land
+	// EnableNATGateway=&false into the user's nil field, and the mapper's
+	// fail-fast would then reject the very value the composer itself chose.
+	// Make the COMPUTED default component-aware so the default path resolves to
+	// true. See overrideNATGatewayDefaultForPrivateSubnets for why this is
+	// provenance-safe (it only rewrites the overlay's own zero-only default).
+	overrideNATGatewayDefaultForPrivateSubnets(&out, comps)
+
 	return out, nil
+}
+
+// overrideNATGatewayDefaultForPrivateSubnets makes the EnableNATGateway preset
+// default component-aware: for stacks that need private subnets (EKS / ECS /
+// RDS / ElastiCache / OpenSearch / EC2 node groups), the overlay's NAT default
+// is true rather than the aws/vpc HCL backstop (false). It mutates ONLY the
+// overlay, never cfg.
+//
+// Provenance safety — this can never clobber a user-set value, by construction:
+//
+//   - The overlay carries a non-nil EnableNATGateway ONLY when the user left
+//     cfg.AWSVPC.EnableNATGateway zero (overlayStructFromDefaults is zero-only).
+//     So out.AWSVPC.EnableNATGateway != nil already PROVES the user didn't
+//     author it. Rewriting it false→true is safe and is exactly "the computed
+//     default for a needs-private stack."
+//   - When the user explicitly authored EnableNATGateway (incl. =false), the
+//     overlay leaves the field nil here; this function leaves it nil too, so
+//     the later zero-only MergeConfigs never touches the user's pointer and the
+//     intentional EnableNATGateway=false fail-fast still fires in the mapper.
+//   - We never ALLOCATE an overlay AWSVPC sub-block or invent the field: if the
+//     overlay didn't compute a default here (e.g. aws/vpc not in `selected`),
+//     there is no default to make component-aware, so we leave it untouched.
+//
+// Symmetric in spirit to applyGPUInstanceTypeDefault: adjust the overlay's
+// default value; the zero-only merge fills the blank without overriding an
+// explicit pick.
+func overrideNATGatewayDefaultForPrivateSubnets(out *Config, comps *Components) {
+	if !stackNeedsPrivateSubnets(comps) {
+		return
+	}
+	if out.AWSVPC == nil || out.AWSVPC.EnableNATGateway == nil {
+		return
+	}
+	enable := true
+	out.AWSVPC.EnableNATGateway = &enable
 }
 
 // applyGPUInstanceTypeDefault overlays defaultGPUInstanceType onto the EC2/EKS

--- a/pkg/composer/selfvalidation_test.go
+++ b/pkg/composer/selfvalidation_test.go
@@ -1,0 +1,170 @@
+package composer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Guard B — class-level "composer never self-rejects its own default output".
+//
+// The #393/#805 NAT-gateway bug was ONE instance of a CLASS: a cross-component
+// DEFAULT value drifting out of sync with a VALIDATION rule, so the composer
+// emits a default config that its OWN validator (the mapper) rejects — which
+// reliable then surfaces as a red "Terraform Error". The NAT regression tests
+// in coherence_test.go pin the NAT instance specifically; Guard B catches the
+// WHOLE class, including future, non-NAT drift.
+//
+// It does so by enumerating EVERY component key programmatically
+// (AllComponentKeys — components added later are auto-covered) and, for each,
+// constructing a minimally-valid DEFAULT-config stack, running the exact
+// default+coherence pipeline reliable applies, then sweeping the mapper over
+// every selected component and asserting NONE self-rejects. The invariant under
+// test is specifically: "defaulting must not INTRODUCE a validation failure."
+//
+// Guard B already earned its keep: it discovered a SECOND instance of the class
+// (aws_lambda's bare-integer "3" Timeout default tripping the mapper's strict
+// duration parser), fixed alongside it in defaults.go
+// (overrideLambdaTimeoutUnitDefault).
+
+// derivedComponentKeys lists ComponentKeys that legitimately have NO selecting
+// field on the Components struct because they are auto-included by
+// ResolveDependenciesForCompose rather than selected directly. Guard B cannot
+// mark them on a Components value, and that is EXPECTED — not a coverage gap.
+// Every entry MUST carry a comment justifying why it has no field.
+//
+// Keep this list MINIMAL. A new key that the harness cannot place and is NOT in
+// this list fails Guard B LOUDLY (buildDefaultStackForKey t.Fatalf), forcing a
+// human to wire it into selectComponentOnto or document it here — never a
+// silent skip.
+var derivedComponentKeys = map[ComponentKey]bool{
+	// aws_eks_nodegroup has no standalone Components field; it is auto-included
+	// whenever aws_eks is selected (ResolveDependenciesForCompose, issue #206),
+	// and ComponentSelected(c, KeyAWSEKSNodeGroup) is false by design.
+	KeyAWSEKSNodeGroup: true,
+}
+
+// selectComponentOnto marks `key` as selected on the shared Components value
+// `c`, mirroring the per-key rules of selectingComponentsFor but mutating in
+// place so an entire dependency closure can be assembled onto ONE Components.
+// The three string-typed keys and the two backup-struct keys are handled
+// explicitly; every other key is a *bool selection placed reflectively by json
+// tag (setPointerToBoolTrueByTag) — so new *bool components are auto-covered.
+func selectComponentOnto(c *Components, key ComponentKey) {
+	switch key {
+	case KeyAWSVPC:
+		c.AWSVPC = "Public VPC"
+	case KeyAWSEC2:
+		c.AWSEC2 = "Intel"
+	case KeyGCPCompute:
+		c.GCPCompute = "n2-standard-2"
+	case KeyAWSBackups:
+		c.AWSBackups = selectingComponentsFor(KeyAWSBackups).AWSBackups
+	case KeyGCPBackups:
+		c.GCPBackups = selectingComponentsFor(KeyGCPBackups).GCPBackups
+	default:
+		setPointerToBoolTrueByTag(c, string(key))
+	}
+}
+
+// buildDefaultStackForKey assembles a minimally-valid, DEFAULT-config stack
+// that selects `primary` plus its mandatory dependency closure (a VPC/network
+// where the component requires one — supplied by ResolveDependenciesForCompose
+// via ImplicitDependencies), then runs the EXACT default+coherence pipeline
+// reliable applies before composing a stack:
+//
+//	StripOrphanConfig -> DeriveCrossComponentFields -> ComputePresetDefaults ->
+//	MergeConfigs -> DeriveCrossComponentFields
+//
+// cfg starts EMPTY (no user-authored fields) so ONLY the composer's own
+// defaults populate it — that is the whole point: we are testing the composer's
+// own output, not a user's. It returns the resolved comps, cfg, and the full
+// dependency-expanded selected key set, ready for the mapper sweep.
+//
+// Loud-failure contract: every resolved key must be placeable onto Components
+// (or be a documented derivedComponentKeys entry). A NEW key the harness cannot
+// place is a t.Fatalf, never a silent skip.
+func buildDefaultStackForKey(t *testing.T, primary ComponentKey) (*Components, *Config, []ComponentKey) {
+	t.Helper()
+
+	cloud := strings.ToUpper(CloudFor(primary)) // "AWS" / "GCP"
+	selected := ResolveDependenciesForCompose([]ComponentKey{primary}, nil)
+
+	comps := &Components{Cloud: cloud}
+	for _, k := range selected {
+		selectComponentOnto(comps, k)
+	}
+	for _, k := range selected {
+		if !ComponentSelected(comps, k) && !derivedComponentKeys[k] {
+			t.Fatalf("Guard B cannot place component %q onto a Components value "+
+				"(while building the default stack for %q): wire it into "+
+				"selectComponentOnto, or — if it is genuinely field-less and "+
+				"dependency-derived — document it in derivedComponentKeys. "+
+				"An unplaceable key is a coverage failure, not a pass.", k, primary)
+		}
+	}
+
+	cfg := &Config{Cloud: cloud}
+	c := New() // real embedded preset FS, so real HCL defaults flow through
+	StripOrphanConfig(comps, cfg)
+	DeriveCrossComponentFields(comps, cfg)
+	overlay, err := c.ComputePresetDefaults(*cfg, comps, selected)
+	require.NoErrorf(t, err,
+		"ComputePresetDefaults must not error for a default-config stack selecting %q", primary)
+	MergeConfigs(cfg, &overlay)
+	DeriveCrossComponentFields(comps, cfg)
+	return comps, cfg, selected
+}
+
+// TestComposer_DefaultOutput_NeverSelfRejects is GUARD B. For every component
+// key in AllComponentKeys it builds a default-config stack (key + minimal
+// deps), runs the full default+coherence pipeline, and sweeps the mapper over
+// every selected component — asserting the composer never produces a default
+// its own validator rejects.
+//
+// To prove this is a real guard (not a vacuous pass): comment out the
+// overrideNATGatewayDefaultForPrivateSubnets call in defaults.go and the seven
+// needs-private subtests (aws_eks/ecs/rds/elasticache/opensearch/ec2 +
+// nodegroup) fail with the EnableNATGateway=false self-reject; comment out
+// overrideLambdaTimeoutUnitDefault and the aws_lambda / aws_bedrock_agent /
+// aws_agentcore_gateway subtests fail with the bare-integer Timeout self-reject.
+func TestComposer_DefaultOutput_NeverSelfRejects(t *testing.T) {
+	t.Parallel()
+
+	for _, primary := range AllComponentKeys {
+		primary := primary
+		t.Run(string(primary), func(t *testing.T) {
+			t.Parallel()
+
+			comps, cfg, selected := buildDefaultStackForKey(t, primary)
+
+			// Sweep the mapper over EVERY selected component. The NAT bug was a
+			// KeyAWSVPC self-reject; the Lambda-timeout bug a KeyAWSLambda one.
+			// Any component whose mapper rejects a value the composer's OWN
+			// defaulting produced is the class under test.
+			for _, k := range selected {
+				_, err := (DefaultMapper{}).BuildModuleValues(k, comps, cfg, "test", "us-east-1")
+				require.NoErrorf(t, err,
+					"composer self-rejected its OWN default output: the default-config "+
+						"stack %v (primary %q) produced a config that component %q's mapper "+
+						"rejects. This is a cross-component default/validation drift "+
+						"(class of #393/#805) — fix the COMPUTED default in defaults.go, "+
+						"do NOT relax the validator.",
+					selected, primary, k)
+			}
+
+			// Targeted NAT-class tripwire: if the resolved default ends with
+			// EnableNATGateway set, it must be consistent with the validator —
+			// never false while the stack needs private subnets. This trips if
+			// someone adds a key to the needs-private set (stackNeedsPrivate
+			// Subnets) without wiring the component-aware NAT default.
+			if cfg.AWSVPC != nil && cfg.AWSVPC.EnableNATGateway != nil && stackNeedsPrivateSubnets(comps) {
+				assert.Truef(t, *cfg.AWSVPC.EnableNATGateway,
+					"needs-private stack %v resolved its OWN EnableNATGateway default to "+
+						"false — the mapper fail-fast would reject it (#393/#805)", selected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The composer contradicted itself for any stack that has a VPC plus a component needing private subnets (RDS / EKS / ECS / ElastiCache / OpenSearch / EC2 node groups), built with default VPC config (user never set `EnableNATGateway`):

- `ComputePresetDefaults` injected the `aws/vpc` HCL backstop default (`enable_nat_gateway=false`, #393) into the user's nil `EnableNATGateway` via the zero-only overlay, then
- the mapper's own validation (`mapper.go`, `KeyAWSVPC`) rejected that exact value with `AWSVPC.EnableNATGateway=false is incompatible with components that require private subnets ...`.

reliable surfaced that error as a red "Terraform Error" button.

**Root cause** is an asymmetry in `DeriveCrossComponentFields`: it only ACTS on the `!needsPrivate` case (clears NAT); for the `needsPrivate` case it does nothing, so the overlay-injected `false` survives to the mapper.

## Staging repro

Session `sess_v2_ygVBb4cl1nJf` — stack = `aws_vpc + aws_rds + aws_lambda + aws_apigateway + aws_s3 + aws_secretsmanager + aws_bedrock + aws_sqs + aws_cognito + aws_cloudwatch_logs + aws_github_actions + aws_kms`, default VPC config. `tf-compose-from-session` returned the `EnableNATGateway=false is incompatible ...` validation error.

## Fix

Overlay-level and provenance-safe — make the COMPUTED preset default component-aware so the overlay's `EnableNATGateway` default is `true` (not the HCL backstop `false`) for needs-private stacks. New helper `overrideNATGatewayDefaultForPrivateSubnets` in `pkg/composer/defaults.go`, called at the end of `ComputePresetDefaults` (symmetric to `applyGPUInstanceTypeDefault`).

Why this preserves the intentional guard:

- The overlay is zero-only (`overlayStructFromDefaults` / `MergeConfigs`), so a non-nil overlay `EnableNATGateway` only exists when the user left their field nil. Rewriting that overlay default `false`→`true` can never clobber a user value.
- A user-explicit `EnableNATGateway=false` is a non-nil pointer the overlay never carries, so it reaches the mapper unchanged and the fail-fast still fires.
- The `aws/vpc` HCL backstop default is left untouched (it is an intentional backstop, #393).

Also extends the `DeriveCrossComponentFields` doc comment to spell out the derive-vs-default-vs-explicit three-way contract for `EnableNATGateway`.

## Before / after

Headline regression test on `origin/main` (pre-fix) fails with the composer rejecting its own default:

```
--- FAIL: TestCoherence_DefaultPathNATForNeedsPrivate_Issue393 (0.00s)
    Error: Received unexpected error:
        AWSVPC.EnableNATGateway=false is incompatible with components that require private subnets
        (EKS/ECS/RDS/ElastiCache/OpenSearch/EC2 node groups): private subnets without NAT cannot
        reach the public internet, breaking image pulls and package installs. ...
    Messages: #393: a default-config VPC+RDS stack must NOT trip the composer's own
        EnableNATGateway=false fail-fast — the computed default must be NAT=true
```

Post-fix: all pass.

## Regression tests (`pkg/composer/coherence_test.go`)

All run the exact reliable sequence (strip → derive → `ComputePresetDefaults` → `MergeConfigs` → derive) with the real embedded `aws/vpc` preset, then the mapper validation:

- `TestCoherence_DefaultPathNATForNeedsPrivate_Issue393` — headline: VPC + RDS, default config → no error, resolved `EnableNATGateway=true`, tfvar `enable_nat_gateway=true`.
- `TestCoherence_DefaultPathNAT_AllNeedsPrivateComponents` — table-driven across the whole needs-private set (EKS, ECS, RDS, ElastiCache, OpenSearch, EC2 node group, plus EKS+RDS combined) → NAT on, no error.
- `TestCoherence_DefaultPathNAT_PreservesExplicitFalse` — user-explicit `EnableNATGateway=false` + EKS → STILL fails fast with the intentional error.
- `TestCoherence_DefaultPathNAT_NoNeedsPrivateStaysOff` — VPC + S3 (no private-subnet consumer) → NAT stays off/nil, no error.

`go test ./pkg/composer/...` → 2428 passed; `go test -race ./pkg/composer/...`, `go build ./...`, `go vet ./...`, `gofmt` all clean.

Fixes a reliable-surfaced "Terraform Error" regression. References the #393 mapper-sets-NAT contract.

---

## Guard B — class-level self-validation (follow-up commits)

The NAT bug was one instance of a CLASS: a cross-component default drifting out of sync with a validation rule, so the composer emits a default its own validator rejects. Two commits added on top of the NAT fix:

- **`test(composer)`: class-level guard** (`pkg/composer/selfvalidation_test.go`) — `TestComposer_DefaultOutput_NeverSelfRejects` enumerates every key in `AllComponentKeys`, builds a default-config stack (key + its mandatory dependency closure via `ResolveDependenciesForCompose`), runs the full default+coherence pipeline reliable applies, then sweeps the mapper over every selected component and asserts none self-rejects. Plus a targeted tripwire: a resolved `EnableNATGateway` default is never `false` on a needs-private stack. New components are auto-covered (programmatic enumeration; `*bool` keys placed reflectively by json tag); a key the harness can't place fails loudly (`t.Fatalf`, no silent skip); the one field-less derived key (`aws_eks_nodegroup`) sits in a documented allowlist. Proven non-vacuous — reverting `overrideNATGatewayDefaultForPrivateSubnets` fails the 7 needs-private subtests.

- **`fix(composer)`: Lambda timeout default** (`pkg/composer/defaults.go`) — Guard B immediately found a SECOND instance of the class: a default-config `aws_lambda` stack got `AWSLambda.Timeout="3"` from the overlay (the HCL `timeout = 3` number stringified), which the mapper's strict duration parser rejects (it wants `"3s"`). Fixed the same overlay-safe way (`overrideLambdaTimeoutUnitDefault`, `"3"`→`"3s"`); a user-explicit `"30s"` is never echoed into the overlay and is preserved. Regression tests `TestCoherence_DefaultPathLambdaTimeoutUnit` + `TestCoherence_DefaultPathLambdaTimeout_PreservesUserValue` in `coherence_test.go`. Reverting this fix fails the 3 Lambda-bearing Guard B subtests.

`go test ./pkg/composer/...` passes (Guard B: 61/61 component subtests green).
