### PR TITLE
fix(composer): heal frozen NAT/Lambda values at map time instead of failing

### DIFF
--- a/pkg/composer/coherence_test.go
+++ b/pkg/composer/coherence_test.go
@@ -889,24 +889,35 @@ func TestCoherence_DefaultPathNAT_AllNeedsPrivateComponents(t *testing.T) {
 	}
 }
 
-// TestCoherence_DefaultPathNAT_PreservesExplicitFalse locks the intentional
-// guard: a user who EXPLICITLY sets EnableNATGateway=false on a needs-private
-// stack must STILL get the validation error. The fix is overlay-only and the
-// overlay is zero-only, so an explicit (non-nil) false is never echoed back nor
-// flipped — it reaches the mapper unchanged and fails fast.
-func TestCoherence_DefaultPathNAT_PreservesExplicitFalse(t *testing.T) {
+// TestCoherence_DefaultPathNAT_CoercesExplicitFalse locks the REVERSED
+// contract (supersedes #805's fail-fast, per the heal decision): an explicit
+// EnableNATGateway=false on a needs-private stack is a known-always-invalid
+// value that pre-#805 snapshots froze into stored config reliable composes
+// verbatim, so the mapper now HEALS it — coercing enable_nat_gateway=true with
+// no error — instead of failing fast the user can't act on.
+//
+// This was TestCoherence_DefaultPathNAT_PreservesExplicitFalse (#805), which
+// asserted the opposite (STILL errors). It is intentionally inverted, not
+// deleted: the explicit-false guard is replaced by the heal coercion.
+func TestCoherence_DefaultPathNAT_CoercesExplicitFalse(t *testing.T) {
 	t.Parallel()
 
 	comps := &Components{Cloud: "AWS", AWSVPC: "Public VPC", AWSEKS: boolPtr(true)}
 	cfg := cfgWithVPCSubBlock(nil, boolPtr(false), nil) // user-explicit NAT=false
 	selected := []ComponentKey{KeyAWSVPC, KeyAWSEKS}
 
-	_, _, err := runDefaultCoherenceThenMapNAT(t, comps, cfg, selected)
-	require.Error(t, err,
-		"user-explicit EnableNATGateway=false on a needs-private stack must STILL fail fast — "+
-			"the overlay-only fix must not suppress the intentional guard")
-	assert.Contains(t, err.Error(), "AWSVPC.EnableNATGateway=false is incompatible",
-		"must surface the specific #389/#393 fail-fast, not some other error path")
+	natVal, resolved, err := runDefaultCoherenceThenMapNAT(t, comps, cfg, selected)
+	require.NoError(t, err,
+		"explicit EnableNATGateway=false on a needs-private stack must now be HEALED "+
+			"(coerced to NAT=true), not rejected — supersedes the #805 fail-fast")
+	assert.Equal(t, true, natVal,
+		"mapper must coerce enable_nat_gateway=true for a needs-private stack with frozen NAT=false")
+	// Provenance: the heal rewrites only the emitted tfvars, never the stored
+	// Config — the explicit false survives in cfg (reliable's source of truth).
+	require.NotNil(t, resolved.AWSVPC)
+	require.NotNil(t, resolved.AWSVPC.EnableNATGateway)
+	assert.False(t, *resolved.AWSVPC.EnableNATGateway,
+		"the stored Config is NOT mutated by the heal; only the emitted tfvars are coerced")
 }
 
 // TestCoherence_DefaultPathNAT_NoNeedsPrivateStaysOff is the negative case: a

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -112,19 +113,18 @@ func (m DefaultMapper) BuildModuleValues(
 		// Topology knobs from Config.AWSVPC override Public-VPC-derived defaults.
 		// Unset pointer fields defer to the HCL default.
 		if cfg != nil && cfg.AWSVPC != nil {
-			// Reject EnableNATGateway=false when the stack has components that
-			// require private subnets with egress (EKS/ECS/RDS/ElastiCache/
-			// OpenSearch/EC2 node groups). Private subnets without NAT can't
-			// pull container images or run package installs, so the apply
-			// would break much later than it needs to. Fail fast here.
-			if cfg.AWSVPC.EnableNATGateway != nil && !*cfg.AWSVPC.EnableNATGateway && stackNeedsPrivateSubnets(comps) {
-				return nil, NewValidationError(
-					"AWSVPC.EnableNATGateway=false is incompatible with components that require private subnets " +
-						"(EKS/ECS/RDS/ElastiCache/OpenSearch/EC2 node groups): private subnets without NAT cannot reach " +
-						"the public internet, breaking image pulls and package installs. Either re-enable NAT or drop " +
-						"the downstream components",
-				)
-			}
+			// NOTE: EnableNATGateway=false on a stack that needs private subnets
+			// (EKS/ECS/RDS/ElastiCache/OpenSearch/EC2 node groups) is always
+			// invalid — private subnets without NAT can't pull container images
+			// or run package installs. #805 failed fast here, but existing
+			// stack snapshots froze EnableNATGateway=false into their stored
+			// config BEFORE #805 fixed the defaulting path, and reliable
+			// composes that stored config verbatim (no re-derive), so a
+			// fail-fast only yields an error the user can't act on. We now HEAL
+			// it instead: the coercion at the end of this case forces
+			// enable_nat_gateway=true (the final word over the explicit-false
+			// assignment below). See the heal block tagged "heal frozen NAT".
+			//
 			// AZCount bounds — HCL validation says >= 1; enforce the same at
 			// the mapper so users see a Go-level error before `terraform plan`.
 			if cfg.AWSVPC.AZCount != nil && *cfg.AWSVPC.AZCount < 1 {
@@ -166,6 +166,28 @@ func (m DefaultMapper) BuildModuleValues(
 		// coercion to upstream callers so the stale field can be cleared.
 		if pSubn, ok := vals["enable_private_subnets"].(bool); ok && !pSubn {
 			vals["enable_nat_gateway"] = false
+		}
+
+		// Heal frozen NAT: a stack that needs private subnets but ends up with
+		// enable_nat_gateway=false is always invalid (private subnets without
+		// NAT can't reach the internet). This supersedes #805's explicit-false
+		// fail-fast — pre-#805 snapshots froze that bad value into stored
+		// config that reliable composes verbatim, so we coerce instead of
+		// erroring. This runs LAST so it is the final word over the
+		// explicit-false / derived-false assignments above; the #389 coercion
+		// just above only sets NAT=false when private subnets are disabled,
+		// which never overlaps a needs-private stack. enable_private_subnets is
+		// pinned true so the outputs.tf invariant "enable_nat_gateway=true
+		// requires enable_private_subnets=true" cannot trip.
+		if stackNeedsPrivateSubnets(comps) {
+			if nat, ok := vals["enable_nat_gateway"].(bool); ok && !nat {
+				log.Printf("[composer/mapper] AWSVPC heal: enable_nat_gateway=false is " +
+					"incompatible with a stack that needs private subnets " +
+					"(EKS/ECS/RDS/ElastiCache/OpenSearch/EC2); coercing " +
+					"enable_nat_gateway=true and enable_private_subnets=true (frozen pre-#805 value)")
+				vals["enable_nat_gateway"] = true
+				vals["enable_private_subnets"] = true
+			}
 		}
 
 	case KeyCloud:
@@ -917,13 +939,26 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["memory_size"] = n
 			}
 			if cfg.AWSLambda.Timeout != "" {
-				// Strict: support only "<N>s", "<N>m", "<N>h" — the IR
-				// enum is {"3s","30s","15m"}. Earlier versions dropped
-				// anything that didn't end in s or m (e.g. "1h", bare
-				// "30", "30 s") and produced 0 by accident on a few
-				// malformed shapes. Fail fast on unrecognised format
-				// rather than silently feeding the module its default.
-				secs, err := parseDurationToSeconds(cfg.AWSLambda.Timeout, "AWSLambda.Timeout")
+				// Support "<N>s", "<N>m", "<N>h" — the IR enum is
+				// {"3s","30s","15m"}.
+				//
+				// Heal frozen bare integers: pre-#805 snapshots froze a
+				// bare-integer timeout (e.g. "3", "30") — the composer's own
+				// preset overlay stringified the HCL number default — into
+				// stored config that reliable composes verbatim. The strict
+				// parser rejects a bare integer (it wants a unit), so erroring
+				// only yields an error the user can't act on. A bare integer is
+				// unambiguously seconds, so coerce "<N>" -> "<N>s" before
+				// parsing. Genuinely malformed values (e.g. "abc", "5y") still
+				// error — only bare integers are the known-safe coercion.
+				timeout := strings.TrimSpace(cfg.AWSLambda.Timeout)
+				if bareIntRe.MatchString(timeout) {
+					coerced := timeout + "s"
+					log.Printf("[composer/mapper] AWSLambda heal: timeout=%q is a bare "+
+						"integer; coercing to %q (seconds) (frozen pre-#805 value)", timeout, coerced)
+					timeout = coerced
+				}
+				secs, err := parseDurationToSeconds(timeout, "AWSLambda.Timeout")
 				if err != nil {
 					return nil, err
 				}
@@ -1614,6 +1649,10 @@ var (
 	leadingIntRe     = regexp.MustCompile(`^\s*(-?\d+)`)
 	storageSizeRe    = regexp.MustCompile(`^\s*(\d+)\s*(GB|TB|MB)\s*$`)
 	mapperDurationRe = regexp.MustCompile(`^\s*(\d+)\s*([smh])\s*$`)
+	// bareIntRe matches an unsuffixed non-negative integer ("3", "30"). Used to
+	// heal frozen pre-#805 Lambda timeouts that lack a unit by coercing to
+	// "<N>s" (seconds) before the strict duration parser runs.
+	bareIntRe = regexp.MustCompile(`^[0-9]+$`)
 )
 
 // canonicalDdbBillingMode maps IR enum values to the uppercase tokens

--- a/pkg/composer/mapper_audit_test.go
+++ b/pkg/composer/mapper_audit_test.go
@@ -468,12 +468,20 @@ func TestBuildModuleValues_AWSLambda_MemoryAndTimeout(t *testing.T) {
 		assertValidationError(t, err)
 	})
 
-	t.Run("rejects bare-integer timeout (no unit) with ValidationError", func(t *testing.T) {
-		_, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", "30"), "", "")
-		assertValidationError(t, err)
+	t.Run("normalizes bare-integer timeout (no unit) to seconds instead of erroring", func(t *testing.T) {
+		// REVERSED contract (supersedes #805's fail-fast, per the heal
+		// decision): a bare-integer timeout is a known-always-invalid frozen
+		// value (pre-#805 snapshots stringified the HCL number default) that
+		// reliable composes verbatim. A bare integer is unambiguously seconds,
+		// so the mapper coerces "30" -> "30s" instead of rejecting it.
+		vals, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", "30"), "", "")
+		require.NoError(t, err, "bare-integer timeout must be healed, not rejected")
+		assert.Equal(t, 30, vals["timeout"], `"30" normalizes to 30 seconds`)
 	})
 
 	t.Run("rejects unknown timeout unit with ValidationError", func(t *testing.T) {
+		// Only bare integers are the known-safe coercion; a non-numeric /
+		// unknown-unit value still fails fast.
 		_, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", "5y"), "", "")
 		assertValidationError(t, err)
 	})

--- a/pkg/composer/mapper_heal_test.go
+++ b/pkg/composer/mapper_heal_test.go
@@ -1,0 +1,145 @@
+package composer
+
+// Regression tests for the "heal frozen values" decision: PR #805 fixed the
+// DEFAULTING path so new stacks get good values, but existing stack snapshots
+// froze two known-always-invalid values into their stored config, which
+// reliable composes verbatim (no re-derive). The mapper now COERCES those two
+// values instead of erroring, healing existing sessions at compose time:
+//
+//  1. enable_nat_gateway=false on a stack that needs private subnets -> NAT on
+//  2. a bare-integer Lambda timeout ("30") -> unit-suffixed ("30s")
+//
+// These tests pin the new coercion contract (and reverse the #805 fail-fast —
+// see the inverted tests in coherence_test.go / mapper_test.go /
+// mapper_audit_test.go).
+
+import (
+	"bytes"
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildModuleValues_VPC_NATHeal covers every needs-private component shape
+// (RDS plus a table over EKS/ECS/ElastiCache/OpenSearch/EC2): an explicit
+// Config EnableNATGateway=false must be HEALED to enable_nat_gateway=true AND
+// enable_private_subnets=true, with no error.
+func TestBuildModuleValues_VPC_NATHeal(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+
+	cases := []struct {
+		name  string
+		comps *Components
+	}{
+		{"RDS", &Components{AWSVPC: "Public VPC", AWSRDS: boolPtr(true)}},
+		{"EKS", &Components{AWSVPC: "Public VPC", AWSEKS: boolPtr(true)}},
+		{"ECS", &Components{AWSVPC: "Public VPC", AWSECS: boolPtr(true)}},
+		{"ElastiCache", &Components{AWSVPC: "Public VPC", AWSElastiCache: boolPtr(true)}},
+		{"OpenSearch", &Components{AWSVPC: "Public VPC", AWSOpenSearch: boolPtr(true)}},
+		{"EC2 node group", &Components{AWSVPC: "Public VPC", AWSEC2: "Intel"}},
+		{"Private VPC + RDS", &Components{AWSVPC: "Private VPC", AWSRDS: boolPtr(true)}},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := cfgWithAWSVPC(nil, boolPtr(false), nil) // frozen NAT=false
+			vals, err := m.BuildModuleValues(KeyAWSVPC, tc.comps, cfg, "test", "us-east-1")
+			require.NoError(t, err,
+				"%s: frozen EnableNATGateway=false must be healed, not rejected", tc.name)
+			assert.Equal(t, true, vals["enable_nat_gateway"],
+				"%s: mapper must coerce enable_nat_gateway=true", tc.name)
+			assert.Equal(t, true, vals["enable_private_subnets"],
+				"%s: mapper must pin enable_private_subnets=true so the outputs.tf NAT invariant cannot trip", tc.name)
+		})
+	}
+}
+
+// TestBuildModuleValues_Lambda_TimeoutHeal pins the bare-integer normalization:
+// a bare integer ("30"/"3") is coerced to the unit-suffixed seconds form;
+// already-valid values pass through unchanged; genuinely-invalid values
+// ("abc") still error.
+func TestBuildModuleValues_Lambda_TimeoutHeal(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+
+	t.Run("coerces and passes through", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			in     string
+			wantT  int
+			reason string
+		}{
+			{"30", 30, `bare "30" -> 30s`},
+			{"3", 3, `bare "3" -> 3s`},
+			{"30s", 30, `already-valid "30s" stays 30s`},
+			{"15m", 900, `already-valid "15m" stays 900s`},
+		}
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.in, func(t *testing.T) {
+				t.Parallel()
+				vals, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", tc.in), "", "")
+				require.NoError(t, err, tc.reason)
+				assert.Equal(t, tc.wantT, vals["timeout"], tc.reason)
+			})
+		}
+	})
+
+	t.Run("non-numeric timeout still errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", "abc"), "", "")
+		require.Error(t, err, `"abc" is not a bare integer and is not a valid duration; must still error`)
+		var verr *ValidationError
+		assert.ErrorAs(t, err, &verr, "must remain a ValidationError")
+	})
+}
+
+// TestBuildModuleValues_Heal_EmitsWarning verifies both coercions log a
+// "[composer/mapper] ... heal" warning via the package's log.Printf idiom.
+//
+// Serial (no t.Parallel): it swaps the global log output, which Go's test
+// runner guarantees does not overlap any t.Parallel test (parallel tests are
+// paused until all serial tests at this level finish). The mapper is
+// synchronous with no background goroutines, so a plain buffer is race-safe.
+func TestBuildModuleValues_Heal_EmitsWarning(t *testing.T) {
+	m := DefaultMapper{}
+
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+
+	// NAT heal warning.
+	buf.Reset()
+	_, err := m.BuildModuleValues(KeyAWSVPC, &Components{AWSVPC: "Public VPC", AWSRDS: boolPtr(true)},
+		cfgWithAWSVPC(nil, boolPtr(false), nil), "test", "us-east-1")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "[composer/mapper] AWSVPC heal",
+		"NAT coercion must emit a [composer/mapper] AWSVPC heal warning")
+
+	// Lambda heal warning.
+	buf.Reset()
+	_, err = m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", "30"), "", "")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "[composer/mapper] AWSLambda heal",
+		"bare-integer timeout coercion must emit a [composer/mapper] AWSLambda heal warning")
+
+	// Negative control: a valid timeout must NOT emit a heal warning.
+	buf.Reset()
+	_, err = m.BuildModuleValues(KeyAWSLambda, nil, lambdaCfg("", "", "30s"), "", "")
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "heal",
+		"an already-valid value must not emit any heal warning")
+}

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -180,21 +180,21 @@ func TestBuildModuleValues_VPC_PublicPrivateMode(t *testing.T) {
 			"mapper must explicitly emit enable_nat_gateway=true when private subnets are needed and the user hasn't authored AWSVPC.EnableNATGateway (#393)")
 	})
 
-	t.Run("user-authored AWSVPC.EnableNATGateway=false wins over #393 explicit-true branch", func(t *testing.T) {
-		// Regression guard: the #393 explicit-true branch must NOT clobber a
-		// user who deliberately set EnableNATGateway=false. The fail-fast
-		// branch at mapper.go:120-127 catches the truly inconsistent
-		// "false + needs private subnets" combination and rejects with an
-		// error before vals is returned.
+	t.Run("AWSVPC.EnableNATGateway=false on a needs-private stack is HEALED to NAT=true", func(t *testing.T) {
+		// REVERSED contract (supersedes #805's fail-fast, per the heal
+		// decision): EnableNATGateway=false + a needs-private component is a
+		// known-always-invalid value that pre-#805 snapshots froze into stored
+		// config reliable composes verbatim. The mapper now coerces it instead
+		// of erroring: enable_nat_gateway=true AND enable_private_subnets=true
+		// (the latter pins the outputs.tf invariant).
 		comps := &Components{AWSVPC: "Private VPC", AWSEKS: boolPtr(true)}
 		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
-		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
-		require.Error(t, err, "user-authored EnableNATGateway=false + EKS must fail-fast at the mapper, NOT be silently overridden to true by the #393 branch")
-		// Pin the specific fail-fast at mapper.go:120-127; a future
-		// refactor returning a different error from a different code path
-		// would still satisfy require.Error and silently weaken this gate.
-		assert.Contains(t, err.Error(), "AWSVPC.EnableNATGateway=false is incompatible",
-			"must surface the specific #389 fail-fast, not some other error path")
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err, "frozen EnableNATGateway=false + EKS must be HEALED, not rejected")
+		assert.Equal(t, true, vals["enable_nat_gateway"],
+			"mapper must coerce enable_nat_gateway=true (final word over the explicit false)")
+		assert.Equal(t, true, vals["enable_private_subnets"],
+			"mapper must pin enable_private_subnets=true so the outputs.tf NAT invariant cannot trip")
 	})
 }
 
@@ -313,30 +313,34 @@ func TestBuildModuleValues_VPC_AWSVPCConfig(t *testing.T) {
 }
 
 // TestBuildModuleValues_VPC_AWSVPCConfig_Validation pins the mapper-level
-// validation for invalid Config.AWSVPC combinations that would produce a
-// broken stack (private subnets without egress) or fail at `terraform validate`.
-// Catching these in Go fails fast and gives actionable errors.
+// validation for invalid Config.AWSVPC combinations. AZCount bounds still fail
+// fast (the user can fix them). The NAT-off + needs-private combination is no
+// longer a fail-fast: it is a known-always-invalid value pre-#805 snapshots
+// froze into stored config reliable composes verbatim, so the mapper now HEALS
+// it (coerces NAT=true) instead of erroring — see the inverted subtests below.
 func TestBuildModuleValues_VPC_AWSVPCConfig_Validation(t *testing.T) {
 	m := DefaultMapper{}
 	boolPtr := func(v bool) *bool { return &v }
 	intPtr := func(v int) *int { return &v }
 
-	t.Run("EnableNATGateway=false with EKS returns ValidationError", func(t *testing.T) {
+	t.Run("EnableNATGateway=false with EKS is HEALED to NAT=true (was ValidationError)", func(t *testing.T) {
+		// REVERSED contract (supersedes #805's fail-fast): heal instead of error.
 		comps := &Components{AWSEKS: boolPtr(true)}
 		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
-		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
-		require.Error(t, err)
-		var verr *ValidationError
-		assert.ErrorAs(t, err, &verr, "should return ValidationError so API-layer can HTTP 400")
-		assert.Contains(t, err.Error(), "EnableNATGateway=false",
-			"error should name the offending knob")
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err, "frozen NAT=false + EKS must be healed, not rejected")
+		assert.Equal(t, true, vals["enable_nat_gateway"], "coerced enable_nat_gateway=true")
+		assert.Equal(t, true, vals["enable_private_subnets"], "coerced enable_private_subnets=true")
 	})
 
-	t.Run("EnableNATGateway=false with RDS returns ValidationError", func(t *testing.T) {
+	t.Run("EnableNATGateway=false with RDS is HEALED to NAT=true (was ValidationError)", func(t *testing.T) {
+		// REVERSED contract (supersedes #805's fail-fast): heal instead of error.
 		comps := &Components{AWSRDS: boolPtr(true)}
 		cfg := cfgWithAWSVPC(nil, boolPtr(false), nil)
-		_, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
-		require.Error(t, err)
+		vals, err := m.BuildModuleValues(KeyAWSVPC, comps, cfg, "test", "us-east-1")
+		require.NoError(t, err, "frozen NAT=false + RDS must be healed, not rejected")
+		assert.Equal(t, true, vals["enable_nat_gateway"], "coerced enable_nat_gateway=true")
+		assert.Equal(t, true, vals["enable_private_subnets"], "coerced enable_private_subnets=true")
 	})
 
 	t.Run("EnableNATGateway=false without downstream components is allowed", func(t *testing.T) {

--- a/pkg/composer/validate_aws_vpc_test.go
+++ b/pkg/composer/validate_aws_vpc_test.go
@@ -54,7 +54,7 @@ func TestValidateAWSVPCNATConsistency(t *testing.T) {
 		// VPC-shape gating.
 		{name: "Private VPC is a no-op (NAT is the documented default)", cloud: "aws", comps: &Components{AWSVPC: "Private VPC"}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
 		{name: "empty AWSVPC is a no-op", cloud: "aws", comps: &Components{}, cfg: awsVPCNATCfg(boolPtr(true)), wantIssue: false},
-		{name: "EnableNATGateway=false on Public VPC is a no-op (mapper's :120 reject handles the inverse)", cloud: "aws", comps: &Components{AWSVPC: "Public VPC"}, cfg: awsVPCNATCfg(boolPtr(false)), wantIssue: false},
+		{name: "EnableNATGateway=false on Public VPC is a no-op (the mapper heals the needs-private inverse)", cloud: "aws", comps: &Components{AWSVPC: "Public VPC"}, cfg: awsVPCNATCfg(boolPtr(false)), wantIssue: false},
 
 		// Consumer-presence gating — when a private-subnet-needing component
 		// is present, EnableNATGateway=true is legitimate. Cover every


### PR DESCRIPTION
## Why

PR #805 fixed the **defaulting** path so new stacks get good values. But existing stack snapshots froze two known-always-invalid values into their stored config, and reliable's compose path reads stored config **verbatim** (no re-derive). So existing sessions still failed compose with the composer's own validation errors the user can't act on.

There is no legitimate "NAT off + needs-private" or "bare-integer lambda timeout" state, so the mapper now **coerces** these two values instead of erroring — healing existing sessions at compose with zero reliable-side change.

## What

- **AWSVPC NAT** (`pkg/composer/mapper.go`, `KeyAWSVPC` case): a needs-private stack (EKS/ECS/RDS/ElastiCache/OpenSearch/EC2) with `enable_nat_gateway=false` is coerced to `enable_nat_gateway=true` and `enable_private_subnets=true` (pinning the `outputs.tf` invariant `enable_nat_gateway=true requires enable_private_subnets=true`). The coercion runs **last** in the case so it is the final word over the explicit-false / derived-false assignments above. **This reverses #805's explicit-false fail-fast by design.**
- **AWSLambda timeout** (`pkg/composer/mapper.go`, `KeyAWSLambda` case): a bare-integer timeout (`"3"` / `"30"`) is normalized to the unit-suffixed seconds form (`"3s"` / `"30s"`) before the strict parser runs. Already-valid (`"30s"`) and genuinely-invalid (`"abc"`) values are unchanged.

Both coercions emit a `[composer/mapper] ... heal` warning via the package's `log.Printf` idiom. A structured `ValidationIssue` was deliberately **not** used — it escalates to an error under `StrictValidate`, which would re-break the heal.

HCL defaults are untouched (#805 handled those).

## Tests

- Inverted (not deleted) the obsolete #805 fail-fast assertions to the new coerce contract:
  - `TestCoherence_DefaultPathNAT_PreservesExplicitFalse` → `TestCoherence_DefaultPathNAT_CoercesExplicitFalse`
  - `TestBuildModuleValues_VPC_AWSVPCConfig_Validation` NAT-with-EKS / NAT-with-RDS subtests
  - `TestBuildModuleValues_VPC_PublicPrivateMode` `#393 explicit-true` subtest
  - `TestBuildModuleValues_AWSLambda_MemoryAndTimeout` bare-integer reject subtest
  - stale comment in `validate_aws_vpc_test.go`
- New `pkg/composer/mapper_heal_test.go`: NAT coercion table (RDS + EKS/ECS/ElastiCache/OpenSearch/EC2), Lambda timeout normalization table, and a warning-emission test.
- Guard B (`TestComposer_DefaultOutput_NeverSelfRejects`) stays green.

`go test ./pkg/composer/...` and `go test -race ./pkg/composer/...`: 2507 passed, 0 data races (only the pre-existing `TestComposeGCPVPC_PlanHasNoForEachUnknownKey` terraform-provider-install integration test fails locally, for lack of network — unrelated to this change).

## Data

4 sessions / 13 versions have NAT-off + needs-private; 68 versions have a bare-integer lambda timeout. Unblocks reliable session `sess_v2_ygVBb4cl1nJf`.

Refs #805.