### PR TITLE
Composed AWS AI-stack e2e test + fix two apply-blocking preset bugs

### DIFF
--- a/aws/agentcore_gateway/main.tf
+++ b/aws/agentcore_gateway/main.tf
@@ -58,7 +58,14 @@ locals {
   # The Lambda target (and the gateway's permission to invoke it) only exist
   # when a backing Lambda ARN is wired in. A gateway with OpenAPI/REST targets
   # supplied out-of-band, or one stood up before its tools, leaves this off.
-  has_lambda_target = var.target_lambda_arn != null
+  #
+  # enable_lambda_target (when set) is the plan-time-known gate: composed stacks
+  # wire target_lambda_arn from module.aws_lambda.function_arn, an output whose
+  # value is unknown at plan, so `var.target_lambda_arn != null` is itself
+  # unknown and Terraform rejects it as a count argument. The composer sets
+  # enable_lambda_target explicitly; standalone callers leave it null and fall
+  # back to auto-detecting from the (literal, plan-time-known) ARN.
+  has_lambda_target = var.enable_lambda_target != null ? var.enable_lambda_target : (var.target_lambda_arn != null)
 }
 
 # --- Gateway IAM role ---------------------------------------------------------

--- a/aws/agentcore_gateway/main.tf
+++ b/aws/agentcore_gateway/main.tf
@@ -176,6 +176,20 @@ resource "aws_bedrockagentcore_gateway" "this" {
 
   tags = merge(module.name.tags, var.tags)
 
+  # AWS CreateGateway rejects a CUSTOM_JWT authorizer that defines none of
+  # allowedAudience / allowedClients (ValidationException). The provider treats
+  # both as optional, so this only surfaces at apply against the real API — fail
+  # fast at plan with an actionable message instead. A working gateway must pin
+  # the audiences and/or client IDs its issuer mints; there is no safe default
+  # to invent, so the caller supplies one via
+  # Config.aws_agentcore_gateway.jwtAllowedAudience / jwtAllowedClients.
+  lifecycle {
+    precondition {
+      condition     = length(var.jwt_allowed_audience) > 0 || length(var.jwt_allowed_clients) > 0
+      error_message = "AgentCore CUSTOM_JWT authorizer requires at least one of jwt_allowed_audience or jwt_allowed_clients to be non-empty — AWS CreateGateway rejects an authorizer with neither. Set Config.aws_agentcore_gateway.jwtAllowedAudience and/or jwtAllowedClients to the audience(s) / client ID(s) your OIDC issuer mints."
+    }
+  }
+
   depends_on = [aws_iam_role.gateway]
 }
 

--- a/aws/agentcore_gateway/tests/shape.tftest.hcl
+++ b/aws/agentcore_gateway/tests/shape.tftest.hcl
@@ -61,6 +61,15 @@ variables {
 run "defaults" {
   command = plan
 
+  # The CUSTOM_JWT authorizer requires at least one non-empty allowlist — AWS
+  # CreateGateway rejects an authorizer with neither, enforced by the gateway
+  # precondition in main.tf. So even the "defaults" shape must pin one. Audience
+  # is set here; clients is left unset so the null-emission security assertion
+  # below still exercises the unset path.
+  variables {
+    jwt_allowed_audience = ["insideout-agents"]
+  }
+
   # Gateway role is always created (the gateway requires role_arn).
   assert {
     condition     = aws_iam_role.gateway.name == "iotest-gw-agentcore-gw-role"
@@ -117,16 +126,18 @@ run "defaults" {
     error_message = "Gateway MCP block must carry the default instructions."
   }
 
-  # SECURITY: unset JWT allowlists must be null (not []) so the gateway does
-  # not pin an empty allowlist — the preset promises this (main.tf header on
-  # the conditional). An empty-list allowlist on a JWT authorizer is
-  # ambiguous (allow-none vs allow-all depending on provider); pinning null
-  # is the safe, documented shape.
+  # The set allowlist (audience) flows through to the authorizer.
   assert {
-    condition     = aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_audience == null
-    error_message = "Unset jwt_allowed_audience must emit null, not an empty allowlist."
+    condition     = contains(aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_audience, "insideout-agents")
+    error_message = "Gateway JWT authorizer must carry the supplied allowed_audience."
   }
 
+  # SECURITY: an unset JWT allowlist must be null (not []) so the gateway does
+  # not pin an empty allowlist — the preset promises this (main.tf header on
+  # the conditional). An empty-list allowlist on a JWT authorizer is ambiguous
+  # (allow-none vs allow-all depending on provider); pinning null is the safe,
+  # documented shape. Asserted on the unset clients allowlist (audience is set
+  # above to satisfy the gateway precondition).
   assert {
     condition     = aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_clients == null
     error_message = "Unset jwt_allowed_clients must emit null, not an empty allowlist."
@@ -163,7 +174,8 @@ run "with_lambda_target" {
   command = apply
 
   variables {
-    target_lambda_arn = "arn:aws:lambda:us-east-1:111111111111:function:iotest-gw-fn"
+    target_lambda_arn    = "arn:aws:lambda:us-east-1:111111111111:function:iotest-gw-fn"
+    jwt_allowed_audience = ["insideout-agents"]
   }
 
   assert {
@@ -283,7 +295,8 @@ run "govcloud_lambda_arn_accepted" {
   command = plan
 
   variables {
-    target_lambda_arn = "arn:aws-us-gov:lambda:us-gov-west-1:111111111111:function:iotest-gw-fn"
+    target_lambda_arn    = "arn:aws-us-gov:lambda:us-gov-west-1:111111111111:function:iotest-gw-fn"
+    jwt_allowed_audience = ["insideout-agents"]
   }
 
   assert {
@@ -328,6 +341,13 @@ run "bad_lambda_arn_rejected" {
 
   variables {
     target_lambda_arn = "not-an-arn"
+    # An allowlist is required to satisfy the gateway precondition: target_lambda_arn
+    # is not consumed by aws_bedrockagentcore_gateway.this, so an invalid value does
+    # not block that resource from planning (and evaluating its precondition) the way
+    # an invalid protocol_type / discovery_url / search_type / gateway_name does. The
+    # expected failure here is the target_lambda_arn variable validation, not the
+    # precondition.
+    jwt_allowed_audience = ["insideout-agents"]
   }
 
   expect_failures = [
@@ -358,4 +378,73 @@ run "bad_gateway_name_rejected" {
   expect_failures = [
     var.gateway_name,
   ]
+}
+
+# --- Precondition: CUSTOM_JWT requires an allowlist --------------------------
+#
+# Denial test for the gateway precondition (main.tf): a CUSTOM_JWT authorizer
+# with NEITHER allowlist must be rejected at plan, not deferred to AWS
+# CreateGateway's ValidationException. Deleting the precondition leaves the rest
+# of the suite green, so this is the only run that guards it.
+run "jwt_neither_allowlist_rejected" {
+  command = plan
+
+  # No jwt_allowed_audience, no jwt_allowed_clients (both default []).
+  expect_failures = [
+    aws_bedrockagentcore_gateway.this,
+  ]
+}
+
+# Symmetric to the defaults run (audience set, clients asserted null): set only
+# clients and assert the unset audience collapses to null, not []. The two
+# allowlist conditionals (main.tf) are independent, so each null branch needs
+# its own coverage.
+run "clients_only_audience_emits_null" {
+  command = plan
+
+  variables {
+    jwt_allowed_clients = ["client-abc"]
+  }
+
+  assert {
+    condition     = aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_audience == null
+    error_message = "Unset jwt_allowed_audience must emit null, not an empty allowlist."
+  }
+
+  assert {
+    condition     = contains(aws_bedrockagentcore_gateway.this.authorizer_configuration[0].custom_jwt_authorizer[0].allowed_clients, "client-abc")
+    error_message = "Gateway JWT authorizer must carry the supplied allowed_clients."
+  }
+}
+
+# --- Module half of the count-on-computed fix (#807) -------------------------
+#
+# The composer gates the Lambda target on a plan-time-known enable_lambda_target
+# flag, not the computed target_lambda_arn. Prove the preset honors it: with the
+# flag false but a non-null ARN supplied, NO target / invoke policy / permission
+# may be created — count must follow the bool, not the ARN. A revert to
+# `count = var.target_lambda_arn != null` makes this run fail.
+run "enable_lambda_target_false_overrides_arn" {
+  command = plan
+
+  variables {
+    target_lambda_arn    = "arn:aws:lambda:us-east-1:111111111111:function:iotest-gw-fn"
+    enable_lambda_target = false
+    jwt_allowed_audience = ["insideout-agents"]
+  }
+
+  assert {
+    condition     = length(aws_bedrockagentcore_gateway_target.lambda) == 0
+    error_message = "enable_lambda_target=false must suppress the Lambda target even when target_lambda_arn is set."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.gateway_invoke) == 0
+    error_message = "enable_lambda_target=false must suppress the gateway invoke policy."
+  }
+
+  assert {
+    condition     = length(aws_lambda_permission.gateway_invoke) == 0
+    error_message = "enable_lambda_target=false must suppress the Lambda invoke permission."
+  }
 }

--- a/aws/agentcore_gateway/variables.tf
+++ b/aws/agentcore_gateway/variables.tf
@@ -115,3 +115,9 @@ variable "target_lambda_arn" {
     error_message = "target_lambda_arn must be a Lambda function ARN (arn:aws:lambda:...) or null."
   }
 }
+
+variable "enable_lambda_target" {
+  description = "Explicitly enable (true) or disable (false) the Lambda target, its gateway invoke policy, and the Lambda invoke permission. Null (the default) auto-detects from target_lambda_arn — correct for standalone use where the ARN is a literal known at plan. The InsideOut composer sets this true when it wires target_lambda_arn from module.aws_lambda.function_arn: a wired output's value is unknown at plan, so `target_lambda_arn != null` cannot gate a count (Terraform raises 'Invalid count argument'). This plan-time-known toggle is the gate instead."
+  type        = bool
+  default     = null
+}

--- a/aws/bedrock/outputs.tf
+++ b/aws/bedrock/outputs.tf
@@ -33,6 +33,11 @@ output "knowledge_base_id" {
   description = "ID of the Bedrock Knowledge Base. null when enable_knowledge_base is false. Pass to aws_bedrockagent_agent_knowledge_base_association or RetrieveAndGenerate at runtime."
 }
 
+output "knowledge_base_enabled" {
+  value       = var.enable_knowledge_base
+  description = "Whether the Knowledge Base is provisioned. Plan-time-known (it is the input toggle, not a computed resource attribute), so a consumer can gate count/for_each on it — unlike knowledge_base_id, whose null-ness is unknown at plan when wired across modules. The composer feeds this into aws_bedrock_agent's enable_knowledge_base_association."
+}
+
 output "knowledge_base_arn" {
   value       = var.enable_knowledge_base ? aws_bedrockagent_knowledge_base.this[0].arn : null
   description = "ARN of the Bedrock Knowledge Base. null when disabled."

--- a/aws/bedrock_agent/main.tf
+++ b/aws/bedrock_agent/main.tf
@@ -28,9 +28,17 @@ locals {
 
   # The action group / Lambda invoke permission only exist when a backing
   # Lambda is wired in. A KB-only or chat-only agent leaves these off.
-  has_action_group = var.action_group_lambda_arn != null
+  #
+  # The enable_* toggles are the plan-time-known gates. Composed stacks wire
+  # action_group_lambda_arn / knowledge_base_id from other modules' outputs,
+  # whose values are unknown at plan, so `var.x != null` is itself unknown and
+  # Terraform rejects it as a count argument. The composer sets the toggles
+  # explicitly (enable_knowledge_base_association from the bedrock module's
+  # plan-time-known knowledge_base_enabled output); standalone callers leave
+  # them null and fall back to auto-detecting from the (literal) inputs.
+  has_action_group = var.enable_action_group != null ? var.enable_action_group : (var.action_group_lambda_arn != null)
   # The KB association only exists when a Knowledge Base id is wired in.
-  has_knowledge_base = var.knowledge_base_id != null
+  has_knowledge_base = var.enable_knowledge_base_association != null ? var.enable_knowledge_base_association : (var.knowledge_base_id != null)
 }
 
 # --- Agent resource IAM role --------------------------------------------------

--- a/aws/bedrock_agent/tests/shape.tftest.hcl
+++ b/aws/bedrock_agent/tests/shape.tftest.hcl
@@ -239,3 +239,38 @@ run "bad_lambda_arn_rejected" {
     var.action_group_lambda_arn,
   ]
 }
+
+# --- Module half of the count-on-computed fix (#807) -------------------------
+#
+# The composer gates the action group on a plan-time-known enable_action_group
+# flag and the KB association on enable_knowledge_base_association (fed from
+# bedrock's plan-time-known knowledge_base_enabled output), NOT on the computed
+# action_group_lambda_arn / knowledge_base_id. Prove the preset honors the
+# flags: with both false but non-null inputs supplied, NO action group, invoke
+# permission, or KB association may be created — counts must follow the bools,
+# not the inputs. A revert to `count = var.<input> != null` makes this run fail.
+run "enable_flags_false_override_inputs" {
+  command = plan
+
+  variables {
+    action_group_lambda_arn           = "arn:aws:lambda:us-east-1:111111111111:function:iotest-bra-fn"
+    knowledge_base_id                 = "EMDPPAYPZI"
+    enable_action_group               = false
+    enable_knowledge_base_association = false
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_agent_action_group.this) == 0
+    error_message = "enable_action_group=false must suppress the action group even when action_group_lambda_arn is set."
+  }
+
+  assert {
+    condition     = length(aws_lambda_permission.agent_invoke) == 0
+    error_message = "enable_action_group=false must suppress the Lambda invoke permission."
+  }
+
+  assert {
+    condition     = length(aws_bedrockagent_agent_knowledge_base_association.this) == 0
+    error_message = "enable_knowledge_base_association=false must suppress the KB association even when knowledge_base_id is set."
+  }
+}

--- a/aws/bedrock_agent/variables.tf
+++ b/aws/bedrock_agent/variables.tf
@@ -87,6 +87,12 @@ variable "action_group_lambda_arn" {
   }
 }
 
+variable "enable_action_group" {
+  description = "Explicitly enable (true) or disable (false) the action group, its Lambda invoke permission, and the alias's tool wiring. Null (the default) auto-detects from action_group_lambda_arn — correct for standalone use where the ARN is a literal known at plan. The InsideOut composer sets this true when it wires action_group_lambda_arn from module.aws_lambda.function_arn: a wired output's value is unknown at plan, so `action_group_lambda_arn != null` cannot gate a count (Terraform raises 'Invalid count argument'). This plan-time-known toggle is the gate instead."
+  type        = bool
+  default     = null
+}
+
 variable "action_group_name" {
   description = "Name of the agent's action group. Defaults to \"actions\" when null."
   type        = string
@@ -98,6 +104,12 @@ variable "action_group_name" {
 variable "knowledge_base_id" {
   description = "ID of a Bedrock Knowledge Base to associate with the agent for RAG. When null no association is created (the agent answers without retrieval). In a composed stack DefaultWiring supplies this from module.aws_bedrock.knowledge_base_id when aws_bedrock is selected with its Knowledge Base enabled."
   type        = string
+  default     = null
+}
+
+variable "enable_knowledge_base_association" {
+  description = "Explicitly enable (true) or disable (false) the Knowledge Base association. Null (the default) auto-detects from knowledge_base_id — correct for standalone use where the id is a literal known at plan. The InsideOut composer sets this from module.aws_bedrock.knowledge_base_enabled (a plan-time-known bool reflecting whether the KB is provisioned): the wired knowledge_base_id is a computed output whose null-ness is unknown at plan, so it cannot gate a count (Terraform raises 'Invalid count argument'). This plan-time-known toggle is the gate instead."
+  type        = bool
   default     = null
 }
 

--- a/aws/kendra/main.tf
+++ b/aws/kendra/main.tf
@@ -59,7 +59,14 @@ locals {
   # The S3 data source (and its access role/policy) only exist when a backing
   # S3 bucket is wired in. A Kendra index with documents ingested out-of-band,
   # or one stood up before its corpus, leaves the data source off.
-  has_s3_source = var.s3_bucket_name != null
+  #
+  # enable_s3_data_source (when set) is the plan-time-known gate: composed
+  # stacks wire s3_bucket_name from module.aws_s3.bucket_name, an output whose
+  # value is unknown at plan, so `var.s3_bucket_name != null` is itself unknown
+  # and Terraform rejects it as a count argument. The composer sets
+  # enable_s3_data_source explicitly; standalone callers leave it null and fall
+  # back to auto-detecting from the (literal, plan-time-known) bucket name.
+  has_s3_source = var.enable_s3_data_source != null ? var.enable_s3_data_source : (var.s3_bucket_name != null)
 }
 
 # --- Index IAM role -----------------------------------------------------------

--- a/aws/kendra/tests/shape.tftest.hcl
+++ b/aws/kendra/tests/shape.tftest.hcl
@@ -342,3 +342,34 @@ run "bad_bucket_arn_rejected" {
     var.s3_bucket_arn,
   ]
 }
+
+# --- Module half of the count-on-computed fix (#807) -------------------------
+#
+# The composer gates the S3 data source on a plan-time-known enable_s3_data_source
+# flag, not the (composed: computed) s3_bucket_name. Prove the preset honors it:
+# with the flag false but a non-null bucket name supplied, NO data source /
+# access role / policy may be created — count must follow the bool, not the name.
+# A revert to `count = var.s3_bucket_name != null` makes this run fail.
+run "enable_s3_data_source_false_overrides_name" {
+  command = plan
+
+  variables {
+    s3_bucket_name        = "iotkdr-docs"
+    enable_s3_data_source = false
+  }
+
+  assert {
+    condition     = length(aws_kendra_data_source.s3) == 0
+    error_message = "enable_s3_data_source=false must suppress the S3 data source even when s3_bucket_name is set."
+  }
+
+  assert {
+    condition     = length(aws_iam_role.data_source) == 0
+    error_message = "enable_s3_data_source=false must suppress the data-source access role."
+  }
+
+  assert {
+    condition     = length(aws_iam_role_policy.data_source) == 0
+    error_message = "enable_s3_data_source=false must suppress the data-source access policy."
+  }
+}

--- a/aws/kendra/variables.tf
+++ b/aws/kendra/variables.tf
@@ -89,6 +89,12 @@ variable "s3_bucket_name" {
   }
 }
 
+variable "enable_s3_data_source" {
+  description = "Explicitly enable (true) or disable (false) the S3 data source and its access role/policy. Null (the default) auto-detects from s3_bucket_name — correct for standalone use where s3_bucket_name is a literal whose null-ness is known at plan. The InsideOut composer sets this true when it wires s3_bucket_name from another module's output: a wired output's value is unknown at plan, so `s3_bucket_name != null` cannot gate a count/for_each (Terraform raises 'Invalid count argument'). This plan-time-known toggle is the gate instead."
+  type        = bool
+  default     = null
+}
+
 variable "s3_bucket_arn" {
   description = "Optional ARN of the S3 bucket named by s3_bucket_name, used to scope the data-source access policy least-privilege. When null it is derived from s3_bucket_name. In a composed stack DefaultWiring supplies this from module.aws_s3.bucket_arn."
   type        = string

--- a/pkg/composer/compose_ai_stack_test.go
+++ b/pkg/composer/compose_ai_stack_test.go
@@ -1,0 +1,418 @@
+package composer
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This file closes the composed-stack test gap for the AWS AI catalog
+// (tracking #755): the per-component composer tests prove each AI module
+// composes and wires correctly in isolation, but nothing exercised a
+// SINGLE composed bundle holding the whole 7-layer AWS AI stack through
+// terraform end-to-end. The three tests below form a ladder:
+//
+//   1. TestComposeAWSAIStack_Compose        — pure compose-from-IR + wiring
+//                                             asserts (hermetic, always runs)
+//   2. TestComposeAWSAIStack_InitValidate   — terraform init + validate of the
+//                                             composed bundle (hermetic, no
+//                                             creds; skips w/o terraform/-short)
+//   3. TestComposeAWSAIStack_ApplyDestroy   — real apply→confirm→destroy against
+//                                             a live AWS account (opt-in via
+//                                             AI_STACK_APPLY=1; proven in cust3)
+//
+// The stack composes the full Phase-1/2 AWS AI surface:
+//
+//   aws_vpc (Private) ─▶ aws_lambda ─▶ aws_bedrock_agent (action-group executor)
+//                            └────────▶ aws_agentcore_gateway (MCP lambda target)
+//   aws_s3 ─▶ aws_bedrock (Knowledge Base on S3 Vectors + Guardrails)
+//   aws_bedrock(KB) ─▶ aws_bedrock_agent (knowledge_base_association)
+//   aws_s3 ─▶ aws_kendra (S3 data source)
+//   aws_sagemaker (real-time inference endpoint)
+//   aws_opensearch (Serverless VECTORSEARCH collection)
+
+// defaultSageMakerImage is the AWS HuggingFace PyTorch inference DLC proven
+// green against a real account in aws/sagemaker/tests/integration.tftest.hcl
+// (#761). It hub-pulls a tiny model at boot, so no model_data_url is needed.
+// Override with AI_STACK_SAGEMAKER_IMAGE for a different region/image.
+const defaultSageMakerImage = "763104351884.dkr.ecr.us-east-1.amazonaws.com/" +
+	"huggingface-pytorch-inference:2.6.0-transformers4.51.3-cpu-py312-ubuntu22.04-v2.1"
+
+// aiStackKeys is the full Phase-1/2 AWS AI component selection. vpc/lambda/s3
+// are listed explicitly (rather than relying on implicit-dep injection) so the
+// selection reads as the real stack a caller would request.
+var aiStackKeys = []ComponentKey{
+	KeyAWSVPC,
+	KeyAWSLambda,
+	KeyAWSS3,
+	KeyAWSBedrock,
+	KeyAWSBedrockAgent,
+	KeyAWSAgentCoreGateway,
+	KeyAWSKendra,
+	KeyAWSSageMaker,
+	KeyAWSOpenSearch,
+}
+
+// aiStackComps selects every AI component plus its hard deps.
+func aiStackComps() *Components {
+	return &Components{
+		AWSVPC:              "Private",
+		AWSLambda:           ptrBool(true),
+		AWSS3:               ptrBool(true),
+		AWSBedrock:          ptrBool(true),
+		AWSBedrockAgent:     ptrBool(true),
+		AWSAgentCoreGateway: ptrBool(true),
+		AWSKendra:           ptrBool(true),
+		AWSSageMaker:        ptrBool(true),
+		AWSOpenSearch:       ptrBool(true),
+	}
+}
+
+// aiStackConfig builds the apply-realistic Config for the AI stack. It is built
+// via JSON unmarshal because several AI sub-configs are anonymous struct fields
+// on Config that can't be set with an inline composite literal. modelImage is
+// the SageMaker serving image (env-overridable); the rest pin the cheapest
+// real-deployable options (KB on S3 Vectors, Kendra DEVELOPER_EDITION, AOSS
+// serverless) and force_destroy so the teardown is clean.
+func aiStackConfig(t *testing.T, modelImage string) *Config {
+	t.Helper()
+
+	// The agentcore gateway's JWT authorizer needs an OIDC discovery URL. The
+	// preset default is a syntactically-valid example.com placeholder that
+	// satisfies compose/validate but that AWS may reject at CREATE. Keep that
+	// faithful default for the hermetic tests; let the live apply override it
+	// with a reachable issuer via AI_STACK_JWT_DISCOVERY_URL.
+	jwtURL := "https://example.com/.well-known/openid-configuration"
+	if v := strings.TrimSpace(os.Getenv("AI_STACK_JWT_DISCOVERY_URL")); v != "" {
+		jwtURL = v
+	}
+
+	// Foundation / base model IDs. The committed defaults keep the hermetic
+	// tests self-describing (they never invoke a model). For a live apply the
+	// IDs must be ACTIVE + access-granted in the target account/region —
+	// legacy Claude IDs are now invoke-blocked and newer ones are
+	// inference-profile-only (us.* prefix) — so the live run overrides them via
+	// AI_STACK_FOUNDATION_MODEL / AI_STACK_BEDROCK_MODEL_ID.
+	foundationModel := "anthropic.claude-3-5-sonnet-20240620-v1:0"
+	if v := strings.TrimSpace(os.Getenv("AI_STACK_FOUNDATION_MODEL")); v != "" {
+		foundationModel = v
+	}
+	bedrockModelID := "anthropic.claude-3-5-sonnet-20240620-v1:0"
+	if v := strings.TrimSpace(os.Getenv("AI_STACK_BEDROCK_MODEL_ID")); v != "" {
+		bedrockModelID = v
+	}
+
+	configJSON := `{
+		"region": "us-east-1",
+		"aws_bedrock": {
+			"enableKnowledgeBase": true,
+			"vectorStore": "s3vectors",
+			"modelId": ` + mustJSONString(bedrockModelID) + `,
+			"embeddingModelId": "amazon.titan-embed-text-v2:0"
+		},
+		"aws_bedrock_agent": {
+			"foundationModel": ` + mustJSONString(foundationModel) + `,
+			"agentName": "ioaistack-agent"
+		},
+		"aws_agentcore_gateway": {
+			"protocolType": "MCP",
+			"jwtDiscoveryUrl": ` + mustJSONString(jwtURL) + `,
+			"jwtAllowedAudience": ["ioaistack-agentcore"]
+		},
+		"aws_kendra": {
+			"edition": "DEVELOPER_EDITION"
+		},
+		"aws_opensearch": {
+			"deploymentType": "serverless"
+		},
+		"aws_sagemaker": {
+			"enableInference": true,
+			"endpointInstanceType": "ml.m5.large",
+			"modelEnvironment": {
+				"HF_MODEL_ID": "sshleifer/tiny-distilbert-base-cased-distilled-squad",
+				"HF_TASK": "question-answering"
+			}
+		}
+	}`
+
+	var cfg Config
+	require.NoError(t, json.Unmarshal([]byte(configJSON), &cfg),
+		"aiStackConfig: unmarshal config JSON")
+	require.NotNil(t, cfg.AWSSageMaker, "aiStackConfig: aws_sagemaker config must parse")
+	cfg.AWSSageMaker.ModelImage = modelImage
+	return &cfg
+}
+
+// mustJSONString JSON-encodes s (with surrounding quotes) for safe embedding
+// in a JSON literal.
+func mustJSONString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// composeAIStack composes the full AWS AI stack from the IR and returns the
+// bundle. Shared by all three tests so they exercise identical composition.
+func composeAIStack(t *testing.T, modelImage string) Files {
+	t.Helper()
+
+	c := newTestClient()
+	out, err := c.ComposeStack(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: aiStackKeys,
+		Comps:        aiStackComps(),
+		Cfg:          aiStackConfig(t, modelImage),
+		Project:      "ioaistack",
+		Region:       "us-east-1",
+	})
+	require.NoError(t, err, "ComposeStack(full AWS AI stack) must succeed")
+	return out
+}
+
+// TestComposeAWSAIStack_Compose proves the IR→stack path: the full AI selection
+// composes into one bundle with every module present and the headline
+// cross-module wiring resolved. Hermetic; runs in CI.
+func TestComposeAWSAIStack_Compose(t *testing.T) {
+	t.Parallel()
+
+	out := composeAIStack(t, defaultSageMakerImage)
+	mainTF := string(out["/main.tf"])
+	require.NotEmpty(t, mainTF, "composed bundle must contain /main.tf")
+
+	// Independent assertions use assert (not require) so a regression that
+	// drops several modules or wires at once surfaces all of them in one run —
+	// the multi-wire breakage this test exists to catch.
+
+	// Every AI-stack module must be present.
+	for _, mod := range []string{
+		"aws_vpc", "aws_lambda", "aws_s3", "aws_bedrock", "aws_bedrock_agent",
+		"aws_agentcore_gateway", "aws_kendra", "aws_sagemaker", "aws_opensearch",
+	} {
+		assert.Contains(t, mainTF, `module "`+mod+`"`,
+			"composed AI stack must declare module %q", mod)
+	}
+
+	// Headline wiring: the agent's action-group executor is the lambda.
+	assert.True(t, wiresAttr(mainTF, "action_group_lambda_arn", "module.aws_lambda.function_arn"),
+		"agent action_group_lambda_arn must wire from module.aws_lambda.function_arn")
+
+	// Headline wiring: the agent does RAG against the bedrock KB.
+	assert.True(t, wiresAttr(mainTF, "knowledge_base_id", "module.aws_bedrock.knowledge_base_id"),
+		"agent knowledge_base_id must wire from module.aws_bedrock.knowledge_base_id")
+
+	// Compose ordering: bedrock (KB output) must precede the agent that
+	// references it. Require both present first so a missing module (Index ==
+	// -1) can't make the ordering check pass spuriously.
+	bedrockPos := strings.Index(mainTF, `module "aws_bedrock"`)
+	agentPos := strings.Index(mainTF, `module "aws_bedrock_agent"`)
+	require.NotEqual(t, -1, bedrockPos, "aws_bedrock module must be present for the ordering check")
+	require.NotEqual(t, -1, agentPos, "aws_bedrock_agent module must be present for the ordering check")
+	assert.Less(t, bedrockPos, agentPos,
+		"aws_bedrock must compose before aws_bedrock_agent so its KB output is available")
+
+	// Plan-time-known count gates. Each AI module gates its optional resources
+	// (S3 data source, Lambda target, action group, KB association) on a
+	// boolean. The wired inputs they used to gate on (s3_bucket_name,
+	// target_lambda_arn, action_group_lambda_arn, knowledge_base_id) are
+	// COMPUTED module outputs, so `<input> != null` is unknown at plan and
+	// Terraform rejects it as a count argument ("Invalid count argument"). The
+	// composer must therefore emit an explicit plan-time-known enable_* flag at
+	// each wire. Missing any of these reintroduces the apply-time break that the
+	// per-component tests and `terraform validate` cannot see — only a composed
+	// `terraform plan` does. These string asserts are the hermetic stand-in for
+	// that plan (which needs live credentials).
+	assert.True(t, wiresAttr(mainTF, "enable_action_group", "true"),
+		"agent action group must be gated on a plan-time-known enable_action_group=true, not on the computed action_group_lambda_arn")
+	assert.True(t, wiresAttr(mainTF, "enable_lambda_target", "true"),
+		"agentcore lambda target must be gated on a plan-time-known enable_lambda_target=true, not on the computed target_lambda_arn")
+	assert.True(t, wiresAttr(mainTF, "enable_s3_data_source", "true"),
+		"kendra S3 data source must be gated on a plan-time-known enable_s3_data_source=true, not on the computed s3_bucket_name")
+	assert.True(t, wiresAttr(mainTF, "enable_knowledge_base_association", "module.aws_bedrock.knowledge_base_enabled"),
+		"agent KB association must be gated on the bedrock module's plan-time-known knowledge_base_enabled output, not on the computed knowledge_base_id")
+
+	// No fabricated preview values may leak into a composed stack.
+	assert.NotContains(t, mainTF, "composerpreview",
+		"no fabricated preview value may leak into the composed AI stack")
+}
+
+// TestComposeAWSAIStack_InitValidate writes the composed bundle to a tempdir and
+// runs `terraform init -backend=false` + `terraform validate` against the real
+// provider schema. This is the composed-bundle validity gate the per-component
+// tests don't provide. Hermetic — needs NO AWS credentials (validate resolves
+// the graph and types without contacting AWS). Skipped under -short or when the
+// terraform binary is absent so the core suite stays fast/hermetic.
+func TestComposeAWSAIStack_InitValidate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("-short skips terraform init+validate of the composed AI stack")
+	}
+	tfBin, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skipf("terraform binary not on PATH: %v", err)
+	}
+
+	out := composeAIStack(t, defaultSageMakerImage)
+	dir := t.TempDir()
+	writeOutputs(t, out, dir)
+
+	initCmd := exec.Command(tfBin, "init", "-backend=false", "-input=false", "-no-color")
+	initCmd.Dir = dir
+	if o, err := initCmd.CombinedOutput(); err != nil {
+		// init reaches the registry; tolerate offline/network flakiness in
+		// local dev but fail hard in CI where the network is available.
+		if os.Getenv("CI") == "true" {
+			require.NoError(t, err, "terraform init must succeed in CI:\n%s", o)
+		}
+		t.Skipf("terraform init unavailable (network/registry) in local dev: %v\n%s", err, o)
+	}
+
+	validateCmd := exec.Command(tfBin, "validate", "-no-color")
+	validateCmd.Dir = dir
+	o, err := validateCmd.CombinedOutput()
+	require.NoError(t, err,
+		"terraform validate must pass on the composed full AWS AI stack:\n%s", o)
+}
+
+// TestComposeAWSAIStack_ApplyDestroy is the live end-to-end gate: compose →
+// init → plan → apply → confirm resources exist → destroy. It stands up REAL,
+// billable AWS resources and is therefore opt-in: set AI_STACK_APPLY=1 with
+// valid credentials for the target account on PATH.
+//
+//	AI_STACK_APPLY=1 AWS_REGION=us-east-1 \
+//	  go test -v -timeout 90m -run TestComposeAWSAIStack_ApplyDestroy ./pkg/composer/
+//
+// Account prerequisites (cannot be set via Terraform):
+//   - Bedrock model access enabled in the region for the Anthropic Claude
+//     family (agent foundation model + bedrock base model) AND Amazon Titan
+//     Text Embeddings V2 (the Knowledge Base embedding model).
+//   - SageMaker servable image reachable from the account (default is the
+//     public AWS HuggingFace DLC; override with AI_STACK_SAGEMAKER_IMAGE).
+//
+// The bundle is written under .tmp/ (gitignored), NOT t.TempDir(), so its
+// state file survives an interrupted run and the stack can be torn down
+// out-of-band. Destroy is registered via t.Cleanup so it runs even when an
+// assertion fails mid-apply.
+func TestComposeAWSAIStack_ApplyDestroy(t *testing.T) {
+	if os.Getenv("AI_STACK_APPLY") != "1" {
+		t.Skip("set AI_STACK_APPLY=1 (with live AWS creds) to run the real apply/destroy gate")
+	}
+	tfBin, err := exec.LookPath("terraform")
+	require.NoError(t, err, "terraform binary required for the apply gate")
+
+	modelImage := defaultSageMakerImage
+	if v := strings.TrimSpace(os.Getenv("AI_STACK_SAGEMAKER_IMAGE")); v != "" {
+		modelImage = v
+	}
+
+	out := composeAIStack(t, modelImage)
+
+	// Stable, gitignored working dir so state persists across an interrupt.
+	repoRoot, err := repoRootDir()
+	require.NoError(t, err)
+	dir := filepath.Join(repoRoot, ".tmp", "ai-stack-apply")
+
+	// Refuse to clobber a dir that still holds non-empty state: that would be
+	// a prior run that was interrupted (signal kills the t.Cleanup destroy)
+	// leaving real, billable resources tracked only by this state file.
+	// Deleting it strands them with no way to `terraform destroy`. Surface it
+	// so the operator tears the old stack down first.
+	if st, serr := os.Stat(filepath.Join(dir, "terraform.tfstate")); serr == nil && st.Size() > 0 {
+		t.Fatalf("refusing to overwrite %s: a non-empty terraform.tfstate from a prior run exists — "+
+			"`terraform destroy` it (or remove the dir) before re-running so live resources are not orphaned", dir)
+	}
+	require.NoError(t, os.RemoveAll(dir), "clean prior apply dir")
+	writeOutputs(t, out, dir)
+	t.Logf("composed AI stack written to %s", dir)
+
+	// run streams terraform output to stdout in real time (so the multi-minute
+	// AOSS / SageMaker-endpoint / Kendra-index waits aren't a silent black box
+	// under `go test -v`) while also capturing it for assertions.
+	run := func(name string, args ...string) ([]byte, error) {
+		t.Logf("→ terraform %s", name)
+		var buf bytes.Buffer
+		cmd := exec.Command(tfBin, args...)
+		cmd.Dir = dir
+		cmd.Env = os.Environ()
+		cmd.Stdout = io.MultiWriter(&buf, os.Stdout)
+		cmd.Stderr = io.MultiWriter(&buf, os.Stderr)
+		err := cmd.Run()
+		return buf.Bytes(), err
+	}
+
+	// applyReached gates the cleanup's failure severity: only an apply that was
+	// actually started can leave resources behind. If init/plan failed first,
+	// nothing was created, so a destroy error there is informational noise
+	// (e.g. providers never installed) rather than an orphan alarm.
+	applyReached := false
+
+	// Always attempt teardown, even if apply fails partway.
+	t.Cleanup(func() {
+		o, derr := run("destroy", "destroy", "-auto-approve", "-input=false", "-no-color")
+		switch {
+		case derr != nil && applyReached:
+			t.Errorf("terraform destroy FAILED — resources may be orphaned in %s; destroy manually:\n%s", dir, o)
+		case derr != nil:
+			t.Logf("terraform destroy errored but apply never ran (nothing to orphan):\n%s", o)
+		}
+	})
+
+	o, err := run("init", "init", "-input=false", "-no-color")
+	require.NoError(t, err, "terraform init must succeed:\n%s", o)
+
+	o, err = run("plan", "plan", "-input=false", "-no-color")
+	require.NoError(t, err, "terraform plan must succeed:\n%s", o)
+
+	applyReached = true
+	o, err = run("apply", "apply", "-auto-approve", "-input=false", "-no-color")
+	require.NoError(t, err, "terraform apply must stand up the full AI stack:\n%s", o)
+
+	// Confirm resources for every one of the nine modules actually exist in
+	// state — a partial apply that AWS accepted for only some modules would
+	// otherwise slip through.
+	o, err = run("state-list", "state", "list")
+	require.NoError(t, err, "terraform state list must succeed after apply:\n%s", o)
+	state := string(o)
+	for _, want := range []string{
+		"module.aws_vpc.",
+		"module.aws_lambda.",
+		"module.aws_s3.",
+		"module.aws_bedrock.",
+		"module.aws_bedrock_agent.",
+		"module.aws_agentcore_gateway.",
+		"module.aws_kendra.",
+		"module.aws_sagemaker.",
+		"module.aws_opensearch.",
+	} {
+		assert.Contains(t, state, want,
+			"applied state must contain %s", want)
+	}
+}
+
+// repoRootDir walks up from the test's working directory to the module root
+// (the dir containing go.mod) so the apply gate writes to a stable repo-local
+// .tmp/ regardless of where `go test` is invoked.
+func repoRootDir() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return os.Getwd()
+		}
+		dir = parent
+	}
+}

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1123,17 +1123,25 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		// in the stack here — wire the agent's action_group_lambda_arn from the
 		// lambda module's function_arn output unconditionally.
 		wi.RawHCL["action_group_lambda_arn"] = lambdaRef(selected) + ".function_arn"
-		wi.Names = append(wi.Names, "action_group_lambda_arn")
+		// enable_action_group is the plan-time-known gate for the action group /
+		// invoke permission. action_group_lambda_arn above is a computed output,
+		// so the preset can't gate its count on `!= null` (unknown at plan).
+		// Lambda is a HARD dep here, so the action group always exists → true.
+		wi.RawHCL["enable_action_group"] = "true"
+		wi.Names = append(wi.Names, "action_group_lambda_arn", "enable_action_group")
 		// "Agent that does RAG": when aws/bedrock is also selected with its
 		// Knowledge Base enabled, wire the KB's id into the agent so the preset
 		// creates an aws_bedrockagent_agent_knowledge_base_association. The
 		// bedrock preset's knowledge_base_id output is null when the KB is
-		// disabled, so the association is gated preset-side on a non-null id —
-		// composing aws_bedrock without enable_knowledge_base leaves the agent
-		// KB-less, which is correct.
+		// disabled — but its null-ness is unknown at plan, so we gate the
+		// association on the bedrock module's plan-time-known
+		// knowledge_base_enabled output (true iff the KB is provisioned) rather
+		// than on knowledge_base_id. Composing aws_bedrock without
+		// enable_knowledge_base leaves the agent KB-less, which is correct.
 		if selected[KeyAWSBedrock] {
 			wi.RawHCL["knowledge_base_id"] = bedrockRef(selected) + ".knowledge_base_id"
-			wi.Names = append(wi.Names, "knowledge_base_id")
+			wi.RawHCL["enable_knowledge_base_association"] = bedrockRef(selected) + ".knowledge_base_enabled"
+			wi.Names = append(wi.Names, "knowledge_base_id", "enable_knowledge_base_association")
 		}
 
 	case KeyAWSAgentCoreGateway:
@@ -1144,7 +1152,12 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		// preset gates the Lambda target / invoke policy / permission on a
 		// non-null arn, so the wire is what turns the Lambda into an MCP tool.
 		wi.RawHCL["target_lambda_arn"] = lambdaRef(selected) + ".function_arn"
-		wi.Names = append(wi.Names, "target_lambda_arn")
+		// enable_lambda_target is the plan-time-known gate for the Lambda target /
+		// invoke policy / permission. target_lambda_arn above is a computed
+		// output, so the preset can't gate their count on `!= null` (unknown at
+		// plan). Lambda is a HARD dep here, so the target always exists → true.
+		wi.RawHCL["enable_lambda_target"] = "true"
+		wi.Names = append(wi.Names, "target_lambda_arn", "enable_lambda_target")
 
 	case KeyAWSKendra:
 		// Kendra has NO hard dependency — a bare index is valid. The optional
@@ -1156,7 +1169,12 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 			s3 := s3Ref(selected)
 			wi.RawHCL["s3_bucket_name"] = s3 + ".bucket_name"
 			wi.RawHCL["s3_bucket_arn"] = s3 + ".bucket_arn"
-			wi.Names = append(wi.Names, "s3_bucket_name", "s3_bucket_arn")
+			// enable_s3_data_source is the plan-time-known gate for the S3 data
+			// source / access role / policy. s3_bucket_name above is a computed
+			// output, so the preset can't gate their count on `!= null` (unknown
+			// at plan). aws_s3 is selected here, so the data source exists → true.
+			wi.RawHCL["enable_s3_data_source"] = "true"
+			wi.Names = append(wi.Names, "s3_bucket_name", "s3_bucket_arn", "enable_s3_data_source")
 		}
 
 	case KeyAWSBackups:


### PR DESCRIPTION
## Summary

Adds the **composed-bundle test** the AWS AI stack was missing, and fixes the **two real, apply-blocking bugs** it immediately surfaced. Both bugs were invisible to standalone `terraform validate` and the per-module `*.tftest.hcl` (which use literal inputs) — they only manifest when a module's inputs are *wired computed outputs*, i.e. in a real composed stack.

Proven end-to-end against **AWS cust3 (us-east-1)**: the composed full AI stack now plans clean (`Plan: 90 to add`, was 5 `Invalid count argument` errors), applies all 9 modules, and tears down clean.

## Bugs fixed

**[#807] Composed AI stack un-appliable — `Invalid count argument`**
`aws/kendra`, `aws/agentcore_gateway`, and `aws/bedrock_agent` gated optional resources' `count` on wired inputs (`s3_bucket_name`, `target_lambda_arn`, `action_group_lambda_arn`, `knowledge_base_id`). In a composed stack those are computed module outputs → unknown at plan → `count` can't resolve. Fix: plan-time-known `enable_*` booleans (`null` = auto-detect from the literal, preserving standalone use); `aws/bedrock` emits a plan-time-known `knowledge_base_enabled` output; the composer sets the flags at each wire site. Mirrors the existing `enable_knowledge_base` / `enable_inference` pattern.

**[#808] AgentCore `CreateGateway` ValidationException**
The `CUSTOM_JWT` authorizer defaulted `jwt_allowed_audience` + `jwt_allowed_clients` both empty; AWS requires ≥1. Fix: a `lifecycle.precondition` that fails fast at plan with an actionable message instead of the cryptic AWS apply-time error.

## The test (`pkg/composer/compose_ai_stack_test.go`)

Three rungs over the full Phase-1/2 AWS AI stack (vpc+lambda+s3+bedrock(KB/S3Vectors/guardrails)+bedrock_agent+agentcore_gateway+kendra+sagemaker+opensearch):
- **Compose** — IR → bundle; asserts cross-module wiring + the plan-time-known `enable_*` gates (hermetic, CI).
- **InitValidate** — `terraform init` + `validate` of the composed bundle against the real provider schema (hermetic, no creds; CI).
- **ApplyDestroy** — real apply → confirm 9 modules in state → destroy, opt-in via `AI_STACK_APPLY=1` (proven green in cust3).

Module-level guards added to each `shape.tftest.hcl` (`enable_*=false` + non-null input → `count==0`) so the *module half* of the fix is also caught hermetically in CI, plus a denial test for the new AgentCore precondition.

## Test plan
- [x] `go test ./pkg/composer/` (hermetic: compose + init/validate)
- [x] `terraform test` on kendra / agentcore_gateway / bedrock_agent (incl. new guard + denial runs)
- [x] Live `AI_STACK_APPLY=1` apply→destroy in cust3 us-east-1: 87 resources up, all destroyed, 0 orphans
- [x] `terraform validate` + `terraform fmt` + `go vet` + `gofmt`

## Review notes
- /review: 1 P1 (precondition broke committed agentcore tests) fixed; P2/P3 drive-bys addressed (assert-vs-require, cleanup-error gating, state dir clobber guard).
- qa-professor: added the precondition denial test, restored symmetric null-emission coverage, added module-half count guards, hardened the apply harness against clobbering live state.

Closes #807
Closes #808