### PR TITLE
fix(composer): heal frozen out-of-enum vCPU sizing (RDS/ElastiCache) at map time

### DIFF
--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1653,7 +1653,54 @@ var (
 	// heal frozen pre-#805 Lambda timeouts that lack a unit by coercing to
 	// "<N>s" (seconds) before the strict duration parser runs.
 	bareIntRe = regexp.MustCompile(`^[0-9]+$`)
+	// vcpuLabelRe matches a "<N> vCPU" sizing label (case-insensitive, optional
+	// surrounding/inner whitespace, e.g. "2 vCPU", "16 VCPU"). Used to heal
+	// frozen out-of-enum vCPU sizes (RDS CPUSize / ElastiCache NodeSize) by
+	// snapping N up to the nearest valid tier — see snapVCPUTier and the
+	// canonicalRdsInstanceClass / canonicalRedisNodeType heal blocks
+	// (#805/#806/#2097). Only the integer-vCPU shape matches, so genuinely
+	// malformed labels (e.g. "abc", "2.5 vCPU") still fall through to an error.
+	vcpuLabelRe = regexp.MustCompile(`(?i)^\s*(\d+)\s*vcpu\s*$`)
 )
+
+// vcpuTiers is the ascending set of valid IR vCPU sizing tiers, derived from
+// the canonicalRdsInstanceClass / canonicalRedisNodeType switch cases below
+// (the typed IR enum is {1, 4, 8} vCPU; both RDS and ElastiCache share it).
+// snapVCPUTier snaps an out-of-enum label up to the nearest of these.
+var vcpuTiers = []int{1, 4, 8}
+
+// snapVCPUTier heals a frozen out-of-enum "<N> vCPU" sizing label by snapping N
+// UP to the nearest valid vCPU tier (vcpuTiers), returning the canonical tier
+// label (e.g. "4 vCPU"). If N exceeds the max tier it snaps to the max. ok is
+// true ONLY for the recognizable "<integer> vCPU" shape; any other value
+// (e.g. "abc", a concrete db.*/cache.* type, "2.5 vCPU") returns ok=false so
+// the caller still errors. Callers invoke this only AFTER the exact-tier switch
+// misses, so a match here is always a genuinely out-of-enum value to heal.
+//
+// This is the third frozen-value heal after #805 (defaulting) and #806
+// (NAT-off / bare-int lambda timeout): pre-strict-composer snapshots froze a
+// formerly-compose-valid size (e.g. "2 vCPU", per reliable#2097) into stored
+// config that reliable composes verbatim, so a hard error here is one the user
+// can't act on. Rounding UP keeps the deployed footprint at least as large as
+// the frozen request.
+func snapVCPUTier(t string) (string, bool) {
+	m := vcpuLabelRe.FindStringSubmatch(t)
+	if m == nil {
+		return "", false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil { // unreachable given the \d+ regex, but keep it honest
+		return "", false
+	}
+	snap := vcpuTiers[len(vcpuTiers)-1] // N exceeds the max tier -> snap to max
+	for _, tier := range vcpuTiers {
+		if n <= tier {
+			snap = tier
+			break
+		}
+	}
+	return fmt.Sprintf("%d vCPU", snap), true
+}
 
 // canonicalDdbBillingMode maps IR enum values to the uppercase tokens
 // aws/dynamodb/variables.tf accepts: "PAY_PER_REQUEST" or "PROVISIONED".
@@ -1686,12 +1733,26 @@ func canonicalRdsInstanceClass(s string) (string, error) {
 		return "db.m7i.xlarge", nil
 	case "8 vcpu":
 		return "db.m7i.2xlarge", nil
-	default:
-		return "", NewValidationError(fmt.Sprintf(
-			"AWSRDS.CPUSize=%q: expected \"1 vCPU\" / \"4 vCPU\" / \"8 vCPU\" or a concrete db.* instance class (e.g. \"db.m7i.large\")",
-			s,
-		))
 	}
+	// Heal frozen out-of-enum vCPU sizes: an "<N> vCPU" label outside the
+	// {1,4,8} enum (e.g. "2 vCPU", reliable#2097) was once compose-valid under
+	// a permissive legacy TS mapper but the strict Go composer rejects it. That
+	// frozen value lives in stored config reliable composes verbatim, so a hard
+	// error is one the user can't act on — the third frozen-value heal after
+	// #805/#806. Snap UP to the nearest valid tier and re-map (snapVCPUTier
+	// always returns a valid tier label, so the recursion resolves in one hop).
+	// Genuinely-malformed labels (e.g. "abc", "2.5 vCPU") don't match the
+	// integer-vCPU shape and still error below.
+	if snapped, ok := snapVCPUTier(t); ok {
+		log.Printf("[composer/mapper] AWSRDS heal: CPUSize=%q is an out-of-enum vCPU "+
+			"label; snapping to %q (nearest valid tier, rounding up) "+
+			"(frozen formerly-valid value; see #805/#806/#2097)", s, snapped)
+		return canonicalRdsInstanceClass(snapped)
+	}
+	return "", NewValidationError(fmt.Sprintf(
+		"AWSRDS.CPUSize=%q: expected \"1 vCPU\" / \"4 vCPU\" / \"8 vCPU\" or a concrete db.* instance class (e.g. \"db.m7i.large\")",
+		s,
+	))
 }
 
 // canonicalRedisNodeType maps the IR vCPU enum to a cache.* node type.
@@ -1708,12 +1769,26 @@ func canonicalRedisNodeType(s string) (string, error) {
 		return "cache.r6g.xlarge", nil
 	case "8 vcpu":
 		return "cache.r6g.2xlarge", nil
-	default:
-		return "", NewValidationError(fmt.Sprintf(
-			"AWSElastiCache.NodeSize=%q: expected \"1 vCPU\" / \"4 vCPU\" / \"8 vCPU\" or a concrete cache.* node type (e.g. \"cache.r6g.large\")",
-			s,
-		))
 	}
+	// Heal frozen out-of-enum vCPU sizes: an "<N> vCPU" label outside the
+	// {1,4,8} enum (e.g. "2 vCPU", reliable#2097) was once compose-valid under
+	// a permissive legacy TS mapper but the strict Go composer rejects it. That
+	// frozen value lives in stored config reliable composes verbatim, so a hard
+	// error is one the user can't act on — the third frozen-value heal after
+	// #805/#806. Snap UP to the nearest valid tier and re-map (snapVCPUTier
+	// always returns a valid tier label, so the recursion resolves in one hop).
+	// Genuinely-malformed labels (e.g. "abc", "2.5 vCPU") don't match the
+	// integer-vCPU shape and still error below.
+	if snapped, ok := snapVCPUTier(t); ok {
+		log.Printf("[composer/mapper] AWSElastiCache heal: NodeSize=%q is an out-of-enum vCPU "+
+			"label; snapping to %q (nearest valid tier, rounding up) "+
+			"(frozen formerly-valid value; see #805/#806/#2097)", s, snapped)
+		return canonicalRedisNodeType(snapped)
+	}
+	return "", NewValidationError(fmt.Sprintf(
+		"AWSElastiCache.NodeSize=%q: expected \"1 vCPU\" / \"4 vCPU\" / \"8 vCPU\" or a concrete cache.* node type (e.g. \"cache.r6g.large\")",
+		s,
+	))
 }
 
 // parseLeadingInt extracts the leading integer from a string like

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1656,8 +1656,10 @@ var (
 	// vcpuLabelRe matches a "<N> vCPU" sizing label (case-insensitive, optional
 	// surrounding/inner whitespace, e.g. "2 vCPU", "16 VCPU"). Used to heal
 	// frozen out-of-enum vCPU sizes (RDS CPUSize / ElastiCache NodeSize) by
-	// snapping N up to the nearest valid tier — see snapVCPUTier and the
-	// canonicalRdsInstanceClass / canonicalRedisNodeType heal blocks
+	// mapping N to the CONCRETE same-family class with exactly N vCPU (preserving
+	// the deployed footprint), or — for a vCPU count with no concrete class —
+	// falling back to the nearest valid tier. See vcpuExactSuffix / snapVCPUTier
+	// and the canonicalRdsInstanceClass / canonicalRedisNodeType heal blocks
 	// (#805/#806/#2097). Only the integer-vCPU shape matches, so genuinely
 	// malformed labels (e.g. "abc", "2.5 vCPU") still fall through to an error.
 	vcpuLabelRe = regexp.MustCompile(`(?i)^\s*(\d+)\s*vcpu\s*$`)
@@ -1666,30 +1668,66 @@ var (
 // vcpuTiers is the ascending set of valid IR vCPU sizing tiers, derived from
 // the canonicalRdsInstanceClass / canonicalRedisNodeType switch cases below
 // (the typed IR enum is {1, 4, 8} vCPU; both RDS and ElastiCache share it).
-// snapVCPUTier snaps an out-of-enum label up to the nearest of these.
+// snapVCPUTier (the heal FALLBACK) snaps an out-of-enum label up to the nearest
+// of these — but only for a vCPU count that has no concrete class of its own.
 var vcpuTiers = []int{1, 4, 8}
 
-// snapVCPUTier heals a frozen out-of-enum "<N> vCPU" sizing label by snapping N
-// UP to the nearest valid vCPU tier (vcpuTiers), returning the canonical tier
-// label (e.g. "4 vCPU"). If N exceeds the max tier it snaps to the max. ok is
-// true ONLY for the recognizable "<integer> vCPU" shape; any other value
-// (e.g. "abc", a concrete db.*/cache.* type, "2.5 vCPU") returns ok=false so
-// the caller still errors. Callers invoke this only AFTER the exact-tier switch
-// misses, so a match here is always a genuinely out-of-enum value to heal.
+// vcpuExactSuffix maps an EXACT vCPU count to the AWS instance-size suffix used
+// by the m7i / r6g families the composer's 4/8-vCPU tiers already emit
+// (large=2, xlarge=4, 2xlarge=8, 4xlarge=16, ...; the same vCPU→suffix ladder
+// the legacy TS sizing mapper used). It is the PRIMARY heal for a frozen
+// out-of-enum "<N> vCPU" label: map N to the CONCRETE class with EXACTLY N vCPU
+// (e.g. "2 vCPU" -> db.m7i.large / cache.r6g.large) so the healed value is the
+// same footprint the resource is already running as, NOT a larger tier — which
+// would be a real instance_class / node_type change (RDS restart / ElastiCache
+// node replacement, ~2x cost) on the next apply (reliable#2097). The 4/8 entries
+// are in-enum and never reach the heal (the switch returns first); they are
+// listed only to keep the vCPU→suffix ladder self-documenting.
+var vcpuExactSuffix = map[int]string{
+	2:  "large",
+	4:  "xlarge",
+	8:  "2xlarge",
+	16: "4xlarge",
+	32: "8xlarge",
+	48: "12xlarge",
+	64: "16xlarge",
+	96: "24xlarge",
+}
+
+// parseVCPULabel extracts N from a "<N> vCPU" label (case-insensitive, optional
+// surrounding/inner whitespace). ok is true ONLY for that integer-vCPU shape;
+// any other value (e.g. "abc", "2.5 vCPU", a concrete db.*/cache.* type) returns
+// ok=false so the caller still errors.
+func parseVCPULabel(t string) (int, bool) {
+	m := vcpuLabelRe.FindStringSubmatch(t)
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(m[1])
+	if err != nil { // unreachable given the \d+ regex, but keep it honest
+		return 0, false
+	}
+	return n, true
+}
+
+// snapVCPUTier is the heal FALLBACK for a frozen out-of-enum "<N> vCPU" label
+// whose N has NO concrete same-family class (i.e. N is not in vcpuExactSuffix —
+// e.g. 3, 5, 6, 7). It snaps N UP to the nearest valid vCPU tier (vcpuTiers),
+// returning the canonical tier label (e.g. "3 vCPU" -> "4 vCPU"); N above the
+// max tier snaps to the max. ok mirrors parseVCPULabel. Callers invoke this only
+// AFTER both the exact-tier switch AND the preserve-footprint exact-vCPU path
+// miss, so a match here is always a genuinely out-of-enum gap value to heal.
 //
 // This is the third frozen-value heal after #805 (defaulting) and #806
 // (NAT-off / bare-int lambda timeout): pre-strict-composer snapshots froze a
 // formerly-compose-valid size (e.g. "2 vCPU", per reliable#2097) into stored
 // config that reliable composes verbatim, so a hard error here is one the user
-// can't act on. Rounding UP keeps the deployed footprint at least as large as
-// the frozen request.
+// can't act on. The PRIMARY heal preserves the footprint (exact-vCPU concrete
+// class, vcpuExactSuffix); this round-up only covers vCPU counts with no
+// concrete class.
 func snapVCPUTier(t string) (string, bool) {
-	m := vcpuLabelRe.FindStringSubmatch(t)
-	if m == nil {
-		return "", false
-	}
-	n, err := strconv.Atoi(m[1])
-	if err != nil { // unreachable given the \d+ regex, but keep it honest
+	n, ok := parseVCPULabel(t)
+	if !ok {
 		return "", false
 	}
 	snap := vcpuTiers[len(vcpuTiers)-1] // N exceeds the max tier -> snap to max
@@ -1739,13 +1777,30 @@ func canonicalRdsInstanceClass(s string) (string, error) {
 	// a permissive legacy TS mapper but the strict Go composer rejects it. That
 	// frozen value lives in stored config reliable composes verbatim, so a hard
 	// error is one the user can't act on — the third frozen-value heal after
-	// #805/#806. Snap UP to the nearest valid tier and re-map (snapVCPUTier
-	// always returns a valid tier label, so the recursion resolves in one hop).
-	// Genuinely-malformed labels (e.g. "abc", "2.5 vCPU") don't match the
-	// integer-vCPU shape and still error below.
-	if snapped, ok := snapVCPUTier(t); ok {
-		log.Printf("[composer/mapper] AWSRDS heal: CPUSize=%q is an out-of-enum vCPU "+
-			"label; snapping to %q (nearest valid tier, rounding up) "+
+	// #805/#806.
+	//
+	// PRESERVE THE DEPLOYED FOOTPRINT (do NOT round up). The legacy TS mapper
+	// emitted the CONCRETE db.m7i.<size> class with exactly N vCPU for "<N> vCPU"
+	// (large=2, xlarge=4, ...), so the reliable#2097 Intel session deployed
+	// "2 vCPU" as db.m7i.large. Rounding up to the next tier (db.m7i.xlarge,
+	// 4 vCPU) would be a real instance_class change → an RDS restart + ~2x cost
+	// on the next apply (a Codex review confirmed the round-up branch emitted
+	// xlarge while legacy emitted large). Instead, map N to the concrete
+	// same-family class with EXACTLY N vCPU — identical to what is already
+	// running. Only a vCPU with no concrete class (e.g. 3,5,6,7) falls back to
+	// rounding UP to the nearest tier. Malformed labels (e.g. "abc", "2.5 vCPU")
+	// don't match the integer-vCPU shape and still error below.
+	if n, ok := parseVCPULabel(t); ok {
+		if suffix, exact := vcpuExactSuffix[n]; exact {
+			cls := "db.m7i." + suffix
+			log.Printf("[composer/mapper] AWSRDS heal: CPUSize=%q is an out-of-enum vCPU "+
+				"label; healed frozen %d vCPU to concrete %q to preserve the deployed "+
+				"footprint (no resize) (frozen formerly-valid value; see #805/#806/#2097)", s, n, cls)
+			return cls, nil
+		}
+		snapped, _ := snapVCPUTier(t) // N has no concrete class; round up to nearest tier
+		log.Printf("[composer/mapper] AWSRDS heal: CPUSize=%q has no exact-vCPU concrete "+
+			"class; snapping to %q (nearest valid tier, rounding up) "+
 			"(frozen formerly-valid value; see #805/#806/#2097)", s, snapped)
 		return canonicalRdsInstanceClass(snapped)
 	}
@@ -1770,18 +1825,33 @@ func canonicalRedisNodeType(s string) (string, error) {
 	case "8 vcpu":
 		return "cache.r6g.2xlarge", nil
 	}
-	// Heal frozen out-of-enum vCPU sizes: an "<N> vCPU" label outside the
-	// {1,4,8} enum (e.g. "2 vCPU", reliable#2097) was once compose-valid under
-	// a permissive legacy TS mapper but the strict Go composer rejects it. That
-	// frozen value lives in stored config reliable composes verbatim, so a hard
-	// error is one the user can't act on — the third frozen-value heal after
-	// #805/#806. Snap UP to the nearest valid tier and re-map (snapVCPUTier
-	// always returns a valid tier label, so the recursion resolves in one hop).
-	// Genuinely-malformed labels (e.g. "abc", "2.5 vCPU") don't match the
-	// integer-vCPU shape and still error below.
-	if snapped, ok := snapVCPUTier(t); ok {
-		log.Printf("[composer/mapper] AWSElastiCache heal: NodeSize=%q is an out-of-enum vCPU "+
-			"label; snapping to %q (nearest valid tier, rounding up) "+
+	// Heal frozen out-of-enum vCPU sizes (see canonicalRdsInstanceClass for the
+	// full rationale): PRESERVE the deployed footprint by mapping "<N> vCPU" to
+	// the concrete cache.r6g.<size> node type with EXACTLY N vCPU (large=2,
+	// xlarge=4, ...) instead of rounding up to a larger tier — which would
+	// replace the ElastiCache node on the next apply (reliable#2097). Only a vCPU
+	// with no concrete class (e.g. 3,5,6,7) falls back to rounding up. Malformed
+	// labels (e.g. "abc", "2.5 vCPU") don't match the integer-vCPU shape and
+	// still error below.
+	//
+	// Family note: the legacy TS mapper emitted r7i/r7g.<size> WITHOUT the
+	// "cache." prefix — an invalid, un-deployable ElastiCache node type, so there
+	// is no real r7i.* resource to preserve. The composer's canonical ElastiCache
+	// family is cache.r6g (its 4/8-vCPU tiers and the preset default
+	// cache.r6g.xlarge), so we emit cache.r6g.<size>: a valid node type matching
+	// the composer/preset family, with the size (large = 2 vCPU) footprint-
+	// identical to the frozen request.
+	if n, ok := parseVCPULabel(t); ok {
+		if suffix, exact := vcpuExactSuffix[n]; exact {
+			typ := "cache.r6g." + suffix
+			log.Printf("[composer/mapper] AWSElastiCache heal: NodeSize=%q is an out-of-enum vCPU "+
+				"label; healed frozen %d vCPU to concrete %q to preserve the deployed "+
+				"footprint (no resize) (frozen formerly-valid value; see #805/#806/#2097)", s, n, typ)
+			return typ, nil
+		}
+		snapped, _ := snapVCPUTier(t) // N has no concrete class; round up to nearest tier
+		log.Printf("[composer/mapper] AWSElastiCache heal: NodeSize=%q has no exact-vCPU "+
+			"concrete class; snapping to %q (nearest valid tier, rounding up) "+
 			"(frozen formerly-valid value; see #805/#806/#2097)", s, snapped)
 		return canonicalRedisNodeType(snapped)
 	}

--- a/pkg/composer/mapper_audit_test.go
+++ b/pkg/composer/mapper_audit_test.go
@@ -278,14 +278,18 @@ func TestBuildModuleValues_AWSRDS_VariableNames(t *testing.T) {
 		assert.Equal(t, "db.r6g.4xlarge", vals["instance_class"])
 	})
 
-	t.Run("above-max vCPU label snaps to the max tier (was ValidationError)", func(t *testing.T) {
-		// REVERSED contract (heal, mirroring #806): "16 vCPU" exceeds the max
-		// {1,4,8} tier, so instead of erroring the mapper snaps it UP to the
-		// max (8 vCPU -> db.m7i.2xlarge). Frozen formerly-valid value; see
-		// reliable#2097.
+	t.Run("out-of-enum vCPU label heals to its concrete same-vCPU class (was ValidationError)", func(t *testing.T) {
+		// REVERSED contract (heal, mirroring #806) — PRESERVE FOOTPRINT, not
+		// round up: "16 vCPU" is outside the {1,4,8} tier set but has a concrete
+		// db.m7i class with exactly 16 vCPU (4xlarge), so instead of erroring the
+		// mapper heals it to db.m7i.4xlarge — the same footprint the resource is
+		// already running as. The earlier revision snapped this DOWN to the
+		// 8-vCPU max tier (db.m7i.2xlarge), which would resize the instance; a
+		// Codex review flagged that resize for the "2 vCPU" case. Frozen
+		// formerly-valid value; see reliable#2097.
 		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("16 vCPU", "", ""), "", "")
-		require.NoError(t, err, "above-max vCPU must snap to the max tier, not error")
-		assert.Equal(t, "db.m7i.2xlarge", vals["instance_class"])
+		require.NoError(t, err, "out-of-enum vCPU with a concrete class must heal, not error")
+		assert.Equal(t, "db.m7i.4xlarge", vals["instance_class"])
 	})
 
 	t.Run("genuinely-malformed CPU label still errors with ValidationError", func(t *testing.T) {

--- a/pkg/composer/mapper_audit_test.go
+++ b/pkg/composer/mapper_audit_test.go
@@ -278,8 +278,21 @@ func TestBuildModuleValues_AWSRDS_VariableNames(t *testing.T) {
 		assert.Equal(t, "db.r6g.4xlarge", vals["instance_class"])
 	})
 
-	t.Run("rejects unknown CPU label with ValidationError", func(t *testing.T) {
-		_, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("16 vCPU", "", ""), "", "")
+	t.Run("above-max vCPU label snaps to the max tier (was ValidationError)", func(t *testing.T) {
+		// REVERSED contract (heal, mirroring #806): "16 vCPU" exceeds the max
+		// {1,4,8} tier, so instead of erroring the mapper snaps it UP to the
+		// max (8 vCPU -> db.m7i.2xlarge). Frozen formerly-valid value; see
+		// reliable#2097.
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("16 vCPU", "", ""), "", "")
+		require.NoError(t, err, "above-max vCPU must snap to the max tier, not error")
+		assert.Equal(t, "db.m7i.2xlarge", vals["instance_class"])
+	})
+
+	t.Run("genuinely-malformed CPU label still errors with ValidationError", func(t *testing.T) {
+		// Only the recognizable "<integer> vCPU" shape heals; a non-numeric /
+		// otherwise-malformed label must STILL fail fast (mirror #806's "bare
+		// int heals, 'abc' still errors").
+		_, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("ginormous", "", ""), "", "")
 		assertValidationError(t, err)
 	})
 }

--- a/pkg/composer/mapper_heal_test.go
+++ b/pkg/composer/mapper_heal_test.go
@@ -149,14 +149,27 @@ func TestBuildModuleValues_Heal_EmitsWarning(t *testing.T) {
 // A sizing value like "2 vCPU" was once compose-valid under a permissive legacy
 // TS mapper but the strict Go composer hard-errors (the IR enum is {1,4,8}
 // vCPU). That frozen value lives in stored config reliable composes verbatim,
-// so the mapper now HEALS it: snap UP to the nearest valid tier (rounding up),
-// snap above-max to the max, and leave valid tiers + concrete provider
-// instance/node types untouched. Genuinely-malformed labels still error.
-// Mirrors the #805/#806 heal style.
+// so the mapper now HEALS it — PRESERVING THE DEPLOYED FOOTPRINT: an out-of-enum
+// "<N> vCPU" maps to the CONCRETE same-family class with EXACTLY N vCPU
+// (e.g. "2 vCPU" -> db.m7i.large / cache.r6g.large), the same class the resource
+// is already running as. An earlier revision of this heal rounded UP to the next
+// tier ("2 vCPU" -> xlarge, 4 vCPU); that is a real instance_class / node_type
+// change → an RDS restart / ElastiCache node replacement (~2x cost) on the next
+// apply, so it was changed to preserve the footprint (reliable#2097; a Codex
+// review confirmed the round-up emitted xlarge while the legacy TS mapper
+// emitted large for this Intel session). Only a vCPU with no concrete class
+// falls back to rounding up to the nearest tier; valid tiers + concrete provider
+// instance/node types pass through untouched; genuinely-malformed labels still
+// error. Mirrors the #805/#806 heal style.
 
-// TestSnapVCPUTier pins the round-up-to-nearest-tier rule directly, including
-// the "only the <integer> vCPU shape matches" guard that keeps malformed values
-// erroring at the call sites.
+// TestSnapVCPUTier pins the round-up-to-nearest-tier rule of the FALLBACK helper
+// directly, including the "only the <integer> vCPU shape matches" guard that
+// keeps malformed values erroring at the call sites. NOTE: snapVCPUTier is now
+// only the fallback — the mapper intercepts exact-vCPU counts (2, 16, 32, ...)
+// via vcpuExactSuffix and preserves the footprint BEFORE snapVCPUTier runs, so
+// e.g. "2 vCPU" / "16 vCPU" never reach this helper through the mapper (see
+// TestBuildModuleValues_VCPUSizingHeal). The cases below pin the pure helper
+// math, which still backs the genuinely-no-concrete-class gap values (3,5,6,7).
 func TestSnapVCPUTier(t *testing.T) {
 	t.Parallel()
 
@@ -199,37 +212,64 @@ func TestSnapVCPUTier(t *testing.T) {
 
 // TestBuildModuleValues_VCPUSizingHeal exercises the heal through the mapper for
 // both doubly-affected fields (the reliable#2097 session has BOTH
-// AWSElastiCache.NodeSize="2 vCPU" and AWSRDS.CPUSize="2 vCPU"): out-of-enum
-// snaps up, valid tiers and concrete provider types pass through unchanged, and
-// a genuinely-malformed value still errors.
+// AWSElastiCache.NodeSize="2 vCPU" and AWSRDS.CPUSize="2 vCPU"): an out-of-enum
+// vCPU with a concrete same-family class heals to THAT class (preserve the
+// deployed footprint — no resize), a vCPU with no concrete class falls back to
+// rounding up, valid tiers and concrete provider types pass through unchanged,
+// and a genuinely-malformed value still errors.
 func TestBuildModuleValues_VCPUSizingHeal(t *testing.T) {
 	t.Parallel()
 
 	m := DefaultMapper{}
 
-	t.Run("ElastiCache NodeSize 2 vCPU heals to 4 vCPU node type", func(t *testing.T) {
+	// PRESERVE-FOOTPRINT contract (reliable#2097): the Intel session deployed
+	// "2 vCPU" via the legacy TS mapper as db.m7i.large / (cache.)r6g.large — the
+	// 2-vCPU `large` size, NOT the 4-vCPU `xlarge`. An earlier revision rounded
+	// "2 vCPU" UP to xlarge; a Codex review flagged that as a silent RESIZE (RDS
+	// restart / ElastiCache node replacement, ~2x cost) on the next apply because
+	// the running resource is `large`. So "2 vCPU" must heal to the concrete
+	// 2-vCPU `large` class, leaving the footprint identical.
+	t.Run("ElastiCache NodeSize 2 vCPU heals to the concrete 2-vCPU node type (preserve)", func(t *testing.T) {
 		t.Parallel()
 		vals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("2 vCPU", "", ""), "", "")
 		require.NoError(t, err, "frozen out-of-enum NodeSize must heal, not error")
-		assert.Equal(t, "cache.r6g.xlarge", vals["node_type"], `"2 vCPU" snaps up to the 4 vCPU tier`)
+		assert.Equal(t, "cache.r6g.large", vals["node_type"],
+			`"2 vCPU" heals to the concrete 2-vCPU node type (cache.r6g.large), preserving the deployed footprint — NOT cache.r6g.xlarge (4 vCPU)`)
 	})
 
-	t.Run("RDS CPUSize 2 vCPU heals to 4 vCPU instance class", func(t *testing.T) {
+	t.Run("RDS CPUSize 2 vCPU heals to the concrete 2-vCPU instance class (preserve)", func(t *testing.T) {
 		t.Parallel()
 		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("2 vCPU", "", ""), "", "")
 		require.NoError(t, err, "frozen out-of-enum CPUSize must heal, not error")
-		assert.Equal(t, "db.m7i.xlarge", vals["instance_class"], `"2 vCPU" snaps up to the 4 vCPU tier`)
+		assert.Equal(t, "db.m7i.large", vals["instance_class"],
+			`"2 vCPU" heals to the concrete 2-vCPU instance class (db.m7i.large) — the exact class the reliable#2097 Intel session deployed — NOT db.m7i.xlarge (4 vCPU)`)
 	})
 
-	t.Run("above-max snaps to the max tier", func(t *testing.T) {
+	t.Run("larger exact-vCPU labels also preserve (16 vCPU)", func(t *testing.T) {
 		t.Parallel()
+		// 16 vCPU has a concrete same-family class (4xlarge), so it PRESERVES at
+		// 16 vCPU rather than snapping down to the 8-vCPU max tier (the earlier
+		// round-up contract). Preserve beats clamp for any vCPU with a concrete class.
 		ecVals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("16 vCPU", "", ""), "", "")
 		require.NoError(t, err)
-		assert.Equal(t, "cache.r6g.2xlarge", ecVals["node_type"], `"16 vCPU" snaps to the 8 vCPU max tier`)
+		assert.Equal(t, "cache.r6g.4xlarge", ecVals["node_type"], `"16 vCPU" preserves at the concrete 16-vCPU node type`)
 
 		rdsVals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("16 vCPU", "", ""), "", "")
 		require.NoError(t, err)
-		assert.Equal(t, "db.m7i.2xlarge", rdsVals["instance_class"], `"16 vCPU" snaps to the 8 vCPU max tier`)
+		assert.Equal(t, "db.m7i.4xlarge", rdsVals["instance_class"], `"16 vCPU" preserves at the concrete 16-vCPU instance class`)
+	})
+
+	t.Run("out-of-enum vCPU with no concrete class falls back to round-up", func(t *testing.T) {
+		t.Parallel()
+		// 3 and 5 vCPU have no concrete same-family class, so the heal falls back
+		// to rounding UP to the nearest valid tier (3 -> 4 vCPU, 5 -> 8 vCPU).
+		ec3, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("3 vCPU", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "cache.r6g.xlarge", ec3["node_type"], `"3 vCPU" rounds up to the 4 vCPU tier (no concrete 3-vCPU class)`)
+
+		rds5, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("5 vCPU", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "db.m7i.2xlarge", rds5["instance_class"], `"5 vCPU" rounds up to the 8 vCPU tier (no concrete 5-vCPU class)`)
 	})
 
 	t.Run("valid tiers are preserved (no heal)", func(t *testing.T) {

--- a/pkg/composer/mapper_heal_test.go
+++ b/pkg/composer/mapper_heal_test.go
@@ -143,3 +143,166 @@ func TestBuildModuleValues_Heal_EmitsWarning(t *testing.T) {
 	assert.NotContains(t, buf.String(), "heal",
 		"an already-valid value must not emit any heal warning")
 }
+
+// --- Third frozen-value heal: out-of-enum "<N> vCPU" sizing (reliable#2097) ---
+//
+// A sizing value like "2 vCPU" was once compose-valid under a permissive legacy
+// TS mapper but the strict Go composer hard-errors (the IR enum is {1,4,8}
+// vCPU). That frozen value lives in stored config reliable composes verbatim,
+// so the mapper now HEALS it: snap UP to the nearest valid tier (rounding up),
+// snap above-max to the max, and leave valid tiers + concrete provider
+// instance/node types untouched. Genuinely-malformed labels still error.
+// Mirrors the #805/#806 heal style.
+
+// TestSnapVCPUTier pins the round-up-to-nearest-tier rule directly, including
+// the "only the <integer> vCPU shape matches" guard that keeps malformed values
+// erroring at the call sites.
+func TestSnapVCPUTier(t *testing.T) {
+	t.Parallel()
+
+	t.Run("snaps up to the nearest valid tier", func(t *testing.T) {
+		t.Parallel()
+		cases := []struct {
+			in   string
+			want string
+		}{
+			{"1 vCPU", "1 vCPU"},     // exact tier, unchanged
+			{"2 vCPU", "4 vCPU"},     // round up across the 1->4 gap
+			{"3 vCPU", "4 vCPU"},     // round up
+			{"4 vCPU", "4 vCPU"},     // exact tier, unchanged
+			{"5 vCPU", "8 vCPU"},     // round up across the 4->8 gap
+			{"7 vCPU", "8 vCPU"},     // round up
+			{"8 vCPU", "8 vCPU"},     // exact max tier, unchanged
+			{"16 vCPU", "8 vCPU"},    // above max -> snap to max
+			{"  2  vCPU ", "4 vCPU"}, // whitespace tolerated
+			{"2 vcpu", "4 vCPU"},     // case-insensitive
+		}
+		for _, tc := range cases {
+			tc := tc
+			t.Run(tc.in, func(t *testing.T) {
+				t.Parallel()
+				got, ok := snapVCPUTier(tc.in)
+				require.True(t, ok, "%q must be recognized as a vCPU label", tc.in)
+				assert.Equal(t, tc.want, got)
+			})
+		}
+	})
+
+	t.Run("does not match non-vCPU / malformed shapes", func(t *testing.T) {
+		t.Parallel()
+		for _, in := range []string{"abc", "2.5 vCPU", "vCPU", "2 cpu", "cache.r6g.large", "db.m7i.large", ""} {
+			_, ok := snapVCPUTier(in)
+			assert.False(t, ok, "%q must NOT be treated as a healable vCPU label", in)
+		}
+	})
+}
+
+// TestBuildModuleValues_VCPUSizingHeal exercises the heal through the mapper for
+// both doubly-affected fields (the reliable#2097 session has BOTH
+// AWSElastiCache.NodeSize="2 vCPU" and AWSRDS.CPUSize="2 vCPU"): out-of-enum
+// snaps up, valid tiers and concrete provider types pass through unchanged, and
+// a genuinely-malformed value still errors.
+func TestBuildModuleValues_VCPUSizingHeal(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultMapper{}
+
+	t.Run("ElastiCache NodeSize 2 vCPU heals to 4 vCPU node type", func(t *testing.T) {
+		t.Parallel()
+		vals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("2 vCPU", "", ""), "", "")
+		require.NoError(t, err, "frozen out-of-enum NodeSize must heal, not error")
+		assert.Equal(t, "cache.r6g.xlarge", vals["node_type"], `"2 vCPU" snaps up to the 4 vCPU tier`)
+	})
+
+	t.Run("RDS CPUSize 2 vCPU heals to 4 vCPU instance class", func(t *testing.T) {
+		t.Parallel()
+		vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("2 vCPU", "", ""), "", "")
+		require.NoError(t, err, "frozen out-of-enum CPUSize must heal, not error")
+		assert.Equal(t, "db.m7i.xlarge", vals["instance_class"], `"2 vCPU" snaps up to the 4 vCPU tier`)
+	})
+
+	t.Run("above-max snaps to the max tier", func(t *testing.T) {
+		t.Parallel()
+		ecVals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("16 vCPU", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "cache.r6g.2xlarge", ecVals["node_type"], `"16 vCPU" snaps to the 8 vCPU max tier`)
+
+		rdsVals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("16 vCPU", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "db.m7i.2xlarge", rdsVals["instance_class"], `"16 vCPU" snaps to the 8 vCPU max tier`)
+	})
+
+	t.Run("valid tiers are preserved (no heal)", func(t *testing.T) {
+		t.Parallel()
+		ec := map[string]string{"1 vCPU": "cache.t3.medium", "4 vCPU": "cache.r6g.xlarge", "8 vCPU": "cache.r6g.2xlarge"}
+		for in, want := range ec {
+			vals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg(in, "", ""), "", "")
+			require.NoError(t, err)
+			assert.Equal(t, want, vals["node_type"], "%s must map to its canonical node type unchanged", in)
+		}
+		rds := map[string]string{"1 vCPU": "db.t3.medium", "4 vCPU": "db.m7i.xlarge", "8 vCPU": "db.m7i.2xlarge"}
+		for in, want := range rds {
+			vals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg(in, "", ""), "", "")
+			require.NoError(t, err)
+			assert.Equal(t, want, vals["instance_class"], "%s must map to its canonical instance class unchanged", in)
+		}
+	})
+
+	t.Run("concrete provider types pass through untouched", func(t *testing.T) {
+		t.Parallel()
+		ecVals, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("cache.m6g.large", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "cache.m6g.large", ecVals["node_type"], "a concrete cache.* type must not be healed")
+
+		rdsVals, err := m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("db.r6g.4xlarge", "", ""), "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "db.r6g.4xlarge", rdsVals["instance_class"], "a concrete db.* type must not be healed")
+	})
+
+	t.Run("genuinely-malformed sizing still errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("ginormous", "", ""), "", "")
+		var ecVerr *ValidationError
+		require.ErrorAs(t, err, &ecVerr, "a non-vCPU NodeSize must still fail fast as ValidationError")
+
+		_, err = m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("2.5 vCPU", "", ""), "", "")
+		var rdsVerr *ValidationError
+		require.ErrorAs(t, err, &rdsVerr, `"2.5 vCPU" is not the integer-vCPU shape and must still error`)
+	})
+}
+
+// TestBuildModuleValues_VCPUSizingHeal_EmitsWarning verifies the sizing heal
+// logs a "[composer/mapper] ... heal" warning, and that a valid tier does not.
+// Serial (no t.Parallel) for the same reason as TestBuildModuleValues_Heal_EmitsWarning.
+func TestBuildModuleValues_VCPUSizingHeal_EmitsWarning(t *testing.T) {
+	m := DefaultMapper{}
+
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+
+	buf.Reset()
+	_, err := m.BuildModuleValues(KeyAWSElastiCache, nil, elasticacheCfg("2 vCPU", "", ""), "", "")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "[composer/mapper] AWSElastiCache heal",
+		"out-of-enum NodeSize must emit a [composer/mapper] AWSElastiCache heal warning")
+
+	buf.Reset()
+	_, err = m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("2 vCPU", "", ""), "", "")
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "[composer/mapper] AWSRDS heal",
+		"out-of-enum CPUSize must emit a [composer/mapper] AWSRDS heal warning")
+
+	// Negative control: a valid tier must NOT emit a heal warning.
+	buf.Reset()
+	_, err = m.BuildModuleValues(KeyAWSRDS, nil, rdsCfg("4 vCPU", "", ""), "", "")
+	require.NoError(t, err)
+	assert.NotContains(t, buf.String(), "heal",
+		"an already-valid tier must not emit any heal warning")
+}


### PR DESCRIPTION
Third frozen-value heal after #805 and #806. A `compose-audit` sweep found a sizing value `"2 vCPU"` that was once compose-valid under a permissive legacy TS mapper but the strict Go composer now hard-errors on it (typed IR enum is `{1,4,8}` vCPU). The formerly-valid value froze into stored config that reliable composes verbatim, so the error is one the user can't act on.

Cites luthersystems/reliable#2097 — one affected session (`sess_v2_oSNw2ECnIKBT`, Intel) has BOTH `AWSElastiCache.NodeSize="2 vCPU"` and `aws_rds.cpuSize="2 vCPU"` (same hard-error class).

## Fix — heal to PRESERVE the deployed footprint, not round up

`canonicalRdsInstanceClass` (RDS `cpuSize`) and `canonicalRedisNodeType` (ElastiCache `NodeSize`) HEAL an out-of-enum `"<N> vCPU"` label by mapping N to the CONCRETE same-family class with EXACTLY N vCPU (`vcpuExactSuffix`: large=2, xlarge=4, 2xlarge=8, ...) — the same class the resource is already running as — instead of snapping to a different tier:

- `"2 vCPU"` -> `db.m7i.large` (RDS) / `cache.r6g.large` (ElastiCache). The legacy TS mapper emitted exactly these 2-vCPU classes for this Intel session (`sizeSuffixForVcpu(2)="large"`).
- Both are valid concrete `db.*` / `cache.*` passthrough types the composer already accepts, so compose still heals (no error) and the audit stays green — with NO resize.
- Only a vCPU with no concrete same-family class (e.g. 3, 5, 6, 7) falls back to the prior round-up-to-nearest-tier (`snapVCPUTier`). `"16 vCPU"` now preserves at `*.4xlarge` (16 vCPU) rather than snapping down to the 8-vCPU max.
- Valid tiers and concrete provider types pass through untouched. Genuinely-malformed labels (`"abc"`, `"2.5 vCPU"`) still fail fast as `ValidationError`.
- The `[composer/mapper] ... heal` warning is kept (now "healed frozen N vCPU to concrete <class> to preserve the deployed footprint").

### Why round-up was wrong

The earlier revision rounded `"2 vCPU"` UP to the 4-vCPU tier (`db.m7i.xlarge` / `cache.r6g.xlarge`). On an already-configured stack that is a real `instance_class` / `node_type` change — a silent RESIZE (RDS restart, ElastiCache node replacement, ~2x cost) on the next apply. A Codex review independently confirmed it: the branch emitted `xlarge` while legacy emitted `large`.

ElastiCache family note: the legacy mapper emitted `r7i`/`r7g.<size>` WITHOUT the `cache.` prefix — an invalid, un-deployable ElastiCache node type, so there is no real `r7i.*` resource to match. `cache.r6g` is the composer/preset canonical family (its 4/8 tiers and the preset default `cache.r6g.xlarge`), so `cache.r6g.large` is the valid node type that keeps the 2-vCPU (`large`) footprint identical.

## Tests

- The `"2 vCPU"` regression expectations flip from the round-up (`xlarge`, 4 vCPU) to the CONCRETE 2-vCPU class (`db.m7i.large` / `cache.r6g.large`) — a deliberate behavior change (preserve-footprint, ref reliable#2097 + the Codex finding); updated, not deleted, with the rationale in-comment.
- `"16 vCPU"` now preserves at the concrete 16-vCPU class (`*.4xlarge`) instead of snapping to the max tier (the `mapper_audit_test.go` assertion is updated accordingly).
- New case covers the no-concrete-class round-up fallback (`3 -> 4 vCPU`, `5 -> 8 vCPU`).
- Valid tiers preserved; concrete `db.*` / `cache.*` passthrough preserved; malformed still errors; heal warning still emitted.
- Non-vacuous proof: removing the `2 -> large` mapping makes the two `"2 vCPU"` preserve tests FAIL (they get `xlarge`), confirming they catch the resize.
- Guard B (`TestComposer_DefaultOutput_NeverSelfRejects`) stays green.

`go test ./pkg/composer/...` (incl. `-race`), `go build ./...`, `go vet ./...`, `gofmt -l` all clean.

Refs #805, #806, reliable#2097.