### PR TITLE
Support Claude Code on the web (cloud sandbox)

### DIFF
--- a/docs/CLAUDE_CODE_WEB.md
+++ b/docs/CLAUDE_CODE_WEB.md
@@ -1,0 +1,108 @@
+# Claude Code on the web — running this repo in the cloud
+
+This repo is set up to run under [Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web)
+(cloud sandboxes at [claude.ai/code](https://claude.ai/code)), so you can dispatch
+tickets and get branches/PRs back without running anything on your laptop.
+
+There are two halves: **what lives in this repo** (committed, travels to every cloud
+session automatically) and **what you configure once in the web UI** (the environment:
+setup script, env vars, network — these cannot be committed).
+
+## What's in the repo vs the web UI
+
+| Thing | Where | File / location |
+|---|---|---|
+| System tools install (terraform, tflint, gh, go, codex CLI) | repo, **pasted into the UI setup script** | [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh) |
+| Repo deps + codex auth mode (per session) | repo (SessionStart hook) | [`scripts/cloud-session-start.sh`](../scripts/cloud-session-start.sh) |
+| codex plugin enablement + the hook wiring | repo | `.claude/settings.json` (see below) |
+| `OPENAI_API_KEY` (codex auth) | **web UI only** — Environment variables | never committed |
+| Network allowlist (`api.openai.com`) | **web UI only** — Network access | never committed |
+
+## One-time web-UI setup
+
+1. **Start a session**: [claude.ai/code](https://claude.ai/code) → **New session** → pick
+   `luthersystems/insideout-terraform-presets`.
+2. **Open the environment**: click the **cloud icon** (shows the current environment name)
+   → **Add environment** (or the gear icon to edit). There is no "Environments" page
+   under account Settings — it lives on this selector.
+3. **Setup script**: paste the full contents of
+   [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh). Runs once as root,
+   cached ~7 days; only re-runs when you change it. Installs Terraform 1.7.5 (matches CI),
+   tflint, gh, Go (if the preinstalled one is too old for `go.mod`), and the OpenAI
+   `codex` CLI.
+4. **Environment variables** (`.env` format, one per line, **no quotes**):
+   - `OPENAI_API_KEY=sk-...` — required for the codex plugin. See the security note below.
+   - `GITHUB_TOKEN=...` — *optional*, only if `tflint --init` hits GitHub rate limits when
+     fetching its aws/google rulesets.
+5. **Network access**: switch to **Custom**, keep "include default package managers"
+   checked, and add:
+   ```
+   api.openai.com
+   ```
+   The defaults already cover `releases.hashicorp.com`, `registry.terraform.io`,
+   `github.com`, npm, etc. `api.openai.com` is **not** in the default allowlist, so codex
+   is blocked without this.
+
+## The `.claude/settings.json` change
+
+This enables the `codex` plugin and wires the SessionStart hook for **everyone** who opens
+this repo in Claude Code (local and cloud). Add these keys alongside the existing
+`permissions` block:
+
+```jsonc
+{
+  "permissions": { /* unchanged */ },
+
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": { "source": "github", "repo": "openai/codex-plugin-cc" }
+    }
+  },
+  "enabledPlugins": {
+    "codex@openai-codex": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          { "type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/cloud-session-start.sh\"" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Security: never commit the API key
+
+The OpenAI key goes in the web-UI **Environment variables** field, never in this repo.
+GitHub push-protection will block a committed key, OpenAI auto-revokes leaked keys, and it
+would be readable by anyone with repo access. The codex CLI reads `OPENAI_API_KEY` from the
+environment automatically — nothing about the secret needs to live in git. Note that env
+vars are visible to anyone who can edit the environment, so treat that list accordingly.
+
+## Caching: what persists between sessions
+
+Only the **setup-script output** is cached (a filesystem snapshot). Each session is
+otherwise a fresh VM, so the Go module cache and Terraform provider downloads **repeat
+every session** — the SessionStart hook pre-warms `go mod download`; Terraform providers
+(`aws 6.45.0`, `google 6.10.0`) and tflint plugins download lazily the first time a task
+runs `terraform init` / `tflint --init`.
+
+## Running tickets
+
+- Paste an issue URL or say "work issue #N" — the built-in GitHub tools read issues/PRs
+  with no extra setup. Each task runs in its own VM on its own branch, then pushes for review.
+- For unattended runs, see [Routines](https://code.claude.com/docs/en/routines) (scheduled
+  or API-triggered). Note GitHub event triggers fire on `pull_request`/`release`, not on
+  `issues`.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| codex plugin says "not authenticated" | Confirm `OPENAI_API_KEY` is set in the environment's env vars and `api.openai.com` is in the Custom allowlist. |
+| codex network errors / timeouts to OpenAI | Network is still on "Trusted" — switch to **Custom** and add `api.openai.com`. |
+| `go build` fails on a language-version error | Preinstalled Go is older than `go.mod`; the setup script installs Go `1.25.0` when that happens — re-check it ran. |
+| Setup script "cache build failed" | It must finish within ~5 min and exit 0. Check the failing installer in the build log. |
+| `tflint --init` rate-limited | Add an optional `GITHUB_TOKEN` env var. |

--- a/scripts/cloud-session-start.sh
+++ b/scripts/cloud-session-start.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook for Claude Code (wired in .claude/settings.json).
+#
+# Runs on EVERY session -- local AND Claude Code on the web -- AFTER Claude launches,
+# with the repository already cloned. Unlike the cached setup script, this repeats each
+# session, so keep it light. Cloud-only behaviour is gated on CLAUDE_CODE_REMOTE so it
+# never touches a local developer's machine.
+#
+set -uo pipefail
+
+# Pre-warm the Go module cache so the first `go build` / `go test -race ./...` is fast.
+# A fresh cloud VM has no module cache; locally this is a no-op. Non-fatal.
+if command -v go >/dev/null 2>&1; then
+  go mod download || true
+fi
+
+if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
+  # Cloud only: force the codex CLI to use API-key auth. The sandbox is headless, so
+  # there is no interactive `codex login` and no ~/.codex/auth.json; codex picks up the
+  # OPENAI_API_KEY env var (set in the environment's "Environment variables" field).
+  # Writing preferred_auth_method makes that choice explicit/defensive. We never write
+  # this locally, so a developer's existing `codex login` is untouched.
+  mkdir -p "${HOME}/.codex"
+  if ! grep -q '^preferred_auth_method' "${HOME}/.codex/config.toml" 2>/dev/null; then
+    printf 'preferred_auth_method = "apikey"\n' >> "${HOME}/.codex/config.toml"
+  fi
+fi
+
+exit 0

--- a/scripts/cloud-web-setup.sh
+++ b/scripts/cloud-web-setup.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Claude Code on the web -- environment "Setup script" for insideout-terraform-presets.
+#
+# HOW TO USE: copy the FULL contents of this file into the "Setup script" field of
+# your Claude Code on the web environment:
+#     claude.ai/code -> New session -> click the cloud icon (environment name)
+#     -> Add environment (or the gear to edit) -> "Setup script".
+#
+# It runs ONCE as root on a fresh Ubuntu 24.04 VM and its filesystem output is
+# CACHED (~7-day expiry), so it only re-runs when you edit it. Keep it to
+# repo-independent system tools only -- the repo is NOT reliably present here.
+# Repo-specific warmup (go mod download, codex auth) lives in
+# scripts/cloud-session-start.sh, wired as a SessionStart hook in .claude/settings.json.
+#
+# This file is version-controlled so the pasted script and the repo stay in sync.
+# Pins mirror .github/workflows/terraform-validate.yml.
+#
+set -euo pipefail
+
+TERRAFORM_VERSION=1.7.5   # matches CI: hashicorp/setup-terraform terraform_version
+GO_VERSION=1.25.0         # matches go.mod `go 1.25.0`
+ARCH=amd64                # cloud sandbox is x86_64
+
+log() { echo "[cloud-web-setup] $*"; }
+
+install_terraform() {
+  log "installing terraform ${TERRAFORM_VERSION}"
+  curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip" -o /tmp/terraform.zip
+  unzip -o /tmp/terraform.zip -d /usr/local/bin
+  /usr/local/bin/terraform version
+}
+
+install_tflint() {
+  log "installing tflint (plugins are fetched lazily via 'tflint --init')"
+  curl -fsSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+  tflint --version
+}
+
+install_gh() {
+  command -v gh >/dev/null 2>&1 && { log "gh already present"; return 0; }
+  log "installing gh CLI"
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
+  chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list
+  apt-get update -y
+  apt-get install -y gh
+}
+
+install_codex() {
+  # Codex CLI backs the `codex` Claude Code plugin (enabled in .claude/settings.json).
+  # node/npm are preinstalled in the sandbox; a global install puts `codex` on PATH for
+  # the session user. AUTH is via the OPENAI_API_KEY env var you set in the environment's
+  # "Environment variables" field -- it is NOT, and must not be, committed to this repo.
+  log "installing OpenAI codex CLI (@openai/codex)"
+  npm install -g @openai/codex
+  codex --version
+}
+
+ensure_go() {
+  if command -v go >/dev/null 2>&1; then
+    have="$(go version | awk '{print $3}' | sed 's/^go//')"
+    want="${GO_VERSION%.*}"  # major.minor
+    if [ "$(printf '%s\n%s\n' "$want" "$have" | sort -V | head -1)" = "$want" ]; then
+      log "preinstalled go ${have} satisfies go.mod (>= ${want}); skipping"
+      return 0
+    fi
+    log "preinstalled go ${have} is older than ${want}; installing ${GO_VERSION}"
+  else
+    log "go not found; installing ${GO_VERSION}"
+  fi
+  curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tgz
+  rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tgz
+  ln -sf /usr/local/go/bin/go /usr/local/bin/go
+  ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+  go version
+}
+
+# Phase 1 (sync): base packages the parallel installers depend on (unzip for
+# terraform/tflint, jq for the lint scripts).
+log "installing base apt packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y --no-install-recommends unzip jq ca-certificates curl gnupg
+
+# Phase 2 (parallel): independent installers. gh is the only apt user here.
+pids=()
+install_terraform & pids+=("$!")
+install_tflint    & pids+=("$!")
+install_codex     & pids+=("$!")
+ensure_go         & pids+=("$!")
+install_gh        & pids+=("$!")
+
+fail=0
+for pid in "${pids[@]}"; do wait "$pid" || fail=1; done
+if [ "$fail" -ne 0 ]; then
+  log "ERROR: one or more installs failed (see above); failing so the cache is not poisoned"
+  exit 1
+fi
+
+log "setup complete: $(terraform version | head -1), $(tflint --version | head -1), go $(go version | awk '{print $3}'), codex $(codex --version 2>/dev/null | head -1)"


### PR DESCRIPTION
Lets this repo run under Claude Code on the web (cloud sandboxes at claude.ai/code) so tickets can be worked in cloud VMs without running anything locally.

## Shared environment with reliable

One Claude Code on the web environment is reused across this repo and `reliable` (luthersystems/reliable#2110). The environment supplies the tool image (setup script) + the scoped 1Password token + the network allowlist; each repo's committed `.claude/` config decides what to run and which secrets to pull. The setup script is the **union** of both repos' tools, committed identically in both (copy from either). For a TF-only leaner env, drop reliable's tools.

## Secrets: 1Password service account, not plaintext env vars

The cloud env-vars field is plaintext and visible to anyone who can edit the environment (the UI warns against secrets), and there's no dedicated secrets store. So the only thing in the env field is a scoped, read-only `OP_SERVICE_ACCOUNT_TOKEN`; real secrets stay in 1Password (`Reliable-Dev`) and resolve at session start via `op inject`. Matches this codebase's op-as-source-of-truth convention. The real secrets never persist in Claude's config or this repo.

## What's here

- `scripts/cloud-web-setup.sh` — the shared **Setup script** to paste into the web UI (union: Terraform 1.7.5, tflint, golangci-lint v2.6.2, gh, op, codex, vercel, git-lfs, Playwright deps; Go guarded to go.mod's 1.25). Runs once as root, cached. Identical to the reliable copy.
- `scripts/cloud-session-start.sh` — SessionStart hook (generic, identical in both repos): pre-warms `go mod download`; in cloud `op inject`s `scripts/cloud-secrets.op.tpl`, pulls Git LFS if used, sets codex API-key auth. Gated on `CLAUDE_CODE_REMOTE`.
- `scripts/cloud-secrets.op.tpl` — `op://` references only (no secret values); for presets this is just codex's `OPENAI_API_KEY`.
- `docs/CLAUDE_CODE_WEB.md` — shared-env setup, the single env var + `*.1password.com` / `api.openai.com` network allowlist, repo-vs-UI split.

## Action required — not in this PR

The `.claude/settings.json` change (register the `openai-codex` marketplace, enable the `codex` plugin, wire the SessionStart hook) is documented in the doc but not applied here — it enables a plugin + an auto-running hook for everyone who opens the repo, so it should be a deliberate, reviewed change.

## Verification
- `bash -n` passes on both scripts; the two shared scripts are byte-identical to the reliable copies; template confirmed references-only.
- Not yet run in a real cloud session — confirm `op inject` resolves and codex authenticates headlessly on first run.