### PR TITLE
Claude Code on the web: land full setup (follow-up to #811)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,5 +30,30 @@
       "Bash(mkdir:*)",
       "Bash(go build:*)"
     ]
+  },
+  "extraKnownMarketplaces": {
+    "openai-codex": {
+      "source": { "source": "github", "repo": "openai/codex-plugin-cc" }
+    },
+    "claude-config": {
+      "source": { "source": "github", "repo": "sam-at-luther/claude-config" }
+    }
+  },
+  "enabledPlugins": {
+    "codex@openai-codex": true,
+    "claude-config@claude-config": true,
+    "firecrawl@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/cloud-session-start.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/docs/CLAUDE_CODE_WEB.md
+++ b/docs/CLAUDE_CODE_WEB.md
@@ -8,11 +8,18 @@ There are two halves: **what lives in this repo** (committed, travels to every c
 session automatically) and **what you configure once in the web UI** (the environment:
 setup script, env vars, network — these cannot be committed).
 
+**Shared environment.** This repo and `reliable` share ONE Claude Code on the web
+environment. The setup script below is the **union** of both repos' tools and is committed
+identically in both — copy it from either. The environment supplies the tool image + the
+1Password token + the network allowlist; each repo's committed `.claude/` config decides
+what to run and which secrets to pull. (For a TF-only, leaner environment, drop reliable's
+tools from the script.)
+
 ## What's in the repo vs the web UI
 
 | Thing | Where | File / location |
 |---|---|---|
-| System tools install (terraform, tflint, gh, go, codex CLI, **op CLI**) | repo, **pasted into the UI setup script** | [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh) |
+| System tools (union: terraform, tflint, golangci-lint, gh, op, codex, vercel, git-lfs, go) | repo, **pasted into the shared UI setup script** | [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh) |
 | Go warmup + **secret fetch from 1Password** + codex auth mode | repo (SessionStart hook) | [`scripts/cloud-session-start.sh`](../scripts/cloud-session-start.sh) |
 | Which secrets to pull, as `op://` references (no secret values) | repo | [`scripts/cloud-secrets.op.tpl`](../scripts/cloud-secrets.op.tpl) |
 | codex plugin enablement + the hook wiring | repo | `.claude/settings.json` (see below) |

--- a/docs/CLAUDE_CODE_WEB.md
+++ b/docs/CLAUDE_CODE_WEB.md
@@ -61,15 +61,16 @@ keep it least-privilege (read-only, single vault) and rotate it.
    [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh). Runs once as root,
    cached ~7 days. Installs Terraform 1.7.5 (matches CI), tflint, gh, Go (if the
    preinstalled one is older than `go.mod`), the OpenAI `codex` CLI, and the `op` CLI.
-4. **Environment variables** (`.env` format, one per line, **no quotes**) — two bootstrap
-   tokens only (real secrets come from 1Password at session start):
+4. **Environment variables** (`.env` format, one per line, **no quotes**) — just the
+   bootstrap token (real secrets come from 1Password at session start):
    ```
    OP_SERVICE_ACCOUNT_TOKEN=ops_...
-   GH_TOKEN=github_pat_...
    ```
-   `GH_TOKEN` is a **read-only, fine-grained** PAT scoped to `sam-at-luther/claude-config`
-   (Contents: read) — needed at session start to fetch the **private** `claude-config`
-   plugin marketplace (op-injected secrets arrive too late for plugin install).
+   **No GitHub PAT needed up front:** cloud's GitHub proxy authenticates git as your
+   connected identity (it's how the private working repo clones), so the private
+   `claude-config` marketplace should fetch with no extra token. *Only if* the
+   `claude-config:*` skills fail to install, add a read-only fine-grained PAT
+   (Contents: read, scoped to `sam-at-luther/claude-config`) as `GH_TOKEN`.
 5. **Network access**: switch to **Custom**, keep "include default package managers"
    checked, and add:
    ```
@@ -114,9 +115,10 @@ block:
 ```
 
 - `claude-config@claude-config` brings qa-professor + pr + golang-guidance etc. It's a
-  **private** marketplace — needs the `GH_TOKEN` above. **Unverified in cloud**: if it
-  doesn't load on the first session, fall back to committing those skills into this repo's
-  `.claude/agents` + `.claude/skills`.
+  **private** marketplace; the cloud GitHub proxy should fetch it as your connected
+  identity (no token), with the `GH_TOKEN` fallback above if not. **Unverified in cloud**:
+  if it doesn't load even with the PAT, fall back to committing those skills into this
+  repo's `.claude/agents` + `.claude/skills`.
 - `firecrawl@claude-plugins-official` is a bundled Anthropic marketplace, so it needs no
   `extraKnownMarketplaces` entry. Needs `FIRECRAWL_API_KEY` (op-injected) +
   `api.firecrawl.dev` in the allowlist.

--- a/docs/CLAUDE_CODE_WEB.md
+++ b/docs/CLAUDE_CODE_WEB.md
@@ -12,36 +12,63 @@ setup script, env vars, network — these cannot be committed).
 
 | Thing | Where | File / location |
 |---|---|---|
-| System tools install (terraform, tflint, gh, go, codex CLI) | repo, **pasted into the UI setup script** | [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh) |
-| Repo deps + codex auth mode (per session) | repo (SessionStart hook) | [`scripts/cloud-session-start.sh`](../scripts/cloud-session-start.sh) |
+| System tools install (terraform, tflint, gh, go, codex CLI, **op CLI**) | repo, **pasted into the UI setup script** | [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh) |
+| Go warmup + **secret fetch from 1Password** + codex auth mode | repo (SessionStart hook) | [`scripts/cloud-session-start.sh`](../scripts/cloud-session-start.sh) |
+| Which secrets to pull, as `op://` references (no secret values) | repo | [`scripts/cloud-secrets.op.tpl`](../scripts/cloud-secrets.op.tpl) |
 | codex plugin enablement + the hook wiring | repo | `.claude/settings.json` (see below) |
-| `OPENAI_API_KEY` (codex auth) | **web UI only** — Environment variables | never committed |
-| Network allowlist (`api.openai.com`) | **web UI only** — Network access | never committed |
+| `OP_SERVICE_ACCOUNT_TOKEN` (scoped 1Password token) | **web UI only** — Environment variables | never committed |
+| Network allowlist (`api.openai.com`, `*.1password.com`) | **web UI only** — Network access | never committed |
+
+## Secrets: 1Password service account (not the plaintext env-vars field)
+
+The cloud env-vars field is **plaintext and visible to anyone who can edit the
+environment** — the UI warns against putting secrets there, and there is no dedicated
+secrets store yet. So instead of dropping real secrets in, we put a **single scoped
+1Password service-account token** there and pull the real secrets at session start. This
+matches how the rest of the codebase treats 1Password as the source of truth.
+
+**Why this is better:** only one credential sits in the env config, it's **read-only and
+scoped to one vault**, it's **centrally rotatable/revocable** in 1Password with an **audit
+log**, and the actual secrets (OpenAI key, etc.) never persist in Claude's config or this
+repo. Residual risk: the service-account token is still plaintext in the env config, so
+keep it least-privilege (read-only, single vault) and rotate it.
+
+### One-time 1Password setup
+
+1. Create a **service account** scoped **read-only** to the `Reliable-Dev` vault
+   (1Password → Developer → Service Accounts). Copy its token (`ops_...`).
+2. Make sure the secrets you reference exist in that vault. For codex, create an item
+   holding your OpenAI key and point [`scripts/cloud-secrets.op.tpl`](../scripts/cloud-secrets.op.tpl)
+   at it (`op://Reliable-Dev/<item>/<field>`). The default reference is
+   `op://Reliable-Dev/openai-api-key/credential` — adjust to match your item/field.
+3. Use a **scoped, spend-capped OpenAI key** so a leak is low-blast-radius.
 
 ## One-time web-UI setup
 
 1. **Start a session**: [claude.ai/code](https://claude.ai/code) → **New session** → pick
    `luthersystems/insideout-terraform-presets`.
-2. **Open the environment**: click the **cloud icon** (shows the current environment name)
-   → **Add environment** (or the gear icon to edit). There is no "Environments" page
-   under account Settings — it lives on this selector.
+2. **Open the environment**: click the **cloud icon** (shows the environment name) →
+   **Add environment** (or the gear to edit). There is no "Environments" page under
+   account Settings — it lives on this selector.
 3. **Setup script**: paste the full contents of
    [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh). Runs once as root,
-   cached ~7 days; only re-runs when you change it. Installs Terraform 1.7.5 (matches CI),
-   tflint, gh, Go (if the preinstalled one is too old for `go.mod`), and the OpenAI
-   `codex` CLI.
-4. **Environment variables** (`.env` format, one per line, **no quotes**):
-   - `OPENAI_API_KEY=sk-...` — required for the codex plugin. See the security note below.
-   - `GITHUB_TOKEN=...` — *optional*, only if `tflint --init` hits GitHub rate limits when
-     fetching its aws/google rulesets.
+   cached ~7 days. Installs Terraform 1.7.5 (matches CI), tflint, gh, Go (if the
+   preinstalled one is older than `go.mod`), the OpenAI `codex` CLI, and the `op` CLI.
+4. **Environment variables** (`.env` format, one per line, **no quotes**) — only the
+   bootstrap token goes here:
+   ```
+   OP_SERVICE_ACCOUNT_TOKEN=ops_...
+   ```
 5. **Network access**: switch to **Custom**, keep "include default package managers"
    checked, and add:
    ```
    api.openai.com
+   *.1password.com
    ```
-   The defaults already cover `releases.hashicorp.com`, `registry.terraform.io`,
-   `github.com`, npm, etc. `api.openai.com` is **not** in the default allowlist, so codex
-   is blocked without this.
+   `api.openai.com` is what codex calls at runtime; `*.1password.com` covers both the
+   `op` CLI download (`downloads.1password.com`) and its runtime API. Neither is in the
+   default "Trusted" set. (If the rare Go-toolchain install path fires, also allow
+   `go.dev`.)
 
 ## The `.claude/settings.json` change
 
@@ -73,36 +100,44 @@ this repo in Claude Code (local and cloud). Add these keys alongside the existin
 }
 ```
 
-## Security: never commit the API key
+## How it fits together at session start
 
-The OpenAI key goes in the web-UI **Environment variables** field, never in this repo.
-GitHub push-protection will block a committed key, OpenAI auto-revokes leaked keys, and it
-would be readable by anyone with repo access. The codex CLI reads `OPENAI_API_KEY` from the
-environment automatically — nothing about the secret needs to live in git. Note that env
-vars are visible to anyone who can edit the environment, so treat that list accordingly.
+```
+Cloud env-vars: OP_SERVICE_ACCOUNT_TOKEN  ─┐
+                                           ▼
+SessionStart hook ── op inject scripts/cloud-secrets.op.tpl
+                                           │  (resolves op:// refs)
+                                           ▼
+                     $CLAUDE_ENV_FILE  (OPENAI_API_KEY=sk-...)
+                                           ▼
+                     codex plugin reads OPENAI_API_KEY  →  api.openai.com
+```
+
+Real secrets exist only inside the isolated VM for the life of the session. Adding a new
+secret = add one `op://` line to `scripts/cloud-secrets.op.tpl` (and the item in 1Password).
 
 ## Caching: what persists between sessions
 
 Only the **setup-script output** is cached (a filesystem snapshot). Each session is
 otherwise a fresh VM, so the Go module cache and Terraform provider downloads **repeat
-every session** — the SessionStart hook pre-warms `go mod download`; Terraform providers
-(`aws 6.45.0`, `google 6.10.0`) and tflint plugins download lazily the first time a task
-runs `terraform init` / `tflint --init`.
+every session** — the hook pre-warms `go mod download`; Terraform providers
+(`aws 6.45.0`, `google 6.10.0`) and tflint plugins download lazily on first
+`terraform init` / `tflint --init`.
 
 ## Running tickets
 
 - Paste an issue URL or say "work issue #N" — the built-in GitHub tools read issues/PRs
   with no extra setup. Each task runs in its own VM on its own branch, then pushes for review.
 - For unattended runs, see [Routines](https://code.claude.com/docs/en/routines) (scheduled
-  or API-triggered). Note GitHub event triggers fire on `pull_request`/`release`, not on
-  `issues`.
+  or API-triggered). GitHub event triggers fire on `pull_request`/`release`, not on `issues`.
+- Keep sessions **Private** — a shared/public session link can expose transcript contents.
 
 ## Troubleshooting
 
 | Symptom | Fix |
 |---|---|
-| codex plugin says "not authenticated" | Confirm `OPENAI_API_KEY` is set in the environment's env vars and `api.openai.com` is in the Custom allowlist. |
-| codex network errors / timeouts to OpenAI | Network is still on "Trusted" — switch to **Custom** and add `api.openai.com`. |
-| `go build` fails on a language-version error | Preinstalled Go is older than `go.mod`; the setup script installs Go `1.25.0` when that happens — re-check it ran. |
-| Setup script "cache build failed" | It must finish within ~5 min and exit 0. Check the failing installer in the build log. |
-| `tflint --init` rate-limited | Add an optional `GITHUB_TOKEN` env var. |
+| Hook logs "skipping secret injection" | `OP_SERVICE_ACCOUNT_TOKEN` not set, `op` not installed, or the template is missing. Check the env var and that the setup script ran. |
+| `op inject` fails / auth error | Token wrong, expired, or lacks read access to `Reliable-Dev`; or `*.1password.com` not in the Custom allowlist. |
+| codex "not authenticated" | The `op://` item/field in `scripts/cloud-secrets.op.tpl` doesn't resolve to a valid key, or `api.openai.com` isn't allowlisted. |
+| `go build` fails on a language-version error | Preinstalled Go older than `go.mod`; the setup script installs Go `1.25.0` then (also allowlist `go.dev`). |
+| Setup script "cache build failed" | Must finish within ~5 min and exit 0. Check the failing installer in the build log. |

--- a/docs/CLAUDE_CODE_WEB.md
+++ b/docs/CLAUDE_CODE_WEB.md
@@ -61,39 +61,45 @@ keep it least-privilege (read-only, single vault) and rotate it.
    [`scripts/cloud-web-setup.sh`](../scripts/cloud-web-setup.sh). Runs once as root,
    cached ~7 days. Installs Terraform 1.7.5 (matches CI), tflint, gh, Go (if the
    preinstalled one is older than `go.mod`), the OpenAI `codex` CLI, and the `op` CLI.
-4. **Environment variables** (`.env` format, one per line, **no quotes**) — only the
-   bootstrap token goes here:
+4. **Environment variables** (`.env` format, one per line, **no quotes**) — two bootstrap
+   tokens only (real secrets come from 1Password at session start):
    ```
    OP_SERVICE_ACCOUNT_TOKEN=ops_...
+   GH_TOKEN=github_pat_...
    ```
+   `GH_TOKEN` is a **read-only, fine-grained** PAT scoped to `sam-at-luther/claude-config`
+   (Contents: read) — needed at session start to fetch the **private** `claude-config`
+   plugin marketplace (op-injected secrets arrive too late for plugin install).
 5. **Network access**: switch to **Custom**, keep "include default package managers"
    checked, and add:
    ```
    api.openai.com
+   api.firecrawl.dev
    *.1password.com
    ```
-   `api.openai.com` is what codex calls at runtime; `*.1password.com` covers both the
-   `op` CLI download (`downloads.1password.com`) and its runtime API. Neither is in the
-   default "Trusted" set. (If the rare Go-toolchain install path fires, also allow
-   `go.dev`.)
+   `api.openai.com` is what codex calls at runtime; `api.firecrawl.dev` is for the
+   firecrawl plugin; `*.1password.com` covers both the `op` CLI download
+   (`downloads.1password.com`) and its runtime API. None are in the default "Trusted" set.
+   (If the rare Go-toolchain install path fires, also allow `go.dev`.)
 
 ## The `.claude/settings.json` change
 
-This enables the `codex` plugin and wires the SessionStart hook for **everyone** who opens
-this repo in Claude Code (local and cloud). Add these keys alongside the existing
-`permissions` block:
+This enables the plugins and wires the SessionStart hook for **everyone** who opens this
+repo in Claude Code (local and cloud). Add these keys alongside the existing `permissions`
+block:
 
 ```jsonc
 {
   "permissions": { /* unchanged */ },
 
   "extraKnownMarketplaces": {
-    "openai-codex": {
-      "source": { "source": "github", "repo": "openai/codex-plugin-cc" }
-    }
+    "openai-codex":  { "source": { "source": "github", "repo": "openai/codex-plugin-cc" } },
+    "claude-config": { "source": { "source": "github", "repo": "sam-at-luther/claude-config" } }
   },
   "enabledPlugins": {
-    "codex@openai-codex": true
+    "codex@openai-codex": true,
+    "claude-config@claude-config": true,
+    "firecrawl@claude-plugins-official": true
   },
   "hooks": {
     "SessionStart": [
@@ -106,6 +112,14 @@ this repo in Claude Code (local and cloud). Add these keys alongside the existin
   }
 }
 ```
+
+- `claude-config@claude-config` brings qa-professor + pr + golang-guidance etc. It's a
+  **private** marketplace — needs the `GH_TOKEN` above. **Unverified in cloud**: if it
+  doesn't load on the first session, fall back to committing those skills into this repo's
+  `.claude/agents` + `.claude/skills`.
+- `firecrawl@claude-plugins-official` is a bundled Anthropic marketplace, so it needs no
+  `extraKnownMarketplaces` entry. Needs `FIRECRAWL_API_KEY` (op-injected) +
+  `api.firecrawl.dev` in the allowlist.
 
 ## How it fits together at session start
 

--- a/scripts/cloud-secrets.op.tpl
+++ b/scripts/cloud-secrets.op.tpl
@@ -1,0 +1,15 @@
+# Secrets to pull from 1Password into a Claude Code on the web session.
+#
+# SAFE TO COMMIT: this file contains only `op://` references, never secret values.
+# scripts/cloud-session-start.sh resolves these via `op inject` (using the scoped
+# OP_SERVICE_ACCOUNT_TOKEN set in the cloud environment) and writes the resolved
+# KEY=value lines into the session env. The real secrets never enter the persisted
+# environment config or this repo.
+#
+# Format:  ENV_VAR=op://<vault>/<item>/<field>
+# Add a line per secret you need in the sandbox. Vault is `Reliable-Dev` (see the
+# project's .env.*.example files for the reference convention).
+
+# Used by the OpenAI codex CLI / codex plugin. Create this item in 1Password
+# (vault Reliable-Dev) and adjust the item/field name to match what you store.
+OPENAI_API_KEY=op://Reliable-Dev/openai-api-key/credential

--- a/scripts/cloud-secrets.op.tpl
+++ b/scripts/cloud-secrets.op.tpl
@@ -10,7 +10,7 @@
 # Add a line per secret you need in the sandbox. Vault is `Reliable-Dev` (see the
 # project's .env.*.example files for the reference convention).
 
-# Used by the codex CLI/plugin and the firecrawl CLI/plugin. Create these items in
-# 1Password (vault Reliable-Dev) and adjust the item/field names to match what you store.
-OPENAI_API_KEY=op://Reliable-Dev/openai-api-key/credential
-FIRECRAWL_API_KEY=op://Reliable-Dev/firecrawl/api_key
+# Items live in 1Password vault Reliable-Dev. `openai` already exists; create `firecrawl`.
+# (If the OpenAI key lives in the item's `api_key` field rather than `credential`, swap it.)
+OPENAI_API_KEY=op://Reliable-Dev/openai/credential
+FIRECRAWL_API_KEY=op://Reliable-Dev/firecrawl/credential

--- a/scripts/cloud-secrets.op.tpl
+++ b/scripts/cloud-secrets.op.tpl
@@ -1,16 +1,14 @@
-# Secrets to pull from 1Password into a Claude Code on the web session.
+# Cloud-only secrets for a Claude Code on the web session, pulled from 1Password.
 #
-# SAFE TO COMMIT: this file contains only `op://` references, never secret values.
-# scripts/cloud-session-start.sh resolves these via `op inject` (using the scoped
-# OP_SERVICE_ACCOUNT_TOKEN set in the cloud environment) and writes the resolved
-# KEY=value lines into the session env. The real secrets never enter the persisted
-# environment config or this repo.
+# SAFE TO COMMIT: only 1Password secret references, never secret values.
+# scripts/cloud-session-start.sh resolves these with the op CLI (using the scoped
+# OP_SERVICE_ACCOUNT_TOKEN) into the session env. Real secret values never enter the
+# persisted environment config or this repo.
 #
-# Format:  ENV_VAR=op://<vault>/<item>/<field>
-# Add a line per secret you need in the sandbox. Vault is `Reliable-Dev` (see the
-# project's .env.*.example files for the reference convention).
-
-# Items live in 1Password vault Reliable-Dev. `openai` already exists; create `firecrawl`.
-# (If the OpenAI key lives in the item's `api_key` field rather than `credential`, swap it.)
-OPENAI_API_KEY=op://Reliable-Dev/openai/credential
+# NOTE: keep this file free of stray "op:" tokens in comments -- op inject does raw
+# text substitution and treats any such token as a (malformed) reference.
+#
+# Used by the codex CLI/plugin and the firecrawl CLI/plugin.
+# Items live in 1Password vault Reliable-Dev (openai + firecrawl).
+OPENAI_API_KEY=op://Reliable-Dev/openai/api_key
 FIRECRAWL_API_KEY=op://Reliable-Dev/firecrawl/credential

--- a/scripts/cloud-secrets.op.tpl
+++ b/scripts/cloud-secrets.op.tpl
@@ -10,6 +10,7 @@
 # Add a line per secret you need in the sandbox. Vault is `Reliable-Dev` (see the
 # project's .env.*.example files for the reference convention).
 
-# Used by the OpenAI codex CLI / codex plugin. Create this item in 1Password
-# (vault Reliable-Dev) and adjust the item/field name to match what you store.
+# Used by the codex CLI/plugin and the firecrawl CLI/plugin. Create these items in
+# 1Password (vault Reliable-Dev) and adjust the item/field names to match what you store.
 OPENAI_API_KEY=op://Reliable-Dev/openai-api-key/credential
+FIRECRAWL_API_KEY=op://Reliable-Dev/firecrawl/api_key

--- a/scripts/cloud-session-start.sh
+++ b/scripts/cloud-session-start.sh
@@ -3,43 +3,49 @@
 # SessionStart hook for Claude Code (wired in .claude/settings.json).
 #
 # Runs on EVERY session -- local AND Claude Code on the web -- AFTER Claude launches,
-# with the repository already cloned. Unlike the cached setup script, this repeats each
-# session, so keep it light. Cloud-only behaviour is gated on CLAUDE_CODE_REMOTE so it
-# never touches a local developer's machine.
+# with the repository cloned. Kept light (it repeats each session, unlike the cached
+# setup script). Cloud-only work is gated on CLAUDE_CODE_REMOTE so a developer's local
+# machine is never touched. This script is committed identically in `reliable` and
+# `insideout-terraform-presets`; behaviour adapts to which files the repo actually has.
 #
 set -uo pipefail
 
-# Pre-warm the Go module cache so the first `go build` / `go test -race ./...` is fast.
-# Fresh cloud VM has no module cache; locally this is a no-op. Non-fatal.
-if command -v go >/dev/null 2>&1; then
-  go mod download || true
+ROOT="${CLAUDE_PROJECT_DIR:-.}"
+
+# Pre-warm Go modules so the first build/test is fast. Cheap locally; useful on a fresh
+# cloud VM. Non-fatal.
+if [ -f "$ROOT/go.mod" ] && command -v go >/dev/null 2>&1; then
+  ( cd "$ROOT" && go mod download ) || true
 fi
 
-# --- Cloud-only: pull secrets from 1Password into the session env -----------------
-# The cloud environment holds ONLY a scoped 1Password service-account token
-# (OP_SERVICE_ACCOUNT_TOKEN, set in the web UI env-vars field). Real secrets live in
-# 1Password and are resolved here at runtime. `.claude/cloud-secrets.env.tpl` lists
-# which vars to pull as `op://` references (no secrets committed). `op inject` resolves
-# them; writing to $CLAUDE_ENV_FILE exposes them to subsequent tool calls (e.g. the
-# codex plugin), so the values never enter the persisted environment config.
+# --- Cloud-only -------------------------------------------------------------------
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
-  tpl="${CLAUDE_PROJECT_DIR:-.}/scripts/cloud-secrets.op.tpl"
-  if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && command -v op >/dev/null 2>&1 && [ -f "$tpl" ]; then
-    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-      # Resolve op:// refs to KEY=value lines and append to the session env file.
-      if op inject -i "$tpl" >> "$CLAUDE_ENV_FILE" 2>/tmp/op-inject.err; then
-        echo "[cloud-session-start] injected secrets from 1Password into session env"
+  # Secrets: the environment holds only a scoped 1Password service-account token
+  # (OP_SERVICE_ACCOUNT_TOKEN). Resolve real secrets at runtime from the repo's
+  # `op://` sources and write them to $CLAUDE_ENV_FILE so subsequent tool calls (incl.
+  # the codex plugin) see them. Values never enter the persisted environment config.
+  #   - .env.local.example: reliable's canonical dev env (all Reliable-Dev refs)
+  #   - scripts/cloud-secrets.op.tpl: cloud-only extras (e.g. codex's OPENAI_API_KEY)
+  if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && command -v op >/dev/null 2>&1 && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    for src in "$ROOT/.env.local.example" "$ROOT/scripts/cloud-secrets.op.tpl"; do
+      [ -f "$src" ] || continue
+      if op inject -i "$src" >> "$CLAUDE_ENV_FILE" 2>/tmp/op-inject.err; then
+        echo "[cloud-session-start] injected secrets from $(basename "$src")"
       else
-        echo "[cloud-session-start] WARNING: op inject failed: $(cat /tmp/op-inject.err 2>/dev/null)" >&2
+        echo "[cloud-session-start] WARNING: op inject failed for $(basename "$src"): $(cat /tmp/op-inject.err 2>/dev/null)" >&2
       fi
-    fi
+    done
   else
-    echo "[cloud-session-start] skipping secret injection (need OP_SERVICE_ACCOUNT_TOKEN, the op CLI, and $tpl)" >&2
+    echo "[cloud-session-start] skipping secret injection (need OP_SERVICE_ACCOUNT_TOKEN + op CLI + CLAUDE_ENV_FILE)" >&2
   fi
 
-  # Force the codex CLI to use API-key auth (it reads OPENAI_API_KEY, now injected
-  # above). The headless sandbox has no interactive `codex login` / ~/.codex/auth.json.
-  # Never written locally, so a developer's existing codex login is untouched.
+  # Pull Git LFS objects (reliable's go tests read an LFS-tracked tokenizer model).
+  if command -v git-lfs >/dev/null 2>&1 && [ -f "$ROOT/.gitattributes" ] && grep -q 'filter=lfs' "$ROOT/.gitattributes" 2>/dev/null; then
+    ( cd "$ROOT" && git lfs pull ) || echo "[cloud-session-start] WARNING: git lfs pull failed" >&2
+  fi
+
+  # Force codex to API-key auth (it reads the injected OPENAI_API_KEY). The headless
+  # sandbox has no interactive `codex login` / ~/.codex/auth.json. Never written locally.
   mkdir -p "${HOME}/.codex"
   if ! grep -q '^preferred_auth_method' "${HOME}/.codex/config.toml" 2>/dev/null; then
     printf 'preferred_auth_method = "apikey"\n' >> "${HOME}/.codex/config.toml"

--- a/scripts/cloud-session-start.sh
+++ b/scripts/cloud-session-start.sh
@@ -10,17 +10,36 @@
 set -uo pipefail
 
 # Pre-warm the Go module cache so the first `go build` / `go test -race ./...` is fast.
-# A fresh cloud VM has no module cache; locally this is a no-op. Non-fatal.
+# Fresh cloud VM has no module cache; locally this is a no-op. Non-fatal.
 if command -v go >/dev/null 2>&1; then
   go mod download || true
 fi
 
+# --- Cloud-only: pull secrets from 1Password into the session env -----------------
+# The cloud environment holds ONLY a scoped 1Password service-account token
+# (OP_SERVICE_ACCOUNT_TOKEN, set in the web UI env-vars field). Real secrets live in
+# 1Password and are resolved here at runtime. `.claude/cloud-secrets.env.tpl` lists
+# which vars to pull as `op://` references (no secrets committed). `op inject` resolves
+# them; writing to $CLAUDE_ENV_FILE exposes them to subsequent tool calls (e.g. the
+# codex plugin), so the values never enter the persisted environment config.
 if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
-  # Cloud only: force the codex CLI to use API-key auth. The sandbox is headless, so
-  # there is no interactive `codex login` and no ~/.codex/auth.json; codex picks up the
-  # OPENAI_API_KEY env var (set in the environment's "Environment variables" field).
-  # Writing preferred_auth_method makes that choice explicit/defensive. We never write
-  # this locally, so a developer's existing `codex login` is untouched.
+  tpl="${CLAUDE_PROJECT_DIR:-.}/scripts/cloud-secrets.op.tpl"
+  if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && command -v op >/dev/null 2>&1 && [ -f "$tpl" ]; then
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+      # Resolve op:// refs to KEY=value lines and append to the session env file.
+      if op inject -i "$tpl" >> "$CLAUDE_ENV_FILE" 2>/tmp/op-inject.err; then
+        echo "[cloud-session-start] injected secrets from 1Password into session env"
+      else
+        echo "[cloud-session-start] WARNING: op inject failed: $(cat /tmp/op-inject.err 2>/dev/null)" >&2
+      fi
+    fi
+  else
+    echo "[cloud-session-start] skipping secret injection (need OP_SERVICE_ACCOUNT_TOKEN, the op CLI, and $tpl)" >&2
+  fi
+
+  # Force the codex CLI to use API-key auth (it reads OPENAI_API_KEY, now injected
+  # above). The headless sandbox has no interactive `codex login` / ~/.codex/auth.json.
+  # Never written locally, so a developer's existing codex login is untouched.
   mkdir -p "${HOME}/.codex"
   if ! grep -q '^preferred_auth_method' "${HOME}/.codex/config.toml" 2>/dev/null; then
     printf 'preferred_auth_method = "apikey"\n' >> "${HOME}/.codex/config.toml"

--- a/scripts/cloud-session-start.sh
+++ b/scripts/cloud-session-start.sh
@@ -29,7 +29,10 @@ if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
   if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && command -v op >/dev/null 2>&1 && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
     for src in "$ROOT/.env.local.example" "$ROOT/scripts/cloud-secrets.op.tpl"; do
       [ -f "$src" ] || continue
-      if op inject -i "$src" >> "$CLAUDE_ENV_FILE" 2>/tmp/op-inject.err; then
+      # Strip comment lines first: op inject does raw text substitution and aborts the
+      # whole file if it sees any "op:" token in a comment (e.g. .env.local.example's
+      # explanatory comments). Comments carry no env vars, so dropping them is safe.
+      if grep -vE '^[[:space:]]*#' "$src" | op inject >> "$CLAUDE_ENV_FILE" 2>/tmp/op-inject.err; then
         echo "[cloud-session-start] injected secrets from $(basename "$src")"
       else
         echo "[cloud-session-start] WARNING: op inject failed for $(basename "$src"): $(cat /tmp/op-inject.err 2>/dev/null)" >&2

--- a/scripts/cloud-web-setup.sh
+++ b/scripts/cloud-web-setup.sh
@@ -47,10 +47,10 @@ install_golangci() {
 }
 
 install_npm_clis() {
-  # codex backs the Claude Code `codex` plugin; vercel for reliable's vercel-* targets.
-  # node/npm are preinstalled.
-  log "installing global npm CLIs: @openai/codex, vercel"
-  npm install -g @openai/codex vercel
+  # codex backs the `codex` plugin; firecrawl-cli backs the `firecrawl` plugin; vercel
+  # for reliable's vercel-* targets. node/npm are preinstalled.
+  log "installing global npm CLIs: @openai/codex, firecrawl-cli, vercel"
+  npm install -g @openai/codex firecrawl-cli vercel
   codex --version
   vercel --version
 }

--- a/scripts/cloud-web-setup.sh
+++ b/scripts/cloud-web-setup.sh
@@ -1,30 +1,28 @@
 #!/usr/bin/env bash
 #
-# Claude Code on the web -- environment "Setup script" for insideout-terraform-presets.
+# Claude Code on the web -- SHARED environment "Setup script".
 #
-# HOW TO USE: copy the FULL contents of this file into the "Setup script" field of
-# your Claude Code on the web environment:
-#     claude.ai/code -> New session -> click the cloud icon (environment name)
-#     -> Add environment (or the gear to edit) -> "Setup script".
+# This is the union of the system tools needed by both `reliable` and
+# `insideout-terraform-presets`, so a single Claude Code on the web environment can be
+# reused across both repos. This file is committed IDENTICALLY in both repos; copy the
+# full contents into the "Setup script" field of the shared environment:
+#     claude.ai/code -> New session -> cloud icon -> Add/Edit environment -> Setup script.
 #
-# It runs ONCE as root on a fresh Ubuntu 24.04 VM and its filesystem output is
-# CACHED (~7-day expiry), so it only re-runs when you edit it. Keep it to
-# repo-independent system tools only -- the repo is NOT reliably present here.
-# Repo-specific warmup + secret fetching live in scripts/cloud-session-start.sh,
-# wired as a SessionStart hook in .claude/settings.json.
+# It runs ONCE as root on a fresh Ubuntu 24.04 VM and its filesystem output is CACHED
+# (~7-day expiry), so it only re-runs when you edit it. Keep it to repo-independent
+# system tools only -- the repo is NOT reliably present here. Repo-specific warmup +
+# secret fetching live in scripts/cloud-session-start.sh (a SessionStart hook).
 #
-# Secrets are NOT handled here. The only credential in the cloud environment is a
-# scoped 1Password service-account token (OP_SERVICE_ACCOUNT_TOKEN, set in the
-# environment's "Environment variables" field). The session hook uses it + the `op`
-# CLI installed below to pull real secrets at runtime. See docs/CLAUDE_CODE_WEB.md.
-#
-# Pins mirror .github/workflows/terraform-validate.yml.
+# Preinstalled in the sandbox (do NOT install): Node, Go, Docker, Postgres, Redis.
+# Secrets are NOT handled here -- the only credential in the environment is a scoped
+# 1Password service-account token (OP_SERVICE_ACCOUNT_TOKEN); see docs/CLAUDE_CODE_WEB.md.
 #
 set -euo pipefail
 
-TERRAFORM_VERSION=1.7.5   # matches CI: hashicorp/setup-terraform terraform_version
-GO_VERSION=1.25.0         # matches go.mod `go 1.25.0`
-ARCH=amd64                # cloud sandbox is x86_64
+TERRAFORM_VERSION=1.7.5     # presets CI pin (hashicorp/setup-terraform)
+GOLANGCI_VERSION=v2.6.2     # reliable CI pin (golangci-lint-action)
+GO_VERSION=1.25.0           # both repos' go.mod
+ARCH=amd64                  # cloud sandbox is x86_64
 
 log() { echo "[cloud-web-setup] $*"; }
 
@@ -32,25 +30,39 @@ install_terraform() {
   log "installing terraform ${TERRAFORM_VERSION}"
   curl -fsSL "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip" -o /tmp/terraform.zip
   unzip -o /tmp/terraform.zip -d /usr/local/bin
-  /usr/local/bin/terraform version
+  terraform version | head -1
 }
 
 install_tflint() {
   log "installing tflint (plugins fetched lazily via 'tflint --init')"
   curl -fsSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
-  tflint --version
+  tflint --version | head -1
 }
 
-install_codex() {
-  # Codex CLI backs the `codex` Claude Code plugin (enabled in .claude/settings.json).
-  # node/npm are preinstalled; a global install puts `codex` on PATH for the session user.
-  log "installing OpenAI codex CLI (@openai/codex)"
-  npm install -g @openai/codex
+install_golangci() {
+  log "installing golangci-lint ${GOLANGCI_VERSION} (reliable .golangci.yml is v2)"
+  curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
+    | sh -s -- -b /usr/local/bin "${GOLANGCI_VERSION}"
+  golangci-lint --version
+}
+
+install_npm_clis() {
+  # codex backs the Claude Code `codex` plugin; vercel for reliable's vercel-* targets.
+  # node/npm are preinstalled.
+  log "installing global npm CLIs: @openai/codex, vercel"
+  npm install -g @openai/codex vercel
   codex --version
+  vercel --version
 }
 
-# gh + the 1Password CLI both use apt, so they share ONE apt transaction (no parallel
-# dpkg lock contention). This whole function is run as a single background job.
+install_playwright_deps() {
+  # OS libraries for Playwright's chromium (root/apt). The browser BINARY is fetched
+  # per-session in the hook. Best-effort: only reliable's `make test-mock` needs it.
+  log "installing Playwright chromium OS deps (best-effort)"
+  npx --yes playwright@1.58.2 install-deps chromium || log "playwright install-deps skipped/failed (non-fatal)"
+}
+
+# gh + 1Password CLI both use apt -> ONE transaction (no parallel dpkg lock contention).
 install_apt_extras() {
   export DEBIAN_FRONTEND=noninteractive
   log "configuring gh apt repo"
@@ -83,7 +95,7 @@ install_apt_extras() {
 ensure_go() {
   if command -v go >/dev/null 2>&1; then
     have="$(go version | awk '{print $3}' | sed 's/^go//')"
-    want="${GO_VERSION%.*}"  # major.minor
+    want="${GO_VERSION%.*}"
     if [ "$(printf '%s\n%s\n' "$want" "$have" | sort -V | head -1)" = "$want" ]; then
       log "preinstalled go ${have} satisfies go.mod (>= ${want}); skipping"
       return 0
@@ -99,25 +111,32 @@ ensure_go() {
   go version
 }
 
-# Phase 1 (sync): base packages the parallel installers depend on.
-log "installing base apt packages"
+# Phase 1 (sync): base packages the parallel installers depend on. git-lfs is needed by
+# reliable's go tests (LFS-tracked tokenizer model); 'git lfs install' is system-wide here.
+log "installing base apt packages (incl. git-lfs)"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y --no-install-recommends unzip jq ca-certificates curl gnupg
+apt-get install -y --no-install-recommends unzip jq ca-certificates curl gnupg git-lfs
+git lfs install --system || true
 
 # Phase 2 (parallel): independent installers. install_apt_extras is the only apt user.
 pids=()
-install_terraform  & pids+=("$!")
-install_tflint     & pids+=("$!")
-install_codex      & pids+=("$!")
-ensure_go          & pids+=("$!")
-install_apt_extras & pids+=("$!")
+install_terraform        & pids+=("$!")
+install_tflint           & pids+=("$!")
+install_golangci         & pids+=("$!")
+install_npm_clis         & pids+=("$!")
+install_playwright_deps  & pids+=("$!")
+ensure_go                & pids+=("$!")
+install_apt_extras       & pids+=("$!")
 
 fail=0
 for pid in "${pids[@]}"; do wait "$pid" || fail=1; done
 if [ "$fail" -ne 0 ]; then
-  log "ERROR: one or more installs failed (see above); failing so the cache is not poisoned"
+  log "ERROR: a required installer failed (see above); failing so the cache is not poisoned"
   exit 1
 fi
 
-log "setup complete: $(terraform version | head -1), $(tflint --version | head -1), go $(go version | awk '{print $3}'), codex $(codex --version 2>/dev/null | head -1), op $(op --version)"
+# Docker is preinstalled but its daemon won't be running in a fresh session VM. If a task
+# needs it, start it on demand: `sudo service docker start`. Not required for the standard
+# build/lint/test flow (Postgres is reached via POSTGRES_URL).
+log "setup complete: $(terraform version | head -1), tflint $(tflint --version|head -1), $(golangci-lint --version), go $(go version|awk '{print $3}'), codex $(codex --version 2>/dev/null|head -1), vercel $(vercel --version 2>/dev/null), op $(op --version), gh $(gh --version|head -1)"

--- a/scripts/cloud-web-setup.sh
+++ b/scripts/cloud-web-setup.sh
@@ -10,10 +10,14 @@
 # It runs ONCE as root on a fresh Ubuntu 24.04 VM and its filesystem output is
 # CACHED (~7-day expiry), so it only re-runs when you edit it. Keep it to
 # repo-independent system tools only -- the repo is NOT reliably present here.
-# Repo-specific warmup (go mod download, codex auth) lives in
-# scripts/cloud-session-start.sh, wired as a SessionStart hook in .claude/settings.json.
+# Repo-specific warmup + secret fetching live in scripts/cloud-session-start.sh,
+# wired as a SessionStart hook in .claude/settings.json.
 #
-# This file is version-controlled so the pasted script and the repo stay in sync.
+# Secrets are NOT handled here. The only credential in the cloud environment is a
+# scoped 1Password service-account token (OP_SERVICE_ACCOUNT_TOKEN, set in the
+# environment's "Environment variables" field). The session hook uses it + the `op`
+# CLI installed below to pull real secrets at runtime. See docs/CLAUDE_CODE_WEB.md.
+#
 # Pins mirror .github/workflows/terraform-validate.yml.
 #
 set -euo pipefail
@@ -32,32 +36,48 @@ install_terraform() {
 }
 
 install_tflint() {
-  log "installing tflint (plugins are fetched lazily via 'tflint --init')"
+  log "installing tflint (plugins fetched lazily via 'tflint --init')"
   curl -fsSL https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
   tflint --version
 }
 
-install_gh() {
-  command -v gh >/dev/null 2>&1 && { log "gh already present"; return 0; }
-  log "installing gh CLI"
+install_codex() {
+  # Codex CLI backs the `codex` Claude Code plugin (enabled in .claude/settings.json).
+  # node/npm are preinstalled; a global install puts `codex` on PATH for the session user.
+  log "installing OpenAI codex CLI (@openai/codex)"
+  npm install -g @openai/codex
+  codex --version
+}
+
+# gh + the 1Password CLI both use apt, so they share ONE apt transaction (no parallel
+# dpkg lock contention). This whole function is run as a single background job.
+install_apt_extras() {
+  export DEBIAN_FRONTEND=noninteractive
+  log "configuring gh apt repo"
   install -m 0755 -d /etc/apt/keyrings
   curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg >/dev/null
   chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     > /etc/apt/sources.list.d/github-cli.list
-  apt-get update -y
-  apt-get install -y gh
-}
 
-install_codex() {
-  # Codex CLI backs the `codex` Claude Code plugin (enabled in .claude/settings.json).
-  # node/npm are preinstalled in the sandbox; a global install puts `codex` on PATH for
-  # the session user. AUTH is via the OPENAI_API_KEY env var you set in the environment's
-  # "Environment variables" field -- it is NOT, and must not be, committed to this repo.
-  log "installing OpenAI codex CLI (@openai/codex)"
-  npm install -g @openai/codex
-  codex --version
+  log "configuring 1Password CLI apt repo"
+  curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+    | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" \
+    > /etc/apt/sources.list.d/1password.list
+  mkdir -p /etc/debsig/policies/AC2D62742012EA22/
+  curl -fsSL https://downloads.1password.com/linux/debian/debsig/1password.pol \
+    -o /etc/debsig/policies/AC2D62742012EA22/1password.pol
+  mkdir -p /usr/share/debsig/keyrings/AC2D62742012EA22
+  curl -fsSL https://downloads.1password.com/linux/keys/1password.asc \
+    | gpg --dearmor --output /usr/share/debsig/keyrings/AC2D62742012EA22/debsig.gpg
+
+  log "installing gh + 1password-cli"
+  apt-get update -y
+  apt-get install -y gh 1password-cli
+  gh --version | head -1
+  op --version
 }
 
 ensure_go() {
@@ -68,7 +88,7 @@ ensure_go() {
       log "preinstalled go ${have} satisfies go.mod (>= ${want}); skipping"
       return 0
     fi
-    log "preinstalled go ${have} is older than ${want}; installing ${GO_VERSION}"
+    log "preinstalled go ${have} older than ${want}; installing ${GO_VERSION}"
   else
     log "go not found; installing ${GO_VERSION}"
   fi
@@ -79,20 +99,19 @@ ensure_go() {
   go version
 }
 
-# Phase 1 (sync): base packages the parallel installers depend on (unzip for
-# terraform/tflint, jq for the lint scripts).
+# Phase 1 (sync): base packages the parallel installers depend on.
 log "installing base apt packages"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
 apt-get install -y --no-install-recommends unzip jq ca-certificates curl gnupg
 
-# Phase 2 (parallel): independent installers. gh is the only apt user here.
+# Phase 2 (parallel): independent installers. install_apt_extras is the only apt user.
 pids=()
-install_terraform & pids+=("$!")
-install_tflint    & pids+=("$!")
-install_codex     & pids+=("$!")
-ensure_go         & pids+=("$!")
-install_gh        & pids+=("$!")
+install_terraform  & pids+=("$!")
+install_tflint     & pids+=("$!")
+install_codex      & pids+=("$!")
+ensure_go          & pids+=("$!")
+install_apt_extras & pids+=("$!")
 
 fail=0
 for pid in "${pids[@]}"; do wait "$pid" || fail=1; done
@@ -101,4 +120,4 @@ if [ "$fail" -ne 0 ]; then
   exit 1
 fi
 
-log "setup complete: $(terraform version | head -1), $(tflint --version | head -1), go $(go version | awk '{print $3}'), codex $(codex --version 2>/dev/null | head -1)"
+log "setup complete: $(terraform version | head -1), $(tflint --version | head -1), go $(go version | awk '{print $3}'), codex $(codex --version 2>/dev/null | head -1), op $(op --version)"


### PR DESCRIPTION
Follow-up to #811, which merged at the **first commit only** — so `main` is missing the entire 1Password approach, the union setup script, firecrawl, and the activation. This lands all of it:
- `scripts/cloud-web-setup.sh`: union setup script (terraform, tflint, golangci-lint, gh, op, codex, vercel, git-lfs, firecrawl-cli) — identical to reliable's.
- `scripts/cloud-session-start.sh`: SessionStart hook (op-inject secrets, git-lfs, codex auth).
- `scripts/cloud-secrets.op.tpl`: op:// references (openai + firecrawl) pointing at the real Reliable-Dev items.
- `.claude/settings.json`: enable codex + claude-config + firecrawl plugins + the hook.
- `docs/CLAUDE_CODE_WEB.md`: full shared-env setup.

After this, presets matches reliable. Verify on the first cloud session.