### PR TITLE
Cloud env parity: quote injected secrets + install gopls

### DIFF
--- a/scripts/cloud-session-start.sh
+++ b/scripts/cloud-session-start.sh
@@ -32,7 +32,19 @@ if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
       # Strip comment lines first: op inject does raw text substitution and aborts the
       # whole file if it sees any "op:" token in a comment (e.g. .env.local.example's
       # explanatory comments). Comments carry no env vars, so dropping them is safe.
-      if grep -vE '^[[:space:]]*#' "$src" | op inject >> "$CLAUDE_ENV_FILE" 2>/tmp/op-inject.err; then
+      if resolved=$(grep -vE '^[[:space:]]*#' "$src" | op inject 2>/tmp/op-inject.err); then
+        # $CLAUDE_ENV_FILE is shell-sourced, so SINGLE-QUOTE every value: raw values can
+        # contain &, spaces, $, etc. (e.g. POSTGRES_URL ends in ...&channel_binding=require,
+        # whose unquoted & backgrounds the assignment and drops the var). Escape embedded
+        # single quotes as '\''.
+        printf '%s\n' "$resolved" | while IFS= read -r kv; do
+          case "$kv" in
+            *=*)
+              k=${kv%%=*}; v=${kv#*=}; v=${v//\'/\'\\\'\'}
+              printf "%s='%s'\n" "$k" "$v" >> "$CLAUDE_ENV_FILE"
+              ;;
+          esac
+        done
         echo "[cloud-session-start] injected secrets from $(basename "$src")"
       else
         echo "[cloud-session-start] WARNING: op inject failed for $(basename "$src"): $(cat /tmp/op-inject.err 2>/dev/null)" >&2

--- a/scripts/cloud-web-setup.sh
+++ b/scripts/cloud-web-setup.sh
@@ -46,6 +46,15 @@ install_golangci() {
   golangci-lint --version
 }
 
+install_gopls() {
+  # Go language server for Claude Code's LSP (diagnostics, hover, go-to-def). Not part of
+  # the Go toolchain, so it must be installed separately. GOBIN puts it on /usr/local/bin
+  # (on PATH). Best-effort: a gopls hiccup shouldn't poison the whole cache.
+  log "installing gopls (Go LSP)"
+  GOBIN=/usr/local/bin go install golang.org/x/tools/gopls@latest && gopls version \
+    || log "gopls install failed (non-fatal; Go LSP unavailable)"
+}
+
 install_npm_clis() {
   # codex backs the `codex` plugin; firecrawl-cli backs the `firecrawl` plugin; vercel
   # for reliable's vercel-* targets. node/npm are preinstalled.
@@ -137,11 +146,12 @@ if [ "$fail" -ne 0 ]; then
   exit 1
 fi
 
-# Phase 3 (sequential apt): Playwright OS deps run after apt_extras so the two don't
-# contend on the dpkg lock. Best-effort (only reliable's make test-mock needs chromium).
+# Phase 3 (sequential): runs after phase 2 so it doesn't race the dpkg lock (playwright)
+# and so the Go toolchain is guaranteed present (gopls). Both best-effort.
 install_playwright_deps || true
+install_gopls
 
 # Docker is preinstalled but its daemon won't be running in a fresh session VM. If a task
 # needs it, start it on demand: `sudo service docker start`. Not required for the standard
 # build/lint/test flow (Postgres is reached via POSTGRES_URL).
-log "setup complete: terraform, tflint, golangci-lint, go, codex, firecrawl-cli, vercel, op, gh, git-lfs installed"
+log "setup complete: terraform, tflint, golangci-lint, gopls, go, codex, firecrawl-cli, vercel, op, gh, git-lfs installed"


### PR DESCRIPTION
Re-lands two follow-ups that raced past #813's merge (which landed only the setup-script fix), keeping presets' hook + setup script byte-identical to reliable's:

- **Env quoting** (`cloud-session-start.sh`): single-quote op-resolved values written to `$CLAUDE_ENV_FILE` so values with `&`/spaces survive shell-sourcing.
- **gopls** (`cloud-web-setup.sh`): install the Go language server so Claude Code's LSP works in cloud sessions. Verified in Docker (ubuntu:24.04, amd64): gopls v0.22.0 installs, exit 0.

Mirrors reliable #2117.