### PR TITLE
fix(cloud): install plugins + ChatGPT-subscription codex auth on web

### DIFF
--- a/scripts/cloud-session-start.sh
+++ b/scripts/cloud-session-start.sh
@@ -59,11 +59,106 @@ if [ "${CLAUDE_CODE_REMOTE:-}" = "true" ]; then
     ( cd "$ROOT" && git lfs pull ) || echo "[cloud-session-start] WARNING: git lfs pull failed" >&2
   fi
 
-  # Force codex to API-key auth (it reads the injected OPENAI_API_KEY). The headless
-  # sandbox has no interactive `codex login` / ~/.codex/auth.json. Never written locally.
+  # Install JS deps so the frontend just works on a fresh cloud VM. node_modules is NOT in
+  # the cached setup-script snapshot (that captures /opt + apt, not the repo tree), so every
+  # fresh session starts without it. `make dev` then runs `npx next dev`, which -- with no
+  # local install -- silently fetches a THROWAWAY Next.js into a temp dir and dies with a
+  # Turbopack "couldn't find next/package.json / workspace root" error, so :3000 serves
+  # nothing (the Go API on :3001 is unaffected). A frozen-lockfile install fixes it and also
+  # unblocks Vitest + mock-ui. This is the documented best practice: project setup like
+  # `npm install` belongs in a SessionStart hook, not the cloud setup script
+  # (https://code.claude.com/docs/en/claude-code-on-the-web#setup-scripts-vs-sessionstart-hooks).
+  # Idempotent: skip when node_modules already exists (resumed session) to avoid the reinstall
+  # cost. Non-fatal. Guarded on package-lock.json so it's a no-op in presets (this hook is
+  # committed identically in both repos).
+  if [ -f "$ROOT/package-lock.json" ] && [ ! -d "$ROOT/node_modules" ] && command -v npm >/dev/null 2>&1; then
+    echo "[cloud-session-start] npm ci (installing JS deps for make dev / vitest / mock-ui)"
+    ( cd "$ROOT" && npm ci ) || echo "[cloud-session-start] WARNING: npm ci failed; run it manually before make dev" >&2
+  fi
+
+  # Warm the Go BUILD cache in the background so the first `make dev` / `go test` compile is
+  # fast. `go mod download` (above) only fetches module *sources*; nothing is compiled, and
+  # GOCACHE (~/.cache/go-build) is NOT in the cached snapshot, so a fresh session otherwise
+  # compiles the entire dependency graph on the first build. Backgrounded + best-effort so it
+  # never delays session readiness and overlaps the user picking up the ticket; Go's build
+  # cache is concurrency-safe, so it can run alongside a user-triggered build. A blocking
+  # warm would be pointless (it'd just move the same compile cost to boot). Cloud-only.
+  if [ -f "$ROOT/go.mod" ] && command -v go >/dev/null 2>&1; then
+    echo "[cloud-session-start] warming Go build cache in background (go build ./...)"
+    ( cd "$ROOT" && go build ./... >/tmp/go-build-warm.log 2>&1 ) &
+  fi
+
+  # Postgres: the Go backend uses pgx over raw TCP, which can't egress the proxy. If
+  # POSTGRES_URL points at Neon, auto-enable the WebSocket transport (internal/pgws) by
+  # deriving wss://<host>/v2. No-op until the pgws change is merged (it only sets an env
+  # var nothing reads yet); honored once it is. Local/prod never set this, so unaffected.
+  if [ -z "${PG_WS_PROXY_URL:-}" ] && [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    pghost=$(grep -m1 '^POSTGRES_URL=' "$CLAUDE_ENV_FILE" 2>/dev/null \
+      | sed -E "s/^POSTGRES_URL='?[a-z]+:\/\/[^@]*@([^:\/?']+).*/\1/")
+    case "$pghost" in
+      *.neon.tech)
+        printf "PG_WS_PROXY_URL='wss://%s/v2'\n" "$pghost" >> "$CLAUDE_ENV_FILE"
+        echo "[cloud-session-start] Postgres: WebSocket transport via ${pghost}/v2"
+        ;;
+    esac
+  fi
+
+  # Redis: raw-TCP RESP can't egress and Upstash has no proxy-traversable RESP endpoint.
+  # Blank REDIS_URL so the app uses its in-memory bus (the correct, divergence-free
+  # behavior for a single dev VM) instead of hanging on the unreachable remote. Real
+  # cross-instance pub/sub needs RESP/TCP and is a prod-only concern; prod is unaffected.
+  if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    printf "REDIS_URL=''\nUPSTASH_REDIS_URL=''\n" >> "$CLAUDE_ENV_FILE"
+    echo "[cloud-session-start] Redis: in-memory bus (remote Upstash unreachable over the proxy)"
+  fi
+
+  # Plugin install. The marketplaces named in .claude/settings.json's extraKnownMarketplaces
+  # get cloned at launch, but `enabledPlugins` only ENABLES an already-installed plugin -- it
+  # does NOT install one. On the ephemeral cloud VM nothing ever runs the install, so
+  # installed_plugins.json stays empty and the plugins' skills/agents silently never load.
+  # Install each enabled plugin explicitly; `claude plugin install` is idempotent (no-op if
+  # already installed) and handles both local-subdir sources (codex, claude-config) and
+  # external-git sources (firecrawl). Driven off settings.json so it stays in sync with
+  # enabledPlugins. Keep this hook identical in insideout-terraform-presets.
+  SETTINGS="$ROOT/.claude/settings.json"
+  if command -v claude >/dev/null 2>&1 && [ -f "$SETTINGS" ] && command -v node >/dev/null 2>&1; then
+    node -e 'const s=require(process.argv[1]);for(const k of Object.keys(s.enabledPlugins||{}))if(s.enabledPlugins[k])console.log(k)' "$SETTINGS" 2>/dev/null \
+    | while IFS= read -r plugin; do
+        [ -n "$plugin" ] || continue
+        claude plugin install "$plugin" >/dev/null 2>&1 \
+          && echo "[cloud-session-start] plugin installed: $plugin" \
+          || echo "[cloud-session-start] WARNING: plugin install failed: $plugin" >&2
+      done
+  fi
+
+  # Codex auth = ChatGPT subscription (flat-rate), NOT the metered platform API key. The
+  # headless sandbox can't run the interactive `codex login` OAuth flow, so transplant the
+  # OAuth credential: a `codex login` run on a workstation writes ~/.codex/auth.json
+  # (auth_mode "chatgpt" + a long-lived refresh token); it is stored as a 1Password document
+  # (Reliable-Dev/codex-auth-json/auth.json) and dropped in here. Re-run `codex login` locally
+  # and re-upload when the refresh token rotates.
   mkdir -p "${HOME}/.codex"
-  if ! grep -q '^preferred_auth_method' "${HOME}/.codex/config.toml" 2>/dev/null; then
-    printf 'preferred_auth_method = "apikey"\n' >> "${HOME}/.codex/config.toml"
+  printf 'preferred_auth_method = "chatgpt"\n' > "${HOME}/.codex/config.toml"
+  if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && command -v op >/dev/null 2>&1; then
+    if op read "op://Reliable-Dev/codex-auth-json/auth.json" > "${HOME}/.codex/auth.json" 2>/tmp/codex-auth.err; then
+      chmod 600 "${HOME}/.codex/auth.json"
+      echo "[cloud-session-start] codex: installed ChatGPT-subscription auth.json"
+      # Warm codex in the background. The FIRST call on a fresh VM cold-starts: refresh the
+      # OAuth token, fetch the models list, and open a websocket to
+      # chatgpt.com/backend-api/codex/responses. That cold websocket intermittently stalls
+      # through the sandbox egress proxy (the handshake completes but response frames don't
+      # flow); priming it here -- time-boxed and best-effort -- populates the models cache and
+      # refreshes the token so the user's first real `codex review` / `codex task` is reliable
+      # (warm runs verified 3/3). Backgrounded so it never delays session readiness.
+      if command -v codex >/dev/null 2>&1; then
+        ( cd "$ROOT" && timeout 75 codex exec --skip-git-repo-check "ok" >/tmp/codex-warm.log 2>&1; \
+          echo "[cloud-session-start] codex warmup exited $?" >>/tmp/codex-warm.log ) &
+      fi
+    else
+      echo "[cloud-session-start] WARNING: codex auth.json fetch failed: $(cat /tmp/codex-auth.err 2>/dev/null)" >&2
+    fi
+  else
+    echo "[cloud-session-start] skipping codex auth (need OP_SERVICE_ACCOUNT_TOKEN + op CLI)" >&2
   fi
 fi
 

--- a/scripts/cloud-web-setup.sh
+++ b/scripts/cloud-web-setup.sh
@@ -122,10 +122,13 @@ ensure_go() {
 
 # Phase 1 (sync): base packages the parallel installers depend on. git-lfs is needed by
 # reliable's go tests (LFS-tracked tokenizer model); 'git lfs install' is system-wide here.
-log "installing base apt packages (incl. git-lfs)"
+# bubblewrap is codex's sandbox runtime -- without it on PATH codex warns on every invocation
+# and falls back to its bundled copy. Installed in this single synchronous transaction (not the
+# parallel phase) to avoid dpkg-lock contention with install_apt_extras.
+log "installing base apt packages (incl. git-lfs, bubblewrap)"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y --no-install-recommends unzip jq ca-certificates curl gnupg git-lfs
+apt-get install -y --no-install-recommends unzip jq ca-certificates curl gnupg git-lfs bubblewrap
 git lfs install --system || true
 
 # Phase 2 (parallel): non-apt installers PLUS the single apt user (install_apt_extras).
@@ -154,4 +157,4 @@ install_gopls
 # Docker is preinstalled but its daemon won't be running in a fresh session VM. If a task
 # needs it, start it on demand: `sudo service docker start`. Not required for the standard
 # build/lint/test flow (Postgres is reached via POSTGRES_URL).
-log "setup complete: terraform, tflint, golangci-lint, gopls, go, codex, firecrawl-cli, vercel, op, gh, git-lfs installed"
+log "setup complete: terraform, tflint, golangci-lint, gopls, go, codex, firecrawl-cli, vercel, op, gh, git-lfs, bubblewrap installed"


### PR DESCRIPTION
Fixes Claude Code on the web for the firecrawl and codex plugins, which worked locally but not in cloud sessions. Companion to the identical change in reliable.

## Root causes (all verified in a live web session)

- Plugins never installed. The web sandbox clones the marketplaces named in `extraKnownMarketplaces`, but `enabledPlugins` only *enables* an already-installed plugin — it does not install one. So `installed_plugins.json` stayed empty and firecrawl/codex/claude-config silently never loaded.
- Codex auth. The hook forced metered API-key mode, but `preferred_auth_method = "apikey"` in `config.toml` alone does not attach the bearer — codex 401'd and hung in a websocket→HTTPS retry storm.
- bubblewrap missing. Codex warned about its sandbox runtime on every invocation.

## Changes

- `scripts/cloud-session-start.sh`
  - Run `claude plugin install` for each enabled plugin (idempotent; driven off `settings.json`).
  - Codex now uses the ChatGPT subscription (flat-rate, not metered): drop the OAuth `auth.json` from the 1Password document `Reliable-Dev/codex-auth-json` into `~/.codex` with `preferred_auth_method = "chatgpt"`, plus a background warmup.
  - Now byte-identical to reliable's hook (per the hook header), resolving the earlier drift — reliable-specific steps are guarded by file existence and no-op here.
- `scripts/cloud-web-setup.sh`
  - Install `bubblewrap` in the cached setup script.

## Verification (live web session)

- firecrawl: real scrape returned clean markdown.
- codex: full `codex exec` review on the subscription, exit 0, no 401/quota; 3/3 warm runs succeeded.
- Both scripts pass `bash -n`; the two `cloud-session-start.sh` hooks are byte-identical across repos.

## Operator note

The subscription refresh token rotates — re-run `codex login` on a workstation and re-upload `~/.codex/auth.json` to the 1Password document when it expires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bCT7WC2fWqocDtvbBqGBb

---
_Generated by [Claude Code](https://claude.ai/code/session_019bCT7WC2fWqocDtvbBqGBb)_