### PR TITLE
feat(gcp-ai): Agent Engine + GPU support + Vertex serving (#769, #752, #768)

### DIFF
--- a/gcp/agent_engine/main.tf
+++ b/gcp/agent_engine/main.tf
@@ -110,8 +110,18 @@ resource "google_vertex_ai_reasoning_engine" "this" {
     # startswith — the missing-artifact case is already reported by the
     # precondition above, and Terraform evaluates every precondition.
     precondition {
-      condition = var.staging_bucket == null || var.package_artifact_uri == null || (
-        startswith(var.package_artifact_uri, "${trimsuffix(var.staging_bucket, "/")}/")
+      # Ternary, not `||`: Terraform does NOT short-circuit `||`, so a
+      # `var.staging_bucket == null || ... trimsuffix(var.staging_bucket, ...)`
+      # form still evaluates trimsuffix on a null bucket and errors with
+      # "argument must not be null" (the defaults_compose_engine case, where
+      # the bucket is unwired). Nesting ternaries guards trimsuffix behind the
+      # null checks so it only runs when both inputs are non-null.
+      condition = (
+        var.staging_bucket == null ? true : (
+          var.package_artifact_uri == null ? true : (
+            startswith(var.package_artifact_uri, "${trimsuffix(var.staging_bucket, "/")}/")
+          )
+        )
       )
       error_message = "package_artifact_uri must live under staging_bucket. Got artifact=\"${coalesce(var.package_artifact_uri, "<null>")}\" staging_bucket=\"${coalesce(var.staging_bucket, "<null>")}\". Stage the packaged object inside the wired bucket, or clear staging_bucket to use an absolute artifact URI."
     }

--- a/gcp/agent_engine/main.tf
+++ b/gcp/agent_engine/main.tf
@@ -1,0 +1,119 @@
+# GCP Vertex AI Agent Engine (Reasoning Engine) — issue #769.
+#
+# The managed runtime for ADK / custom agents on Vertex AI. GCP counterpart of
+# aws_bedrock_agent (#762). A single google_vertex_ai_reasoning_engine is the
+# whole preset surface — there is no separate alias / action-group machinery as
+# on Bedrock; the deployable unit is the engine + its packaged artifact spec.
+#
+# Packaged artifact is app-layer (the "Gotcha" in #769):
+#   The engine runs a packaged Python object (a pickled agent) that the
+#   application build stages into a GCS bucket — typically the wired staging
+#   bucket — as `spec.package_spec.pickle_object_gcs_uri`. This preset does NOT
+#   build or upload that artifact; it only VALIDATES that the reference is
+#   present. The provider marks pickle_object_gcs_uri as OPTIONAL (a source-code
+#   / container deploy is the alternative), so a bare engine with no artifact
+#   would plan clean and then fail opaquely at apply / first-invocation. The
+#   preset closes that hole with a fail-loud precondition: package_artifact_uri
+#   MUST be a gs:// URI, surfaced at plan time rather than as a runtime 400.
+#
+# Networking: PUBLIC by default. The Reasoning Engine reaches private resources
+# only via a PSC-Interface network attachment (spec.deployment_spec.
+# psc_interface_config) that gcp/vpc does not provision today — so, like
+# gcp/vertex_ai's private endpoint, that path is deliberately out of scope here
+# and the default composed engine is public. No VPC is a hard dependency.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      # google_vertex_ai_reasoning_engine landed in the hashicorp/google
+      # provider at v7.6.0 (verified absent in 7.5.0, present in 7.6.0). The
+      # composed root provider pin is supplied by the caller / composer; this
+      # floor documents the minimum the resource type requires.
+      version = ">= 7.6"
+    }
+  }
+}
+
+locals {
+  # Default the engine's display name to the stack prefix so a bare compose
+  # still produces a uniquely-named, attributable engine. var.display_name
+  # overrides for a human-friendly label.
+  engine_display_name = var.display_name == null ? "${var.project}-agent-engine" : var.display_name
+}
+
+# The Reasoning Engine. Unconditional (no count / for_each gate) so the preset
+# always produces plan-time infrastructure — TestEveryPresetHasUnconditional
+# Resource and the all-gated-preset guard (#253) both require this.
+resource "google_vertex_ai_reasoning_engine" "this" {
+  project      = var.project_id
+  region       = var.region
+  display_name = local.engine_display_name
+  description  = "InsideOut Vertex AI Agent Engine for ${var.project}."
+
+  spec {
+    # The packaged agent artifact (app-layer). pickle_object_gcs_uri is the
+    # pickled Python object; requirements / dependency files are optional
+    # companions. The preset only wires the references through — it never
+    # builds them.
+    package_spec {
+      pickle_object_gcs_uri    = var.package_artifact_uri
+      requirements_gcs_uri     = var.requirements_uri
+      dependency_files_gcs_uri = var.dependency_files_uri
+      python_version           = var.python_version
+    }
+  }
+
+  # CMEK: encrypt the engine and all its sub-resources with a caller-supplied
+  # Cloud KMS key when set. Null disables CMEK (Google-managed encryption).
+  dynamic "encryption_spec" {
+    for_each = var.encryption_kms_key_name == null ? [] : [var.encryption_kms_key_name]
+    content {
+      kms_key_name = encryption_spec.value
+    }
+  }
+
+  # google_vertex_ai_reasoning_engine is not yet in this repo's typed import
+  # registry (it requires google provider 7.6+; the schema/codegen pin is
+  # 6.10), so it is intentionally absent from the LABEL_CAPABLE_GCP lint
+  # allowlists. Setting labels here is still correct and propagates the Project
+  # identity to the inspector; name-prefix scoping (display_name carries
+  # var.project) is the attribution path the labelless-name-prefix lint checks.
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+
+  lifecycle {
+    # Fail-loud guard: the engine needs a packaged artifact to be useful, but
+    # the provider leaves pickle_object_gcs_uri optional (source-code/container
+    # deploys are the alternative this preset does not surface). Without this
+    # precondition a missing artifact plans clean and then fails opaquely at
+    # apply / first invocation. A per-variable validation can only see its own
+    # variable; this lives on the resource so the failure is attributed to the
+    # engine that needs it.
+    precondition {
+      condition     = var.package_artifact_uri != null && can(regex("^gs://", var.package_artifact_uri))
+      error_message = "package_artifact_uri must be a gs:// URI pointing at the packaged agent object (e.g. gs://<staging-bucket>/agent_engine/agent.pkl). The artifact is built and uploaded by the application layer; this preset only validates the reference."
+    }
+
+    # Cross-variable invariant: when both the staging bucket and the artifact
+    # URI are wired, the artifact must live UNDER that bucket. Catches a stale
+    # / mismatched artifact URI pointing at a different bucket than the one the
+    # stack provisions. Skipped when staging_bucket is null (standalone preview
+    # with a caller-supplied absolute artifact URI). The package_artifact_uri
+    # null-guard keeps this precondition from erroring on a null argument to
+    # startswith — the missing-artifact case is already reported by the
+    # precondition above, and Terraform evaluates every precondition.
+    precondition {
+      condition = var.staging_bucket == null || var.package_artifact_uri == null || (
+        startswith(var.package_artifact_uri, "${trimsuffix(var.staging_bucket, "/")}/")
+      )
+      error_message = "package_artifact_uri must live under staging_bucket. Got artifact=\"${coalesce(var.package_artifact_uri, "<null>")}\" staging_bucket=\"${coalesce(var.staging_bucket, "<null>")}\". Stage the packaged object inside the wired bucket, or clear staging_bucket to use an absolute artifact URI."
+    }
+  }
+}

--- a/gcp/agent_engine/observability.tf
+++ b/gcp/agent_engine/observability.tf
@@ -1,0 +1,44 @@
+# observability.tf — issue #204 / #769
+#
+# Declares the standard per-component observability wiring surface
+# (enable_observability + notification_channels + severity/threshold knobs) so
+# the contract matches the other GCP presets and any future Cloud Monitoring
+# wiring binds cleanly.
+#
+# NO alert policy is emitted yet. Vertex AI Agent Engine (Reasoning Engine) has
+# no catalog-registered Cloud Monitoring metric in this repo — emitting a
+# google_monitoring_alert_policy against an unverified metric type would page on
+# a filter that never matches (or worse, silently never fires). Per the #769
+# guard "no alarms unless catalog-registered", this stays var-only until a
+# verified Reasoning Engine serving metric is added to the catalog. The preset
+# is therefore intentionally NOT listed in PricingDependencies[gcp_cloud_
+# monitoring] (no emitter to wire), mirroring gcp/vertex_ai's dataset-only path.
+
+variable "enable_observability" {
+  description = "When true, emit per-component Cloud Monitoring alert policies (issue #204). No-op today — the Reasoning Engine has no catalog-registered metric yet."
+  type        = bool
+  default     = true
+}
+
+variable "notification_channels" {
+  description = "Cloud Monitoring notification channel names alert policies would page. Unused until a Reasoning Engine alarm is catalog-registered."
+  type        = list(string)
+  default     = []
+}
+
+variable "alarm_severity" {
+  description = "Severity tag that would be attached to alert policies."
+  type        = string
+  default     = "warning"
+
+  validation {
+    condition     = contains(["critical", "warning", "info"], var.alarm_severity)
+    error_message = "alarm_severity must be one of critical|warning|info."
+  }
+}
+
+variable "alarm_threshold_overrides" {
+  description = "Per-metric numeric threshold overrides for future alert policies."
+  type        = map(number)
+  default     = {}
+}

--- a/gcp/agent_engine/observability.tf
+++ b/gcp/agent_engine/observability.tf
@@ -14,18 +14,21 @@
 # is therefore intentionally NOT listed in PricingDependencies[gcp_cloud_
 # monitoring] (no emitter to wire), mirroring gcp/vertex_ai's dataset-only path.
 
+# tflint-ignore: terraform_unused_declarations  # contract-surface var (issue #204): no alert policy is emitted yet (the Reasoning Engine has no catalog-registered Cloud Monitoring metric in this repo — see header), so the module body does not reference it. Declared for parity with the other GCP presets' observability surface.
 variable "enable_observability" {
   description = "When true, emit per-component Cloud Monitoring alert policies (issue #204). No-op today — the Reasoning Engine has no catalog-registered metric yet."
   type        = bool
   default     = true
 }
 
+# tflint-ignore: terraform_unused_declarations  # contract-surface var (issue #204): unused until a Reasoning Engine alarm is catalog-registered and an alert policy references these channels.
 variable "notification_channels" {
   description = "Cloud Monitoring notification channel names alert policies would page. Unused until a Reasoning Engine alarm is catalog-registered."
   type        = list(string)
   default     = []
 }
 
+# tflint-ignore: terraform_unused_declarations  # contract-surface var (issue #204): the severity tag is attached to alert policies, of which none are emitted yet; the validation still guards the input shape.
 variable "alarm_severity" {
   description = "Severity tag that would be attached to alert policies."
   type        = string
@@ -37,6 +40,7 @@ variable "alarm_severity" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations  # contract-surface var (issue #204): per-metric threshold overrides for the future alert policies described in the header; unreferenced until they land.
 variable "alarm_threshold_overrides" {
   description = "Per-metric numeric threshold overrides for future alert policies."
   type        = map(number)

--- a/gcp/agent_engine/outputs.tf
+++ b/gcp/agent_engine/outputs.tf
@@ -1,0 +1,19 @@
+output "reasoning_engine_id" {
+  description = "The resource ID of the Vertex AI Reasoning Engine."
+  value       = google_vertex_ai_reasoning_engine.this.id
+}
+
+output "reasoning_engine_name" {
+  description = "The full generated resource name of the Reasoning Engine (projects/<project>/locations/<region>/reasoningEngines/<id>)."
+  value       = google_vertex_ai_reasoning_engine.this.name
+}
+
+output "reasoning_engine_display_name" {
+  description = "The display name of the Reasoning Engine."
+  value       = google_vertex_ai_reasoning_engine.this.display_name
+}
+
+output "region" {
+  description = "The region the Reasoning Engine is deployed in."
+  value       = google_vertex_ai_reasoning_engine.this.region
+}

--- a/gcp/agent_engine/tests/shape.tftest.hcl
+++ b/gcp/agent_engine/tests/shape.tftest.hcl
@@ -1,0 +1,277 @@
+mock_provider "google" {}
+
+# Issue #769 (gcp/agent_engine — Vertex AI Agent Engine / Reasoning Engine)
+# shape tests. Verifies that:
+#   - A valid artifact URI composes exactly one reasoning engine, flows the
+#     packaged-artifact spec through, defaults the display name to the project
+#     prefix, and carries the project label.
+#   - The fail-loud precondition rejects a missing / non-gs:// artifact URI at
+#     plan time (the artifact is app-layer; the preset validates the reference).
+#   - The cross-variable staging_bucket-membership precondition rejects an
+#     artifact that lives outside the wired staging bucket.
+#   - Optional knobs (requirements/dependency URIs, python_version, CMEK,
+#     display_name override) flow through, and the validations reject obvious
+#     misconfigurations at plan time.
+#
+# Reader note: a run whose resource PRECONDITION fails (e.g. the missing- or
+# outside-bucket-artifact cases) aborts the file, so any run listed AFTER it
+# reports `skip`, not `pass`. The expect_failures runs are grouped last so this
+# ordering never masks a positive-path assertion — but if you see `skip`s
+# trailing a red run, the first hard failure above is the cause to read.
+
+run "defaults_compose_engine" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent_engine/agent.pkl"
+  }
+
+  # Display name defaults to the project-prefixed form (name-prefix scoping —
+  # the labelless-name-prefix attribution path for this label-less-in-registry
+  # resource). The engine is unconditional (no count/for_each), so it is
+  # referenced directly; a clean plan IS the "exactly one composes" assertion.
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.display_name == "test-agent-engine"
+    error_message = "display_name must default to \"<project>-agent-engine\"."
+  }
+
+  # Project is pinned to the real GCP project ID (#287 project-split).
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.project == "test-project"
+    error_message = "engine must pin project = var.project_id."
+  }
+
+  # The packaged artifact URI reaches spec.package_spec.pickle_object_gcs_uri.
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.spec[0].package_spec[0].pickle_object_gcs_uri == "gs://test-bucket/agent_engine/agent.pkl"
+    error_message = "package_artifact_uri must reach spec.package_spec.pickle_object_gcs_uri."
+  }
+
+  # The project label carries var.project (inspector grouping), not project_id.
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.labels["project"] == "test"
+    error_message = "engine must carry the project = var.project label."
+  }
+
+  # CMEK off by default -> no encryption_spec block.
+  assert {
+    condition     = length(google_vertex_ai_reasoning_engine.this.encryption_spec) == 0
+    error_message = "encryption_spec must be absent when no CMEK key is supplied."
+  }
+}
+
+run "display_name_override" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent_engine/agent.pkl"
+    display_name         = "my-custom-agent"
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.display_name == "my-custom-agent"
+    error_message = "display_name override must win over the project-prefixed default."
+  }
+}
+
+run "staging_bucket_membership_ok_trailing_slash" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    # Staging bucket carries a TRAILING SLASH and the artifact lives under it.
+    # This exercises the membership precondition's trimsuffix(staging_bucket,
+    # "/") normalization specifically: without the trimsuffix the prefix would
+    # be "gs://test-bucket//" and this valid artifact would be wrongly
+    # rejected. A clean plan here is the assertion (the precondition holds);
+    # the region passthrough is asserted as a concrete membership-branch marker
+    # distinct from the URI flow-through covered in defaults_compose_engine.
+    staging_bucket       = "gs://test-bucket/"
+    package_artifact_uri = "gs://test-bucket/agent_engine/agent.pkl"
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.region == "us-central1"
+    error_message = "engine must compose (membership precondition holds) when staging_bucket has a trailing slash and the artifact lives under it."
+  }
+}
+
+run "optional_spec_fields_flow_through" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent_engine/agent.pkl"
+    requirements_uri     = "gs://test-bucket/agent_engine/requirements.txt"
+    dependency_files_uri = "gs://test-bucket/agent_engine/deps.tar.gz"
+    python_version       = "3.12"
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.spec[0].package_spec[0].requirements_gcs_uri == "gs://test-bucket/agent_engine/requirements.txt"
+    error_message = "requirements_uri must reach spec.package_spec.requirements_gcs_uri."
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.spec[0].package_spec[0].dependency_files_gcs_uri == "gs://test-bucket/agent_engine/deps.tar.gz"
+    error_message = "dependency_files_uri must reach spec.package_spec.dependency_files_gcs_uri."
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.spec[0].package_spec[0].python_version == "3.12"
+    error_message = "python_version must reach spec.package_spec.python_version."
+  }
+}
+
+run "cmek_encryption_spec_emitted" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    package_artifact_uri    = "gs://test-bucket/agent_engine/agent.pkl"
+    encryption_kms_key_name = "projects/test-project/locations/us-central1/keyRings/kr/cryptoKeys/ck"
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_reasoning_engine.this.encryption_spec) == 1
+    error_message = "encryption_spec must be emitted when a CMEK key is supplied."
+  }
+
+  assert {
+    condition     = google_vertex_ai_reasoning_engine.this.encryption_spec[0].kms_key_name == "projects/test-project/locations/us-central1/keyRings/kr/cryptoKeys/ck"
+    error_message = "CMEK key must flow through to encryption_spec.kms_key_name."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Fail-loud: the packaged-artifact reference is mandatory even though the
+# provider leaves pickle_object_gcs_uri optional.
+# -----------------------------------------------------------------------------
+
+run "rejects_missing_artifact_uri" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    # package_artifact_uri left at its null default — the resource precondition
+    # must fail loudly at plan time.
+  }
+
+  expect_failures = [google_vertex_ai_reasoning_engine.this]
+}
+
+run "rejects_non_gcs_artifact_uri" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "s3://wrong/scheme/agent.pkl"
+  }
+
+  # Variable-level validation rejects the non-gs:// scheme first.
+  expect_failures = [var.package_artifact_uri]
+}
+
+run "rejects_artifact_outside_staging_bucket" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    # Artifact in a DIFFERENT bucket than the wired staging bucket — the
+    # cross-variable membership precondition must fail.
+    staging_bucket       = "gs://stack-bucket"
+    package_artifact_uri = "gs://some-other-bucket/agent.pkl"
+  }
+
+  expect_failures = [google_vertex_ai_reasoning_engine.this]
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: variable validations reject obvious misconfigurations.
+# -----------------------------------------------------------------------------
+
+run "rejects_invalid_python_version" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+    python_version       = "2.7"
+  }
+
+  expect_failures = [var.python_version]
+}
+
+run "rejects_non_gcs_requirements_uri" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+    requirements_uri     = "https://example.com/requirements.txt"
+  }
+
+  expect_failures = [var.requirements_uri]
+}
+
+run "rejects_non_gcs_staging_bucket" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+    staging_bucket       = "test-bucket"
+  }
+
+  expect_failures = [var.staging_bucket]
+}
+
+run "rejects_empty_project" {
+  command = plan
+
+  variables {
+    project              = ""
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+  }
+
+  expect_failures = [var.project]
+}
+
+run "rejects_invalid_project_id" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "BadProjectID"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+  }
+
+  expect_failures = [var.project_id]
+}
+
+run "rejects_invalid_alarm_severity" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    package_artifact_uri = "gs://test-bucket/agent.pkl"
+    alarm_severity       = "fatal"
+  }
+
+  expect_failures = [var.alarm_severity]
+}

--- a/gcp/agent_engine/variables.tf
+++ b/gcp/agent_engine/variables.tf
@@ -1,0 +1,102 @@
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+variable "region" {
+  description = "GCP region for the Reasoning Engine (e.g. us-central1)."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "display_name" {
+  description = "Display name of the Reasoning Engine. Null defaults to \"<project>-agent-engine\" so a bare compose still produces a uniquely-named, attributable engine."
+  type        = string
+  default     = null
+}
+
+variable "package_artifact_uri" {
+  description = "GCS URI (gs://<bucket>/<path>) of the packaged agent object the engine runs — the pickled Python object built and uploaded by the APPLICATION layer (this preset never builds it). Required: a fail-loud precondition rejects a null/non-gs:// value at plan time. When staging_bucket is wired, the artifact must live under it."
+  type        = string
+  default     = null
+
+  # Shape is validated here; presence + bucket-membership are cross-variable
+  # invariants enforced by preconditions on the engine resource (a per-variable
+  # validation can only see its own variable, and "must be set" is clearer as a
+  # resource precondition that names the engine that needs it).
+  validation {
+    condition     = var.package_artifact_uri == null ? true : can(regex("^gs://", var.package_artifact_uri))
+    error_message = "package_artifact_uri must be a gs:// URI."
+  }
+}
+
+variable "staging_bucket" {
+  description = "GCS bucket URL (gs://<bucket>) the application stages the packaged artifact into. Wired from gcp/gcs.bucket_url in a full stack. Null on a standalone preview where the caller supplies an absolute package_artifact_uri. When set, package_artifact_uri must live under it (enforced by a precondition)."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.staging_bucket == null ? true : can(regex("^gs://", var.staging_bucket))
+    error_message = "staging_bucket must be a gs:// URI."
+  }
+}
+
+variable "requirements_uri" {
+  description = "Optional GCS URI (gs://<bucket>/requirements.txt) of the Python requirements file the engine installs alongside the packaged artifact. Null omits it — the engine uses only its bundled dependencies."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.requirements_uri == null ? true : can(regex("^gs://", var.requirements_uri))
+    error_message = "requirements_uri must be a gs:// URI."
+  }
+}
+
+variable "dependency_files_uri" {
+  description = "Optional GCS URI (gs://<bucket>/dependencies.tar.gz) of extra dependency files (tar.gz) the engine unpacks alongside the packaged artifact. Null omits it."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.dependency_files_uri == null ? true : can(regex("^gs://", var.dependency_files_uri))
+    error_message = "dependency_files_uri must be a gs:// URI."
+  }
+}
+
+variable "python_version" {
+  description = "Python runtime version for the packaged agent. Supported: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13. Null lets the provider default (3.10) win."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.python_version == null ? true : contains(["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"], var.python_version)
+    error_message = "python_version must be one of: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13."
+  }
+}
+
+variable "encryption_kms_key_name" {
+  description = "Fully-qualified Cloud KMS CMEK (projects/<p>/locations/<l>/keyRings/<k>/cryptoKeys/<c>) to encrypt the engine and its sub-resources. Null disables CMEK (Google-managed encryption). The key must be in the same region as the engine."
+  type        = string
+  default     = null
+}
+
+variable "labels" {
+  description = "Resource labels merged with the standard { project = var.project } identity label."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/compute/main.tf
+++ b/gcp/compute/main.tf
@@ -17,9 +17,12 @@ locals {
   # the composer machineFamily() derive; kept in lockstep by TestGCPGPUFamiliesDrift.
   _machine_family = lower(split("-", trimspace(var.machine_type))[0])
 
-  # GPUs attach via guest_accelerator ONLY on N1 machines. A2/A3/A4/G2/G4
-  # accelerator-optimized machines bundle their GPU with the machine type, so
-  # attaching a separate accelerator there is invalid and GCP rejects it.
+  # On a Compute Engine VM, GPUs attach via guest_accelerator ONLY on N1 machines.
+  # A2/A3/A4/G2/G4 accelerator-optimized machines have their GPU attached
+  # AUTOMATICALLY by the machine type, so passing a separate guest_accelerator
+  # there is invalid and GCP rejects it (verified: cloud.google.com/compute/docs/gpus
+  # — "the GPU model is automatically attached to the instance"). This is the VM
+  # rule; GKE node pools differ (they DO declare the accelerator) — see gcp/gke.
   _gpu_bundled_machine_families = ["a2", "a3", "a4", "a4x", "g2", "g4"]
   _is_n1_machine                = local._machine_family == "n1"
   _is_bundled_gpu_machine       = contains(local._gpu_bundled_machine_families, local._machine_family)
@@ -110,15 +113,15 @@ resource "google_compute_instance" "this" {
   allow_stopping_for_update = true
 
   lifecycle {
-    # GPU machine-type compatibility (#767). VALIDATE, don't mask. A GPU attaches
-    # via guest_accelerator only on N1 machines; A2/A3/A4/G2/G4 bundle their GPU
-    # with the machine type (so an explicit accelerator is invalid) and every
-    # other family takes none. Cross-variable rule lives here as a resource
-    # precondition (Terraform forbids multi-variable conditions in variable
-    # validation blocks).
+    # GPU machine-type compatibility (#767). VALIDATE, don't mask. On a VM a GPU
+    # attaches via guest_accelerator only on N1 machines; A2/A3/A4/G2/G4 attach
+    # their GPU automatically by machine type (so an explicit guest_accelerator is
+    # invalid) and every other family takes none. Cross-variable rule lives here
+    # as a resource precondition (Terraform forbids multi-variable conditions in
+    # variable validation blocks).
     precondition {
       condition     = !local._gpu_enabled || (local._is_n1_machine && !local._is_bundled_gpu_machine)
-      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GCP attaches GPUs via guest_accelerator only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type — use that machine type alone with no gpu_type."
+      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GCP attaches GPUs via guest_accelerator only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines attach their GPU automatically by the machine type — use that machine type alone with no gpu_type."
     }
   }
 }

--- a/gcp/compute/main.tf
+++ b/gcp/compute/main.tf
@@ -9,6 +9,25 @@ resource "random_id" "suffix" {
 
 locals {
   instance_name = "${var.project}-${var.instance_name}-${random_id.suffix.hex}"
+
+  # GPU attachment (#767). A non-empty gpu_type requests an attached GPU.
+  _gpu_enabled = trimspace(var.gpu_type) != ""
+
+  # Machine family = the part before the first "-" (n1-standard-4 -> n1). Mirrors
+  # the composer machineFamily() derive; kept in lockstep by TestGCPGPUFamiliesDrift.
+  _machine_family = lower(split("-", trimspace(var.machine_type))[0])
+
+  # GPUs attach via guest_accelerator ONLY on N1 machines. A2/A3/A4/G2/G4
+  # accelerator-optimized machines bundle their GPU with the machine type, so
+  # attaching a separate accelerator there is invalid and GCP rejects it.
+  _gpu_bundled_machine_families = ["a2", "a3", "a4", "a4x", "g2", "g4"]
+  _is_n1_machine                = local._machine_family == "n1"
+  _is_bundled_gpu_machine       = contains(local._gpu_bundled_machine_families, local._machine_family)
+
+  # GCP rejects live migration for any GPU-bearing instance, so a GPU instance
+  # MUST terminate on host maintenance. Force it by construction (validate-don't-
+  # mask): the preset never lets MIGRATE coexist with a GPU.
+  _on_host_maintenance = local._gpu_enabled ? "TERMINATE" : (var.preemptible ? "TERMINATE" : "MIGRATE")
 }
 
 data "google_compute_image" "this" {
@@ -45,7 +64,17 @@ resource "google_compute_instance" "this" {
   scheduling {
     preemptible         = var.preemptible
     automatic_restart   = !var.preemptible
-    on_host_maintenance = var.preemptible ? "TERMINATE" : "MIGRATE"
+    on_host_maintenance = local._on_host_maintenance
+  }
+
+  # GPU attachment (#767). Only emitted when gpu_type is set. on_host_maintenance
+  # is forced to TERMINATE above when this block is present.
+  dynamic "guest_accelerator" {
+    for_each = local._gpu_enabled ? [1] : []
+    content {
+      type  = var.gpu_type
+      count = var.gpu_count > 0 ? var.gpu_count : 1
+    }
   }
 
   service_account {
@@ -79,5 +108,18 @@ resource "google_compute_instance" "this" {
   }
 
   allow_stopping_for_update = true
+
+  lifecycle {
+    # GPU machine-type compatibility (#767). VALIDATE, don't mask. A GPU attaches
+    # via guest_accelerator only on N1 machines; A2/A3/A4/G2/G4 bundle their GPU
+    # with the machine type (so an explicit accelerator is invalid) and every
+    # other family takes none. Cross-variable rule lives here as a resource
+    # precondition (Terraform forbids multi-variable conditions in variable
+    # validation blocks).
+    precondition {
+      condition     = !local._gpu_enabled || (local._is_n1_machine && !local._is_bundled_gpu_machine)
+      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GCP attaches GPUs via guest_accelerator only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type — use that machine type alone with no gpu_type."
+    }
+  }
 }
 

--- a/gcp/compute/tests/gpu.tftest.hcl
+++ b/gcp/compute/tests/gpu.tftest.hcl
@@ -1,0 +1,124 @@
+mock_provider "google" {}
+
+# gcp/compute GPU shape tests (#767). Verifies that:
+#   - A GPU on an N1 machine attaches guest_accelerator (type + count) and
+#     forces scheduling.on_host_maintenance = "TERMINATE" (GCP rejects live
+#     migration for GPU instances).
+#   - A non-GPU instance attaches no accelerator and keeps the normal
+#     MIGRATE maintenance policy.
+#   - The machine-type precondition rejects a GPU on a non-N1 machine and on a
+#     bundled-GPU (G2/A2) machine (expect_failures on the instance resource).
+
+run "gpu_vm_on_n1_attaches_accelerator_and_terminates" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "n1-standard-4"
+    gpu_type          = "nvidia-tesla-t4"
+    gpu_count         = 2
+  }
+
+  assert {
+    condition     = length(google_compute_instance.this.guest_accelerator) == 1
+    error_message = "A GPU instance must attach exactly one guest_accelerator block."
+  }
+
+  assert {
+    condition     = google_compute_instance.this.guest_accelerator[0].type == "nvidia-tesla-t4"
+    error_message = "guest_accelerator.type must be the configured gpu_type."
+  }
+
+  assert {
+    condition     = google_compute_instance.this.guest_accelerator[0].count == 2
+    error_message = "guest_accelerator.count must be the configured gpu_count."
+  }
+
+  assert {
+    condition     = google_compute_instance.this.scheduling[0].on_host_maintenance == "TERMINATE"
+    error_message = "GPU instances must set on_host_maintenance=TERMINATE; GCP rejects live migration with a GPU attached."
+  }
+}
+
+run "gpu_count_defaults_to_one" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "n1-standard-4"
+    gpu_type          = "nvidia-tesla-t4"
+  }
+
+  assert {
+    condition     = google_compute_instance.this.guest_accelerator[0].count == 1
+    error_message = "gpu_count must default to 1 when unset (preset default)."
+  }
+}
+
+run "no_gpu_attaches_nothing_and_keeps_migrate" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "e2-medium"
+  }
+
+  assert {
+    condition     = length(google_compute_instance.this.guest_accelerator) == 0
+    error_message = "A non-GPU instance must attach no guest_accelerator block."
+  }
+
+  assert {
+    condition     = google_compute_instance.this.scheduling[0].on_host_maintenance == "MIGRATE"
+    error_message = "A non-GPU, non-preemptible instance must keep the default MIGRATE maintenance policy."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: the machine-type precondition (resource-hosted because it is a
+# cross-variable rule) rejects GPU on incompatible machine types at plan time.
+# expect_failures matches by resource address.
+# -----------------------------------------------------------------------------
+
+run "gpu_on_non_n1_machine_fails_precondition" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "e2-standard-4" # not N1 — cannot attach a GPU
+    gpu_type          = "nvidia-tesla-t4"
+  }
+
+  expect_failures = [
+    google_compute_instance.this,
+  ]
+}
+
+run "gpu_on_bundled_g2_machine_fails_precondition" {
+  command = plan
+
+  variables {
+    project           = "test"
+    project_id        = "test-project"
+    network_self_link = "projects/test/global/networks/default"
+    subnet_self_link  = "projects/test/regions/us-central1/subnetworks/default"
+    machine_type      = "g2-standard-4" # G2 bundles its L4 GPU — guest_accelerator invalid
+    gpu_type          = "nvidia-l4"
+  }
+
+  expect_failures = [
+    google_compute_instance.this,
+  ]
+}

--- a/gcp/compute/variables.tf
+++ b/gcp/compute/variables.tf
@@ -38,9 +38,26 @@ variable "instance_name" {
 }
 
 variable "machine_type" {
-  description = "Machine type (e.g., e2-medium, n2-standard-2)"
+  description = "Machine type (e.g., e2-medium, n2-standard-2). To attach a GPU via guest_accelerator, use an N1 machine (e.g. n1-standard-4); A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type and do not take a guest_accelerator."
   type        = string
   default     = "e2-medium"
+}
+
+variable "gpu_type" {
+  description = "NVIDIA accelerator type to attach via guest_accelerator (e.g. nvidia-tesla-t4). Empty = no GPU. Only N1 machines accept attached GPUs; when set, the instance is forced to on_host_maintenance=TERMINATE because GCP rejects live migration for GPU instances. GPU types are zone-constrained and quota-gated — a deploy-time operator concern."
+  type        = string
+  default     = ""
+}
+
+variable "gpu_count" {
+  description = "Number of GPUs of gpu_type to attach. Ignored unless gpu_type is set."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.gpu_count >= 0
+    error_message = "gpu_count must be >= 0."
+  }
 }
 
 variable "network_self_link" {

--- a/gcp/compute/variables.tf
+++ b/gcp/compute/variables.tf
@@ -50,13 +50,13 @@ variable "gpu_type" {
 }
 
 variable "gpu_count" {
-  description = "Number of GPUs of gpu_type to attach. Ignored unless gpu_type is set."
+  description = "Number of GPUs of gpu_type to attach. Ignored unless gpu_type is set. Valid counts are 1, 2, 4, 8, or 16 (0 = no GPU). The exact legal count is GPU-type/zone-specific (e.g. T4: 1/2/4, V100: 1/2/4/8) — a deploy-time/quota concern — but counts outside this set are always rejected by GCP."
   type        = number
   default     = 0
 
   validation {
-    condition     = var.gpu_count >= 0
-    error_message = "gpu_count must be >= 0."
+    condition     = contains([0, 1, 2, 4, 8, 16], var.gpu_count)
+    error_message = "gpu_count must be one of 0, 1, 2, 4, 8, 16."
   }
 }
 

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -5,10 +5,44 @@
 # cluster name (issue #159). GKE cluster names are limited to 40 chars.
 resource "random_id" "suffix" {
   byte_length = 4
+
+  lifecycle {
+    # GPU machine-type compatibility (#767). VALIDATE, don't mask. Hosted on the
+    # always-present suffix resource because the node pool is created inside the
+    # vendored gke module (no local resource to attach a precondition to). An
+    # accelerator attaches via the node pool accelerator config only on N1
+    # machines; A2/A3/A4/G2/G4 bundle their GPU with the machine type (so an
+    # explicit accelerator is invalid) and every other family takes none.
+    precondition {
+      condition     = !local._gpu_enabled || (local._is_n1_machine && !local._is_bundled_gpu_machine)
+      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GKE attaches accelerators via the node pool accelerator config only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type — use that machine type alone with no gpu_type."
+    }
+  }
 }
 
 locals {
   cluster_name = "${var.project}-${var.cluster_name}-${random_id.suffix.hex}"
+
+  # GPU node pool (#767). A non-empty gpu_type requests an attached accelerator.
+  _gpu_enabled = trimspace(var.gpu_type) != ""
+
+  # Machine family = the part before the first "-" (n1-standard-4 -> n1). Mirrors
+  # the composer machineFamily() derive; kept in lockstep by TestGCPGPUFamiliesDrift.
+  _machine_family = lower(split("-", trimspace(var.machine_type))[0])
+
+  # Accelerators attach to the node pool ONLY on N1 machines. A2/A3/A4/G2/G4
+  # accelerator-optimized machines bundle their GPU with the machine type.
+  _gpu_bundled_machine_families = ["a2", "a3", "a4", "a4x", "g2", "g4"]
+  _is_n1_machine                = local._machine_family == "n1"
+  _is_bundled_gpu_machine       = contains(local._gpu_bundled_machine_families, local._machine_family)
+
+  # Resolved accelerator config fed into the node pool object below. Inert (count
+  # 0, empty type/driver) when no GPU, so the module skips guest_accelerator and
+  # the auto-driver config. Surfaced via the gpu_node_pool output for assertions
+  # and downstream consumers.
+  _gpu_accelerator_count   = local._gpu_enabled ? (var.gpu_count > 0 ? var.gpu_count : 1) : 0
+  _gpu_accelerator_type    = local._gpu_enabled ? var.gpu_type : ""
+  _gpu_node_driver_version = local._gpu_enabled ? var.gpu_driver_version : ""
 }
 
 module "gke" {
@@ -73,6 +107,15 @@ module "gke" {
       enable_gvnic       = true
       image_type         = "COS_CONTAINERD"
       initial_node_count = var.node_count
+
+      # GPU accelerator (#767). The module emits guest_accelerator only when
+      # accelerator_count > 0, and gpu_driver_installation_config only when
+      # gpu_driver_version != "" — so a non-GPU pool leaves these inert.
+      # gpu_driver_version drives GKE auto NVIDIA driver install (no in-cluster
+      # device-plugin work, unlike EKS).
+      accelerator_count  = local._gpu_accelerator_count
+      accelerator_type   = local._gpu_accelerator_type
+      gpu_driver_version = local._gpu_node_driver_version
     }
   ]
 

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -7,15 +7,23 @@ resource "random_id" "suffix" {
   byte_length = 4
 
   lifecycle {
-    # GPU machine-type compatibility (#767). VALIDATE, don't mask. Hosted on the
-    # always-present suffix resource because the node pool is created inside the
-    # vendored gke module (no local resource to attach a precondition to). An
-    # accelerator attaches via the node pool accelerator config only on N1
-    # machines; A2/A3/A4/G2/G4 bundle their GPU with the machine type (so an
-    # explicit accelerator is invalid) and every other family takes none.
+    # GPU machine-type compatibility (#767, #752 review). VALIDATE, don't mask.
+    # Hosted on the always-present suffix resource because the node pool is
+    # created inside the vendored gke module (no local resource to attach a
+    # precondition to). Unlike a Compute VM, a GKE node pool DECLARES the
+    # accelerator even for the accelerator-optimized families: N1 attaches
+    # T4/V100/P100/P4, and A2/A3/A4/G2/G4 pair the machine type with its bundled
+    # accelerator (g2->nvidia-l4, a2->nvidia-tesla-a100, a3->nvidia-h100-80gb, ...).
+    # Every other family takes no GPU. Two preconditions: (1) the machine family
+    # must be GPU-capable; (2) on a bundled family the gpu_type must match the
+    # family's accelerator(s).
     precondition {
-      condition     = !local._gpu_enabled || (local._is_n1_machine && !local._is_bundled_gpu_machine)
-      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot attach a GPU: GKE attaches accelerators via the node pool accelerator config only on N1 machines (e.g. n1-standard-4). A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type — use that machine type alone with no gpu_type."
+      condition     = !local._gpu_enabled || local._is_n1_machine || local._is_bundled_gpu_machine
+      error_message = "gpu_type is set but machine_type=${var.machine_type} cannot run a GPU node pool: GKE needs an N1 machine (attaches T4/V100/P100/P4) or an accelerator-optimized machine (a2-*/a3-*/a4-*/g2-*/g4-*, whose accelerator the node pool declares). Pick one of those machine types."
+    }
+    precondition {
+      condition     = !local._gpu_enabled || !local._is_bundled_gpu_machine || contains(local._gpu_bundled_family_accelerators, lower(trimspace(var.gpu_type)))
+      error_message = "gpu_type=${var.gpu_type} does not pair with machine_type=${var.machine_type}: a GKE ${upper(local._machine_family)} node pool declares the accelerator that matches the machine family (expected one of ${join(", ", local._gpu_bundled_family_accelerators)}). Use the matching accelerator type."
     }
   }
 }
@@ -30,11 +38,25 @@ locals {
   # the composer machineFamily() derive; kept in lockstep by TestGCPGPUFamiliesDrift.
   _machine_family = lower(split("-", trimspace(var.machine_type))[0])
 
-  # Accelerators attach to the node pool ONLY on N1 machines. A2/A3/A4/G2/G4
-  # accelerator-optimized machines bundle their GPU with the machine type.
+  # Accelerator-optimized families pair the machine type with a fixed accelerator
+  # (the node pool still DECLARES it, unlike a VM). N1 attaches T4/V100/P100/P4.
   _gpu_bundled_machine_families = ["a2", "a3", "a4", "a4x", "g2", "g4"]
   _is_n1_machine                = local._machine_family == "n1"
   _is_bundled_gpu_machine       = contains(local._gpu_bundled_machine_families, local._machine_family)
+
+  # Per-family accelerator pairing for the bundled families (#752 review). Mirrors
+  # the composer gpuBundledFamilyAccelerators map; the second GPU precondition
+  # above checks gpu_type against the entry for the selected family. Empty list
+  # for a non-bundled family (the lookup default) so the precondition is inert.
+  _gpu_bundled_family_accelerator_map = {
+    a2  = ["nvidia-tesla-a100", "nvidia-a100-80gb"]
+    a3  = ["nvidia-h100-80gb", "nvidia-h100-mega-80gb", "nvidia-h200-141gb"]
+    a4  = ["nvidia-b200"]
+    a4x = ["nvidia-gb200", "nvidia-gb300"]
+    g2  = ["nvidia-l4"]
+    g4  = ["nvidia-rtx-pro-6000"]
+  }
+  _gpu_bundled_family_accelerators = lookup(local._gpu_bundled_family_accelerator_map, local._machine_family, [])
 
   # Resolved accelerator config fed into the node pool object below. Inert (count
   # 0, empty type/driver) when no GPU, so the module skips guest_accelerator and

--- a/gcp/gke/outputs.tf
+++ b/gcp/gke/outputs.tf
@@ -40,3 +40,13 @@ output "identity_namespace" {
   value       = var.enable_workload_identity ? "${var.project_id}.svc.id.goog" : null
 }
 
+output "gpu_node_pool" {
+  description = "Resolved GPU accelerator config for the default node pool (#767). enabled=false and count=0 when no GPU is attached. type/count are the guest_accelerator attached to each node; driver_version drives GKE auto NVIDIA driver install."
+  value = {
+    enabled        = local._gpu_enabled
+    type           = local._gpu_accelerator_type
+    count          = local._gpu_accelerator_count
+    driver_version = local._gpu_node_driver_version
+  }
+}
+

--- a/gcp/gke/tests/gpu.tftest.hcl
+++ b/gcp/gke/tests/gpu.tftest.hcl
@@ -232,7 +232,7 @@ run "gpu_on_bundled_g2_with_mismatched_type_fails_pairing" {
     services_range_name = "svcs"
     regional            = false
     node_zones          = ["us-central1-a"]
-    machine_type        = "g2-standard-4"  # G2 pairs with nvidia-l4 only
+    machine_type        = "g2-standard-4"     # G2 pairs with nvidia-l4 only
     gpu_type            = "nvidia-tesla-a100" # A100 is an A2 GPU — wrong pairing
   }
 

--- a/gcp/gke/tests/gpu.tftest.hcl
+++ b/gcp/gke/tests/gpu.tftest.hcl
@@ -2,15 +2,20 @@ mock_provider "google" {}
 mock_provider "kubernetes" {}
 mock_provider "random" {}
 
-# gcp/gke GPU node-pool shape tests (#767). Verifies that:
+# gcp/gke GPU node-pool shape tests (#767, #752 review). Verifies that:
 #   - A GPU on an N1 machine resolves the node-pool accelerator config (type +
 #     count + auto-driver version) that the vendored gke module wires into
 #     guest_accelerator { ... gpu_driver_installation_config { ... } }.
+#   - A GPU on an accelerator-optimized family (G2->nvidia-l4, A3->nvidia-h100)
+#     ALSO resolves the accelerator config: unlike a Compute VM, a GKE node pool
+#     DECLARES the accelerator paired with the machine type. This is the #752
+#     review fix — the bundled families are valid on GKE, not rejected.
 #   - A non-GPU node pool resolves an inert accelerator config (count 0, no
 #     driver) so the module emits no guest_accelerator block.
-#   - The machine-type precondition (hosted on random_id.suffix because the node
-#     pool lives inside the module) rejects a GPU on a non-N1 machine and on a
-#     bundled-GPU (A3) machine (expect_failures on random_id.suffix).
+#   - The machine-family precondition (hosted on random_id.suffix because the node
+#     pool lives inside the module) rejects a GPU on a family that takes none
+#     (e.g. N2), and the pairing precondition rejects a bundled family paired with
+#     the wrong GPU type (expect_failures on random_id.suffix).
 #
 # Assertions read the gpu_node_pool output: the gke module's node-pool resources
 # are not directly addressable from tftest (only module outputs are), so the
@@ -82,6 +87,72 @@ run "gpu_count_defaults_to_one_and_driver_override" {
   }
 }
 
+run "gpu_nodepool_on_g2_resolves_bundled_l4_accelerator" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "g2-standard-4" # G2 pairs with nvidia-l4 — VALID on GKE
+    gpu_type            = "nvidia-l4"
+    gpu_count           = 1
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.enabled == true
+    error_message = "A G2 GPU node pool must report enabled=true — GKE declares the bundled accelerator."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.type == "nvidia-l4"
+    error_message = "G2 node-pool accelerator type must be nvidia-l4."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 1
+    error_message = "G2 node-pool accelerator count must be the configured gpu_count."
+  }
+}
+
+run "gpu_nodepool_on_a3_resolves_bundled_h100_accelerator" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "a3-highgpu-8g" # A3 pairs with nvidia-h100-80gb — VALID on GKE
+    gpu_type            = "nvidia-h100-80gb"
+    gpu_count           = 8
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.enabled == true
+    error_message = "An A3 GPU node pool must report enabled=true — GKE declares the bundled accelerator."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.type == "nvidia-h100-80gb"
+    error_message = "A3 node-pool accelerator type must be nvidia-h100-80gb."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 8
+    error_message = "A3 node-pool accelerator count must be the configured gpu_count."
+  }
+}
+
 run "no_gpu_resolves_inert_accelerator_config" {
   command = plan
 
@@ -114,16 +185,21 @@ run "no_gpu_resolves_inert_accelerator_config" {
 }
 
 # -----------------------------------------------------------------------------
-# Negative cases: the machine-type precondition (hosted on random_id.suffix)
-# rejects GPU on incompatible machine types at plan time. expect_failures
-# matches by resource address.
+# Negative cases: the GPU preconditions (hosted on random_id.suffix because the
+# node pool lives inside the vendored module) reject GPU on a non-GPU machine
+# family and a bundled family paired with the wrong GPU type at plan time.
+# expect_failures matches by resource address.
 #
-# Maintainer note: random_id.suffix currently carries exactly one precondition
-# (the GPU machine-type rule). If a second precondition is added to that
-# resource, split these negative exercises so the failures don't collide.
+# Maintainer note: random_id.suffix now carries TWO GPU preconditions — the
+# machine-family rule and the bundled-family pairing rule. expect_failures
+# matches by resource address, so each case below only needs to trip ONE of
+# them; that is exactly what these exercise (the n2 case trips the family rule,
+# the g2+wrong-type case trips the pairing rule). If a NON-GPU precondition is
+# ever added to this resource, split these so an unrelated failure can't mask a
+# regression in the GPU rules.
 # -----------------------------------------------------------------------------
 
-run "gpu_on_non_n1_machine_fails_precondition" {
+run "gpu_on_non_gpu_family_fails_precondition" {
   command = plan
 
   variables {
@@ -135,7 +211,7 @@ run "gpu_on_non_n1_machine_fails_precondition" {
     services_range_name = "svcs"
     regional            = false
     node_zones          = ["us-central1-a"]
-    machine_type        = "n2-standard-4" # not N1 — cannot attach a GPU
+    machine_type        = "n2-standard-4" # neither N1 nor accelerator-optimized — no GPU
     gpu_type            = "nvidia-tesla-t4"
   }
 
@@ -144,7 +220,7 @@ run "gpu_on_non_n1_machine_fails_precondition" {
   ]
 }
 
-run "gpu_on_bundled_a3_machine_fails_precondition" {
+run "gpu_on_bundled_g2_with_mismatched_type_fails_pairing" {
   command = plan
 
   variables {
@@ -156,8 +232,8 @@ run "gpu_on_bundled_a3_machine_fails_precondition" {
     services_range_name = "svcs"
     regional            = false
     node_zones          = ["us-central1-a"]
-    machine_type        = "a3-highgpu-8g" # A3 bundles its H100 — accelerator config invalid
-    gpu_type            = "nvidia-h100-80gb"
+    machine_type        = "g2-standard-4"  # G2 pairs with nvidia-l4 only
+    gpu_type            = "nvidia-tesla-a100" # A100 is an A2 GPU — wrong pairing
   }
 
   expect_failures = [

--- a/gcp/gke/tests/gpu.tftest.hcl
+++ b/gcp/gke/tests/gpu.tftest.hcl
@@ -1,0 +1,166 @@
+mock_provider "google" {}
+mock_provider "kubernetes" {}
+mock_provider "random" {}
+
+# gcp/gke GPU node-pool shape tests (#767). Verifies that:
+#   - A GPU on an N1 machine resolves the node-pool accelerator config (type +
+#     count + auto-driver version) that the vendored gke module wires into
+#     guest_accelerator { ... gpu_driver_installation_config { ... } }.
+#   - A non-GPU node pool resolves an inert accelerator config (count 0, no
+#     driver) so the module emits no guest_accelerator block.
+#   - The machine-type precondition (hosted on random_id.suffix because the node
+#     pool lives inside the module) rejects a GPU on a non-N1 machine and on a
+#     bundled-GPU (A3) machine (expect_failures on random_id.suffix).
+#
+# Assertions read the gpu_node_pool output: the gke module's node-pool resources
+# are not directly addressable from tftest (only module outputs are), so the
+# preset surfaces the resolved accelerator config it feeds the module.
+
+run "gpu_nodepool_on_n1_resolves_accelerator_and_driver" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "n1-standard-4"
+    gpu_type            = "nvidia-tesla-t4"
+    gpu_count           = 2
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.enabled == true
+    error_message = "A GPU node pool must report enabled=true."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.type == "nvidia-tesla-t4"
+    error_message = "node-pool accelerator type must be the configured gpu_type."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 2
+    error_message = "node-pool accelerator count must be the configured gpu_count."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.driver_version == "DEFAULT"
+    error_message = "GKE auto driver install must default to DEFAULT (gpu_driver_installation_config.gpu_driver_version)."
+  }
+}
+
+run "gpu_count_defaults_to_one_and_driver_override" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "n1-standard-8"
+    gpu_type            = "nvidia-tesla-v100"
+    gpu_driver_version  = "LATEST"
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 1
+    error_message = "gpu_count must default to 1 when unset."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.driver_version == "LATEST"
+    error_message = "gpu_driver_version override (LATEST) must flow into the node-pool driver config."
+  }
+}
+
+run "no_gpu_resolves_inert_accelerator_config" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "e2-standard-4"
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.enabled == false
+    error_message = "A non-GPU node pool must report enabled=false."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.count == 0
+    error_message = "A non-GPU node pool must resolve accelerator_count=0 so the module emits no guest_accelerator."
+  }
+
+  assert {
+    condition     = output.gpu_node_pool.driver_version == ""
+    error_message = "A non-GPU node pool must resolve an empty driver_version so the module emits no gpu_driver_installation_config."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Negative cases: the machine-type precondition (hosted on random_id.suffix)
+# rejects GPU on incompatible machine types at plan time. expect_failures
+# matches by resource address.
+#
+# Maintainer note: random_id.suffix currently carries exactly one precondition
+# (the GPU machine-type rule). If a second precondition is added to that
+# resource, split these negative exercises so the failures don't collide.
+# -----------------------------------------------------------------------------
+
+run "gpu_on_non_n1_machine_fails_precondition" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "n2-standard-4" # not N1 — cannot attach a GPU
+    gpu_type            = "nvidia-tesla-t4"
+  }
+
+  expect_failures = [
+    random_id.suffix,
+  ]
+}
+
+run "gpu_on_bundled_a3_machine_fails_precondition" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    network_self_link   = "projects/test/global/networks/default"
+    subnet_self_link    = "projects/test/regions/us-central1/subnetworks/default"
+    pods_range_name     = "pods"
+    services_range_name = "svcs"
+    regional            = false
+    node_zones          = ["us-central1-a"]
+    machine_type        = "a3-highgpu-8g" # A3 bundles its H100 — accelerator config invalid
+    gpu_type            = "nvidia-h100-80gb"
+  }
+
+  expect_failures = [
+    random_id.suffix,
+  ]
+}

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -140,9 +140,37 @@ variable "max_node_count" {
 }
 
 variable "machine_type" {
-  description = "Machine type for nodes"
+  description = "Machine type for nodes. To attach a GPU via the node pool accelerator config, use an N1 machine (e.g. n1-standard-4); A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type and do not take a separate accelerator."
   type        = string
   default     = "e2-standard-4"
+}
+
+variable "gpu_type" {
+  description = "NVIDIA accelerator type to attach to the node pool (e.g. nvidia-tesla-t4). Empty = no GPU. Only N1 node machines accept attached accelerators. When set, GKE auto-installs the NVIDIA driver (gpu_driver_version=DEFAULT) — no in-cluster device-plugin work needed, unlike EKS. GPU types are zone-constrained and quota-gated — a deploy-time operator concern."
+  type        = string
+  default     = ""
+}
+
+variable "gpu_count" {
+  description = "Number of GPUs of gpu_type per node. Ignored unless gpu_type is set."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.gpu_count >= 0
+    error_message = "gpu_count must be >= 0."
+  }
+}
+
+variable "gpu_driver_version" {
+  description = "GKE GPU driver auto-install version: DEFAULT (driver for the node GKE version), LATEST, or INSTALLATION_DISABLED. Applied only when gpu_type is set."
+  type        = string
+  default     = "DEFAULT"
+
+  validation {
+    condition     = contains(["DEFAULT", "LATEST", "INSTALLATION_DISABLED"], var.gpu_driver_version)
+    error_message = "gpu_driver_version must be one of: DEFAULT, LATEST, INSTALLATION_DISABLED."
+  }
 }
 
 variable "disk_size_gb" {

--- a/gcp/gke/variables.tf
+++ b/gcp/gke/variables.tf
@@ -140,25 +140,25 @@ variable "max_node_count" {
 }
 
 variable "machine_type" {
-  description = "Machine type for nodes. To attach a GPU via the node pool accelerator config, use an N1 machine (e.g. n1-standard-4); A2/A3/A4/G2/G4 accelerator-optimized machines bundle their GPU with the machine type and do not take a separate accelerator."
+  description = "Machine type for nodes. For a GPU node pool, use an N1 machine (e.g. n1-standard-4, attaches T4/V100/P100/P4) or an accelerator-optimized machine (a2-*/a3-*/a4-*/g2-*/g4-*, whose accelerator the node pool declares — paired with the family's GPU type). Unlike a Compute VM, a GKE node pool DECLARES the accelerator even for the accelerator-optimized families."
   type        = string
   default     = "e2-standard-4"
 }
 
 variable "gpu_type" {
-  description = "NVIDIA accelerator type to attach to the node pool (e.g. nvidia-tesla-t4). Empty = no GPU. Only N1 node machines accept attached accelerators. When set, GKE auto-installs the NVIDIA driver (gpu_driver_version=DEFAULT) — no in-cluster device-plugin work needed, unlike EKS. GPU types are zone-constrained and quota-gated — a deploy-time operator concern."
+  description = "NVIDIA accelerator type the node pool declares (e.g. nvidia-tesla-t4 on N1, nvidia-l4 on g2, nvidia-tesla-a100 on a2, nvidia-h100-80gb on a3). Empty = no GPU. Must pair with the machine family. When set, GKE auto-installs the NVIDIA driver (gpu_driver_version=DEFAULT) — no in-cluster device-plugin work needed, unlike EKS. GPU types are zone-constrained and quota-gated — a deploy-time operator concern."
   type        = string
   default     = ""
 }
 
 variable "gpu_count" {
-  description = "Number of GPUs of gpu_type per node. Ignored unless gpu_type is set."
+  description = "Number of GPUs of gpu_type per node. Ignored unless gpu_type is set. Valid counts are 1, 2, 4, 8, or 16 (0 = no GPU). The exact legal count is GPU-type/zone/machine-specific (e.g. T4: 1/2/4; a2-highgpu-8g exposes 8) — a deploy-time/quota concern — but counts outside this set are always rejected by GCP."
   type        = number
   default     = 0
 
   validation {
-    condition     = var.gpu_count >= 0
-    error_message = "gpu_count must be >= 0."
+    condition     = contains([0, 1, 2, 4, 8, 16], var.gpu_count)
+    error_message = "gpu_count must be one of 0, 1, 2, 4, 8, 16."
   }
 }
 

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -81,9 +81,17 @@ locals {
   serving_endpoint_name = tostring(parseint(substr(sha256(var.project), 0, 8), 16))
 
   # The Model Garden one-shot deployment is created only when serving is on AND
-  # a model is named. A bare endpoint (no model) is the enable_serving-only
-  # path; attach a model out-of-band there.
+  # a model is named. It provisions its OWN managed endpoint (with the model
+  # deployed onto it), so the bare endpoint below is mutually exclusive with it:
+  # creating both would leave an empty bare endpoint sitting next to the real
+  # one the model lives on, and the outputs would point at the empty shell.
   model_garden_enabled = var.enable_serving && var.model_garden_model != null
+
+  # The bare serving endpoint is the enable_serving-WITHOUT-a-model path: a
+  # generic attach point for custom/other models, deployed out-of-band. When a
+  # Model Garden model IS named, that resource owns the endpoint instead, so the
+  # bare endpoint is NOT created (mutually exclusive count-gate).
+  bare_endpoint_enabled = var.enable_serving && var.model_garden_model == null
 
   # Attach dedicated accelerators only when an accelerator type is requested.
   # CPU-only serving (the default) omits the machine_spec accelerator fields so
@@ -230,26 +238,35 @@ resource "google_vertex_ai_index_endpoint_deployed_index" "this" {
 
 # --- Model serving (Endpoint + Model Garden) — issue #768 -------------------
 #
-# google_vertex_ai_endpoint:                            serving endpoint (a
+# google_vertex_ai_endpoint:                            bare serving endpoint (a
 #   managed front door for online predictions). Created when enable_serving is
-#   true. PUBLIC by default; the private-endpoint story is unchanged here (it
-#   reuses the same #774 PSC peering range the Vector Search endpoint needs and
-#   is out of scope for this issue).
+#   true AND no Model Garden model is named — the generic attach point for
+#   custom models deployed out-of-band. PUBLIC by default; the private-endpoint
+#   story is unchanged here (it reuses the same #774 PSC peering range the
+#   Vector Search endpoint needs and is out of scope for this issue).
 # google_vertex_ai_endpoint_with_model_garden_deployment: one-shot deploy of an
 #   open Model Garden model (Gemma/Llama/etc) onto its OWN managed endpoint.
 #   Created when enable_serving is true AND model_garden_model is named. The
 #   deploy is the long pole — model downloads + replica spin-up routinely take
 #   30+ minutes — so create/delete carry generous 60m timeouts.
 #
+# The two are MUTUALLY EXCLUSIVE: model_garden manages its own endpoint, so when
+# a model is named the bare endpoint is suppressed. Otherwise the bare endpoint
+# would sit empty next to the real one and the endpoint_id/endpoint_name outputs
+# would point at the empty shell (the bug fixed under #768 review). The outputs
+# return whichever endpoint actually exists.
+#
 # Resources verified against hashicorp/google v7.x (GA tier; both resources are
 # in the GA provider — see PR notes). The dataset and Vector Search resources
 # above are untouched by enable_serving.
 
-# A bare serving endpoint. Models can be deployed onto it out-of-band; the
-# Model Garden resource below provisions its own endpoint, so this one is the
-# generic attach point for custom/other models.
+# A bare serving endpoint, the generic attach point for custom/other models
+# deployed out-of-band. Created ONLY on the enable_serving-without-a-model path:
+# when a Model Garden model is named, the model_garden resource below provisions
+# its own endpoint with the model on it, so this bare one is suppressed (they are
+# mutually exclusive — see local.bare_endpoint_enabled / local.model_garden_enabled).
 resource "google_vertex_ai_endpoint" "serving" {
-  count        = var.enable_serving ? 1 : 0
+  count        = local.bare_endpoint_enabled ? 1 : 0
   name         = local.serving_endpoint_name
   display_name = "${var.project}-serving-endpoint"
   description  = "InsideOut Vertex AI serving endpoint for ${var.project}"

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -70,6 +70,25 @@ locals {
   network_canonical = local.vector_search_private ? (
     "projects/${data.google_project.this.number}/global/networks/${local.network_name}"
   ) : null
+
+  # --- Model serving (#768) -------------------------------------------------
+  # google_vertex_ai_endpoint.name must be NUMERIC, no leading zeros, <=10
+  # digits (the endpoint's resource id). Derive a deterministic number from
+  # var.project so the name is stable across applies for a given stack: parse
+  # the first 8 hex chars of sha256(project) -> an integer <= 4294967295 (10
+  # digits max). tostring renders an int without leading zeros, so the API
+  # constraint holds.
+  serving_endpoint_name = tostring(parseint(substr(sha256(var.project), 0, 8), 16))
+
+  # The Model Garden one-shot deployment is created only when serving is on AND
+  # a model is named. A bare endpoint (no model) is the enable_serving-only
+  # path; attach a model out-of-band there.
+  model_garden_enabled = var.enable_serving && var.model_garden_model != null
+
+  # Attach dedicated accelerators only when an accelerator type is requested.
+  # CPU-only serving (the default) omits the machine_spec accelerator fields so
+  # the deployment does not demand GPU quota it doesn't need.
+  serving_accelerator_enabled = var.serving_accelerator_type != null
 }
 
 # Resolves the caller's project to its numeric project number, which the
@@ -205,6 +224,98 @@ resource "google_vertex_ai_index_endpoint_deployed_index" "this" {
     precondition {
       condition     = var.deployed_index_max_replicas >= var.deployed_index_min_replicas
       error_message = "deployed_index_max_replicas must be >= deployed_index_min_replicas."
+    }
+  }
+}
+
+# --- Model serving (Endpoint + Model Garden) — issue #768 -------------------
+#
+# google_vertex_ai_endpoint:                            serving endpoint (a
+#   managed front door for online predictions). Created when enable_serving is
+#   true. PUBLIC by default; the private-endpoint story is unchanged here (it
+#   reuses the same #774 PSC peering range the Vector Search endpoint needs and
+#   is out of scope for this issue).
+# google_vertex_ai_endpoint_with_model_garden_deployment: one-shot deploy of an
+#   open Model Garden model (Gemma/Llama/etc) onto its OWN managed endpoint.
+#   Created when enable_serving is true AND model_garden_model is named. The
+#   deploy is the long pole — model downloads + replica spin-up routinely take
+#   30+ minutes — so create/delete carry generous 60m timeouts.
+#
+# Resources verified against hashicorp/google v7.x (GA tier; both resources are
+# in the GA provider — see PR notes). The dataset and Vector Search resources
+# above are untouched by enable_serving.
+
+# A bare serving endpoint. Models can be deployed onto it out-of-band; the
+# Model Garden resource below provisions its own endpoint, so this one is the
+# generic attach point for custom/other models.
+resource "google_vertex_ai_endpoint" "serving" {
+  count        = var.enable_serving ? 1 : 0
+  name         = local.serving_endpoint_name
+  display_name = "${var.project}-serving-endpoint"
+  description  = "InsideOut Vertex AI serving endpoint for ${var.project}"
+  # location is the required, canonical field on this resource (region is a
+  # legacy alias and redundant when location is set). The sibling dataset/index
+  # resources only expose region, hence the differing field here.
+  location = var.region
+  project  = var.project_id
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+}
+
+# One-shot Model Garden open-model deployment onto a managed endpoint. EULA
+# acceptance and accelerator quota are operator concerns (see var docs): many
+# open models won't deploy until model_garden_accept_eula is true, and a GPU
+# accelerator_type needs matching quota in the project/region.
+resource "google_vertex_ai_endpoint_with_model_garden_deployment" "model_garden" {
+  count                = local.model_garden_enabled ? 1 : 0
+  publisher_model_name = var.model_garden_model
+  location             = var.region
+  project              = var.project_id
+
+  model_config {
+    accept_eula = var.model_garden_accept_eula
+  }
+
+  deploy_config {
+    dedicated_resources {
+      min_replica_count = var.serving_min_replicas
+      max_replica_count = var.serving_max_replicas
+
+      machine_spec {
+        machine_type = var.serving_machine_type
+        # Accelerator fields only when a GPU/TPU type is requested; CPU-only
+        # serving leaves them unset so no accelerator quota is demanded.
+        accelerator_type  = local.serving_accelerator_enabled ? var.serving_accelerator_type : null
+        accelerator_count = local.serving_accelerator_enabled ? var.serving_accelerator_count : null
+      }
+    }
+  }
+
+  # Model deploys run long (download + replica spin-up). Stay well clear of the
+  # provider's shorter defaults.
+  timeouts {
+    create = "60m"
+    delete = "60m"
+  }
+
+  lifecycle {
+    # Cross-variable invariants live here (a per-variable validation may only
+    # reference its own variable):
+    #   - autoscaling ceiling must not sit below the floor;
+    #   - an accelerator TYPE without a positive COUNT (or vice versa) is a
+    #     half-configured GPU request that the API would reject at apply.
+    precondition {
+      condition     = var.serving_max_replicas >= var.serving_min_replicas
+      error_message = "serving_max_replicas must be >= serving_min_replicas."
+    }
+    precondition {
+      condition     = (var.serving_accelerator_type == null) == (var.serving_accelerator_count == 0)
+      error_message = "serving_accelerator_type and serving_accelerator_count must be set together: a type requires count > 0, and count > 0 requires a type."
     }
   }
 }

--- a/gcp/vertex_ai/observability.tf
+++ b/gcp/vertex_ai/observability.tf
@@ -37,11 +37,17 @@ variable "alarm_threshold_overrides" {
 locals {
   _obs_user_labels = { project = var.project, severity = var.alarm_severity }
   _obs_thresholds = merge({
-    query_latency_p99_ms = 500
+    query_latency_p99_ms      = 500
+    prediction_latency_p99_ms = 2000
+    prediction_error_rate     = 1
   }, var.alarm_threshold_overrides)
 
   # Alarms only make sense when Vector Search is serving queries.
   _obs_enabled = var.enable_observability && var.enable_vector_search
+
+  # Serving alarms (prediction latency / errors) only make sense when a serving
+  # endpoint exists. Gated on enable_serving, independent of Vector Search.
+  _obs_serving_enabled = var.enable_observability && var.enable_serving
 }
 
 resource "google_monitoring_alert_policy" "vector_search_query_latency_high" {
@@ -67,6 +73,68 @@ resource "google_monitoring_alert_policy" "vector_search_query_latency_high" {
       aggregations {
         alignment_period   = "60s"
         per_series_aligner = "ALIGN_PERCENTILE_99"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+  user_labels           = local._obs_user_labels
+}
+
+# --- Serving alarms (#768) --------------------------------------------------
+# Online-prediction latency + error alarms on the serving endpoint. Emitted
+# only when enable_serving (and observability) are on; the bare dataset / a
+# Vector-Search-only stack has no online-prediction surface to alarm on.
+#
+# Metric paths + monitored resource verified against Google's official metrics
+# list (cloud.google.com/monitoring/api/metrics_gcp_a_b#gcp-aiplatform) and the
+# pkg/observability `vertexai` catalog (registered in alarmedGCPMetrics so the
+# inspector flips Alarmed=true): prediction/online/prediction_latencies and
+# prediction/online/error_count, both reported on
+# aiplatform.googleapis.com/Endpoint.
+
+resource "google_monitoring_alert_policy" "serving_prediction_latency_high" {
+  for_each = local._obs_serving_enabled ? { "0" = true } : {}
+
+  project      = var.project_id
+  display_name = "${var.project}-vertex-prediction-latency"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Online prediction p99 latency above ${local._obs_thresholds["prediction_latency_p99_ms"]}ms"
+    condition_threshold {
+      filter          = "metric.type=\"aiplatform.googleapis.com/prediction/online/prediction_latencies\" AND resource.type=\"aiplatform.googleapis.com/Endpoint\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local._obs_thresholds["prediction_latency_p99_ms"]
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_PERCENTILE_99"
+      }
+    }
+  }
+
+  notification_channels = var.notification_channels
+  user_labels           = local._obs_user_labels
+}
+
+resource "google_monitoring_alert_policy" "serving_prediction_errors_high" {
+  for_each = local._obs_serving_enabled ? { "0" = true } : {}
+
+  project      = var.project_id
+  display_name = "${var.project}-vertex-prediction-errors"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Online prediction error rate above ${local._obs_thresholds["prediction_error_rate"]}/s"
+    condition_threshold {
+      filter          = "metric.type=\"aiplatform.googleapis.com/prediction/online/error_count\" AND resource.type=\"aiplatform.googleapis.com/Endpoint\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local._obs_thresholds["prediction_error_rate"]
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_RATE"
       }
     }
   }

--- a/gcp/vertex_ai/outputs.tf
+++ b/gcp/vertex_ai/outputs.tf
@@ -35,3 +35,16 @@ output "deployed_index_id" {
   value       = var.enable_vector_search ? google_vertex_ai_index_endpoint_deployed_index.this[0].deployed_index_id : null
   description = "The deployed-index ID binding the index to the endpoint (null when Vector Search is disabled)"
 }
+
+# --- Model serving (#768) ---------------------------------------------------
+# Null when var.enable_serving is false (the endpoint is not created).
+
+output "endpoint_id" {
+  value       = var.enable_serving ? google_vertex_ai_endpoint.serving[0].id : null
+  description = "The resource ID of the Vertex AI serving endpoint (null when serving is disabled)"
+}
+
+output "endpoint_name" {
+  value       = var.enable_serving ? google_vertex_ai_endpoint.serving[0].name : null
+  description = "The numeric resource name of the Vertex AI serving endpoint (null when serving is disabled)"
+}

--- a/gcp/vertex_ai/outputs.tf
+++ b/gcp/vertex_ai/outputs.tf
@@ -37,14 +37,30 @@ output "deployed_index_id" {
 }
 
 # --- Model serving (#768) ---------------------------------------------------
-# Null when var.enable_serving is false (the endpoint is not created).
+# Null when var.enable_serving is false (no endpoint is created).
+#
+# The bare endpoint and the Model Garden deployment are mutually exclusive (see
+# main.tf): exactly one exists when serving is on. The outputs return whichever
+# one that is, so they never point at an empty shell:
+#   - bare endpoint path (no model named): google_vertex_ai_endpoint.serving
+#   - model-garden path (model named):     google_vertex_ai_endpoint_with_model_garden_deployment.model_garden
+#       .id       -> full resource name projects/<p>/locations/<l>/endpoints/<e>
+#       .endpoint -> the bare endpoint ID segment (matches the bare endpoint's .name)
 
 output "endpoint_id" {
-  value       = var.enable_serving ? google_vertex_ai_endpoint.serving[0].id : null
-  description = "The resource ID of the Vertex AI serving endpoint (null when serving is disabled)"
+  value = (
+    local.model_garden_enabled ? google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].id :
+    local.bare_endpoint_enabled ? google_vertex_ai_endpoint.serving[0].id :
+    null
+  )
+  description = "The full resource name of the Vertex AI serving endpoint — the Model Garden deployment's own endpoint when a model is deployed, otherwise the bare endpoint (null when serving is disabled)"
 }
 
 output "endpoint_name" {
-  value       = var.enable_serving ? google_vertex_ai_endpoint.serving[0].name : null
-  description = "The numeric resource name of the Vertex AI serving endpoint (null when serving is disabled)"
+  value = (
+    local.model_garden_enabled ? google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].endpoint :
+    local.bare_endpoint_enabled ? google_vertex_ai_endpoint.serving[0].name :
+    null
+  )
+  description = "The numeric endpoint ID segment of the Vertex AI serving endpoint — the Model Garden deployment's endpoint when a model is deployed, otherwise the bare endpoint (null when serving is disabled)"
 }

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -357,7 +357,14 @@ run "serving_off_by_default" {
 }
 
 run "serving" {
-  command = plan
+  # apply, not plan: this run asserts on output.endpoint_id, which is sourced
+  # from google_vertex_ai_endpoint.serving[0].id — a provider-computed resource
+  # name (projects/<p>/locations/<l>/endpoints/<e>) that stays "known after
+  # apply" under mock_provider, so `output.endpoint_id != null` cannot be
+  # evaluated at plan ("Unknown condition value"). The mock provider materializes
+  # computed attributes on apply, making the wiring assertion evaluable. The
+  # input-derived asserts (name, display_name, location) hold identically.
+  command = apply
 
   variables {
     project        = "test"
@@ -437,7 +444,11 @@ run "serving" {
 }
 
 run "model_garden" {
-  command = plan
+  # apply, not plan: the endpoint_id / endpoint_name asserts below compare the
+  # outputs against the model-garden deployment's computed .id / .endpoint, which
+  # are "known after apply" under mock_provider (see run "serving"). Apply lets
+  # the mock provider materialize them so the source-wiring equality is evaluable.
+  command = apply
 
   variables {
     project            = "test"

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -412,10 +412,15 @@ run "serving" {
   }
 
   # endpoint_id output is sourced from the bare endpoint on the no-model path
-  # (the model-garden deployment is absent here).
+  # (the model-garden deployment is absent here). The endpoint's .id is a
+  # provider-computed composite (projects/<p>/locations/<l>/endpoints/<e>) that
+  # is unknown at plan, so we can only assert the output is wired and non-null
+  # here — the bare-vs-model SOURCE is pinned by the endpoint_name assert above
+  # (== "2676412545", the bare endpoint's deterministic name) and by the
+  # model_garden run asserting model_garden[0].endpoint on the model path.
   assert {
-    condition     = output.endpoint_id == google_vertex_ai_endpoint.serving[0].id
-    error_message = "endpoint_id output must surface the bare serving endpoint's resource name on the no-model path."
+    condition     = output.endpoint_id != null
+    error_message = "endpoint_id output must be non-null on the no-model serving path (sourced from the bare serving endpoint)."
   }
 
   # Vector Search resources are untouched by the serving flag.

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -314,6 +314,269 @@ run "alert_policy_absent_when_vector_search_off" {
 }
 
 # -----------------------------------------------------------------------------
+# Model serving (#768): endpoint + Model Garden deployment, gated on
+# enable_serving. The dataset and Vector Search resources stay untouched.
+# -----------------------------------------------------------------------------
+
+run "serving_off_by_default" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+
+  # Serving is off by default -> no endpoint, no model-garden deployment.
+  assert {
+    condition     = length(google_vertex_ai_endpoint.serving) == 0
+    error_message = "serving endpoint must NOT be created when enable_serving is false (default)."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_endpoint_with_model_garden_deployment.model_garden) == 0
+    error_message = "model-garden deployment must NOT be created when enable_serving is false (default)."
+  }
+
+  # And no serving alarms.
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_latency_high) == 0
+    error_message = "serving prediction-latency alarm must be absent when serving is off."
+  }
+
+  # Serving outputs are null when serving is off (guards the [0]-index-on-empty
+  # short-circuit in outputs.tf).
+  assert {
+    condition     = output.endpoint_id == null
+    error_message = "endpoint_id output must be null when serving is disabled."
+  }
+
+  assert {
+    condition     = output.endpoint_name == null
+    error_message = "endpoint_name output must be null when serving is disabled."
+  }
+}
+
+run "serving" {
+  command = plan
+
+  variables {
+    project        = "test"
+    project_id     = "test-project"
+    enable_serving = true
+    # No model named -> a bare endpoint, no model-garden deployment.
+  }
+
+  # Exactly one bare serving endpoint, no model-garden deployment.
+  assert {
+    condition     = length(google_vertex_ai_endpoint.serving) == 1
+    error_message = "enable_serving=true must create exactly one serving endpoint."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_endpoint_with_model_garden_deployment.model_garden) == 0
+    error_message = "no model named -> no model-garden deployment (bare endpoint path)."
+  }
+
+  # Endpoint name is the deterministic NUMERIC id the API requires (no leading
+  # zeros, <=10 digits). Asserting the exact literal pins the sha256-derived
+  # name against a mutation of the derivation:
+  # parseint(substr(sha256("test"),0,8),16) = 2676412545.
+  assert {
+    condition     = google_vertex_ai_endpoint.serving[0].name == "2676412545"
+    error_message = "endpoint name must be the deterministic numeric id derived from sha256(var.project)."
+  }
+
+  assert {
+    condition     = can(regex("^[1-9][0-9]{0,9}$", google_vertex_ai_endpoint.serving[0].name))
+    error_message = "endpoint name must be numeric, no leading zeros, <=10 digits (the API constraint)."
+  }
+
+  # Display name carries the var.project prefix (name-prefix scoping).
+  assert {
+    condition     = google_vertex_ai_endpoint.serving[0].display_name == "test-serving-endpoint"
+    error_message = "endpoint display_name must be var.project-prefixed."
+  }
+
+  # location (the required field) is fed from var.region — pin the flow-through
+  # so a swap to the wrong source is caught.
+  assert {
+    condition     = google_vertex_ai_endpoint.serving[0].location == "us-central1"
+    error_message = "endpoint location must be fed from var.region (default us-central1)."
+  }
+
+  # endpoint_name output mirrors the resource name on the serving path (and is
+  # null on the off path — see serving_off_by_default-adjacent coverage).
+  assert {
+    condition     = output.endpoint_name == "2676412545"
+    error_message = "endpoint_name output must surface the numeric endpoint name when serving is on."
+  }
+
+  # Vector Search resources are untouched by the serving flag.
+  assert {
+    condition     = length(google_vertex_ai_index.this) == 0
+    error_message = "enable_serving must not create Vector Search resources (orthogonal flags)."
+  }
+
+  # Dataset still composes.
+  assert {
+    condition     = google_vertex_ai_dataset.dataset.display_name == "main-dataset"
+    error_message = "dataset must still be created when only serving is enabled."
+  }
+}
+
+run "model_garden" {
+  command = plan
+
+  variables {
+    project            = "test"
+    project_id         = "test-project"
+    enable_serving     = true
+    model_garden_model = "publishers/google/models/gemma3@gemma-3-1b-it"
+    # model_garden_accept_eula left at its FALSE default on purpose: asserting
+    # accept_eula == false below pins the variable->attribute edge in the
+    # direction a hardcoded `accept_eula = true` would otherwise survive. The
+    # EULA-true flow-through is exercised in model_garden_with_accelerator.
+  }
+
+  # Both the bare endpoint AND the model-garden deployment compose.
+  assert {
+    condition     = length(google_vertex_ai_endpoint.serving) == 1
+    error_message = "model-garden path still creates the bare serving endpoint."
+  }
+
+  assert {
+    condition     = length(google_vertex_ai_endpoint_with_model_garden_deployment.model_garden) == 1
+    error_message = "enable_serving + model_garden_model must create exactly one model-garden deployment."
+  }
+
+  # The publisher model name flows through verbatim.
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].publisher_model_name == "publishers/google/models/gemma3@gemma-3-1b-it"
+    error_message = "model_garden_model must reach publisher_model_name verbatim."
+  }
+
+  # EULA default (false) reaches model_config.accept_eula. Catches a hardcoded
+  # `accept_eula = true` (consent must not be silently granted).
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].model_config[0].accept_eula == false
+    error_message = "model_garden_accept_eula default (false) must reach model_config.accept_eula — EULA consent must not be hardcoded."
+  }
+
+  # CPU-only default: machine_type set, accelerator fields null.
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].deploy_config[0].dedicated_resources[0].machine_spec[0].machine_type == "n1-standard-4"
+    error_message = "serving_machine_type default (n1-standard-4) must reach machine_spec.machine_type."
+  }
+
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].deploy_config[0].dedicated_resources[0].machine_spec[0].accelerator_type == null
+    error_message = "CPU-only default must leave machine_spec.accelerator_type null (no GPU quota demanded)."
+  }
+
+  # Generous create timeout for the long-running model deploy.
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].timeouts.create == "60m"
+    error_message = "model-garden deployment must carry a generous create timeout (deploys run 30+ min)."
+  }
+}
+
+run "model_garden_with_accelerator" {
+  command = plan
+
+  variables {
+    project                   = "test"
+    project_id                = "test-project"
+    enable_serving            = true
+    model_garden_model        = "publishers/google/models/llama3-2@llama-3.2-1b"
+    model_garden_accept_eula  = true
+    serving_machine_type      = "g2-standard-16"
+    serving_accelerator_type  = "NVIDIA_L4"
+    serving_accelerator_count = 1
+  }
+
+  # GPU path: accelerator type + count flow through to machine_spec.
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].deploy_config[0].dedicated_resources[0].machine_spec[0].accelerator_type == "NVIDIA_L4"
+    error_message = "serving_accelerator_type must reach machine_spec.accelerator_type when set."
+  }
+
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].deploy_config[0].dedicated_resources[0].machine_spec[0].accelerator_count == 1
+    error_message = "serving_accelerator_count must reach machine_spec.accelerator_count when an accelerator type is set."
+  }
+
+  # EULA acceptance flows through when set true (the catch-the-hardcoded-false
+  # direction, paired with the accept_eula == false assert in run "model_garden").
+  assert {
+    condition     = google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].model_config[0].accept_eula == true
+    error_message = "model_garden_accept_eula=true must reach model_config.accept_eula."
+  }
+}
+
+run "serving_alarms_emitted_when_serving_and_observability_on" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_serving       = true
+    enable_observability = true
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_latency_high) == 1
+    error_message = "prediction-latency alarm must be emitted when serving AND observability are both on."
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_errors_high) == 1
+    error_message = "prediction-error alarm must be emitted when serving AND observability are both on."
+  }
+
+  # Filters must carry the metric.types verified against Google's official list
+  # and registered in the pkg/observability vertexai catalog.
+  assert {
+    condition = strcontains(
+      google_monitoring_alert_policy.serving_prediction_latency_high["0"].conditions[0].condition_threshold[0].filter,
+      "metric.type=\"aiplatform.googleapis.com/prediction/online/prediction_latencies\""
+    )
+    error_message = "latency alarm filter must reference prediction/online/prediction_latencies."
+  }
+
+  assert {
+    condition = strcontains(
+      google_monitoring_alert_policy.serving_prediction_errors_high["0"].conditions[0].condition_threshold[0].filter,
+      "metric.type=\"aiplatform.googleapis.com/prediction/online/error_count\""
+    )
+    error_message = "error alarm filter must reference prediction/online/error_count."
+  }
+}
+
+run "serving_alarms_absent_when_serving_off" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_serving       = false
+    enable_observability = true
+    # Vector Search on so observability is clearly active for the vector alarm,
+    # proving the serving alarms gate on enable_serving specifically.
+    enable_vector_search = true
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_latency_high) == 0
+    error_message = "serving alarms must gate on enable_serving, not enable_vector_search."
+  }
+
+  assert {
+    condition     = length(google_monitoring_alert_policy.serving_prediction_errors_high) == 0
+    error_message = "serving error alarm must be absent when serving is off."
+  }
+}
+
+# -----------------------------------------------------------------------------
 # Negative cases: validation blocks must reject misconfigurations at plan time.
 # -----------------------------------------------------------------------------
 
@@ -405,4 +668,78 @@ run "rejects_max_replicas_below_min" {
   # The cross-variable invariant is a resource precondition, not a variable
   # validation, so the failure surfaces on the deployed-index resource.
   expect_failures = [google_vertex_ai_index_endpoint_deployed_index.this]
+}
+
+run "rejects_bad_model_garden_format" {
+  command = plan
+
+  variables {
+    project        = "test"
+    project_id     = "test-project"
+    enable_serving = true
+    # Bare model name, not the publishers/.../models/...@version form.
+    model_garden_model = "gemma-3-1b-it"
+  }
+
+  expect_failures = [var.model_garden_model]
+}
+
+run "rejects_model_garden_missing_version" {
+  command = plan
+
+  variables {
+    project        = "test"
+    project_id     = "test-project"
+    enable_serving = true
+    # Missing the @<version> suffix the API requires.
+    model_garden_model = "publishers/google/models/gemma3"
+  }
+
+  expect_failures = [var.model_garden_model]
+}
+
+run "rejects_serving_max_replicas_below_min" {
+  command = plan
+
+  variables {
+    project              = "test"
+    project_id           = "test-project"
+    enable_serving       = true
+    model_garden_model   = "publishers/google/models/gemma3@gemma-3-1b-it"
+    serving_min_replicas = 3
+    serving_max_replicas = 1 # ceiling below floor
+  }
+
+  # Cross-variable invariant is a precondition on the deployment resource.
+  expect_failures = [google_vertex_ai_endpoint_with_model_garden_deployment.model_garden]
+}
+
+run "rejects_accelerator_type_without_count" {
+  command = plan
+
+  variables {
+    project                  = "test"
+    project_id               = "test-project"
+    enable_serving           = true
+    model_garden_model       = "publishers/google/models/gemma3@gemma-3-1b-it"
+    serving_accelerator_type = "NVIDIA_L4"
+    # count left at its 0 default -> half-configured GPU request.
+  }
+
+  expect_failures = [google_vertex_ai_endpoint_with_model_garden_deployment.model_garden]
+}
+
+run "rejects_accelerator_count_without_type" {
+  command = plan
+
+  variables {
+    project                   = "test"
+    project_id                = "test-project"
+    enable_serving            = true
+    model_garden_model        = "publishers/google/models/gemma3@gemma-3-1b-it"
+    serving_accelerator_count = 2
+    # type left null -> half-configured GPU request.
+  }
+
+  expect_failures = [google_vertex_ai_endpoint_with_model_garden_deployment.model_garden]
 }

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -404,11 +404,18 @@ run "serving" {
     error_message = "endpoint location must be fed from var.region (default us-central1)."
   }
 
-  # endpoint_name output mirrors the resource name on the serving path (and is
-  # null on the off path — see serving_off_by_default-adjacent coverage).
+  # endpoint_name output mirrors the resource name on the bare-serving path (and
+  # is null on the off path — see serving_off_by_default-adjacent coverage).
   assert {
     condition     = output.endpoint_name == "2676412545"
-    error_message = "endpoint_name output must surface the numeric endpoint name when serving is on."
+    error_message = "endpoint_name output must surface the numeric endpoint name when serving is on (bare path)."
+  }
+
+  # endpoint_id output is sourced from the bare endpoint on the no-model path
+  # (the model-garden deployment is absent here).
+  assert {
+    condition     = output.endpoint_id == google_vertex_ai_endpoint.serving[0].id
+    error_message = "endpoint_id output must surface the bare serving endpoint's resource name on the no-model path."
   }
 
   # Vector Search resources are untouched by the serving flag.
@@ -438,15 +445,33 @@ run "model_garden" {
     # EULA-true flow-through is exercised in model_garden_with_accelerator.
   }
 
-  # Both the bare endpoint AND the model-garden deployment compose.
+  # Mutually exclusive (#768 review): when a Model Garden model is named, the
+  # model_garden resource owns its own endpoint, so the BARE endpoint is NOT
+  # created. Otherwise the bare endpoint would sit empty and the outputs would
+  # point at the empty shell.
   assert {
-    condition     = length(google_vertex_ai_endpoint.serving) == 1
-    error_message = "model-garden path still creates the bare serving endpoint."
+    condition     = length(google_vertex_ai_endpoint.serving) == 0
+    error_message = "model-garden path must NOT create the bare serving endpoint (the deployment owns its own endpoint; they are mutually exclusive)."
   }
 
   assert {
     condition     = length(google_vertex_ai_endpoint_with_model_garden_deployment.model_garden) == 1
     error_message = "enable_serving + model_garden_model must create exactly one model-garden deployment."
+  }
+
+  # The serving outputs surface the Model Garden deployment's OWN endpoint, not
+  # the (absent) bare endpoint — this is the #768-review bug fix. endpoint_id is
+  # the deployment's full resource name; endpoint_name is its numeric endpoint
+  # ID segment. The mock provider supplies computed values, so assert they are
+  # non-null and sourced from the deployment rather than a literal.
+  assert {
+    condition     = output.endpoint_id == google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].id
+    error_message = "endpoint_id output must surface the Model Garden deployment's own endpoint resource name, not the absent bare endpoint."
+  }
+
+  assert {
+    condition     = output.endpoint_name == google_vertex_ai_endpoint_with_model_garden_deployment.model_garden[0].endpoint
+    error_message = "endpoint_name output must surface the Model Garden deployment's endpoint ID segment, not the absent bare endpoint."
   }
 
   # The publisher model name flows through verbatim.

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -169,3 +169,91 @@ variable "deployed_index_max_replicas" {
     error_message = "deployed_index_max_replicas must be greater than 0."
   }
 }
+
+# --- Model serving (Endpoint + Model Garden) --------------------------------
+# Issue #768. Independent of Vector Search: enable_serving gates a
+# google_vertex_ai_endpoint, and (optionally) a one-shot Model Garden open-model
+# deployment onto its own managed endpoint. The dataset and Vector Search
+# resources are untouched by these flags.
+
+variable "enable_serving" {
+  description = "When true, provision a Vertex AI serving endpoint (google_vertex_ai_endpoint). With model_garden_model also set, additionally deploy that open model from Model Garden onto a managed endpoint. The dataset and Vector Search resources are unaffected by this flag."
+  type        = bool
+  default     = false
+}
+
+variable "model_garden_model" {
+  description = "Model Garden publisher model to deploy when enable_serving is true. Format: publishers/<publisher>/models/<model>@<version> (e.g. publishers/google/models/gemma3@gemma-3-1b-it). Null provisions a bare endpoint with no model deployed (attach a model out-of-band)."
+  type        = string
+  default     = null
+
+  validation {
+    # Mirror the provider's documented publisher_model_name format
+    # publishers/{publisher}/models/{publisher_model}@{version_id}. Reject a
+    # bare model name or a Hugging Face id here so a malformed value fails at
+    # plan time rather than ~30min into a live model deploy.
+    condition     = var.model_garden_model == null ? true : can(regex("^publishers/[^/]+/models/[^/@]+@[^/@]+$", var.model_garden_model))
+    error_message = "model_garden_model must be null or match publishers/<publisher>/models/<model>@<version> (e.g. publishers/google/models/gemma3@gemma-3-1b-it)."
+  }
+}
+
+variable "model_garden_accept_eula" {
+  description = "Whether the operator accepts the model's End User License Agreement (EULA / ToS). Many Model Garden open models (Gemma, Llama) require this to be true before they will deploy. Surfaced as model_config.accept_eula on the deployment."
+  type        = bool
+  default     = false
+}
+
+variable "serving_machine_type" {
+  description = "Compute Engine machine type for the Model Garden deployment's dedicated serving resources. Defaults to a CPU-only machine (n1-standard-4); pick a GPU-capable type (e.g. g2-standard-16) when pairing with an accelerator."
+  type        = string
+  default     = "n1-standard-4"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]*-[a-z0-9-]+$", var.serving_machine_type))
+    error_message = "serving_machine_type must be a Compute Engine machine type (e.g. n1-standard-4, g2-standard-16)."
+  }
+}
+
+variable "serving_accelerator_type" {
+  description = "GPU/TPU accelerator type for the Model Garden deployment (e.g. NVIDIA_L4, NVIDIA_TESLA_T4). Null = CPU-only serving (the default). Must be paired with serving_accelerator_count > 0."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.serving_accelerator_type == null ? true : can(regex("^[A-Z][A-Z0-9_]+$", var.serving_accelerator_type))
+    error_message = "serving_accelerator_type must be null or an uppercase accelerator enum (e.g. NVIDIA_L4)."
+  }
+}
+
+variable "serving_accelerator_count" {
+  description = "Number of accelerators to attach per serving replica. 0 (default) = CPU-only. Must be > 0 when serving_accelerator_type is set (enforced by a precondition on the deployment)."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.serving_accelerator_count >= 0
+    error_message = "serving_accelerator_count must be >= 0."
+  }
+}
+
+variable "serving_min_replicas" {
+  description = "Minimum serving replicas for the Model Garden deployment's dedicated resources."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.serving_min_replicas > 0
+    error_message = "serving_min_replicas must be greater than 0."
+  }
+}
+
+variable "serving_max_replicas" {
+  description = "Maximum serving replicas (autoscaling ceiling) for the Model Garden deployment. Must be >= serving_min_replicas (enforced by a precondition on the deployment)."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.serving_max_replicas > 0
+    error_message = "serving_max_replicas must be greater than 0."
+  }
+}

--- a/pkg/composer/builders_test.go
+++ b/pkg/composer/builders_test.go
@@ -85,6 +85,64 @@ func configWithAWSEKS(in awsEKSCfgInput) *Config {
 	}
 }
 
+// gcpComputeCfgInput mirrors the subset of Config.GCPCompute fields exercised
+// by GPU mapper tests (#767).
+type gcpComputeCfgInput struct {
+	MachineType string
+	DiskSizeGb  int
+	GPUType     string
+	GPUCount    int
+}
+
+// configWithGCPCompute returns *Config with GCPCompute populated from input,
+// eliding the anonymous-struct redeclaration at each call site.
+func configWithGCPCompute(in gcpComputeCfgInput) *Config {
+	return &Config{
+		GCPCompute: &struct {
+			NumServers  string `json:"numServers,omitempty"`
+			MachineType string `json:"machineType,omitempty"`
+			DiskSizeGb  int    `json:"diskSizeGb,omitempty"`
+			GPUType     string `json:"gpuType,omitempty"`
+			GPUCount    int    `json:"gpuCount,omitempty"`
+		}{
+			MachineType: in.MachineType,
+			DiskSizeGb:  in.DiskSizeGb,
+			GPUType:     in.GPUType,
+			GPUCount:    in.GPUCount,
+		},
+	}
+}
+
+// gcpGKECfgInput mirrors the subset of Config.GCPGKE fields exercised by GPU
+// mapper tests (#767).
+type gcpGKECfgInput struct {
+	Regional    *bool
+	NodeCount   string
+	MachineType string
+	GPUType     string
+	GPUCount    int
+}
+
+// configWithGCPGKE returns *Config with GCPGKE populated from input, eliding the
+// anonymous-struct redeclaration at each call site.
+func configWithGCPGKE(in gcpGKECfgInput) *Config {
+	return &Config{
+		GCPGKE: &struct {
+			Regional    *bool  `json:"regional,omitempty"`
+			NodeCount   string `json:"nodeCount,omitempty"`
+			MachineType string `json:"machineType,omitempty"`
+			GPUType     string `json:"gpuType,omitempty"`
+			GPUCount    int    `json:"gpuCount,omitempty"`
+		}{
+			Regional:    in.Regional,
+			NodeCount:   in.NodeCount,
+			MachineType: in.MachineType,
+			GPUType:     in.GPUType,
+			GPUCount:    in.GPUCount,
+		},
+	}
+}
+
 // awsCognitoCfgInput mirrors the subset of Config.AWSCognito fields exercised
 // by mapper / validator tests.
 type awsCognitoCfgInput struct {

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -138,6 +138,8 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.GCPSecretManager)
 	case KeyGCPVertexAI:
 		return boolPtrTrue(c.GCPVertexAI)
+	case KeyGCPAgentEngine:
+		return boolPtrTrue(c.GCPAgentEngine)
 	case KeyGCPPubSub:
 		return boolPtrTrue(c.GCPPubSub)
 	case KeyGCPCloudLogging:
@@ -306,7 +308,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyGCPCompute, KeyGCPGKE, KeyGCPCloudRun,
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
-		KeyGCPVertexAI,
+		KeyGCPVertexAI, KeyGCPAgentEngine,
 		KeyGCPPubSub, KeyGCPCloudLogging,
 		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
 		KeyGCPCloudDNS, KeyGCPGitHubActions, KeyGCPCloudDeploy:

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -90,6 +90,7 @@ const (
 	KeyGCPCloudDeploy      ComponentKey = "gcp_cloud_deploy"
 	KeyGCPFirestore        ComponentKey = "gcp_firestore"
 	KeyGCPVertexAI         ComponentKey = "gcp_vertex_ai"
+	KeyGCPAgentEngine      ComponentKey = "gcp_agent_engine"
 	KeyGCPCloudArmor       ComponentKey = "gcp_cloud_armor"
 	KeyGCPAPIGateway       ComponentKey = "gcp_api_gateway"
 	KeyGCPBackups          ComponentKey = "gcp_backups"
@@ -166,6 +167,13 @@ var ComposeOrder = []ComponentKey{
 	KeyAWSBedrockAgent,
 	KeyAWSSageMaker,
 	KeyGCPVertexAI,
+	// Agent Engine (#769) composes after KeyGCPVertexAI and KeyGCPGCS (GCS is
+	// far earlier, ~:124) so its DefaultWiring case can read gcp/gcs's
+	// bucket_url output to wire the staging bucket when GCS is also selected.
+	// No hard ImplicitDependency: a bare engine composes standalone with a
+	// caller-supplied artifact URI (public by default; PSC-private networking
+	// is out of scope until gcp/vpc provisions a network attachment).
+	KeyGCPAgentEngine,
 	// App Runner (#598 row 2). Independent of EKS/ECS/Lambda compute
 	// keys — App Runner is a peer managed-container service (Cloud Run
 	// analog), not a downstream consumer of them. Position adjacent to
@@ -256,6 +264,7 @@ var ModulePath = map[ComponentKey]string{
 	KeyGCPCloudKMS:         "gcp/kms",
 	KeyGCPSecretManager:    "gcp/secret_manager",
 	KeyGCPVertexAI:         "gcp/vertex_ai",
+	KeyGCPAgentEngine:      "gcp/agent_engine",
 	KeyGCPPubSub:           "gcp/pubsub",
 	KeyGCPCloudLogging:     "gcp/cloud_logging",
 	KeyGCPCloudMonitoring:  "gcp/cloud_monitoring",
@@ -476,6 +485,7 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyGCPPubSub:               "pubsub",
 	KeyGCPCloudMonitoring:      "cloud_monitoring",
 	KeyGCPVertexAI:             "vertex_ai",
+	KeyGCPAgentEngine:          "agent_engine",
 	KeyGCPCloudBuild:           "cloud_build",
 	KeyGCPFirestore:            "firestore",
 	KeyGCPCloudArmor:           "cloud_armor",
@@ -583,6 +593,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyAWSVPC,
 	KeyAWSWAF,
 	// GCP
+	KeyGCPAgentEngine,
 	KeyGCPAPIGateway,
 	KeyGCPBackups,
 	KeyGCPBastion,
@@ -1255,6 +1266,18 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		if selected[KeyGCPGCS] {
 			wi.RawHCL["contents_delta_uri"] = "\"${" + WireRef(KeyGCPGCS, "bucket_url") + "}/vertex-index/\""
 			wi.Names = append(wi.Names, "contents_delta_uri")
+		}
+
+	case KeyGCPAgentEngine:
+		// Agent Engine (#769). When GCS is selected, wire the bucket as the
+		// staging bucket the application stages the packaged agent artifact
+		// into. bucket_url is the gs://<bucket> root — the engine's preset
+		// validates that the artifact URI (app-layer, supplied separately)
+		// lives under this bucket. The artifact itself is NOT wired here: it is
+		// built and uploaded by the application layer, not by the composer.
+		if selected[KeyGCPGCS] {
+			wi.RawHCL["staging_bucket"] = WireRef(KeyGCPGCS, "bucket_url")
+			wi.Names = append(wi.Names, "staging_bucket")
 		}
 	}
 

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -197,6 +197,7 @@ func (c *Client) ComputePresetDefaults(cfg Config, comps *Components, selected [
 	// instance type the mapper will actually deploy. Only fills when the user's
 	// own cfg left the instance type blank — an explicit pick is preserved.
 	applyGPUInstanceTypeDefault(&cfg, &out)
+	applyGCPGPUDefaults(&cfg, &out)
 
 	return out, nil
 }
@@ -225,6 +226,41 @@ func applyGPUInstanceTypeDefault(cfg, out *Config) {
 			reflect.ValueOf(&out.AWSEKS).Elem().Set(v)
 		}
 		out.AWSEKS.InstanceType = defaultGPUInstanceType
+	}
+}
+
+// applyGCPGPUDefaults backfills the GCP GPU overlay so the pricing-facing Config
+// is self-consistent when a caller signalled GPU intent with a partial spec
+// (#767): supplying only GPUType leaves GPUCount blank, and supplying only
+// GPUCount leaves GPUType blank. The mapper fills the same blanks at compose
+// time (defaultGCPAccelerator / defaultGCPGPUCount); mirroring it here keeps the
+// overlay Config in sync with what actually deploys. Only fills when the user's
+// cfg signalled a GPU and left the paired field blank — explicit picks are
+// preserved (the overlay is merged zero-only downstream).
+func applyGCPGPUDefaults(cfg, out *Config) {
+	if cfg.GCPCompute != nil && (cfg.GCPCompute.GPUType != "" || cfg.GCPCompute.GPUCount > 0) {
+		if out.GCPCompute == nil {
+			v := reflect.New(reflect.TypeOf(out.GCPCompute).Elem())
+			reflect.ValueOf(&out.GCPCompute).Elem().Set(v)
+		}
+		if out.GCPCompute.GPUType == "" {
+			out.GCPCompute.GPUType = defaultGCPAccelerator
+		}
+		if out.GCPCompute.GPUCount == 0 {
+			out.GCPCompute.GPUCount = defaultGCPGPUCount
+		}
+	}
+	if cfg.GCPGKE != nil && (cfg.GCPGKE.GPUType != "" || cfg.GCPGKE.GPUCount > 0) {
+		if out.GCPGKE == nil {
+			v := reflect.New(reflect.TypeOf(out.GCPGKE).Elem())
+			reflect.ValueOf(&out.GCPGKE).Elem().Set(v)
+		}
+		if out.GCPGKE.GPUType == "" {
+			out.GCPGKE.GPUType = defaultGCPAccelerator
+		}
+		if out.GCPGKE.GPUCount == 0 {
+			out.GCPGKE.GPUCount = defaultGCPGPUCount
+		}
 	}
 }
 

--- a/pkg/composer/defaults.go
+++ b/pkg/composer/defaults.go
@@ -256,7 +256,16 @@ func applyGCPGPUDefaults(cfg, out *Config) {
 			reflect.ValueOf(&out.GCPGKE).Elem().Set(v)
 		}
 		if out.GCPGKE.GPUType == "" {
-			out.GCPGKE.GPUType = defaultGCPAccelerator
+			// GKE pairs a bundled accelerator-optimized family (g2/a2/a3/...) with
+			// its own GPU type; fall back to the shared N1 default only when the
+			// machine family has no bundled pairing (#752 review). Mirrors the
+			// mapper's defaultGKEGPUType so the pricing-facing overlay matches what
+			// deploys.
+			if def := defaultGKEGPUType(cfg.GCPGKE.MachineType); def != "" {
+				out.GCPGKE.GPUType = def
+			} else {
+				out.GCPGKE.GPUType = defaultGCPAccelerator
+			}
 		}
 		if out.GCPGKE.GPUCount == 0 {
 			out.GCPGKE.GPUCount = defaultGCPGPUCount

--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -63,6 +63,9 @@ var GCPServices = map[ComponentKey][]GCPService{
 	KeyGCPCloudBuild:       {{Name: "cloudbuild.googleapis.com", Title: "Cloud Build"}},
 	KeyGCPFirestore:        {{Name: "firestore.googleapis.com", Title: "Cloud Firestore"}},
 	KeyGCPVertexAI:         {{Name: "aiplatform.googleapis.com", Title: "Vertex AI"}},
+	// Agent Engine / Reasoning Engine is the same Vertex AI plane as datasets +
+	// vector search, so it rides on aiplatform.googleapis.com (#769).
+	KeyGCPAgentEngine: {{Name: "aiplatform.googleapis.com", Title: "Vertex AI"}},
 	KeyGCPAPIGateway: {
 		{Name: "apigateway.googleapis.com", Title: "API Gateway"},
 		// API Gateway plane requires both Service Control (request

--- a/pkg/composer/gpu_gcp.go
+++ b/pkg/composer/gpu_gcp.go
@@ -1,0 +1,173 @@
+package composer
+
+import (
+	"fmt"
+	"strings"
+)
+
+// gpu_gcp.go centralises the single source of truth the GCP GPU mapper branches
+// (#767) share: the default attachable accelerator type, the set of NVIDIA
+// accelerator types that attach to N1 machines via guest_accelerator, and the
+// set of machine families that bundle a GPU with the machine type (so attaching
+// a separate accelerator there is invalid). Both the gcp/gke node-pool branch
+// and the gcp/compute instance branch consume these so the knowledge can't drift
+// between them, and a drift test (gpu_gcp_families_drift_test.go) asserts the Go
+// sets stay in lockstep with the HCL `_gpu_attachable_accelerators` and
+// `_gpu_bundled_machine_families` locals in gcp/compute/main.tf and
+// gcp/gke/main.tf — the presets' own preconditions are the runtime SoT.
+//
+// GCP attaches GPUs in two distinct ways, and the validation enforces the right
+// one (validate, don't mask — the #759 lesson applied to GCP):
+//
+//   - N1 general-purpose machines accept ATTACHED GPUs via guest_accelerator
+//     (T4 / V100 / P100 / P4). This is the path GPUType/GPUCount drive.
+//   - A2 / A3 / A4 / G2 / G4 accelerator-optimized machines BUNDLE their GPU
+//     with the machine type (A100 / H100 / H200 / B200 / L4 / RTX-PRO-6000).
+//     Setting guest_accelerator there is rejected by GCP — the GPU is implied
+//     by the machine type, so we reject an explicit GPUType for those families.
+//   - Every other family (E2, N2, C3, ...) cannot take a GPU at all.
+//
+// GCP also forbids live-migration for any GPU-bearing instance, so the compute
+// preset forces scheduling.on_host_maintenance = "TERMINATE" by construction
+// when a GPU is attached (validate-don't-mask: the mapper never lets MIGRATE
+// coexist with a GPU).
+
+// defaultGCPAccelerator is the accelerator type the mapper supplies when a
+// caller sets GPUCount on an N1 machine but does not pin an explicit GPUType.
+// nvidia-tesla-t4 is the cheapest, most broadly available N1-attachable NVIDIA
+// GPU and is shared by the GKE node-pool and Compute instance GPU paths.
+const defaultGCPAccelerator = "nvidia-tesla-t4"
+
+// defaultGCPGPUCount is the accelerator count the mapper supplies when a caller
+// pins a GPUType on an N1 machine but leaves GPUCount unset (a single GPU).
+const defaultGCPGPUCount = 1
+
+// gpuAttachableAccelerators is the allow-list of NVIDIA accelerator types that
+// attach to N1 machines via guest_accelerator (#767). vws variants are the
+// virtual-workstation SKUs of the same silicon and attach the same way.
+//
+// This set MUST stay in lockstep with the HCL `_gpu_attachable_accelerators`
+// locals in gcp/compute/main.tf and gcp/gke/main.tf — TestGCPGPUFamiliesDrift
+// enforces it.
+var gpuAttachableAccelerators = map[string]struct{}{
+	"nvidia-tesla-t4":       {},
+	"nvidia-tesla-t4-vws":   {},
+	"nvidia-tesla-p4":       {},
+	"nvidia-tesla-p4-vws":   {},
+	"nvidia-tesla-v100":     {},
+	"nvidia-tesla-p100":     {},
+	"nvidia-tesla-p100-vws": {},
+}
+
+// gpuBundledMachineFamilies is the set of machine-type family prefixes whose
+// GPU is BUNDLED with the machine type (#767): A2 / A3 / A4 / A4X (A100 / H100 /
+// H200 / B200 / GB200 / GB300), G2 (L4), and G4 (RTX-PRO-6000). For these you
+// select the GPU by picking the machine type; attaching a guest_accelerator is
+// invalid and GCP rejects it. We reject an explicit GPUType on these families at
+// compose time rather than silently attaching an incompatible accelerator.
+//
+// This set MUST stay in lockstep with the HCL `_gpu_bundled_machine_families`
+// locals in gcp/compute/main.tf and gcp/gke/main.tf — TestGCPGPUFamiliesDrift
+// enforces it.
+var gpuBundledMachineFamilies = map[string]struct{}{
+	"a2":  {},
+	"a3":  {},
+	"a4":  {},
+	"a4x": {},
+	"g2":  {},
+	"g4":  {},
+}
+
+// machineFamily returns the family prefix of a GCP machine type — the part
+// before the first "-" — matching the HCL `split("-", ...)[0]` derive. For
+// "n1-standard-4" it returns "n1"; for "a2-highgpu-1g" it returns "a2". The
+// input is trimmed and lower-cased first so surrounding whitespace or a
+// capitalised family still matches (GCP machine types are canonically
+// lower-case).
+func machineFamily(machineType string) string {
+	normalized := strings.ToLower(strings.TrimSpace(machineType))
+	return strings.SplitN(normalized, "-", 2)[0]
+}
+
+// isN1Machine reports whether machineType is an N1 general-purpose machine, the
+// only family that takes an ATTACHED GPU via guest_accelerator. An empty machine
+// type is not N1 (the preset defaults to a non-N1 type), so an attached GPU with
+// no machine type is rejected — the caller must pick an N1 machine.
+func isN1Machine(machineType string) bool {
+	return machineFamily(machineType) == "n1"
+}
+
+// isBundledGPUMachine reports whether machineType belongs to a family whose GPU
+// is bundled with the machine type (per gpuBundledMachineFamilies), so attaching
+// a separate guest_accelerator is invalid.
+func isBundledGPUMachine(machineType string) bool {
+	_, ok := gpuBundledMachineFamilies[machineFamily(machineType)]
+	return ok
+}
+
+// isAttachableAccelerator reports whether gpuType is a known N1-attachable NVIDIA
+// accelerator type (per gpuAttachableAccelerators). Used to validate an explicit
+// GPUType so an unknown or bundled-only accelerator is rejected at compose time
+// instead of producing an apply-time GCP error.
+func isAttachableAccelerator(gpuType string) bool {
+	_, ok := gpuAttachableAccelerators[strings.ToLower(strings.TrimSpace(gpuType))]
+	return ok
+}
+
+// validateGCPGPU enforces the GCP attach-a-GPU rules shared by the gcp_compute
+// and gcp_gke mapper branches (#767), so both reject the same invalid configs
+// with identical, actionable error content. component is the IR field name used
+// in the error message ("GCPCompute" / "GCPGKE"). It validates, in order:
+//
+//  1. A bundled-GPU machine family (A2/A3/A4/G2/G4) with an explicit GPUType is
+//     rejected — the GPU comes with the machine type, so attaching a separate
+//     accelerator is invalid and GCP rejects it.
+//  2. A non-N1 machine type that is not a bundled-GPU family cannot take a GPU at
+//     all — rejected (only N1 attaches GPUs via guest_accelerator).
+//  3. An explicit GPUType that is not a known N1-attachable accelerator is
+//     rejected (typo, or a bundled-only / TPU type used by mistake).
+//
+// An empty machine type is treated as the non-N1 preset default and rejected
+// with the same N1 guidance — the caller must pick an N1 machine to attach a GPU.
+func validateGCPGPU(component, machineType, gpuType string) error {
+	if isBundledGPUMachine(machineType) {
+		return NewValidationError(fmt.Sprintf(
+			"%s machine_type=%q bundles its GPU with the machine type "+
+				"(A2/A3/A4/G2/G4 families ship a fixed GPU): you select the GPU by "+
+				"picking the machine type, so an explicit GPUType is invalid. "+
+				"Clear GPUType/GPUCount and use the accelerator-optimized machine "+
+				"type alone, or pick an N1 machine to attach %s.",
+			component, machineType, gpuTypeForMsg(gpuType),
+		))
+	}
+	if !isN1Machine(machineType) {
+		return NewValidationError(fmt.Sprintf(
+			"%s requests a GPU but machine_type=%q does not accept one: GCP attaches "+
+				"GPUs via guest_accelerator only on N1 general-purpose machines "+
+				"(e.g. n1-standard-4). Pick an N1 machine type to attach a GPU, or "+
+				"use an accelerator-optimized machine type (a2-*/a3-*/g2-*) whose GPU "+
+				"is bundled and set no GPUType.",
+			component, machineType,
+		))
+	}
+	if gpuType != "" && !isAttachableAccelerator(gpuType) {
+		return NewValidationError(fmt.Sprintf(
+			"%s GPUType=%q is not a known N1-attachable NVIDIA accelerator "+
+				"(expected one of nvidia-tesla-t4/nvidia-tesla-t4-vws/"+
+				"nvidia-tesla-p4/nvidia-tesla-p4-vws/nvidia-tesla-v100/"+
+				"nvidia-tesla-p100/nvidia-tesla-p100-vws). Clear GPUType to default "+
+				"to %s, or pick a supported accelerator.",
+			component, gpuType, defaultGCPAccelerator,
+		))
+	}
+	return nil
+}
+
+// gpuTypeForMsg renders the GPU type for an error message, falling back to "a
+// GPU" when the caller signalled GPU intent via GPUCount only (empty GPUType).
+func gpuTypeForMsg(gpuType string) string {
+	if strings.TrimSpace(gpuType) == "" {
+		return "a GPU"
+	}
+	return gpuType
+}

--- a/pkg/composer/gpu_gcp.go
+++ b/pkg/composer/gpu_gcp.go
@@ -7,25 +7,40 @@ import (
 
 // gpu_gcp.go centralises the single source of truth the GCP GPU mapper branches
 // (#767) share: the default attachable accelerator type, the set of NVIDIA
-// accelerator types that attach to N1 machines via guest_accelerator, and the
-// set of machine families that bundle a GPU with the machine type (so attaching
-// a separate accelerator there is invalid). Both the gcp/gke node-pool branch
-// and the gcp/compute instance branch consume these so the knowledge can't drift
+// accelerator types that attach to N1 machines via guest_accelerator, the set of
+// machine families that bundle a GPU with the machine type, and — for GKE only —
+// the bundled-family → GPU-type pairing. Both the gcp/gke node-pool branch and
+// the gcp/compute instance branch consume these so the knowledge can't drift
 // between them, and a drift test (gpu_gcp_families_drift_test.go) asserts the Go
 // sets stay in lockstep with the HCL `_gpu_attachable_accelerators` and
 // `_gpu_bundled_machine_families` locals in gcp/compute/main.tf and
 // gcp/gke/main.tf — the presets' own preconditions are the runtime SoT.
 //
-// GCP attaches GPUs in two distinct ways, and the validation enforces the right
-// one (validate, don't mask — the #759 lesson applied to GCP):
+// GCP attaches GPUs in two distinct ways, and the validation differs by service
+// (validate, don't mask — the #759 lesson applied to GCP). The crucial split is
+// Compute Engine VMs vs. GKE node pools (#752 review):
 //
-//   - N1 general-purpose machines accept ATTACHED GPUs via guest_accelerator
-//     (T4 / V100 / P100 / P4). This is the path GPUType/GPUCount drive.
-//   - A2 / A3 / A4 / G2 / G4 accelerator-optimized machines BUNDLE their GPU
-//     with the machine type (A100 / H100 / H200 / B200 / L4 / RTX-PRO-6000).
-//     Setting guest_accelerator there is rejected by GCP — the GPU is implied
-//     by the machine type, so we reject an explicit GPUType for those families.
-//   - Every other family (E2, N2, C3, ...) cannot take a GPU at all.
+//   - On a Compute Engine VM (google_compute_instance), only N1 general-purpose
+//     machines accept an ATTACHED GPU via guest_accelerator (T4 / V100 / P100 /
+//     P4). A2 / A3 / A4 / G2 / G4 accelerator-optimized machines have their GPU
+//     ATTACHED AUTOMATICALLY by the machine type — you do NOT pass
+//     guest_accelerator, and doing so is invalid. Every other family (E2, N2,
+//     C3, ...) cannot take a GPU at all. Verified against
+//     https://cloud.google.com/compute/docs/gpus ("For these machine types, the
+//     GPU model is automatically attached to the instance") and the create-VM
+//     guide (no --accelerator for A2/A3/G2; --accelerator required for N1).
+//
+//   - On a GKE node pool (google_container_node_pool), guest_accelerator IS
+//     REQUIRED even for the accelerator-optimized families — the node pool must
+//     declare the accelerator type+count that matches the machine type. g2 pairs
+//     with nvidia-l4, a2 with nvidia-tesla-a100 / nvidia-a100-80gb, a3 with
+//     nvidia-h100-80gb / nvidia-h200-141gb, etc. N1 node pools attach the same
+//     N1-attachable accelerators as a VM. Verified against
+//     https://cloud.google.com/kubernetes-engine/docs/how-to/gpus
+//     ("gcloud container node-pools create ... --accelerator type=nvidia-l4 ...
+//     --machine-type g2-standard-4"). This is the bug the #752 review caught:
+//     the GKE path reused the Compute bundled-family REJECTION, which would have
+//     rejected the very configs GKE GPU node pools require.
 //
 // GCP also forbids live-migration for any GPU-bearing instance, so the compute
 // preset forces scheduling.on_host_maintenance = "TERMINATE" by construction
@@ -41,6 +56,23 @@ const defaultGCPAccelerator = "nvidia-tesla-t4"
 // defaultGCPGPUCount is the accelerator count the mapper supplies when a caller
 // pins a GPUType on an N1 machine but leaves GPUCount unset (a single GPU).
 const defaultGCPGPUCount = 1
+
+// validGCPGPUCounts is the set of accelerator counts GCP accepts across the
+// N1-attachable GPU models (T4: 1/2/4, V100: 1/2/4/8, P100: 1/2/4, P4: 1/2/4)
+// and the per-node counts the accelerator-optimized families expose (1/2/4/8/16
+// depending on the machine type, e.g. a2-highgpu-8g = 8, a2-megagpu-16g = 16).
+// We validate against this union rather than the full per-type/per-machine
+// matrix: the exact legal count is type- AND zone-AND-machine-specific (a
+// deploy-time / quota concern), but a count outside this set is always wrong and
+// is worth catching at compose time. Verified against
+// https://cloud.google.com/compute/docs/gpus.
+var validGCPGPUCounts = map[int]struct{}{
+	1:  {},
+	2:  {},
+	4:  {},
+	8:  {},
+	16: {},
+}
 
 // gpuAttachableAccelerators is the allow-list of NVIDIA accelerator types that
 // attach to N1 machines via guest_accelerator (#767). vws variants are the
@@ -61,10 +93,13 @@ var gpuAttachableAccelerators = map[string]struct{}{
 
 // gpuBundledMachineFamilies is the set of machine-type family prefixes whose
 // GPU is BUNDLED with the machine type (#767): A2 / A3 / A4 / A4X (A100 / H100 /
-// H200 / B200 / GB200 / GB300), G2 (L4), and G4 (RTX-PRO-6000). For these you
-// select the GPU by picking the machine type; attaching a guest_accelerator is
-// invalid and GCP rejects it. We reject an explicit GPUType on these families at
-// compose time rather than silently attaching an incompatible accelerator.
+// H200 / B200 / GB200 / GB300), G2 (L4), and G4 (RTX-PRO-6000).
+//
+// On Compute Engine VMs the GPU is attached automatically and a guest_accelerator
+// is invalid, so the compute mapper rejects an explicit GPUType on these. On GKE
+// node pools the accelerator IS declared (paired with the machine type), so the
+// gke mapper ACCEPTS these families and validates the type/family pairing against
+// gpuBundledFamilyAccelerators below.
 //
 // This set MUST stay in lockstep with the HCL `_gpu_bundled_machine_families`
 // locals in gcp/compute/main.tf and gcp/gke/main.tf — TestGCPGPUFamiliesDrift
@@ -76,6 +111,24 @@ var gpuBundledMachineFamilies = map[string]struct{}{
 	"a4x": {},
 	"g2":  {},
 	"g4":  {},
+}
+
+// gpuBundledFamilyAccelerators maps each bundled-GPU machine family to the
+// accelerator type(s) GKE pairs with it in the node-pool accelerator config.
+// Used only by the GKE path: when a caller requests a GPU node pool on one of
+// these families, the gpu_type must be one of the family's accelerators (or is
+// defaulted to the first listed when unset). Verified against
+// https://cloud.google.com/kubernetes-engine/docs/how-to/gpus.
+//
+// Keys MUST exactly match gpuBundledMachineFamilies — TestGCPGPUBundledPairings
+// enforces that every bundled family has a pairing entry and vice-versa.
+var gpuBundledFamilyAccelerators = map[string][]string{
+	"a2":  {"nvidia-tesla-a100", "nvidia-a100-80gb"},
+	"a3":  {"nvidia-h100-80gb", "nvidia-h100-mega-80gb", "nvidia-h200-141gb"},
+	"a4":  {"nvidia-b200"},
+	"a4x": {"nvidia-gb200", "nvidia-gb300"},
+	"g2":  {"nvidia-l4"},
+	"g4":  {"nvidia-rtx-pro-6000"},
 }
 
 // machineFamily returns the family prefix of a GCP machine type — the part
@@ -98,8 +151,7 @@ func isN1Machine(machineType string) bool {
 }
 
 // isBundledGPUMachine reports whether machineType belongs to a family whose GPU
-// is bundled with the machine type (per gpuBundledMachineFamilies), so attaching
-// a separate guest_accelerator is invalid.
+// is bundled with the machine type (per gpuBundledMachineFamilies).
 func isBundledGPUMachine(machineType string) bool {
 	_, ok := gpuBundledMachineFamilies[machineFamily(machineType)]
 	return ok
@@ -114,10 +166,37 @@ func isAttachableAccelerator(gpuType string) bool {
 	return ok
 }
 
-// validateGCPGPU enforces the GCP attach-a-GPU rules shared by the gcp_compute
-// and gcp_gke mapper branches (#767), so both reject the same invalid configs
-// with identical, actionable error content. component is the IR field name used
-// in the error message ("GCPCompute" / "GCPGKE"). It validates, in order:
+// normalizeGPUType lower-cases and trims a GPU type so the value the mapper
+// emits is the canonical form GCP expects ("  NVIDIA-Tesla-T4 " → "nvidia-tesla-t4").
+func normalizeGPUType(gpuType string) string {
+	return strings.ToLower(strings.TrimSpace(gpuType))
+}
+
+// validateGCPGPUCount rejects an accelerator count GCP never accepts (per
+// validGCPGPUCounts). component is the IR field name used in the message. A
+// count of 0 is treated as "default to 1" by the caller and is not validated
+// here — only an explicit positive count is checked.
+func validateGCPGPUCount(component string, count int) error {
+	if count <= 0 {
+		return nil
+	}
+	if _, ok := validGCPGPUCounts[count]; !ok {
+		return NewValidationError(fmt.Sprintf(
+			"%s GPUCount=%d is not a valid GCP accelerator count (expected one of "+
+				"1, 2, 4, 8, 16). The exact legal count is GPU-type/zone/machine-"+
+				"specific (a deploy-time concern), but counts outside this set are "+
+				"always rejected by GCP.",
+			component, count,
+		))
+	}
+	return nil
+}
+
+// validateGCPComputeGPU enforces the Compute Engine VM attach-a-GPU rules
+// (#752 review). On a VM the GPU attaches via guest_accelerator ONLY on N1
+// machines; A2/A3/A4/G2/G4 attach their GPU automatically by machine type and
+// reject an explicit guest_accelerator, and every other family takes none. It
+// validates, in order:
 //
 //  1. A bundled-GPU machine family (A2/A3/A4/G2/G4) with an explicit GPUType is
 //     rejected — the GPU comes with the machine type, so attaching a separate
@@ -126,17 +205,19 @@ func isAttachableAccelerator(gpuType string) bool {
 //     all — rejected (only N1 attaches GPUs via guest_accelerator).
 //  3. An explicit GPUType that is not a known N1-attachable accelerator is
 //     rejected (typo, or a bundled-only / TPU type used by mistake).
+//  4. An explicit GPUCount outside the valid GCP set is rejected.
 //
 // An empty machine type is treated as the non-N1 preset default and rejected
 // with the same N1 guidance — the caller must pick an N1 machine to attach a GPU.
-func validateGCPGPU(component, machineType, gpuType string) error {
+func validateGCPComputeGPU(machineType, gpuType string, gpuCount int) error {
+	const component = "GCPCompute"
 	if isBundledGPUMachine(machineType) {
 		return NewValidationError(fmt.Sprintf(
-			"%s machine_type=%q bundles its GPU with the machine type "+
-				"(A2/A3/A4/G2/G4 families ship a fixed GPU): you select the GPU by "+
-				"picking the machine type, so an explicit GPUType is invalid. "+
-				"Clear GPUType/GPUCount and use the accelerator-optimized machine "+
-				"type alone, or pick an N1 machine to attach %s.",
+			"%s machine_type=%q attaches its GPU automatically (A2/A3/A4/G2/G4 "+
+				"families ship a fixed GPU with the machine type): on a Compute Engine "+
+				"VM you do not set a guest_accelerator, so an explicit GPUType is "+
+				"invalid. Clear GPUType/GPUCount and use the accelerator-optimized "+
+				"machine type alone, or pick an N1 machine to attach %s.",
 			component, machineType, gpuTypeForMsg(gpuType),
 		))
 	}
@@ -146,7 +227,7 @@ func validateGCPGPU(component, machineType, gpuType string) error {
 				"GPUs via guest_accelerator only on N1 general-purpose machines "+
 				"(e.g. n1-standard-4). Pick an N1 machine type to attach a GPU, or "+
 				"use an accelerator-optimized machine type (a2-*/a3-*/g2-*) whose GPU "+
-				"is bundled and set no GPUType.",
+				"is attached automatically and set no GPUType.",
 			component, machineType,
 		))
 	}
@@ -160,7 +241,91 @@ func validateGCPGPU(component, machineType, gpuType string) error {
 			component, gpuType, defaultGCPAccelerator,
 		))
 	}
-	return nil
+	return validateGCPGPUCount(component, gpuCount)
+}
+
+// validateGCPGKEGPU enforces the GKE node-pool attach-a-GPU rules (#752 review).
+// Unlike a Compute VM, a GKE node pool DECLARES the accelerator even for the
+// accelerator-optimized families — the node pool's accelerator config must pair
+// the machine type with its GPU. It validates, in order:
+//
+//  1. An N1 machine accepts the N1-attachable accelerators (T4/V100/P100/P4); an
+//     explicit GPUType that is not one is rejected.
+//  2. A bundled-GPU machine family (A2/A3/A4/G2/G4) is ACCEPTED, but an explicit
+//     GPUType must be one of the accelerators GKE pairs with that family (per
+//     gpuBundledFamilyAccelerators) — a mismatched type is rejected. An empty
+//     GPUType is allowed; the mapper defaults it to the family's accelerator.
+//  3. Any other family cannot take a GPU at all — rejected.
+//  4. An explicit GPUCount outside the valid GCP set is rejected.
+//
+// An empty machine type is treated as the non-N1 preset default and rejected
+// with N1 guidance — the caller must pick an N1 or accelerator-optimized machine.
+func validateGCPGKEGPU(machineType, gpuType string, gpuCount int) error {
+	const component = "GCPGKE"
+	fam := machineFamily(machineType)
+	switch {
+	case fam == "n1":
+		if gpuType != "" && !isAttachableAccelerator(gpuType) {
+			return NewValidationError(fmt.Sprintf(
+				"%s GPUType=%q is not a known N1-attachable NVIDIA accelerator "+
+					"(expected one of nvidia-tesla-t4/nvidia-tesla-t4-vws/"+
+					"nvidia-tesla-p4/nvidia-tesla-p4-vws/nvidia-tesla-v100/"+
+					"nvidia-tesla-p100/nvidia-tesla-p100-vws). Clear GPUType to default "+
+					"to %s, or pick a supported accelerator.",
+				component, gpuType, defaultGCPAccelerator,
+			))
+		}
+	case isBundledGPUMachine(machineType):
+		if gpuType != "" && !isBundledFamilyAccelerator(fam, gpuType) {
+			return NewValidationError(fmt.Sprintf(
+				"%s GPUType=%q does not pair with machine_type=%q: a GKE %s node pool "+
+					"declares the accelerator that matches the machine family (expected "+
+					"one of %s). Clear GPUType to default to %s, or pick the matching "+
+					"accelerator.",
+				component, gpuType, machineType, strings.ToUpper(fam),
+				strings.Join(gpuBundledFamilyAccelerators[fam], "/"),
+				gpuBundledFamilyAccelerators[fam][0],
+			))
+		}
+	default:
+		return NewValidationError(fmt.Sprintf(
+			"%s requests a GPU but machine_type=%q does not accept one: a GKE GPU node "+
+				"pool needs an N1 machine (attaches T4/V100/P100/P4) or an accelerator-"+
+				"optimized machine (a2-*/a3-*/a4-*/g2-*/g4-*, whose GPU is declared by "+
+				"the matching accelerator type). Pick one of those machine types.",
+			component, machineType,
+		))
+	}
+	return validateGCPGPUCount(component, gpuCount)
+}
+
+// isBundledFamilyAccelerator reports whether gpuType is one of the accelerators
+// GKE pairs with the given bundled machine family. gpuType is normalized before
+// the lookup so case/whitespace don't matter.
+func isBundledFamilyAccelerator(family, gpuType string) bool {
+	want := normalizeGPUType(gpuType)
+	for _, a := range gpuBundledFamilyAccelerators[family] {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultGKEGPUType returns the accelerator type the GKE mapper supplies when a
+// caller requests a GPU node pool on machineType but does not pin a GPUType. For
+// N1 it is the shared default (nvidia-tesla-t4); for a bundled family it is that
+// family's first paired accelerator. Returns "" for a family that cannot take a
+// GPU (validation rejects those before this is consulted).
+func defaultGKEGPUType(machineType string) string {
+	fam := machineFamily(machineType)
+	if fam == "n1" {
+		return defaultGCPAccelerator
+	}
+	if accs := gpuBundledFamilyAccelerators[fam]; len(accs) > 0 {
+		return accs[0]
+	}
+	return ""
 }
 
 // gpuTypeForMsg renders the GPU type for an error message, falling back to "a

--- a/pkg/composer/gpu_gcp_families_drift_test.go
+++ b/pkg/composer/gpu_gcp_families_drift_test.go
@@ -93,3 +93,119 @@ func parseGCPBundledFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
 	}
 	return out
 }
+
+// TestGCPGPUBundledPairings asserts the Go bundled-family → accelerator pairing
+// map (gpuBundledFamilyAccelerators, GKE-only) is internally consistent and stays
+// in lockstep with the HCL `_gpu_bundled_family_accelerator_map` in gcp/gke/main.tf
+// (#752 review). Two contracts:
+//
+//  1. Every bundled machine family (gpuBundledMachineFamilies) has a pairing entry
+//     and vice-versa — a family with no accelerator could never compose a GKE GPU
+//     node pool, and a stray pairing entry would never be reachable.
+//  2. The Go pairing map matches the GKE HCL map exactly (family → set of GPU
+//     types). If they drift, a gpu_type the composer accepts for a family could be
+//     rejected by the preset's pairing precondition at apply (or vice-versa) —
+//     exactly the failure the split validation exists to prevent.
+//
+// The pairing map is GKE-only: on a Compute VM the accelerator is attached
+// automatically and the compute preset rejects an explicit gpu_type on these
+// families, so there is no compute HCL pairing map to drift against.
+func TestGCPGPUBundledPairings(t *testing.T) {
+	// (1) keys of the pairing map == the bundled-family set, and no family maps
+	// to an empty accelerator list.
+	for fam := range gpuBundledMachineFamilies {
+		accs, ok := gpuBundledFamilyAccelerators[fam]
+		if !ok {
+			t.Errorf("bundled family %q has no accelerator pairing in gpuBundledFamilyAccelerators", fam)
+			continue
+		}
+		if len(accs) == 0 {
+			t.Errorf("bundled family %q maps to an empty accelerator list", fam)
+		}
+	}
+	for fam := range gpuBundledFamilyAccelerators {
+		if _, ok := gpuBundledMachineFamilies[fam]; !ok {
+			t.Errorf("gpuBundledFamilyAccelerators has pairing for %q but it is not a bundled machine family", fam)
+		}
+	}
+
+	// (2) the Go pairing map matches the GKE HCL `_gpu_bundled_family_accelerator_map`.
+	path := filepath.Join("..", "..", "gcp", "gke", "main.tf")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	hclMap := parseGCPBundledFamilyAcceleratorMapHCL(t, string(b))
+	if len(hclMap) == 0 {
+		t.Fatalf("no entries parsed from _gpu_bundled_family_accelerator_map in %s — parser or HCL shape changed", path)
+	}
+
+	for fam, goAccs := range gpuBundledFamilyAccelerators {
+		hclAccs, ok := hclMap[fam]
+		if !ok {
+			t.Errorf("family %q in gpuBundledFamilyAccelerators (gpu_gcp.go) but missing from %s _gpu_bundled_family_accelerator_map", fam, path)
+			continue
+		}
+		want := append([]string(nil), goAccs...)
+		got := append([]string(nil), hclAccs...)
+		sort.Strings(want)
+		sort.Strings(got)
+		if strings.Join(want, ",") != strings.Join(got, ",") {
+			t.Errorf("family %q accelerator pairing drift: gpu_gcp.go=%v, %s=%v", fam, want, path, got)
+		}
+	}
+	for fam := range hclMap {
+		if _, ok := gpuBundledFamilyAccelerators[fam]; !ok {
+			t.Errorf("family %q in %s _gpu_bundled_family_accelerator_map but missing from gpuBundledFamilyAccelerators (gpu_gcp.go)", fam, path)
+		}
+	}
+}
+
+// parseGCPBundledFamilyAcceleratorMapHCL extracts the
+// `_gpu_bundled_family_accelerator_map = { fam = [ ... ] ... }` local from the
+// GKE main.tf into a family → []accelerator map. It isolates the braced map body
+// (balanced-brace scan from the first "{" after the assignment), strips inline
+// comments, then matches each `key = [ "a", "b" ]` entry.
+func parseGCPBundledFamilyAcceleratorMapHCL(t *testing.T, hcl string) map[string][]string {
+	t.Helper()
+	anchor := regexp.MustCompile(`_gpu_bundled_family_accelerator_map\s*=\s*\{`)
+	loc := anchor.FindStringIndex(hcl)
+	if loc == nil {
+		t.Fatalf("could not locate `_gpu_bundled_family_accelerator_map = {` in main.tf")
+	}
+	// Balanced-brace scan starting at the opening brace.
+	open := loc[1] - 1
+	depth := 0
+	end := -1
+	for i := open; i < len(hcl); i++ {
+		switch hcl[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				end = i
+			}
+		}
+		if end >= 0 {
+			break
+		}
+	}
+	if end < 0 {
+		t.Fatalf("unbalanced braces in `_gpu_bundled_family_accelerator_map`")
+	}
+	body := stripHCLLineComments(hcl[open+1 : end])
+
+	entryRe := regexp.MustCompile(`(?m)^\s*([A-Za-z0-9_]+)\s*=\s*\[([^\]]*)\]`)
+	tokenRe := regexp.MustCompile(`"([^"]+)"`)
+	out := map[string][]string{}
+	for _, em := range entryRe.FindAllStringSubmatch(body, -1) {
+		fam := strings.TrimSpace(em[1])
+		var accs []string
+		for _, tm := range tokenRe.FindAllStringSubmatch(em[2], -1) {
+			accs = append(accs, strings.TrimSpace(tm[1]))
+		}
+		out[fam] = accs
+	}
+	return out
+}

--- a/pkg/composer/gpu_gcp_families_drift_test.go
+++ b/pkg/composer/gpu_gcp_families_drift_test.go
@@ -1,0 +1,95 @@
+package composer
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestGCPGPUFamiliesDrift asserts the Go bundled-GPU machine-family set
+// (gpuBundledMachineFamilies in gpu_gcp.go) stays in lockstep with the HCL
+// `_gpu_bundled_machine_families` locals in BOTH gcp/compute/main.tf and
+// gcp/gke/main.tf (#767). The HCL lists drive each preset's plan-time GPU
+// machine-type precondition; the Go set drives the composer's compose-time
+// rejection of an explicit GPUType on a bundled-GPU machine. If any of the three
+// drift, a machine family rejected by one layer might be accepted by another, so
+// a config that composes could fail at apply (or vice-versa) — exactly the
+// failure the validation exists to prevent. This fails the moment any list adds
+// or removes a family without the other two.
+//
+// The N1-attachable accelerator allow-list (gpuAttachableAccelerators) is
+// deliberately Go-only: the presets attach whatever gpu_type the composer passes
+// and gate it with the machine-family precondition, so there is no HCL
+// accelerator list to drift against.
+func TestGCPGPUFamiliesDrift(t *testing.T) {
+	goFamilies := map[string]struct{}{}
+	for f := range gpuBundledMachineFamilies {
+		goFamilies[f] = struct{}{}
+	}
+
+	for _, src := range []struct {
+		name string
+		path string
+	}{
+		{"compute", filepath.Join("..", "..", "gcp", "compute", "main.tf")},
+		{"gke", filepath.Join("..", "..", "gcp", "gke", "main.tf")},
+	} {
+		t.Run(src.name, func(t *testing.T) {
+			b, err := os.ReadFile(src.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", src.path, err)
+			}
+
+			hclFamilies := parseGCPBundledFamiliesHCL(t, string(b))
+			if len(hclFamilies) == 0 {
+				t.Fatalf("no families parsed from _gpu_bundled_machine_families in %s — parser or HCL shape changed", src.path)
+			}
+
+			var missingInGo []string
+			for f := range hclFamilies {
+				if _, ok := goFamilies[f]; !ok {
+					missingInGo = append(missingInGo, f)
+				}
+			}
+			var missingInHCL []string
+			for f := range goFamilies {
+				if _, ok := hclFamilies[f]; !ok {
+					missingInHCL = append(missingInHCL, f)
+				}
+			}
+
+			sort.Strings(missingInGo)
+			sort.Strings(missingInHCL)
+			if len(missingInGo) > 0 {
+				t.Errorf("families in %s _gpu_bundled_machine_families but missing from gpuBundledMachineFamilies (gpu_gcp.go): %v", src.path, missingInGo)
+			}
+			if len(missingInHCL) > 0 {
+				t.Errorf("families in gpuBundledMachineFamilies (gpu_gcp.go) but missing from %s _gpu_bundled_machine_families: %v", src.path, missingInHCL)
+			}
+		})
+	}
+}
+
+// parseGCPBundledFamiliesHCL extracts the quoted family strings from the
+// `_gpu_bundled_machine_families = [ ... ]` local assignment, mirroring
+// parseGPUFamiliesHCL (the AWS analogue). It isolates the bracketed list body,
+// strips inline `#` comments, then pulls every double-quoted token so reordering
+// or reflowing the HCL doesn't affect the result.
+func parseGCPBundledFamiliesHCL(t *testing.T, hcl string) map[string]struct{} {
+	t.Helper()
+	listRe := regexp.MustCompile(`(?s)_gpu_bundled_machine_families\s*=\s*\[(.*?)\]`)
+	m := listRe.FindStringSubmatch(hcl)
+	if m == nil {
+		t.Fatalf("could not locate `_gpu_bundled_machine_families = [...]` in main.tf")
+	}
+	body := stripHCLLineComments(m[1])
+	tokenRe := regexp.MustCompile(`"([^"]+)"`)
+	out := map[string]struct{}{}
+	for _, tm := range tokenRe.FindAllStringSubmatch(body, -1) {
+		out[strings.TrimSpace(tm[1])] = struct{}{}
+	}
+	return out
+}

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -217,6 +217,7 @@ var GCPIAMPermissions = map[ComponentKey][]string{
 	KeyGCPCloudBuild:       {"cloudbuild.builds.create"},
 	KeyGCPFirestore:        {"datastore.databases.create"},
 	KeyGCPVertexAI:         {"aiplatform.endpoints.create"},
+	KeyGCPAgentEngine:      {"aiplatform.reasoningEngines.create"},
 	KeyGCPAPIGateway:       {"apigateway.gateways.create"},
 	KeyGCPBackups:          {"backupdr.managementServers.create"},
 	// Cloud DNS (#593). managedZones.create + resourceRecordSets.create

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1045,6 +1045,12 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.GCPVertexAI.ModelGardenModel != "" {
 				vals["model_garden_model"] = cfg.GCPVertexAI.ModelGardenModel
 			}
+			// EULA acceptance for EULA-gated open models (Gemma/Llama). Only
+			// emit when the caller explicitly set it so the preset's
+			// explicit-consent default (false) wins when left unset.
+			if cfg.GCPVertexAI.ModelGardenAcceptEULA != nil {
+				vals["model_garden_accept_eula"] = *cfg.GCPVertexAI.ModelGardenAcceptEULA
+			}
 		}
 
 	case KeyGCPPubSub:

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -953,6 +953,28 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.GCPCompute.DiskSizeGb > 0 {
 				vals["disk_size_gb"] = cfg.GCPCompute.DiskSizeGb
 			}
+			// GPU instance (#767): VALIDATE, don't mask. Either GPUType or
+			// GPUCount signals "attach a GPU". GCP only attaches GPUs via
+			// guest_accelerator on N1 machines; A2/A3/A4/G2/G4 bundle their GPU
+			// with the machine type, and every other family takes none. Reject
+			// an incompatible machine type at compose time, and emit the GPU
+			// tfvars so the preset attaches the accelerator AND forces
+			// on_host_maintenance=TERMINATE (GCP rejects MIGRATE with a GPU).
+			if cfg.GCPCompute.GPUType != "" || cfg.GCPCompute.GPUCount > 0 {
+				if err := validateGCPGPU("GCPCompute", cfg.GCPCompute.MachineType, cfg.GCPCompute.GPUType); err != nil {
+					return nil, err
+				}
+				gpuType := cfg.GCPCompute.GPUType
+				if gpuType == "" {
+					gpuType = defaultGCPAccelerator
+				}
+				gpuCount := cfg.GCPCompute.GPUCount
+				if gpuCount <= 0 {
+					gpuCount = defaultGCPGPUCount
+				}
+				vals["gpu_type"] = gpuType
+				vals["gpu_count"] = gpuCount
+			}
 		}
 
 	case KeyGCPGKE:
@@ -972,6 +994,26 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 			if cfg.GCPGKE.Regional != nil {
 				vals["regional"] = *cfg.GCPGKE.Regional
+			}
+			// GPU node pool (#767): VALIDATE, don't mask. Same N1-attachable vs
+			// bundled-family rule as gcp_compute. When a GPU is requested, emit
+			// the accelerator tfvars; the preset wires them into the node pool's
+			// accelerator config and turns on GKE auto NVIDIA driver install (no
+			// in-cluster device-plugin work, unlike EKS).
+			if cfg.GCPGKE.GPUType != "" || cfg.GCPGKE.GPUCount > 0 {
+				if err := validateGCPGPU("GCPGKE", cfg.GCPGKE.MachineType, cfg.GCPGKE.GPUType); err != nil {
+					return nil, err
+				}
+				gpuType := cfg.GCPGKE.GPUType
+				if gpuType == "" {
+					gpuType = defaultGCPAccelerator
+				}
+				gpuCount := cfg.GCPGKE.GPUCount
+				if gpuCount <= 0 {
+					gpuCount = defaultGCPGPUCount
+				}
+				vals["gpu_type"] = gpuType
+				vals["gpu_count"] = gpuCount
 			}
 		}
 

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1034,6 +1034,17 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.GCPVertexAI.IndexDimensions > 0 {
 				vals["index_dimensions"] = cfg.GCPVertexAI.IndexDimensions
 			}
+			// Serving (#768): orthogonal to Vector Search. enable_serving
+			// gates the endpoint; model_garden_model (when set) drives the
+			// Model Garden deployment. Same partial-config discipline: only
+			// emit a field the caller populated so the preset defaults
+			// (enable_serving=false, no model) win when left unset.
+			if cfg.GCPVertexAI.EnableServing != nil {
+				vals["enable_serving"] = *cfg.GCPVertexAI.EnableServing
+			}
+			if cfg.GCPVertexAI.ModelGardenModel != "" {
+				vals["model_garden_model"] = cfg.GCPVertexAI.ModelGardenModel
+			}
 		}
 
 	case KeyGCPPubSub:

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -954,17 +954,19 @@ func (m DefaultMapper) BuildModuleValues(
 				vals["disk_size_gb"] = cfg.GCPCompute.DiskSizeGb
 			}
 			// GPU instance (#767): VALIDATE, don't mask. Either GPUType or
-			// GPUCount signals "attach a GPU". GCP only attaches GPUs via
-			// guest_accelerator on N1 machines; A2/A3/A4/G2/G4 bundle their GPU
-			// with the machine type, and every other family takes none. Reject
-			// an incompatible machine type at compose time, and emit the GPU
-			// tfvars so the preset attaches the accelerator AND forces
-			// on_host_maintenance=TERMINATE (GCP rejects MIGRATE with a GPU).
+			// GPUCount signals "attach a GPU". On a Compute Engine VM, GCP only
+			// attaches GPUs via guest_accelerator on N1 machines; A2/A3/A4/G2/G4
+			// attach their GPU automatically by machine type (an explicit
+			// guest_accelerator is invalid there) and every other family takes
+			// none. Reject an incompatible machine type at compose time, and emit
+			// the GPU tfvars (canonical lower-case type) so the preset attaches
+			// the accelerator AND forces on_host_maintenance=TERMINATE (GCP rejects
+			// MIGRATE with a GPU).
 			if cfg.GCPCompute.GPUType != "" || cfg.GCPCompute.GPUCount > 0 {
-				if err := validateGCPGPU("GCPCompute", cfg.GCPCompute.MachineType, cfg.GCPCompute.GPUType); err != nil {
+				if err := validateGCPComputeGPU(cfg.GCPCompute.MachineType, cfg.GCPCompute.GPUType, cfg.GCPCompute.GPUCount); err != nil {
 					return nil, err
 				}
-				gpuType := cfg.GCPCompute.GPUType
+				gpuType := normalizeGPUType(cfg.GCPCompute.GPUType)
 				if gpuType == "" {
 					gpuType = defaultGCPAccelerator
 				}
@@ -995,18 +997,21 @@ func (m DefaultMapper) BuildModuleValues(
 			if cfg.GCPGKE.Regional != nil {
 				vals["regional"] = *cfg.GCPGKE.Regional
 			}
-			// GPU node pool (#767): VALIDATE, don't mask. Same N1-attachable vs
-			// bundled-family rule as gcp_compute. When a GPU is requested, emit
-			// the accelerator tfvars; the preset wires them into the node pool's
-			// accelerator config and turns on GKE auto NVIDIA driver install (no
-			// in-cluster device-plugin work, unlike EKS).
+			// GPU node pool (#767, #752 review): VALIDATE, don't mask. Unlike a
+			// Compute VM, a GKE node pool DECLARES the accelerator even for the
+			// accelerator-optimized families — g2 pairs with nvidia-l4, a2 with
+			// nvidia-tesla-a100, a3 with nvidia-h100-80gb, etc. — and N1 attaches
+			// the T4/V100/P100/P4 accelerators. When a GPU is requested, emit the
+			// accelerator tfvars (canonical lower-case type); the preset wires them
+			// into the node pool's accelerator config and turns on GKE auto NVIDIA
+			// driver install (no in-cluster device-plugin work, unlike EKS).
 			if cfg.GCPGKE.GPUType != "" || cfg.GCPGKE.GPUCount > 0 {
-				if err := validateGCPGPU("GCPGKE", cfg.GCPGKE.MachineType, cfg.GCPGKE.GPUType); err != nil {
+				if err := validateGCPGKEGPU(cfg.GCPGKE.MachineType, cfg.GCPGKE.GPUType, cfg.GCPGKE.GPUCount); err != nil {
 					return nil, err
 				}
-				gpuType := cfg.GCPGKE.GPUType
+				gpuType := normalizeGPUType(cfg.GCPGKE.GPUType)
 				if gpuType == "" {
-					gpuType = defaultGCPAccelerator
+					gpuType = defaultGKEGPUType(cfg.GCPGKE.MachineType)
 				}
 				gpuCount := cfg.GCPGKE.GPUCount
 				if gpuCount <= 0 {

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1036,6 +1036,19 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyGCPAgentEngine:
+		// Vertex AI Agent Engine (#769). Partial-config: only emit a field the
+		// caller actually populated so the preset's own defaults win when left
+		// unset (display_name defaults to "<project>-agent-engine"). The
+		// packaged-artifact URI is app-layer (supplied via package_artifact_uri
+		// directly, not modeled in Config), and staging_bucket is wired by
+		// DefaultWiring from gcp/gcs — neither is emitted here.
+		if cfg != nil && cfg.GCPAgentEngine != nil {
+			if strings.TrimSpace(cfg.GCPAgentEngine.DisplayName) != "" {
+				vals["display_name"] = strings.TrimSpace(cfg.GCPAgentEngine.DisplayName)
+			}
+		}
+
 	case KeyGCPPubSub:
 		vals["topic_name"] = "events"
 		if cfg != nil && cfg.GCPPubSub != nil {

--- a/pkg/composer/mapper_gcp_gpu_test.go
+++ b/pkg/composer/mapper_gcp_gpu_test.go
@@ -38,13 +38,13 @@ func TestBuildModuleValues_GCPCompute_GPU(t *testing.T) {
 		assert.Equal(t, 4, vals["gpu_count"])
 	})
 
-	t.Run("capitalised + padded GPUType normalizes and is accepted", func(t *testing.T) {
+	t.Run("capitalised + padded GPUType normalizes and is emitted canonical", func(t *testing.T) {
 		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "  NVIDIA-Tesla-T4  "})
 		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
 		require.NoError(t, err)
-		// The mapper passes the user's literal through to HCL; validation
-		// normalizes case/whitespace before the allow-list check.
-		assert.Equal(t, "  NVIDIA-Tesla-T4  ", vals["gpu_type"])
+		// The mapper emits the canonical (lower-cased, trimmed) form so the
+		// composed HCL is the type string GCP expects (#752 review, P2-2).
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"])
 	})
 
 	t.Run("no GPU leaves gpu_type/gpu_count unset", func(t *testing.T) {
@@ -58,18 +58,28 @@ func TestBuildModuleValues_GCPCompute_GPU(t *testing.T) {
 		assert.Equal(t, "e2-medium", vals["machine_type"], "non-GPU fields unchanged")
 	})
 
-	t.Run("bundled-GPU machine (G2) with explicit GPUType is rejected", func(t *testing.T) {
+	t.Run("bundled-GPU machine (G2) with explicit GPUType is rejected on a VM", func(t *testing.T) {
+		// On a Compute VM the GPU is attached automatically by the machine type,
+		// so an explicit guest_accelerator is invalid (unlike GKE — see the GKE
+		// test below where the same family is ACCEPTED).
 		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "g2-standard-4", GPUType: "nvidia-l4"})
 		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+		assert.Contains(t, err.Error(), "attaches its GPU automatically")
 	})
 
-	t.Run("bundled-GPU machine (A2) with explicit GPUType is rejected", func(t *testing.T) {
+	t.Run("bundled-GPU machine (A2) with explicit GPUType is rejected on a VM", func(t *testing.T) {
 		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "a2-highgpu-1g", GPUType: "nvidia-tesla-a100"})
 		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+		assert.Contains(t, err.Error(), "attaches its GPU automatically")
+	})
+
+	t.Run("invalid GPUCount on N1 is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4", GPUCount: 3})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid GCP accelerator count")
 	})
 
 	t.Run("non-N1 non-bundled machine (E2) with a GPU is rejected", func(t *testing.T) {
@@ -95,8 +105,10 @@ func TestBuildModuleValues_GCPCompute_GPU(t *testing.T) {
 }
 
 // TestBuildModuleValues_GCPGKE_GPU exercises the gcp_gke GPU mapper branch
-// (#767): same N1-attachable-vs-bundled rule as gcp_compute, applied to the node
-// pool accelerator config.
+// (#767, #752 review). Unlike gcp_compute, a GKE node pool DECLARES the
+// accelerator even for the accelerator-optimized families, so the bundled
+// families (G2/A2/A3/...) are ACCEPTED here (paired with their GPU type), not
+// rejected — while N1 attaches the T4/V100/P100/P4 accelerators.
 func TestBuildModuleValues_GCPGKE_GPU(t *testing.T) {
 	m := DefaultMapper{}
 
@@ -137,11 +149,40 @@ func TestBuildModuleValues_GCPGKE_GPU(t *testing.T) {
 		assert.False(t, hasCount, "non-GPU node pool must not set gpu_count")
 	})
 
-	t.Run("bundled-GPU machine (A3) with explicit GPUType is rejected", func(t *testing.T) {
-		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "a3-highgpu-8g", GPUType: "nvidia-h100-80gb"})
+	t.Run("bundled-GPU machine (G2) with matching GPUType is accepted", func(t *testing.T) {
+		// The #752 review fix: G2 is a valid GKE GPU node pool (paired with
+		// nvidia-l4), where the same config is rejected on a Compute VM.
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "g2-standard-4", GPUType: "nvidia-l4", GPUCount: 1})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-l4", vals["gpu_type"])
+		assert.Equal(t, 1, vals["gpu_count"])
+	})
+
+	t.Run("bundled-GPU machine (A3) with matching GPUType is accepted", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "a3-highgpu-8g", GPUType: "nvidia-h100-80gb", GPUCount: 8})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-h100-80gb", vals["gpu_type"])
+		assert.Equal(t, 8, vals["gpu_count"])
+	})
+
+	t.Run("bundled-GPU machine (G2) with no GPUType defaults to family accelerator", func(t *testing.T) {
+		// GPUCount alone signals GPU intent; the mapper defaults the type to the
+		// family's bundled accelerator (nvidia-l4 for G2), not the N1 T4 default.
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "g2-standard-4", GPUCount: 2})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-l4", vals["gpu_type"], "G2 with no GPUType must default to its bundled nvidia-l4")
+		assert.Equal(t, 2, vals["gpu_count"])
+	})
+
+	t.Run("bundled-GPU machine (G2) with mismatched GPUType is rejected", func(t *testing.T) {
+		// nvidia-tesla-a100 is an A2 accelerator — wrong pairing for G2.
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "g2-standard-4", GPUType: "nvidia-tesla-a100"})
 		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+		assert.Contains(t, err.Error(), "does not pair with machine_type")
 	})
 
 	t.Run("non-N1 non-bundled machine with a GPU is rejected", func(t *testing.T) {
@@ -156,5 +197,19 @@ func TestBuildModuleValues_GCPGKE_GPU(t *testing.T) {
 		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not a known N1-attachable NVIDIA accelerator")
+	})
+
+	t.Run("invalid GPUCount is rejected", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4", GPUCount: 5})
+		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid GCP accelerator count")
+	})
+
+	t.Run("capitalised + padded GPUType normalizes and is emitted canonical", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", GPUType: "  NVIDIA-Tesla-T4  "})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"], "GKE must emit the canonical lower-cased type (#752 review, P2-2)")
 	})
 }

--- a/pkg/composer/mapper_gcp_gpu_test.go
+++ b/pkg/composer/mapper_gcp_gpu_test.go
@@ -1,0 +1,160 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildModuleValues_GCPCompute_GPU exercises the gcp_compute GPU mapper
+// branch (#767): partial-config defaulting and rejection-with-content. The
+// preset forces on_host_maintenance=TERMINATE by construction, so the mapper
+// only emits gpu_type / gpu_count.
+func TestBuildModuleValues_GCPCompute_GPU(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("explicit GPUType on N1 emits gpu_type + default count", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4"})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"])
+		assert.Equal(t, 1, vals["gpu_count"], "GPUType with no count must default to 1")
+	})
+
+	t.Run("GPUCount only on N1 defaults the accelerator type", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-8", GPUCount: 2})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"], "GPUCount with no type must default to nvidia-tesla-t4")
+		assert.Equal(t, 2, vals["gpu_count"])
+	})
+
+	t.Run("explicit GPUType + GPUCount preserved", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-v100", GPUCount: 4})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-v100", vals["gpu_type"])
+		assert.Equal(t, 4, vals["gpu_count"])
+	})
+
+	t.Run("capitalised + padded GPUType normalizes and is accepted", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "  NVIDIA-Tesla-T4  "})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		// The mapper passes the user's literal through to HCL; validation
+		// normalizes case/whitespace before the allow-list check.
+		assert.Equal(t, "  NVIDIA-Tesla-T4  ", vals["gpu_type"])
+	})
+
+	t.Run("no GPU leaves gpu_type/gpu_count unset", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "e2-medium", DiskSizeGb: 50})
+		vals, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasType := vals["gpu_type"]
+		_, hasCount := vals["gpu_count"]
+		assert.False(t, hasType, "non-GPU compute must not set gpu_type")
+		assert.False(t, hasCount, "non-GPU compute must not set gpu_count")
+		assert.Equal(t, "e2-medium", vals["machine_type"], "non-GPU fields unchanged")
+	})
+
+	t.Run("bundled-GPU machine (G2) with explicit GPUType is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "g2-standard-4", GPUType: "nvidia-l4"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+	})
+
+	t.Run("bundled-GPU machine (A2) with explicit GPUType is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "a2-highgpu-1g", GPUType: "nvidia-tesla-a100"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+	})
+
+	t.Run("non-N1 non-bundled machine (E2) with a GPU is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "e2-standard-4", GPUType: "nvidia-tesla-t4"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not accept one")
+	})
+
+	t.Run("GPU with no machine type is rejected (preset default is non-N1)", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{GPUType: "nvidia-tesla-t4"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not accept one")
+	})
+
+	t.Run("unknown accelerator type on N1 is rejected", func(t *testing.T) {
+		cfg := configWithGCPCompute(gcpComputeCfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-l4"})
+		_, err := m.BuildModuleValues(KeyGCPCompute, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a known N1-attachable NVIDIA accelerator")
+	})
+}
+
+// TestBuildModuleValues_GCPGKE_GPU exercises the gcp_gke GPU mapper branch
+// (#767): same N1-attachable-vs-bundled rule as gcp_compute, applied to the node
+// pool accelerator config.
+func TestBuildModuleValues_GCPGKE_GPU(t *testing.T) {
+	m := DefaultMapper{}
+
+	t.Run("explicit GPUType on N1 emits gpu_type + default count", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4"})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"])
+		assert.Equal(t, 1, vals["gpu_count"])
+	})
+
+	t.Run("GPUCount only on N1 defaults the accelerator type", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-8", GPUCount: 2})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-t4", vals["gpu_type"])
+		assert.Equal(t, 2, vals["gpu_count"])
+	})
+
+	t.Run("GPU config coexists with node_count and regional", func(t *testing.T) {
+		f := false
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", NodeCount: "3", Regional: &f, GPUType: "nvidia-tesla-p100", GPUCount: 1})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		assert.Equal(t, "nvidia-tesla-p100", vals["gpu_type"])
+		assert.Equal(t, 1, vals["gpu_count"])
+		assert.Equal(t, 3, vals["node_count"], "non-GPU fields still map")
+		assert.Equal(t, false, vals["regional"])
+	})
+
+	t.Run("no GPU leaves gpu_type/gpu_count unset", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "e2-standard-4", NodeCount: "1"})
+		vals, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.NoError(t, err)
+		_, hasType := vals["gpu_type"]
+		_, hasCount := vals["gpu_count"]
+		assert.False(t, hasType, "non-GPU node pool must not set gpu_type")
+		assert.False(t, hasCount, "non-GPU node pool must not set gpu_count")
+	})
+
+	t.Run("bundled-GPU machine (A3) with explicit GPUType is rejected", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "a3-highgpu-8g", GPUType: "nvidia-h100-80gb"})
+		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bundles its GPU with the machine type")
+	})
+
+	t.Run("non-N1 non-bundled machine with a GPU is rejected", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n2-standard-4", GPUType: "nvidia-tesla-t4"})
+		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not accept one")
+	})
+
+	t.Run("unknown accelerator type on N1 is rejected", func(t *testing.T) {
+		cfg := configWithGCPGKE(gcpGKECfgInput{MachineType: "n1-standard-4", GPUType: "nvidia-h100-80gb"})
+		_, err := m.BuildModuleValues(KeyGCPGKE, nil, cfg, "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a known N1-attachable NVIDIA accelerator")
+	})
+}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -250,9 +250,11 @@ func kitchenSinkConfig() *Config {
 		Versioning   *bool  `json:"versioning,omitempty"`
 	}{StorageClass: "STANDARD", Versioning: &t}
 	cfg.GCPVertexAI = &struct {
-		EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
-		IndexDimensions    int   `json:"indexDimensions,omitempty"`
-	}{EnableVectorSearch: &t, IndexDimensions: 768}
+		EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+		IndexDimensions    int    `json:"indexDimensions,omitempty"`
+		EnableServing      *bool  `json:"enableServing,omitempty"`
+		ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+	}{EnableVectorSearch: &t, IndexDimensions: 768, EnableServing: &t, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
 	cfg.GCPPubSub = &struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	}{MessageRetentionDuration: "604800s"}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -250,11 +250,12 @@ func kitchenSinkConfig() *Config {
 		Versioning   *bool  `json:"versioning,omitempty"`
 	}{StorageClass: "STANDARD", Versioning: &t}
 	cfg.GCPVertexAI = &struct {
-		EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-		IndexDimensions    int    `json:"indexDimensions,omitempty"`
-		EnableServing      *bool  `json:"enableServing,omitempty"`
-		ModelGardenModel   string `json:"modelGardenModel,omitempty"`
-	}{EnableVectorSearch: &t, IndexDimensions: 768, EnableServing: &t, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
+		EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+		IndexDimensions       int    `json:"indexDimensions,omitempty"`
+		EnableServing         *bool  `json:"enableServing,omitempty"`
+		ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+		ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
+	}{EnableVectorSearch: &t, IndexDimensions: 768, EnableServing: &t, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it", ModelGardenAcceptEULA: &t}
 	cfg.GCPPubSub = &struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	}{MessageRetentionDuration: "604800s"}

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -226,16 +226,24 @@ func kitchenSinkConfig() *Config {
 	}{DomainName: "example.com", SubjectAlternativeNames: []string{"www.example.com"}, KeyAlgorithm: "RSA_2048", CertificateTransparencyLogging: "ENABLED", CreateValidation: &t, ValidationTimeout: "45m"}
 
 	// GCP
+	// GPU fields set on N1 machines so the kitchen-sink stays internally
+	// consistent with the #767 GPU machine-type validation (a GPU on an e2/g2
+	// machine would be rejected). This also exercises the gpu_type/gpu_count
+	// keys through the subset gate.
 	cfg.GCPCompute = &struct {
 		NumServers  string `json:"numServers,omitempty"`
 		MachineType string `json:"machineType,omitempty"`
 		DiskSizeGb  int    `json:"diskSizeGb,omitempty"`
-	}{NumServers: "1", MachineType: "e2-medium", DiskSizeGb: 50}
+		GPUType     string `json:"gpuType,omitempty"`
+		GPUCount    int    `json:"gpuCount,omitempty"`
+	}{NumServers: "1", MachineType: "n1-standard-4", DiskSizeGb: 50, GPUType: "nvidia-tesla-t4", GPUCount: 1}
 	cfg.GCPGKE = &struct {
 		Regional    *bool  `json:"regional,omitempty"`
 		NodeCount   string `json:"nodeCount,omitempty"`
 		MachineType string `json:"machineType,omitempty"`
-	}{Regional: &t, NodeCount: "3", MachineType: "e2-standard-2"}
+		GPUType     string `json:"gpuType,omitempty"`
+		GPUCount    int    `json:"gpuCount,omitempty"`
+	}{Regional: &t, NodeCount: "3", MachineType: "n1-standard-4", GPUType: "nvidia-tesla-t4", GPUCount: 1}
 	cfg.GCPCloudSQL = &struct {
 		Tier             string `json:"tier,omitempty"`
 		DiskSizeGb       int    `json:"diskSizeGb,omitempty"`

--- a/pkg/composer/mapper_required_test.go
+++ b/pkg/composer/mapper_required_test.go
@@ -149,6 +149,7 @@ func kitchenSinkComponents() *Components {
 		GCPCloudKMS:         &t,
 		GCPSecretManager:    &t,
 		GCPVertexAI:         &t,
+		GCPAgentEngine:      &t,
 		GCPPubSub:           &t,
 		GCPCloudLogging:     &t,
 		GCPCloudMonitoring:  &t,

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -145,6 +145,7 @@ type PricingData struct {
 		GCPCloudKMS         *PricingItem       `json:"gcp_cloud_kms,omitempty"`
 		GCPSecretManager    *PricingItem       `json:"gcp_secret_manager,omitempty"`
 		GCPVertexAI         *PricingItem       `json:"gcp_vertex_ai,omitempty"`
+		GCPAgentEngine      *PricingItem       `json:"gcp_agent_engine,omitempty"`
 		GCPPubSub           *PricingItem       `json:"gcp_pubsub,omitempty"`
 		GCPCloudLogging     *PricingItem       `json:"gcp_cloud_logging,omitempty"`
 		GCPCloudMonitoring  *PricingItem       `json:"gcp_cloud_monitoring,omitempty"`
@@ -409,6 +410,7 @@ func (p *PricingData) Normalize() {
 		c.GCPCloudKMS = nil
 		c.GCPSecretManager = nil
 		c.GCPVertexAI = nil
+		c.GCPAgentEngine = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudMonitoring = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -374,15 +374,19 @@ type Config struct {
 	// EnableServing (#768) gates a serving endpoint; ModelGardenModel, when
 	// set alongside EnableServing, deploys that open Model Garden model
 	// (publishers/<pub>/models/<model>@<version>) onto a managed endpoint.
+	// ModelGardenAcceptEULA records the operator's acceptance of the model's
+	// EULA/ToS; EULA-gated open models (Gemma, Llama) will not deploy unless it
+	// is true. It defaults to the preset's explicit-consent false when unset.
 	// Vector Search and serving are orthogonal flags.
 	//
 	// Every field is partial-config: the mapper only emits a field the caller
 	// actually populated so the preset's own defaults win when left unset.
 	GCPVertexAI *struct {
-		EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-		IndexDimensions    int    `json:"indexDimensions,omitempty"`
-		EnableServing      *bool  `json:"enableServing,omitempty"`
-		ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+		EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+		IndexDimensions       int    `json:"indexDimensions,omitempty"`
+		EnableServing         *bool  `json:"enableServing,omitempty"`
+		ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+		ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 	} `json:"gcp_vertex_ai,omitempty"`
 
 	GCPPubSub *struct {

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -363,16 +363,26 @@ type Config struct {
 		Versioning   *bool  `json:"versioning,omitempty"`
 	} `json:"gcp_gcs,omitempty"`
 
-	// GCPVertexAI carries the caller-supplied Vertex AI configuration (#764).
+	// GCPVertexAI carries the caller-supplied Vertex AI configuration (#764,
+	// #768).
+	//
 	// EnableVectorSearch gates the Vector Search resources (index + endpoint +
 	// deployed index) in the gcp/vertex_ai preset; the dataset is always
 	// created. IndexDimensions is the embedding dimensionality of the Vector
-	// Search index (immutable — changing it forces destroy/recreate). Both are
-	// partial-config: the mapper only emits a field the caller actually
-	// populated so the preset's own defaults win when left unset.
+	// Search index (immutable — changing it forces destroy/recreate).
+	//
+	// EnableServing (#768) gates a serving endpoint; ModelGardenModel, when
+	// set alongside EnableServing, deploys that open Model Garden model
+	// (publishers/<pub>/models/<model>@<version>) onto a managed endpoint.
+	// Vector Search and serving are orthogonal flags.
+	//
+	// Every field is partial-config: the mapper only emits a field the caller
+	// actually populated so the preset's own defaults win when left unset.
 	GCPVertexAI *struct {
-		EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
-		IndexDimensions    int   `json:"indexDimensions,omitempty"`
+		EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+		IndexDimensions    int    `json:"indexDimensions,omitempty"`
+		EnableServing      *bool  `json:"enableServing,omitempty"`
+		ModelGardenModel   string `json:"modelGardenModel,omitempty"`
 	} `json:"gcp_vertex_ai,omitempty"`
 
 	GCPPubSub *struct {

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -339,12 +339,28 @@ type Config struct {
 		NumServers  string `json:"numServers,omitempty"`
 		MachineType string `json:"machineType,omitempty"`
 		DiskSizeGb  int    `json:"diskSizeGb,omitempty"`
+		// GPU attachment (#767). GPUType is an NVIDIA accelerator type that
+		// attaches to an N1 machine via guest_accelerator (e.g. nvidia-tesla-t4);
+		// GPUCount is how many. Either field signals "attach a GPU" — the mapper
+		// fills the other from a default and forces on_host_maintenance=TERMINATE.
+		// Only N1 machines accept attached GPUs; A2/A3/A4/G2/G4 bundle their GPU
+		// with the machine type, so setting GPUType there is rejected.
+		GPUType  string `json:"gpuType,omitempty"`
+		GPUCount int    `json:"gpuCount,omitempty"`
 	} `json:"gcp_compute,omitempty"`
 
 	GCPGKE *struct {
 		Regional    *bool  `json:"regional,omitempty"`
 		NodeCount   string `json:"nodeCount,omitempty"`
 		MachineType string `json:"machineType,omitempty"`
+		// GPU node pool (#767). GPUType is an NVIDIA accelerator type that
+		// attaches to an N1 node machine via the node pool's accelerator config
+		// (e.g. nvidia-tesla-t4); GPUCount is per-node. Either field signals "GPU
+		// node pool" — the mapper fills the other from a default and enables GKE
+		// auto driver install. Only N1 node machines accept attached accelerators;
+		// A2/A3/A4/G2/G4 bundle their GPU, so setting GPUType there is rejected.
+		GPUType  string `json:"gpuType,omitempty"`
+		GPUCount int    `json:"gpuCount,omitempty"`
 	} `json:"gcp_gke,omitempty"`
 
 	GCPCloudSQL *struct {

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -74,6 +74,7 @@ type Components struct {
 	GCPCloudKMS         *bool  `json:"gcp_cloud_kms,omitempty"`
 	GCPSecretManager    *bool  `json:"gcp_secret_manager,omitempty"`
 	GCPVertexAI         *bool  `json:"gcp_vertex_ai,omitempty"`
+	GCPAgentEngine      *bool  `json:"gcp_agent_engine,omitempty"`
 	GCPPubSub           *bool  `json:"gcp_pubsub,omitempty"`
 	GCPCloudLogging     *bool  `json:"gcp_cloud_logging,omitempty"`
 	GCPCloudMonitoring  *bool  `json:"gcp_cloud_monitoring,omitempty"`
@@ -375,6 +376,18 @@ type Config struct {
 		IndexDimensions    int   `json:"indexDimensions,omitempty"`
 	} `json:"gcp_vertex_ai,omitempty"`
 
+	// GCPAgentEngine carries the caller-supplied Vertex AI Agent Engine
+	// configuration (#769). DisplayName overrides the preset's project-prefixed
+	// default for the Reasoning Engine. The packaged-artifact URI / staging
+	// bucket are not modeled here: the artifact is built by the application
+	// layer and its URI is supplied directly to the preset, and staging_bucket
+	// is wired by DefaultWiring from gcp/gcs. Partial-config: the mapper only
+	// emits a field the caller actually populated so the preset's own defaults
+	// win when left unset.
+	GCPAgentEngine *struct {
+		DisplayName string `json:"displayName,omitempty"`
+	} `json:"gcp_agent_engine,omitempty"`
+
 	GCPPubSub *struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	} `json:"gcp_pubsub,omitempty"`
@@ -646,6 +659,7 @@ func (c *Components) Normalize() {
 		c.GCPCloudKMS = nil
 		c.GCPSecretManager = nil
 		c.GCPVertexAI = nil
+		c.GCPAgentEngine = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudMonitoring = nil
@@ -747,7 +761,7 @@ func (c *Config) Normalize() {
 	}
 	switch c.Cloud {
 	case "AWS":
-		// Clear every GCP sub-config (15 fields — keep in sync with the
+		// Clear every GCP sub-config (18 fields — keep in sync with the
 		// GCPConfiguration section of the Config struct).
 		c.GCPCompute = nil
 		c.GCPGKE = nil
@@ -755,6 +769,7 @@ func (c *Config) Normalize() {
 		c.GCPMemorystore = nil
 		c.GCPGCS = nil
 		c.GCPVertexAI = nil
+		c.GCPAgentEngine = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudRun = nil

--- a/pkg/composer/types_test.go
+++ b/pkg/composer/types_test.go
@@ -135,6 +135,8 @@ func TestConfig_Normalize_ClearsGCPFieldsForAWS(t *testing.T) {
 			Regional    *bool  `json:"regional,omitempty"`
 			NodeCount   string `json:"nodeCount,omitempty"`
 			MachineType string `json:"machineType,omitempty"`
+			GPUType     string `json:"gpuType,omitempty"`
+			GPUCount    int    `json:"gpuCount,omitempty"`
 		}{
 			NodeCount: "3",
 		},

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -39,27 +39,40 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		assert.False(t, hasEnable, "nil GCPVertexAI must not emit enable_vector_search")
 		_, hasDims := vals["index_dimensions"]
 		assert.False(t, hasDims, "nil GCPVertexAI must not emit index_dimensions")
+		_, hasServing := vals["enable_serving"]
+		assert.False(t, hasServing, "nil GCPVertexAI must not emit enable_serving")
+		_, hasModel := vals["model_garden_model"]
+		assert.False(t, hasModel, "nil GCPVertexAI must not emit model_garden_model")
 	})
 
 	t.Run("EnableVectorSearch=true flows through", func(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int   `json:"indexDimensions,omitempty"`
+			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int    `json:"indexDimensions,omitempty"`
+			EnableServing      *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
 		}{EnableVectorSearch: &tr, IndexDimensions: 1536}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
 		assert.Equal(t, true, vals["enable_vector_search"])
 		assert.Equal(t, 1536, vals["index_dimensions"])
+		// Serving fields untouched here -> not emitted (preset defaults win).
+		_, hasServing := vals["enable_serving"]
+		assert.False(t, hasServing, "unset EnableServing must not emit enable_serving")
+		_, hasModel := vals["model_garden_model"]
+		assert.False(t, hasModel, "unset ModelGardenModel must not emit model_garden_model")
 	})
 
 	t.Run("EnableVectorSearch=false flows through, zero dimensions omitted", func(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int   `json:"indexDimensions,omitempty"`
+			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int    `json:"indexDimensions,omitempty"`
+			EnableServing      *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
 		}{EnableVectorSearch: &fa}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
@@ -68,6 +81,42 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		// preset's own default (768) applies rather than an invalid 0.
 		_, hasDims := vals["index_dimensions"]
 		assert.False(t, hasDims, "zero IndexDimensions must be omitted so the preset default wins")
+	})
+
+	t.Run("EnableServing + ModelGardenModel flow through (#768)", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		cfg.GCPVertexAI = &struct {
+			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int    `json:"indexDimensions,omitempty"`
+			EnableServing      *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["enable_serving"])
+		assert.Equal(t, "publishers/google/models/gemma3@gemma-3-1b-it", vals["model_garden_model"])
+		// Vector Search fields untouched -> not emitted (orthogonal flags).
+		_, hasVS := vals["enable_vector_search"]
+		assert.False(t, hasVS, "unset EnableVectorSearch must not emit enable_vector_search when only serving is set")
+	})
+
+	t.Run("EnableServing=false flows through, empty model omitted (#768)", func(t *testing.T) {
+		t.Parallel()
+		cfg := &Config{}
+		cfg.GCPVertexAI = &struct {
+			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions    int    `json:"indexDimensions,omitempty"`
+			EnableServing      *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+		}{EnableServing: &fa}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["enable_serving"])
+		// Empty ModelGardenModel must NOT be emitted so the preset default
+		// (null -> bare endpoint) wins rather than an invalid empty string.
+		_, hasModel := vals["model_garden_model"]
+		assert.False(t, hasModel, "empty ModelGardenModel must be omitted so the preset default wins")
 	})
 }
 

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -49,10 +49,11 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int    `json:"indexDimensions,omitempty"`
-			EnableServing      *bool  `json:"enableServing,omitempty"`
-			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 		}{EnableVectorSearch: &tr, IndexDimensions: 1536}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
@@ -69,10 +70,11 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int    `json:"indexDimensions,omitempty"`
-			EnableServing      *bool  `json:"enableServing,omitempty"`
-			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 		}{EnableVectorSearch: &fa}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
@@ -87,10 +89,11 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int    `json:"indexDimensions,omitempty"`
-			EnableServing      *bool  `json:"enableServing,omitempty"`
-			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)
@@ -101,14 +104,61 @@ func TestBuildModuleValues_GCPVertexAI_PartialConfig(t *testing.T) {
 		assert.False(t, hasVS, "unset EnableVectorSearch must not emit enable_vector_search when only serving is set")
 	})
 
+	t.Run("ModelGardenAcceptEULA flows through only when set (#768 review)", func(t *testing.T) {
+		t.Parallel()
+
+		// Set true -> emitted (EULA-gated Gemma/Llama need it).
+		cfgYes := &Config{}
+		cfgYes.GCPVertexAI = &struct {
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
+		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it", ModelGardenAcceptEULA: &tr}
+		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfgYes, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["model_garden_accept_eula"], "ModelGardenAcceptEULA=true must reach model_garden_accept_eula")
+
+		// Set false -> still emitted (explicit non-consent is a real choice the
+		// caller made; partial-config keys on nil, not on the zero value).
+		cfgNo := &Config{}
+		cfgNo.GCPVertexAI = &struct {
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
+		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it", ModelGardenAcceptEULA: &fa}
+		vals, err = m.BuildModuleValues(KeyGCPVertexAI, nil, cfgNo, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals["model_garden_accept_eula"], "explicit ModelGardenAcceptEULA=false must reach model_garden_accept_eula")
+
+		// Unset (nil) -> NOT emitted so the preset's explicit-consent default
+		// (false) wins rather than a config-supplied value.
+		cfgUnset := &Config{}
+		cfgUnset.GCPVertexAI = &struct {
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
+		}{EnableServing: &tr, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it"}
+		vals, err = m.BuildModuleValues(KeyGCPVertexAI, nil, cfgUnset, "demo", "us-central1")
+		require.NoError(t, err)
+		_, hasEULA := vals["model_garden_accept_eula"]
+		assert.False(t, hasEULA, "unset ModelGardenAcceptEULA must not emit model_garden_accept_eula (preset default wins)")
+	})
+
 	t.Run("EnableServing=false flows through, empty model omitted (#768)", func(t *testing.T) {
 		t.Parallel()
 		cfg := &Config{}
 		cfg.GCPVertexAI = &struct {
-			EnableVectorSearch *bool  `json:"enableVectorSearch,omitempty"`
-			IndexDimensions    int    `json:"indexDimensions,omitempty"`
-			EnableServing      *bool  `json:"enableServing,omitempty"`
-			ModelGardenModel   string `json:"modelGardenModel,omitempty"`
+			EnableVectorSearch    *bool  `json:"enableVectorSearch,omitempty"`
+			IndexDimensions       int    `json:"indexDimensions,omitempty"`
+			EnableServing         *bool  `json:"enableServing,omitempty"`
+			ModelGardenModel      string `json:"modelGardenModel,omitempty"`
+			ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 		}{EnableServing: &fa}
 		vals, err := m.BuildModuleValues(KeyGCPVertexAI, nil, cfg, "demo", "us-central1")
 		require.NoError(t, err)

--- a/pkg/observability/component_metrics_coverage_test.go
+++ b/pkg/observability/component_metrics_coverage_test.go
@@ -49,6 +49,14 @@ var metricsDeferredKeys = map[composer.ComponentKey]string{
 	// Backfill alongside the inspector landing (mirrors the #622 backfill
 	// of apprunner + sagemaker after #618 / #620 added their inspectors).
 	composer.KeyAWSCodeBuild: "[#619] discovery inspector deferred; ComponentMetricsMapping entry pending the codebuild.list-projects handler registration alongside the inspector backfill PR",
+	// Agent Engine (#769). google_vertex_ai_reasoning_engine is deploy-only
+	// (landed in hashicorp/google v7.6.0; this repo's discovery/import schema
+	// pin is 6.10), so there is no reasoning-engine discovery inspector or
+	// vertexai.list-reasoning-engines handler registered in GCPServiceActions
+	// yet. A ComponentMetricsMapping entry would dispatch to an unregistered
+	// service and surface "unsupported service" at runtime. Backfill alongside
+	// the inspector landing once the schema pin advances past 7.6.
+	composer.KeyGCPAgentEngine: "[#769] reasoning-engine discovery inspector deferred; resource is deploy-only on provider >= 7.6 (repo schema pinned 6.10), no vertexai.list-reasoning-engines handler registered yet",
 }
 
 // metricsNonComponentKeys are AllComponentKeys entries that genuinely

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -694,7 +694,17 @@ var alarmedGCPMetrics = map[composer.ComponentKey]AlarmAuthor{
 	composer.KeyGCPLoadbalancer:   {Module: "gcp/loadbalancer", Metrics: []string{"loadbalancing.googleapis.com/https/backend_latencies"}},
 	composer.KeyGCPMemorystore:    {Module: "gcp/memorystore", Metrics: []string{"redis.googleapis.com/stats/cpu_utilization"}},
 	composer.KeyGCPPubSub:         {Module: "gcp/pubsub", Metrics: []string{"pubsub.googleapis.com/subscription/num_undelivered_messages"}},
-	composer.KeyGCPVertexAI:       {Module: "gcp/vertex_ai", Metrics: []string{"aiplatform.googleapis.com/matching_engine/query/latencies"}},
+	// Vector Search query latency (#764) plus the two serving alarms (#768):
+	// online-prediction latency and error_count, both already in the vertexai
+	// catalog above. All three have google_monitoring_alert_policy resources in
+	// gcp/vertex_ai/observability.tf (the for_each gates suppress the serving
+	// pair when enable_serving=false and the vector alarm when
+	// enable_vector_search=false, but the metric.type strings still match).
+	composer.KeyGCPVertexAI: {Module: "gcp/vertex_ai", Metrics: []string{
+		"aiplatform.googleapis.com/matching_engine/query/latencies",
+		"aiplatform.googleapis.com/prediction/online/prediction_latencies",
+		"aiplatform.googleapis.com/prediction/online/error_count",
+	}},
 }
 
 // AlarmedAWSMetrics returns a defensive copy of the AWS authority entry

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -181,6 +181,8 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "GCP Identity Platform"
 	case composer.KeyGCPVertexAI:
 		return "GCP Vertex AI"
+	case composer.KeyGCPAgentEngine:
+		return "GCP Agent Engine"
 	case composer.KeyGCPBastion:
 		return "GCP Bastion"
 	case composer.KeyGCPAPIGateway:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -79,6 +79,7 @@ var configExtractorAllowlist = map[string]string{
 	"gcp_backups":      "[no-inspector] GCP Backup vaults aren't inspected; covered via label-based discovery (#204)",
 	"gcp_cloud_deploy": "[no-inspector] Cloud Deploy delivery-pipeline inspector deferred (#613 explicitly marks discovery inspector + extractor as optional/follow-up); ComponentMetricsMapping has no entry yet so the panel falls back to design values until the per-component extractor lands",
 	"gcp_cloud_dns":    "[no-inspector] Cloud DNS dispatcher landed in #596 (gcp/dns.go); per-component extractor (config map for panel) deferred pending zone-detail field reads (visibility, dnssec_config, record-count summary)",
+	"gcp_agent_engine": "[no-inspector] Agent Engine (#769) creates google_vertex_ai_reasoning_engine, which is deploy-only on provider >= 7.6 (repo discovery/import schema pinned 6.10); no reasoning-engine inspector or extractor lands yet. Surfaced via name-prefix scoping until the schema pin advances and a vertexai.list-reasoning-engines dispatcher ships",
 }
 
 // extractorFixtures are minimal SDK-shape fixtures that exercise each

--- a/tests/lint-labelless-name-prefix.sh
+++ b/tests/lint-labelless-name-prefix.sh
@@ -131,6 +131,14 @@ EXEMPT_LABELLESS_GCP=(
   # dashboard_json carries operator-defined display labels. Project-
   # scoped via API parent (`projects/<id>`).
   google_monitoring_dashboard
+  # google_vertex_ai_endpoint_with_model_garden_deployment — a one-shot
+  # Model Garden deploy keyed by publisher_model_name + location; it has
+  # NO name/display_name/account_id field to carry var.project (the
+  # managed endpoint it creates is named server-side). The sibling bare
+  # google_vertex_ai_endpoint.serving DOES carry the var.project prefix.
+  # Inspector attribution flows through the project-scoped Vertex API
+  # path (`projects/<id>/locations/<loc>/endpoints`).
+  google_vertex_ai_endpoint_with_model_garden_deployment
 )
 
 # Build regex patterns from the arrays.


### PR DESCRIPTION
## What

Single PR subsuming three GCP AI/compute feature branches (all part of #756), rebased onto current `main` and reconciled with drift guards added since their original base.

Closes #769
Closes #752
Closes #768

Supersedes #792, #790, #789.

## Subsumed work

### `gcp_agent_engine` — Vertex AI Agent Engine (#769, was #792)
- New preset `gcp/agent_engine/` (`google_vertex_ai_reasoning_engine`), the GCP counterpart of `aws_bedrock_agent`. Fail-loud preconditions on the packaged-artifact GCS URI + staging-bucket scoping; `project = var.project_id` pin (#287), `var.project`-prefixed `display_name`, labels carry `var.project`.
- New composer key `KeyGCPAgentEngine` registered across `contracts.go`, `types.go`, `mapper.go`, `pricing.go`, `gcp_services.go`, `iam_actions.go`, `coherence.go`.
- `staging_bucket` wired from `gcp/gcs.bucket_url`; artifact URI stays app-supplied.
- Resource is **deploy-only** (`hashicorp/google` v7.6.0+; repo schema pinned 6.10) — stays out of `SUPPORTED_RESOURCES.md` / import matrix; preset pins `>= 7.6` and tftest uses a mock provider.

### GPU support on `gcp_gke` + `gcp_compute` (#752, was #790)
- GKE node pool `guest_accelerator` (type/count) + driver auto-install + machine-family compatibility preconditions.
- Compute `guest_accelerator` + TERMINATE scheduling precondition (GCP rejects MIGRATE with GPUs).
- GPU fields on `Config.GCPGKE` / `Config.GCPCompute`, validate-don't-mask per the #759 pattern.

### Vertex Endpoint + Model Garden serving (#768, was #789)
- `google_vertex_ai_endpoint` + `google_vertex_ai_endpoint_with_model_garden_deployment` gated on `enable_serving`; dataset + vector-search slices unchanged.
- `Config.GCPVertexAI`: `EnableServing` + `ModelGardenModel`.

## Reconciliation with current main

The three branches were cut from an older `main`; rebasing onto current `main` surfaced new observability drift guards that the new `gcp_agent_engine` key trips. Registered it consistently:
- `ComponentDisplayName(gcp_agent_engine)` → `"GCP Agent Engine"`
- `metricsDeferredKeys` — reasoning-engine discovery inspector deferred (deploy-only resource, no `vertexai.list-reasoning-engines` handler yet)
- `configExtractorAllowlist` `[no-inspector]` — same rationale, mirrors `gcp_cloud_deploy`
- `terraform fmt` fix on `gcp/gke/tests/gpu.tftest.hcl`

## QC

- `go build`, `go vet`, `gofmt`, `terraform fmt -check -recursive`: green
- `go test -race ./pkg/...`: green (composer invariant gates — services/IAM/pricing/required-var/mapper-subset/coherence/known-fields — and the observability coverage/extractor drift guards all pass)
- `make verify-gen`, `make verify-supported-resources`: green
- All `tests/lint-*.sh` scripts: green
- Terraform `validate` / `tftest` / `tflint` / phantom-schema gates run in CI (require the provider registry); tftests use mock providers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDsCUc3V8b6wL4WXiT4yq9)_