### PR TITLE
feat(gcp): Document AI + Model Armor components and VPC Private Services Access (#765, #766, #774)

### DIFF
--- a/gcp/document_ai/main.tf
+++ b/gcp/document_ai/main.tf
@@ -1,0 +1,64 @@
+# GCP Document AI — issue #765 (AI stack L2, RAG ingestion).
+#
+# Document AI processors (OCR / form / invoice parsers) turn PDFs and scans
+# into structured text for a RAG pipeline that downstream feeds Vertex AI
+# Vector Search (#764). A single google_document_ai_processor is the always-on
+# preset surface; an optional google_document_ai_processor_default_version pins
+# the processor to a specific pretrained model version when the caller supplies
+# one.
+#
+# Location is NOT a GCP region: Document AI is a multi-region service whose
+# locations are "us" or "eu" only. The composer's mapper translates the stack
+# region's continent into a DocAI location; standalone, the preset derives it
+# from var.region (var.location overrides). Passing an arbitrary region (e.g.
+# "us-central1") to the location field would be rejected by the API, so the
+# preset never does.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      # google_document_ai_processor + _default_version are long-standing in
+      # the hashicorp/google provider; >= 5.0 matches the other GCP presets.
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  # Default the processor display name to a project- and type-scoped value so a
+  # bare compose still produces a uniquely-named, attributable processor.
+  # var.display_name overrides for a human-friendly label.
+  processor_display_name = var.display_name == null ? "${var.project}-docai-${lower(var.processor_type)}" : var.display_name
+
+  # Document AI multi-region is "us" | "eu" only. var.location wins when set;
+  # otherwise derive the continent from the stack region so a standalone
+  # compose (where the mapper has not normalized location) is still valid.
+  docai_location = var.location != null ? var.location : (startswith(var.region, "europe-") ? "eu" : "us")
+}
+
+# The processor. Unconditional (no count / for_each gate) so the preset always
+# produces plan-time infrastructure — TestEveryPresetHasUnconditionalResource
+# and the all-gated-preset guard (#253) both require this.
+resource "google_document_ai_processor" "this" {
+  project      = var.project_id
+  location     = local.docai_location
+  display_name = local.processor_display_name
+  type         = var.processor_type
+
+  # CMEK: encrypt processor data with a caller-supplied Cloud KMS key when set.
+  # Null uses Google-managed encryption.
+  kms_key_name = var.kms_key_name
+}
+
+# Optional: pin the processor's default version to a specific pretrained model
+# version (e.g. a stable "pretrained-ocr-vX" name). Off by default — the
+# processor uses the provider/Google default version until a caller supplies an
+# explicit, type-matched version string.
+resource "google_document_ai_processor_default_version" "this" {
+  count     = var.default_processor_version == null ? 0 : 1
+  processor = google_document_ai_processor.this.id
+  version   = var.default_processor_version
+}

--- a/gcp/document_ai/outputs.tf
+++ b/gcp/document_ai/outputs.tf
@@ -1,0 +1,24 @@
+output "processor_id" {
+  description = "The resource ID of the Document AI processor."
+  value       = google_document_ai_processor.this.id
+}
+
+output "processor_name" {
+  description = "The full generated resource name of the processor (projects/<project>/locations/<location>/processors/<id>)."
+  value       = google_document_ai_processor.this.name
+}
+
+output "processor_type" {
+  description = "The processor type (e.g. OCR_PROCESSOR)."
+  value       = google_document_ai_processor.this.type
+}
+
+output "location" {
+  description = "The Document AI multi-region location the processor runs in (us|eu)."
+  value       = google_document_ai_processor.this.location
+}
+
+output "processor_default_version" {
+  description = "The pinned default processor version, or null when none is pinned."
+  value       = var.default_processor_version == null ? null : google_document_ai_processor_default_version.this[0].version
+}

--- a/gcp/document_ai/tests/shape.tftest.hcl
+++ b/gcp/document_ai/tests/shape.tftest.hcl
@@ -1,0 +1,164 @@
+mock_provider "google" {}
+
+# Issue #765 (gcp/document_ai — Document AI processors for RAG ingestion) shape
+# tests. Verifies that:
+#   - A bare compose produces exactly one processor, defaults the type to OCR,
+#     pins project = var.project_id, derives the us|eu location from the region,
+#     and defaults the display name to the project/type-scoped form.
+#   - var.location overrides and the region→continent derivation both work.
+#   - The optional default-version resource is off until a version is supplied.
+#   - Variable validations reject a bad location / processor type / project at
+#     plan time.
+
+run "defaults_compose_processor" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+
+  assert {
+    condition     = google_document_ai_processor.this.type == "OCR_PROCESSOR"
+    error_message = "processor_type must default to OCR_PROCESSOR."
+  }
+
+  assert {
+    condition     = google_document_ai_processor.this.project == "test-project"
+    error_message = "processor must pin project = var.project_id."
+  }
+
+  # us-central1 -> "us" multi-region location (region is NOT passed through).
+  assert {
+    condition     = google_document_ai_processor.this.location == "us"
+    error_message = "location must derive to \"us\" from a us-* region."
+  }
+
+  assert {
+    condition     = google_document_ai_processor.this.display_name == "test-docai-ocr_processor"
+    error_message = "display_name must default to \"<project>-docai-<type>\"."
+  }
+
+  # Optional default-version resource off by default.
+  assert {
+    condition     = length(google_document_ai_processor_default_version.this) == 0
+    error_message = "default-version resource must be absent until default_processor_version is set."
+  }
+}
+
+run "location_override_wins" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    location   = "eu"
+  }
+
+  assert {
+    condition     = google_document_ai_processor.this.location == "eu"
+    error_message = "var.location must override the region-derived location."
+  }
+}
+
+run "location_derived_from_europe_region" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    region     = "europe-west1"
+  }
+
+  assert {
+    condition     = google_document_ai_processor.this.location == "eu"
+    error_message = "a europe-* region must derive the \"eu\" location."
+  }
+}
+
+run "processor_type_and_kms_flow_through" {
+  command = plan
+
+  variables {
+    project        = "test"
+    project_id     = "test-project"
+    processor_type = "FORM_PARSER_PROCESSOR"
+    kms_key_name   = "projects/test-project/locations/us/keyRings/kr/cryptoKeys/ck"
+  }
+
+  assert {
+    condition     = google_document_ai_processor.this.type == "FORM_PARSER_PROCESSOR"
+    error_message = "processor_type must flow through."
+  }
+
+  assert {
+    condition     = google_document_ai_processor.this.kms_key_name == "projects/test-project/locations/us/keyRings/kr/cryptoKeys/ck"
+    error_message = "kms_key_name must flow through to the processor."
+  }
+}
+
+run "default_version_pinned" {
+  command = plan
+
+  variables {
+    project                   = "test"
+    project_id                = "test-project"
+    default_processor_version = "pretrained-ocr-v1.0-2020-09-23"
+  }
+
+  assert {
+    condition     = length(google_document_ai_processor_default_version.this) == 1
+    error_message = "default-version resource must be created when default_processor_version is set."
+  }
+
+  assert {
+    condition     = google_document_ai_processor_default_version.this[0].version == "pretrained-ocr-v1.0-2020-09-23"
+    error_message = "default_processor_version must flow through to the default-version resource."
+  }
+}
+
+run "rejects_invalid_location" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+    location   = "us-central1"
+  }
+
+  expect_failures = [var.location]
+}
+
+run "rejects_invalid_processor_type" {
+  command = plan
+
+  variables {
+    project        = "test"
+    project_id     = "test-project"
+    processor_type = "lowercase_type"
+  }
+
+  expect_failures = [var.processor_type]
+}
+
+run "rejects_empty_project" {
+  command = plan
+
+  variables {
+    project    = ""
+    project_id = "test-project"
+  }
+
+  expect_failures = [var.project]
+}
+
+run "rejects_invalid_project_id" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "BadProjectID"
+  }
+
+  expect_failures = [var.project_id]
+}

--- a/gcp/document_ai/variables.tf
+++ b/gcp/document_ai/variables.tf
@@ -1,0 +1,65 @@
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+variable "region" {
+  description = "GCP region for the stack. Document AI itself runs in a multi-region location (us|eu), derived from this region's continent unless var.location overrides it."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "location" {
+  description = "Document AI multi-region location: \"us\" or \"eu\" only (NOT a GCP region). Null derives it from var.region's continent. The composer's mapper sets this by translating the stack region; do not pass a region like \"us-central1\"."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.location == null ? true : contains(["us", "eu"], var.location)
+    error_message = "location must be null, \"us\", or \"eu\" (Document AI multi-region locations)."
+  }
+}
+
+variable "processor_type" {
+  description = "Document AI processor type, e.g. OCR_PROCESSOR, FORM_PARSER_PROCESSOR, INVOICE_PROCESSOR. Immutable — changing it forces replacement. Must be an uppercase processor-type identifier."
+  type        = string
+  default     = "OCR_PROCESSOR"
+
+  validation {
+    condition     = can(regex("^[A-Z][A-Z0-9_]+$", var.processor_type))
+    error_message = "processor_type must be an uppercase processor-type identifier (e.g. OCR_PROCESSOR, FORM_PARSER_PROCESSOR)."
+  }
+}
+
+variable "display_name" {
+  description = "Display name of the processor. Null defaults to \"<project>-docai-<type>\" so a bare compose still produces a uniquely-named, attributable processor."
+  type        = string
+  default     = null
+}
+
+variable "kms_key_name" {
+  description = "Fully-qualified Cloud KMS CMEK (projects/<p>/locations/<l>/keyRings/<k>/cryptoKeys/<c>) to encrypt processor data. Null uses Google-managed encryption. The key must be reachable from the processor's location."
+  type        = string
+  default     = null
+}
+
+variable "default_processor_version" {
+  description = "Optional pretrained model version to pin as the processor's default (e.g. a stable \"pretrained-ocr-...\" version name). Null lets the provider/Google default win. Must be a version valid for the chosen processor_type."
+  type        = string
+  default     = null
+}

--- a/gcp/model_armor/main.tf
+++ b/gcp/model_armor/main.tf
@@ -20,11 +20,13 @@ terraform {
   required_providers {
     google = {
       source = "hashicorp/google"
-      # google_model_armor_template / _floorsetting are recent additions to the
-      # hashicorp/google provider and region-limited. >= 6.0 is the floor; the
-      # composer/caller supplies the concrete pin (CI resolves the latest 7.x,
-      # which carries both resources).
-      version = ">= 6.0"
+      # google_model_armor_template landed in hashicorp/google 6.43.0 and
+      # google_model_armor_floorsetting in 6.45.0; this module can create both,
+      # so 6.45.0 is the true floor. A looser >= 6.0 let a caller/root locked to
+      # an earlier 6.x satisfy the constraint and then fail with "Invalid
+      # resource type" before planning (Codex review). The composer/caller still
+      # supplies the concrete pin (CI resolves the latest 7.x, which carries both).
+      version = ">= 6.45.0"
     }
   }
 }

--- a/gcp/model_armor/main.tf
+++ b/gcp/model_armor/main.tf
@@ -1,0 +1,106 @@
+# GCP Model Armor — issue #766 (AI stack L6, safety).
+#
+# Model Armor is GCP's analog of Bedrock Guardrails: prompt/response filtering
+# for prompt-injection & jailbreak, malicious URIs, responsible-AI categories
+# (hate/harassment/sexual/dangerous), and SDP (sensitive-data) inspection. The
+# always-on preset surface is a google_model_armor_template. An optional
+# google_model_armor_floorsetting applies a project-wide enforcement floor.
+#
+# ⚠️ Singleton hazard: the floor setting is a project/org SINGLETON. Creating
+# it on a project that already has one fails, and two stacks in the same project
+# would collide. It is therefore OFF by default (var.manage_floorsetting =
+# false); enable it only for the single stack that owns the project's floor.
+#
+# Model Armor is newer and region-limited; the composed root must supply a
+# hashicorp/google provider recent enough to expose google_model_armor_*.
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      # google_model_armor_template / _floorsetting are recent additions to the
+      # hashicorp/google provider and region-limited. >= 6.0 is the floor; the
+      # composer/caller supplies the concrete pin (CI resolves the latest 7.x,
+      # which carries both resources).
+      version = ">= 6.0"
+    }
+  }
+}
+
+locals {
+  # Region-scoped service. var.location overrides; otherwise use the stack
+  # region directly (Model Armor locations ARE regions, unlike Document AI).
+  armor_location = var.location == null ? var.region : var.location
+
+  # Default the template id to a project-scoped value (name-prefix scoping for
+  # inspector attribution). var.template_id overrides.
+  template_id = var.template_id == null ? "${var.project}-armor" : var.template_id
+}
+
+# The safety template. Unconditional (no count / for_each gate) so the preset
+# always produces plan-time infrastructure — TestEveryPresetHasUnconditional
+# Resource and the all-gated-preset guard (#253) both require this.
+resource "google_model_armor_template" "this" {
+  project     = var.project_id
+  location    = local.armor_location
+  template_id = local.template_id
+
+  filter_config {
+    # Prompt-injection & jailbreak detection at the configured confidence floor.
+    pi_and_jailbreak_filter_settings {
+      filter_enforcement = "ENABLED"
+      confidence_level   = var.filter_confidence_level
+    }
+
+    # Block known-malicious URIs in prompts/responses.
+    malicious_uri_filter_settings {
+      filter_enforcement = "ENABLED"
+    }
+
+    # Responsible-AI category filters at the configured confidence floor.
+    rai_settings {
+      dynamic "rai_filters" {
+        for_each = var.rai_filter_types
+        content {
+          filter_type      = rai_filters.value
+          confidence_level = var.filter_confidence_level
+        }
+      }
+    }
+  }
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+}
+
+# Optional project-wide enforcement floor. SINGLETON — see header. Off by
+# default; enable only for the one stack that owns the project's floor.
+resource "google_model_armor_floorsetting" "this" {
+  count    = var.manage_floorsetting ? 1 : 0
+  parent   = "projects/${var.project_id}/locations/${local.armor_location}"
+  location = local.armor_location
+
+  enable_floor_setting_enforcement = true
+
+  filter_config {
+    pi_and_jailbreak_filter_settings {
+      filter_enforcement = "ENABLED"
+      confidence_level   = var.filter_confidence_level
+    }
+    rai_settings {
+      dynamic "rai_filters" {
+        for_each = var.rai_filter_types
+        content {
+          filter_type      = rai_filters.value
+          confidence_level = var.filter_confidence_level
+        }
+      }
+    }
+  }
+}

--- a/gcp/model_armor/outputs.tf
+++ b/gcp/model_armor/outputs.tf
@@ -1,0 +1,19 @@
+output "template_id" {
+  description = "The template ID of the Model Armor template."
+  value       = google_model_armor_template.this.template_id
+}
+
+output "template_name" {
+  description = "The full generated resource name of the Model Armor template (projects/<project>/locations/<location>/templates/<id>)."
+  value       = google_model_armor_template.this.name
+}
+
+output "location" {
+  description = "The location (region) the Model Armor template runs in."
+  value       = google_model_armor_template.this.location
+}
+
+output "floorsetting_name" {
+  description = "The full resource name of the project floor setting, or null when manage_floorsetting is false."
+  value       = var.manage_floorsetting ? google_model_armor_floorsetting.this[0].name : null
+}

--- a/gcp/model_armor/tests/shape.tftest.hcl
+++ b/gcp/model_armor/tests/shape.tftest.hcl
@@ -1,0 +1,160 @@
+mock_provider "google" {}
+
+# Issue #766 (gcp/model_armor — Model Armor safety templates) shape tests.
+# Verifies that:
+#   - A bare compose produces exactly one template (floor setting OFF by
+#     default — the singleton hazard), pins project = var.project_id, defaults
+#     the template id to the project prefix, defaults the location to the
+#     region, sets the confidence floor on the PI/jailbreak + RAI filters, and
+#     carries the project label.
+#   - manage_floorsetting opts into the singleton floor setting.
+#   - Overrides (confidence, location, template id) flow through.
+#   - Variable validations reject obvious misconfigurations at plan time.
+
+run "defaults_compose_template" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "test-project"
+  }
+
+  assert {
+    condition     = google_model_armor_template.this.template_id == "test-armor"
+    error_message = "template_id must default to \"<project>-armor\"."
+  }
+
+  assert {
+    condition     = google_model_armor_template.this.project == "test-project"
+    error_message = "template must pin project = var.project_id."
+  }
+
+  assert {
+    condition     = google_model_armor_template.this.location == "us-central1"
+    error_message = "location must default to var.region."
+  }
+
+  assert {
+    condition     = google_model_armor_template.this.filter_config[0].pi_and_jailbreak_filter_settings[0].confidence_level == "MEDIUM_AND_ABOVE"
+    error_message = "PI/jailbreak filter must use the default MEDIUM_AND_ABOVE confidence floor."
+  }
+
+  assert {
+    condition     = length(google_model_armor_template.this.filter_config[0].rai_settings[0].rai_filters) == 4
+    error_message = "all four default RAI filter categories must be configured."
+  }
+
+  assert {
+    condition     = google_model_armor_template.this.labels["project"] == "test"
+    error_message = "template must carry the project = var.project label."
+  }
+
+  # Floor setting is the singleton hazard — OFF by default.
+  assert {
+    condition     = length(google_model_armor_floorsetting.this) == 0
+    error_message = "floor setting must be absent unless manage_floorsetting is true."
+  }
+}
+
+run "confidence_and_location_override" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    filter_confidence_level = "HIGH"
+    location                = "europe-west4"
+  }
+
+  assert {
+    condition     = google_model_armor_template.this.filter_config[0].pi_and_jailbreak_filter_settings[0].confidence_level == "HIGH"
+    error_message = "filter_confidence_level must flow through to the PI/jailbreak filter."
+  }
+
+  assert {
+    condition     = google_model_armor_template.this.location == "europe-west4"
+    error_message = "var.location must override var.region."
+  }
+}
+
+run "template_id_override" {
+  command = plan
+
+  variables {
+    project     = "test"
+    project_id  = "test-project"
+    template_id = "custom-armor-template"
+  }
+
+  assert {
+    condition     = google_model_armor_template.this.template_id == "custom-armor-template"
+    error_message = "var.template_id must override the project-prefixed default."
+  }
+}
+
+run "floorsetting_enabled" {
+  command = plan
+
+  variables {
+    project             = "test"
+    project_id          = "test-project"
+    manage_floorsetting = true
+  }
+
+  assert {
+    condition     = length(google_model_armor_floorsetting.this) == 1
+    error_message = "floor setting must be created when manage_floorsetting is true."
+  }
+
+  assert {
+    condition     = google_model_armor_floorsetting.this[0].parent == "projects/test-project/locations/us-central1"
+    error_message = "floor setting parent must be projects/<project_id>/locations/<location>."
+  }
+}
+
+run "rejects_invalid_confidence" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    filter_confidence_level = "PARANOID"
+  }
+
+  expect_failures = [var.filter_confidence_level]
+}
+
+run "rejects_invalid_rai_filter" {
+  command = plan
+
+  variables {
+    project          = "test"
+    project_id       = "test-project"
+    rai_filter_types = ["DANGEROUS", "NOT_A_CATEGORY"]
+  }
+
+  expect_failures = [var.rai_filter_types]
+}
+
+run "rejects_invalid_template_id" {
+  command = plan
+
+  variables {
+    project     = "test"
+    project_id  = "test-project"
+    template_id = "Bad_Template_ID"
+  }
+
+  expect_failures = [var.template_id]
+}
+
+run "rejects_invalid_project_id" {
+  command = plan
+
+  variables {
+    project    = "test"
+    project_id = "BadProjectID"
+  }
+
+  expect_failures = [var.project_id]
+}

--- a/gcp/model_armor/variables.tf
+++ b/gcp/model_armor/variables.tf
@@ -1,0 +1,78 @@
+variable "project" {
+  description = "Naming/label prefix for stack resources (NOT a GCP project ID — see var.project_id)."
+  type        = string
+
+  validation {
+    condition     = length(trimspace(var.project)) > 0
+    error_message = "project must be a non-empty string."
+  }
+}
+
+variable "project_id" {
+  description = "Real GCP project ID where resources are created (e.g. \"my-prod-12345\"). Distinct from var.project, which is the naming/label prefix and need not be a valid GCP project ID."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", var.project_id))
+    error_message = "project_id must be a valid GCP project ID: 6–30 chars, lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+variable "region" {
+  description = "GCP region for the Model Armor template (Model Armor locations ARE regions, e.g. us-central1)."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "location" {
+  description = "Model Armor location (a GCP region). Null uses var.region. Model Armor is region-limited — choose a region where it is available."
+  type        = string
+  default     = null
+}
+
+variable "template_id" {
+  description = "Template ID for the Model Armor template. Null defaults to \"<project>-armor\" so a bare compose produces a uniquely-named, attributable template."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.template_id == null ? true : can(regex("^[a-z][a-z0-9-]{0,61}[a-z0-9]$", var.template_id))
+    error_message = "template_id must be a valid resource id: lowercase letters/digits/hyphens, start with a letter, end alphanumeric."
+  }
+}
+
+variable "filter_confidence_level" {
+  description = "Confidence floor at which filters trip: LOW_AND_ABOVE (most aggressive), MEDIUM_AND_ABOVE, or HIGH (most permissive). Applied to the prompt-injection/jailbreak and responsible-AI filters."
+  type        = string
+  default     = "MEDIUM_AND_ABOVE"
+
+  validation {
+    condition     = contains(["LOW_AND_ABOVE", "MEDIUM_AND_ABOVE", "HIGH"], var.filter_confidence_level)
+    error_message = "filter_confidence_level must be one of LOW_AND_ABOVE, MEDIUM_AND_ABOVE, HIGH."
+  }
+}
+
+variable "rai_filter_types" {
+  description = "Responsible-AI category filters to enforce. Each must be a valid Model Armor RAI filter type."
+  type        = list(string)
+  default     = ["DANGEROUS", "HATE_SPEECH", "SEXUALLY_EXPLICIT", "HARASSMENT"]
+
+  validation {
+    condition = length(var.rai_filter_types) > 0 && alltrue([
+      for t in var.rai_filter_types : contains(["DANGEROUS", "HATE_SPEECH", "SEXUALLY_EXPLICIT", "HARASSMENT"], t)
+    ])
+    error_message = "rai_filter_types must be a non-empty subset of DANGEROUS, HATE_SPEECH, SEXUALLY_EXPLICIT, HARASSMENT."
+  }
+}
+
+variable "manage_floorsetting" {
+  description = "When true, also create the project-wide Model Armor floor setting. ⚠️ SINGLETON: the floor setting is a project/org singleton — creating it where one already exists fails, and two stacks in one project collide. Enable only for the single stack that owns the project's floor. Default false."
+  type        = bool
+  default     = false
+}
+
+variable "labels" {
+  description = "Resource labels merged with the standard { project = var.project } identity label on the template."
+  type        = map(string)
+  default     = {}
+}

--- a/gcp/vertex_ai/main.tf
+++ b/gcp/vertex_ai/main.tf
@@ -183,11 +183,13 @@ resource "google_vertex_ai_index_endpoint" "this" {
   # projects/<NUMBER>/global/networks/<name>, rebuilt from the wired vpc_id
   # (which carries the project ID) via data.google_project.this.number.
   #
-  # NOTE: the private path additionally requires a servicenetworking PSC
-  # peering range on this network (google_service_networking_connection + a
-  # VPC_PEERING global address) that gcp/vpc does not yet provision (#774).
-  # Until that lands, an opt-in private apply needs the peering created
-  # out-of-band. The default (public) path is unaffected.
+  # The private path additionally requires a servicenetworking PSC peering
+  # range on this network (google_service_networking_connection + a VPC_PEERING
+  # global address). gcp/vpc now provisions this when its
+  # enable_service_networking flag is set (#774), and the composer wires the
+  # connection id into var.service_networking_connection so the peering is
+  # created before this endpoint applies. The default (public) path is
+  # unaffected and needs none of it.
   network = local.network_canonical
 
   # Public unless the private path is selected.
@@ -199,6 +201,20 @@ resource "google_vertex_ai_index_endpoint" "this" {
     },
     var.labels
   )
+
+  lifecycle {
+    # Fail-loud: a private (VPC-peered) endpoint cannot serve until the
+    # servicenetworking PSC peering range exists on the network, or the apply
+    # fails ~30-90min into the deployed-index step. Referencing
+    # var.service_networking_connection here both surfaces the missing peering
+    # at plan time AND creates the dependency edge (the composer wires it from
+    # gcp/vpc.service_networking_connection_id) so Terraform orders the peering
+    # before this endpoint. Public path is exempt (it needs no peering). #774.
+    precondition {
+      condition     = local.vector_search_private ? var.service_networking_connection != null : true
+      error_message = "A private Vertex AI index endpoint (enable_private_endpoint = true with a wired network) requires a servicenetworking PSC peering range. Set gcp/vpc's enable_service_networking = true so service_networking_connection is wired, or provision the peering out-of-band (#774/#600)."
+    }
+  }
 }
 
 # Binds the index to the endpoint. The deploy is the long pole: Vertex spins up

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -136,6 +136,9 @@ run "vector_search_private_opt_in" {
     # Project-ID full path: the parser must keep the network NAME and the
     # rebuild must swap the project ID for the pinned project NUMBER.
     network = "projects/test-project/global/networks/test-vpc"
+    # Private path requires the servicenetworking PSC peering (#774) — supplied
+    # here as it would be wired from gcp/vpc.service_networking_connection_id.
+    service_networking_connection = "projects/test-project/global/networks/test-vpc/serviceNetworkingConnections/servicenetworking-googleapis-com"
   }
 
   # network + enable_private_endpoint -> private endpoint (public disabled).
@@ -173,6 +176,8 @@ run "vector_search_private_bare_network_name" {
     enable_vector_search    = true
     enable_private_endpoint = true
     network                 = "my-vpc"
+    # Private path requires the servicenetworking PSC peering (#774).
+    service_networking_connection = "projects/test-project/global/networks/my-vpc/serviceNetworkingConnections/servicenetworking-googleapis-com"
   }
 
   assert {
@@ -201,6 +206,26 @@ run "vector_search_private_opt_in_without_network_stays_public" {
     condition     = google_vertex_ai_index_endpoint.this[0].network == null
     error_message = "endpoint network must be null when no network is wired, regardless of enable_private_endpoint."
   }
+}
+
+# Issue #774: a private (VPC-peered) endpoint requires the servicenetworking PSC
+# peering. When a network is wired AND enable_private_endpoint is set but no
+# service_networking_connection is supplied, the fail-loud precondition must
+# reject the plan rather than let a live apply hang ~30-90min into the
+# deployed-index step.
+run "private_endpoint_without_service_networking_fails" {
+  command = plan
+
+  variables {
+    project                 = "test"
+    project_id              = "test-project"
+    enable_vector_search    = true
+    enable_private_endpoint = true
+    network                 = "projects/test-project/global/networks/test-vpc"
+    # service_networking_connection deliberately left null.
+  }
+
+  expect_failures = [google_vertex_ai_index_endpoint.this]
 }
 
 run "vector_search_public_endpoint_without_network" {

--- a/gcp/vertex_ai/tests/shape.tftest.hcl
+++ b/gcp/vertex_ai/tests/shape.tftest.hcl
@@ -212,7 +212,10 @@ run "vector_search_private_opt_in_without_network_stays_public" {
 # peering. When a network is wired AND enable_private_endpoint is set but no
 # service_networking_connection is supplied, the fail-loud precondition must
 # reject the plan rather than let a live apply hang ~30-90min into the
-# deployed-index step.
+# deployed-index step. The SATISFIED (positive) path is covered by the two
+# private runs above (vector_search_private_opt_in, vector_search_private_bare_
+# network_name): both supply service_networking_connection and plan successfully,
+# so this run isolates the single missing input the precondition guards.
 run "private_endpoint_without_service_networking_fails" {
   command = plan
 

--- a/gcp/vertex_ai/variables.tf
+++ b/gcp/vertex_ai/variables.tf
@@ -143,9 +143,15 @@ variable "network" {
 }
 
 variable "enable_private_endpoint" {
-  description = "When true AND a network is wired, the index endpoint is private (VPC-peered) instead of public. Default false = public endpoint, which works live today. The private path requires a servicenetworking PSC peering range on the network that gcp/vpc does not yet provision (follow-up #774); enabling it before #774 lands means the peering must exist out-of-band or a live apply fails ~30-90min into the deployed-index step."
+  description = "When true AND a network is wired, the index endpoint is private (VPC-peered) instead of public. Default false = public endpoint, which works live today. The private path requires a servicenetworking PSC peering range on the network, now provisioned by gcp/vpc (enable_service_networking = true, #774) and wired in via service_networking_connection; without it a live apply fails ~30-90min into the deployed-index step."
   type        = bool
   default     = false
+}
+
+variable "service_networking_connection" {
+  description = "ID of the servicenetworking PSC peering connection the private index endpoint depends on (#774). Wired by the composer from gcp/vpc.service_networking_connection_id when both are selected; callers who manage the peering out-of-band pass their own connection id. Used only on the private-endpoint path: it orders the endpoint after the peering range exists and fails loud at plan time if a private endpoint is requested without it. Null on the public path (the default) and standalone previews."
+  type        = string
+  default     = null
 }
 
 variable "deployed_index_min_replicas" {

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -119,6 +119,24 @@ resource "google_compute_firewall" "allow_ssh_iap" {
 # public-endpoint paths need none of this). When gcp/vpc owns the peering, all
 # consumers of this network share one range instead of each provisioning their
 # own (gcp/cloudsql still provisions its own when it owns the network).
+# Enable the Service Networking API before the peering connection is created.
+# google_service_networking_connection requires servicenetworking.googleapis.com;
+# in a fresh project where it is not already enabled the first apply of the
+# private path would fail before any consumer (Vertex private endpoint, private
+# CloudSQL/Memorystore) could use the peering (Codex review). Gated on the same
+# flag so plain public VPCs never enable it, and disable_on_destroy=false keeps
+# teardown idempotent (a shared project-level API activation — see the
+# idempotency contract in CLAUDE.md). The composer's GCPServices map leaves
+# gcp_vpc on the always-required set; this conditional enablement is the precise
+# counterpart for the opt-in peering path.
+resource "google_project_service" "servicenetworking" {
+  count = var.enable_service_networking ? 1 : 0
+
+  project            = var.project_id
+  service            = "servicenetworking.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "google_compute_global_address" "private_service_access" {
   count = var.enable_service_networking ? 1 : 0
 
@@ -145,6 +163,10 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   # try() guards the empty-tuple plan-time reference when the gate is off
   # (issue #178 pattern); count already prevents instantiation.
   reserved_peering_ranges = [try(google_compute_global_address.private_service_access[0].name, null)]
+
+  # Order the connection after the API it depends on so a fresh project enables
+  # servicenetworking.googleapis.com before the first connection create.
+  depends_on = [google_project_service.servicenetworking]
 }
 
 # Serverless VPC Access Connector for Cloud Run / Cloud Functions

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -110,6 +110,43 @@ resource "google_compute_firewall" "allow_ssh_iap" {
   source_ranges = ["35.235.240.0/20"]
 }
 
+# Private Services Access (servicenetworking) peering — issue #774.
+#
+# A reserved VPC_PEERING range + a google_service_networking_connection so a
+# fully private Vertex AI index endpoint (#764/#600) — and private-IP CloudSQL/
+# Memorystore that consume this VPC — can reach Google-managed services over a
+# VPC peering. Gated on var.enable_service_networking (off by default: the
+# public-endpoint paths need none of this). When gcp/vpc owns the peering, all
+# consumers of this network share one range instead of each provisioning their
+# own (gcp/cloudsql still provisions its own when it owns the network).
+resource "google_compute_global_address" "private_service_access" {
+  count = var.enable_service_networking ? 1 : 0
+
+  name          = "${var.project}-psa-${random_id.suffix.hex}"
+  project       = var.project_id
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = var.service_networking_prefix_length
+  network       = module.vpc.network_id
+
+  labels = merge(
+    {
+      project = var.project
+    },
+    var.labels
+  )
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  count = var.enable_service_networking ? 1 : 0
+
+  network = module.vpc.network_id
+  service = "servicenetworking.googleapis.com"
+  # try() guards the empty-tuple plan-time reference when the gate is off
+  # (issue #178 pattern); count already prevents instantiation.
+  reserved_peering_ranges = [try(google_compute_global_address.private_service_access[0].name, null)]
+}
+
 # Serverless VPC Access Connector for Cloud Run / Cloud Functions
 resource "google_vpc_access_connector" "serverless" {
   count = var.enable_serverless_connector ? 1 : 0

--- a/gcp/vpc/outputs.tf
+++ b/gcp/vpc/outputs.tf
@@ -59,3 +59,14 @@ output "connector_id" {
   value = var.enable_serverless_connector ? try(google_vpc_access_connector.serverless[0].id, null) : null
 }
 
+output "service_networking_connection_id" {
+  description = "ID of the Private Services Access servicenetworking connection (#774), or null when enable_service_networking is false. Wired into gcp/vertex_ai so a private index endpoint orders after the PSC peering range exists."
+  # Layered ternary + try(): see router_name above (issue #178).
+  value = var.enable_service_networking ? try(google_service_networking_connection.private_vpc_connection[0].id, null) : null
+}
+
+output "service_networking_peering_range" {
+  description = "Name of the reserved VPC_PEERING range backing Private Services Access (#774), or null when disabled."
+  value       = var.enable_service_networking ? try(google_compute_global_address.private_service_access[0].name, null) : null
+}
+

--- a/gcp/vpc/variables.tf
+++ b/gcp/vpc/variables.tf
@@ -114,3 +114,34 @@ variable "connector_max_instances" {
   }
 }
 
+# Private Services Access / servicenetworking peering (issue #774). A fully
+# private Vertex AI index endpoint (#764/#600) requires the consumer VPC to
+# have a servicenetworking.googleapis.com private connection: a reserved
+# VPC_PEERING global address + a google_service_networking_connection. gcp/vpc
+# does not provision this today, so #773's private-endpoint path needs the
+# peering created out-of-band. This lets gcp/vpc own one shared peering range
+# that the Vertex private endpoint (and private-IP CloudSQL/Memorystore) can
+# consume. Off by default — the public-endpoint paths need none of it.
+variable "enable_service_networking" {
+  description = "Create a Private Services Access (servicenetworking) peering on this VPC: a reserved VPC_PEERING range + a google_service_networking_connection. Required for fully private Vertex AI index endpoints (#774/#600) and any managed service that consumes this VPC's peering for private IP. Default false (public paths need none of it)."
+  type        = bool
+  default     = false
+}
+
+variable "service_networking_prefix_length" {
+  description = "Prefix length of the reserved VPC_PEERING range allocated for Private Services Access. GCP requires /8../30; /16 (the default) matches the gcp/cloudsql reservation."
+  type        = number
+  default     = 16
+
+  validation {
+    condition     = var.service_networking_prefix_length >= 8 && var.service_networking_prefix_length <= 30
+    error_message = "service_networking_prefix_length must be between 8 and 30."
+  }
+}
+
+variable "labels" {
+  description = "Resource labels merged with the standard { project = var.project } identity label on label-capable resources (e.g. the Private Services Access range)."
+  type        = map(string)
+  default     = {}
+}
+

--- a/pkg/composer/coherence.go
+++ b/pkg/composer/coherence.go
@@ -144,6 +144,10 @@ func ComponentSelected(c *Components, key ComponentKey) bool {
 		return boolPtrTrue(c.GCPVertexAI)
 	case KeyGCPAgentEngine:
 		return boolPtrTrue(c.GCPAgentEngine)
+	case KeyGCPDocumentAI:
+		return boolPtrTrue(c.GCPDocumentAI)
+	case KeyGCPModelArmor:
+		return boolPtrTrue(c.GCPModelArmor)
 	case KeyGCPPubSub:
 		return boolPtrTrue(c.GCPPubSub)
 	case KeyGCPCloudLogging:
@@ -334,6 +338,7 @@ func isOrphanStrippableKey(key ComponentKey) bool {
 		KeyGCPCloudFunctions, KeyGCPLoadbalancer,
 		KeyGCPCloudSQL, KeyGCPMemorystore, KeyGCPGCS,
 		KeyGCPVertexAI, KeyGCPAgentEngine,
+		KeyGCPDocumentAI, KeyGCPModelArmor,
 		KeyGCPPubSub, KeyGCPCloudLogging,
 		KeyGCPIdentityPlatform, KeyGCPAPIGateway, KeyGCPBackups,
 		KeyGCPCloudDNS, KeyGCPGitHubActions, KeyGCPCloudDeploy:

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -1322,10 +1322,18 @@ func DefaultWiring(selected map[ComponentKey]bool, k ComponentKey, comps *Compon
 		// actually requires (it cannot accept the project-ID form), so the wire
 		// stays vpc_id and the form conversion lives in the preset. The endpoint
 		// is still PUBLIC unless the operator also sets enable_private_endpoint
-		// (the private path needs #774 PSC peering that gcp/vpc lacks today).
+		// (the private path consumes the #774 PSC peering wired below).
 		if selected[KeyGCPVPC] {
 			wi.RawHCL["network"] = WireRef(KeyGCPVPC, "vpc_id")
 			wi.Names = append(wi.Names, "network")
+			// Servicenetworking PSC peering (#774). gcp/vpc provisions the
+			// peering range when its enable_service_networking flag is set;
+			// wiring the connection id orders a private index endpoint after
+			// the peering and lets the preset fail loud at plan time if a
+			// private endpoint is requested without it. Null on the public
+			// path (the default), which needs no peering.
+			wi.RawHCL["service_networking_connection"] = WireRef(KeyGCPVPC, "service_networking_connection_id")
+			wi.Names = append(wi.Names, "service_networking_connection")
 		}
 		// When GCS is selected, seed the index from a dedicated prefix under the
 		// bucket rather than the bucket root. bucket_url is the gs://<bucket>

--- a/pkg/composer/contracts.go
+++ b/pkg/composer/contracts.go
@@ -93,6 +93,8 @@ const (
 	KeyGCPFirestore        ComponentKey = "gcp_firestore"
 	KeyGCPVertexAI         ComponentKey = "gcp_vertex_ai"
 	KeyGCPAgentEngine      ComponentKey = "gcp_agent_engine"
+	KeyGCPDocumentAI       ComponentKey = "gcp_document_ai"
+	KeyGCPModelArmor       ComponentKey = "gcp_model_armor"
 	KeyGCPCloudArmor       ComponentKey = "gcp_cloud_armor"
 	KeyGCPAPIGateway       ComponentKey = "gcp_api_gateway"
 	KeyGCPBackups          ComponentKey = "gcp_backups"
@@ -189,6 +191,12 @@ var ComposeOrder = []ComponentKey{
 	// caller-supplied artifact URI (public by default; PSC-private networking
 	// is out of scope until gcp/vpc provisions a network attachment).
 	KeyGCPAgentEngine,
+	// Document AI (#765) and Model Armor (#766) compose adjacent to the Vertex
+	// keys. Both are standalone (no hard ImplicitDependency): Document AI's
+	// optional GCS input bucket is app-layer, and Model Armor templates are
+	// project-level. Ordering is not significant for either.
+	KeyGCPDocumentAI,
+	KeyGCPModelArmor,
 	// App Runner (#598 row 2). Independent of EKS/ECS/Lambda compute
 	// keys — App Runner is a peer managed-container service (Cloud Run
 	// analog), not a downstream consumer of them. Position adjacent to
@@ -282,6 +290,8 @@ var ModulePath = map[ComponentKey]string{
 	KeyGCPSecretManager:    "gcp/secret_manager",
 	KeyGCPVertexAI:         "gcp/vertex_ai",
 	KeyGCPAgentEngine:      "gcp/agent_engine",
+	KeyGCPDocumentAI:       "gcp/document_ai",
+	KeyGCPModelArmor:       "gcp/model_armor",
 	KeyGCPPubSub:           "gcp/pubsub",
 	KeyGCPCloudLogging:     "gcp/cloud_logging",
 	KeyGCPCloudMonitoring:  "gcp/cloud_monitoring",
@@ -513,6 +523,8 @@ var PresetKeyMap = map[ComponentKey]string{
 	KeyGCPCloudMonitoring:      "cloud_monitoring",
 	KeyGCPVertexAI:             "vertex_ai",
 	KeyGCPAgentEngine:          "agent_engine",
+	KeyGCPDocumentAI:           "document_ai",
+	KeyGCPModelArmor:           "model_armor",
 	KeyGCPCloudBuild:           "cloud_build",
 	KeyGCPFirestore:            "firestore",
 	KeyGCPCloudArmor:           "cloud_armor",
@@ -637,6 +649,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyGCPCloudRun,
 	KeyGCPCloudSQL,
 	KeyGCPCompute,
+	KeyGCPDocumentAI,
 	KeyGCPFirestore,
 	KeyGCPGCS,
 	KeyGCPGKE,
@@ -644,6 +657,7 @@ var AllComponentKeys = []ComponentKey{
 	KeyGCPIdentityPlatform,
 	KeyGCPLoadbalancer,
 	KeyGCPMemorystore,
+	KeyGCPModelArmor,
 	KeyGCPPubSub,
 	KeyGCPSecretManager,
 	KeyGCPVPC,

--- a/pkg/composer/gcp_services.go
+++ b/pkg/composer/gcp_services.go
@@ -66,6 +66,10 @@ var GCPServices = map[ComponentKey][]GCPService{
 	// Agent Engine / Reasoning Engine is the same Vertex AI plane as datasets +
 	// vector search, so it rides on aiplatform.googleapis.com (#769).
 	KeyGCPAgentEngine: {{Name: "aiplatform.googleapis.com", Title: "Vertex AI"}},
+	// Document AI (#765): the processor API.
+	KeyGCPDocumentAI: {{Name: "documentai.googleapis.com", Title: "Document AI"}},
+	// Model Armor (#766): the safety-template API (newer, region-limited).
+	KeyGCPModelArmor: {{Name: "modelarmor.googleapis.com", Title: "Model Armor"}},
 	KeyGCPAPIGateway: {
 		{Name: "apigateway.googleapis.com", Title: "API Gateway"},
 		// API Gateway plane requires both Service Control (request

--- a/pkg/composer/iam_actions.go
+++ b/pkg/composer/iam_actions.go
@@ -220,6 +220,8 @@ var GCPIAMPermissions = map[ComponentKey][]string{
 	KeyGCPFirestore:        {"datastore.databases.create"},
 	KeyGCPVertexAI:         {"aiplatform.endpoints.create"},
 	KeyGCPAgentEngine:      {"aiplatform.reasoningEngines.create"},
+	KeyGCPDocumentAI:       {"documentai.processors.create"},
+	KeyGCPModelArmor:       {"modelarmor.templates.create"},
 	KeyGCPAPIGateway:       {"apigateway.gateways.create"},
 	KeyGCPBackups:          {"backupdr.managementServers.create"},
 	// Cloud DNS (#593). managedZones.create + resourceRecordSets.create

--- a/pkg/composer/mapper.go
+++ b/pkg/composer/mapper.go
@@ -1207,6 +1207,38 @@ func (m DefaultMapper) BuildModuleValues(
 			}
 		}
 
+	case KeyGCPDocumentAI:
+		// Document AI (#765). Translate the stack region's continent into the
+		// DocAI multi-region location (us|eu) — DocAI does NOT accept arbitrary
+		// regions like "us-central1", so region is never passed through. A
+		// caller-supplied cfg.Location overrides the derivation.
+		loc := "us"
+		if strings.HasPrefix(reg, "europe-") || strings.HasPrefix(reg, "eu-") {
+			loc = "eu"
+		}
+		if cfg != nil && cfg.GCPDocumentAI != nil {
+			if strings.TrimSpace(cfg.GCPDocumentAI.Location) != "" {
+				loc = strings.TrimSpace(cfg.GCPDocumentAI.Location)
+			}
+			if strings.TrimSpace(cfg.GCPDocumentAI.ProcessorType) != "" {
+				vals["processor_type"] = strings.TrimSpace(cfg.GCPDocumentAI.ProcessorType)
+			}
+		}
+		vals["location"] = loc
+
+	case KeyGCPModelArmor:
+		// Model Armor (#766). Partial-config: emit only fields the caller
+		// populated so the preset's own defaults win when unset. The
+		// project-singleton floor setting is opt-in (default off in the preset).
+		if cfg != nil && cfg.GCPModelArmor != nil {
+			if strings.TrimSpace(cfg.GCPModelArmor.FilterConfidenceLevel) != "" {
+				vals["filter_confidence_level"] = strings.TrimSpace(cfg.GCPModelArmor.FilterConfidenceLevel)
+			}
+			if cfg.GCPModelArmor.ManageFloorsetting != nil {
+				vals["manage_floorsetting"] = *cfg.GCPModelArmor.ManageFloorsetting
+			}
+		}
+
 	case KeyGCPPubSub:
 		vals["topic_name"] = "events"
 		if cfg != nil && cfg.GCPPubSub != nil {

--- a/pkg/composer/mapper_keys_subset_test.go
+++ b/pkg/composer/mapper_keys_subset_test.go
@@ -300,6 +300,14 @@ func kitchenSinkConfig() *Config {
 		ModelGardenModel      string `json:"modelGardenModel,omitempty"`
 		ModelGardenAcceptEULA *bool  `json:"modelGardenAcceptEula,omitempty"`
 	}{EnableVectorSearch: &t, IndexDimensions: 768, EnableServing: &t, ModelGardenModel: "publishers/google/models/gemma3@gemma-3-1b-it", ModelGardenAcceptEULA: &t}
+	cfg.GCPDocumentAI = &struct {
+		ProcessorType string `json:"processorType,omitempty"`
+		Location      string `json:"location,omitempty"`
+	}{ProcessorType: "FORM_PARSER_PROCESSOR", Location: "eu"}
+	cfg.GCPModelArmor = &struct {
+		FilterConfidenceLevel string `json:"filterConfidenceLevel,omitempty"`
+		ManageFloorsetting    *bool  `json:"manageFloorsetting,omitempty"`
+	}{FilterConfidenceLevel: "HIGH", ManageFloorsetting: &t}
 	cfg.GCPPubSub = &struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	}{MessageRetentionDuration: "604800s"}

--- a/pkg/composer/mapper_required_test.go
+++ b/pkg/composer/mapper_required_test.go
@@ -152,6 +152,8 @@ func kitchenSinkComponents() *Components {
 		GCPSecretManager:    &t,
 		GCPVertexAI:         &t,
 		GCPAgentEngine:      &t,
+		GCPDocumentAI:       &t,
+		GCPModelArmor:       &t,
 		GCPPubSub:           &t,
 		GCPCloudLogging:     &t,
 		GCPCloudMonitoring:  &t,

--- a/pkg/composer/mapper_test.go
+++ b/pkg/composer/mapper_test.go
@@ -1253,3 +1253,121 @@ func TestBuildModuleValues_AWSEC2_GPU(t *testing.T) {
 		assert.False(t, hasKey, "nil GPUEnabled must not set gpu_enabled")
 	})
 }
+
+// TestBuildModuleValues_GCPDocumentAI_LocationTranslation pins the #765 mapper
+// logic (qa-professor B1): the DocAI multi-region location (us|eu) is derived
+// from the stack region's continent — DocAI rejects arbitrary regions like
+// "us-central1" — a caller-supplied Location overrides the derivation, and
+// ProcessorType flows through only when set. This is the one piece of
+// non-trivial transformation the DocAI mapper case adds; mapper_keys_subset_test
+// only proves the emitted keys are declared variables, never the values, so the
+// eu-/europe- branch and the override precedence were previously untested.
+func TestBuildModuleValues_GCPDocumentAI_LocationTranslation(t *testing.T) {
+	m := DefaultMapper{}
+
+	docAICfg := func(processorType, location string) *Config {
+		c := &Config{}
+		c.GCPDocumentAI = &struct {
+			ProcessorType string `json:"processorType,omitempty"`
+			Location      string `json:"location,omitempty"`
+		}{ProcessorType: processorType, Location: location}
+		return c
+	}
+
+	t.Run("europe- region derives eu", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyGCPDocumentAI, nil, nil, "demo", "europe-west1")
+		require.NoError(t, err)
+		assert.Equal(t, "eu", vals["location"])
+	})
+
+	t.Run("eu- region prefix derives eu", func(t *testing.T) {
+		// The mapper defensively also matches an "eu-" prefix (not a real GCP
+		// region, but guards a caller passing shorthand).
+		vals, err := m.BuildModuleValues(KeyGCPDocumentAI, nil, nil, "demo", "eu-west1")
+		require.NoError(t, err)
+		assert.Equal(t, "eu", vals["location"])
+	})
+
+	t.Run("us region derives us", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyGCPDocumentAI, nil, nil, "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, "us", vals["location"])
+	})
+
+	t.Run("non-eu/us region falls back to us", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyGCPDocumentAI, nil, nil, "demo", "asia-east1")
+		require.NoError(t, err)
+		assert.Equal(t, "us", vals["location"])
+	})
+
+	t.Run("explicit Location overrides a europe region", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyGCPDocumentAI, nil, docAICfg("", "us"), "demo", "europe-west1")
+		require.NoError(t, err)
+		assert.Equal(t, "us", vals["location"], "caller Location must win over the region-derived continent")
+	})
+
+	t.Run("explicit Location overrides a us region", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyGCPDocumentAI, nil, docAICfg("", "eu"), "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, "eu", vals["location"])
+	})
+
+	t.Run("ProcessorType flows through; absent when unset", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyGCPDocumentAI, nil, docAICfg("FORM_PARSER_PROCESSOR", ""), "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, "FORM_PARSER_PROCESSOR", vals["processor_type"])
+
+		vals2, err := m.BuildModuleValues(KeyGCPDocumentAI, nil, nil, "demo", "us-central1")
+		require.NoError(t, err)
+		_, hasPT := vals2["processor_type"]
+		assert.False(t, hasPT, "processor_type must not be emitted when unset (preset default wins)")
+	})
+}
+
+// TestBuildModuleValues_GCPModelArmor_PartialConfig pins the #766 partial-config
+// contract (qa-professor S1): the mapper emits manage_floorsetting /
+// filter_confidence_level ONLY when the caller populated them, so the preset's
+// own defaults win when unset. manage_floorsetting gates a project/org SINGLETON
+// that collides if one already exists, so a mutation emitting it unconditionally
+// (default on) would be a real hazard — this test traps it.
+func TestBuildModuleValues_GCPModelArmor_PartialConfig(t *testing.T) {
+	m := DefaultMapper{}
+
+	armorCfg := func(level string, manage *bool) *Config {
+		c := &Config{}
+		c.GCPModelArmor = &struct {
+			FilterConfidenceLevel string `json:"filterConfidenceLevel,omitempty"`
+			ManageFloorsetting    *bool  `json:"manageFloorsetting,omitempty"`
+		}{FilterConfidenceLevel: level, ManageFloorsetting: manage}
+		return c
+	}
+
+	t.Run("nil config emits neither key (preset defaults win)", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyGCPModelArmor, nil, nil, "demo", "us-central1")
+		require.NoError(t, err)
+		_, hasFloor := vals["manage_floorsetting"]
+		assert.False(t, hasFloor, "nil ModelArmor config must NOT emit manage_floorsetting (it gates a singleton)")
+		_, hasLevel := vals["filter_confidence_level"]
+		assert.False(t, hasLevel, "nil ModelArmor config must NOT emit filter_confidence_level")
+	})
+
+	t.Run("FilterConfidenceLevel set, ManageFloorsetting nil emits only the level", func(t *testing.T) {
+		vals, err := m.BuildModuleValues(KeyGCPModelArmor, nil, armorCfg("HIGH", nil), "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, "HIGH", vals["filter_confidence_level"])
+		_, hasFloor := vals["manage_floorsetting"]
+		assert.False(t, hasFloor, "nil ManageFloorsetting must not emit the singleton gate")
+	})
+
+	t.Run("ManageFloorsetting flows through for explicit true and false", func(t *testing.T) {
+		trueVal := true
+		vals, err := m.BuildModuleValues(KeyGCPModelArmor, nil, armorCfg("", &trueVal), "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, true, vals["manage_floorsetting"])
+
+		falseVal := false
+		vals2, err := m.BuildModuleValues(KeyGCPModelArmor, nil, armorCfg("", &falseVal), "demo", "us-central1")
+		require.NoError(t, err)
+		assert.Equal(t, false, vals2["manage_floorsetting"], "explicit false must be emitted (caller opting OUT explicitly)")
+	})
+}

--- a/pkg/composer/pricing.go
+++ b/pkg/composer/pricing.go
@@ -148,6 +148,8 @@ type PricingData struct {
 		GCPSecretManager    *PricingItem       `json:"gcp_secret_manager,omitempty"`
 		GCPVertexAI         *PricingItem       `json:"gcp_vertex_ai,omitempty"`
 		GCPAgentEngine      *PricingItem       `json:"gcp_agent_engine,omitempty"`
+		GCPDocumentAI       *PricingItem       `json:"gcp_document_ai,omitempty"`
+		GCPModelArmor       *PricingItem       `json:"gcp_model_armor,omitempty"`
 		GCPPubSub           *PricingItem       `json:"gcp_pubsub,omitempty"`
 		GCPCloudLogging     *PricingItem       `json:"gcp_cloud_logging,omitempty"`
 		GCPCloudMonitoring  *PricingItem       `json:"gcp_cloud_monitoring,omitempty"`
@@ -415,6 +417,8 @@ func (p *PricingData) Normalize() {
 		c.GCPSecretManager = nil
 		c.GCPVertexAI = nil
 		c.GCPAgentEngine = nil
+		c.GCPDocumentAI = nil
+		c.GCPModelArmor = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudMonitoring = nil

--- a/pkg/composer/types.go
+++ b/pkg/composer/types.go
@@ -77,6 +77,8 @@ type Components struct {
 	GCPSecretManager    *bool  `json:"gcp_secret_manager,omitempty"`
 	GCPVertexAI         *bool  `json:"gcp_vertex_ai,omitempty"`
 	GCPAgentEngine      *bool  `json:"gcp_agent_engine,omitempty"`
+	GCPDocumentAI       *bool  `json:"gcp_document_ai,omitempty"`
+	GCPModelArmor       *bool  `json:"gcp_model_armor,omitempty"`
 	GCPPubSub           *bool  `json:"gcp_pubsub,omitempty"`
 	GCPCloudLogging     *bool  `json:"gcp_cloud_logging,omitempty"`
 	GCPCloudMonitoring  *bool  `json:"gcp_cloud_monitoring,omitempty"`
@@ -442,6 +444,27 @@ type Config struct {
 		DisplayName string `json:"displayName,omitempty"`
 	} `json:"gcp_agent_engine,omitempty"`
 
+	// GCPDocumentAI carries the caller-supplied Document AI configuration
+	// (#765). ProcessorType selects the parser (OCR/form/invoice). Location is
+	// the DocAI multi-region (us|eu); when empty the mapper derives it from the
+	// stack region's continent (DocAI does not accept arbitrary regions).
+	// Partial-config: the mapper only emits a field the caller populated so the
+	// preset's own defaults win when left unset.
+	GCPDocumentAI *struct {
+		ProcessorType string `json:"processorType,omitempty"`
+		Location      string `json:"location,omitempty"`
+	} `json:"gcp_document_ai,omitempty"`
+
+	// GCPModelArmor carries the caller-supplied Model Armor configuration
+	// (#766). FilterConfidenceLevel sets the RAI filter floor; ManageFloorsetting
+	// opts into the project/org-singleton floor setting (off by default — it
+	// collides if one already exists). Partial-config: the mapper only emits a
+	// field the caller populated so the preset's own defaults win when unset.
+	GCPModelArmor *struct {
+		FilterConfidenceLevel string `json:"filterConfidenceLevel,omitempty"`
+		ManageFloorsetting    *bool  `json:"manageFloorsetting,omitempty"`
+	} `json:"gcp_model_armor,omitempty"`
+
 	GCPPubSub *struct {
 		MessageRetentionDuration string `json:"messageRetentionDuration,omitempty"`
 	} `json:"gcp_pubsub,omitempty"`
@@ -714,6 +737,8 @@ func (c *Components) Normalize() {
 		c.GCPSecretManager = nil
 		c.GCPVertexAI = nil
 		c.GCPAgentEngine = nil
+		c.GCPDocumentAI = nil
+		c.GCPModelArmor = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudMonitoring = nil
@@ -826,6 +851,8 @@ func (c *Config) Normalize() {
 		c.GCPGCS = nil
 		c.GCPVertexAI = nil
 		c.GCPAgentEngine = nil
+		c.GCPDocumentAI = nil
+		c.GCPModelArmor = nil
 		c.GCPPubSub = nil
 		c.GCPCloudLogging = nil
 		c.GCPCloudRun = nil

--- a/pkg/composer/vertex_ai_gcp_wiring_test.go
+++ b/pkg/composer/vertex_ai_gcp_wiring_test.go
@@ -189,6 +189,18 @@ func TestDefaultWiring_GCPVertexAI_NetworkAndGCS(t *testing.T) {
 	assert.Equal(t, WireRef(KeyGCPVPC, "vpc_id"), wi.RawHCL["network"],
 		"network must reference gcp/vpc.vpc_id; the preset converts the project-ID path to the project-NUMBER path the API requires")
 
+	// #774 producer<->consumer linkage: the private-endpoint peering connection
+	// is wired from gcp/vpc.service_networking_connection_id into the preset's
+	// service_networking_connection input. Pinning the exact WireRef here closes
+	// the gap where the two halves (gcp/vpc produces the id; gcp/vertex_ai's
+	// precondition consumes it) were only ever tested against a hand-typed string
+	// literal on the consumer side, never against each other (qa-professor B2).
+	require.Contains(t, wi.RawHCL, "service_networking_connection",
+		"VPC selected -> the #774 PSC peering connection must be wired so a private index endpoint orders after the peering")
+	assert.Equal(t, WireRef(KeyGCPVPC, "service_networking_connection_id"), wi.RawHCL["service_networking_connection"],
+		"service_networking_connection must reference gcp/vpc.service_networking_connection_id (the producer output the vertex_ai precondition depends on)")
+	assert.Contains(t, wi.Names, "service_networking_connection")
+
 	require.Contains(t, wi.RawHCL, "contents_delta_uri",
 		"GCS selected -> the index must be seeded from the bucket")
 	// Wired to a dedicated prefix under the bucket, NOT the bucket root —
@@ -212,6 +224,8 @@ func TestDefaultWiring_GCPVertexAI_InertStandalone(t *testing.T) {
 
 	assert.NotContains(t, wi.RawHCL, "network",
 		"no VPC selected -> no network wiring (endpoint is public)")
+	assert.NotContains(t, wi.RawHCL, "service_networking_connection",
+		"no VPC selected -> no #774 PSC peering wiring (the connection id has no producer)")
 	assert.NotContains(t, wi.RawHCL, "contents_delta_uri",
 		"no GCS selected -> the index must be created empty (no contents_delta_uri wiring)")
 }

--- a/pkg/observability/component_metrics_coverage_test.go
+++ b/pkg/observability/component_metrics_coverage_test.go
@@ -57,6 +57,15 @@ var metricsDeferredKeys = map[composer.ComponentKey]string{
 	// service and surface "unsupported service" at runtime. Backfill alongside
 	// the inspector landing once the schema pin advances past 7.6.
 	composer.KeyGCPAgentEngine: "[#769] reasoning-engine discovery inspector deferred; resource is deploy-only on provider >= 7.6 (repo schema pinned 6.10), no vertexai.list-reasoning-engines handler registered yet",
+	// Document AI (#765). No documentai discovery inspector or
+	// documentai.list-processors handler is registered in GCPServiceActions
+	// yet; a ComponentMetricsMapping entry would dispatch to an unregistered
+	// service. Backfill alongside a documentai inspector landing.
+	composer.KeyGCPDocumentAI: "[#765] document-ai discovery inspector deferred; no documentai.list-processors handler registered in GCPServiceActions yet",
+	// Model Armor (#766). google_model_armor_* are newer/region-limited and
+	// not in this repo's discovery/import schema pin; no modelarmor inspector
+	// or list-templates handler is registered. Backfill alongside the inspector.
+	composer.KeyGCPModelArmor: "[#766] model-armor discovery inspector deferred; resource is newer/region-limited (repo schema pinned 6.10), no modelarmor.list-templates handler registered yet",
 }
 
 // metricsNonComponentKeys are AllComponentKeys entries that genuinely

--- a/pkg/observability/display.go
+++ b/pkg/observability/display.go
@@ -183,6 +183,10 @@ func ComponentDisplayName(key composer.ComponentKey) string {
 		return "GCP Vertex AI"
 	case composer.KeyGCPAgentEngine:
 		return "GCP Agent Engine"
+	case composer.KeyGCPDocumentAI:
+		return "GCP Document AI"
+	case composer.KeyGCPModelArmor:
+		return "GCP Model Armor"
 	case composer.KeyGCPBastion:
 		return "GCP Bastion"
 	case composer.KeyGCPAPIGateway:

--- a/pkg/observability/extractors/extractors_drift_test.go
+++ b/pkg/observability/extractors/extractors_drift_test.go
@@ -80,6 +80,8 @@ var configExtractorAllowlist = map[string]string{
 	"gcp_cloud_deploy": "[no-inspector] Cloud Deploy delivery-pipeline inspector deferred (#613 explicitly marks discovery inspector + extractor as optional/follow-up); ComponentMetricsMapping has no entry yet so the panel falls back to design values until the per-component extractor lands",
 	"gcp_cloud_dns":    "[no-inspector] Cloud DNS dispatcher landed in #596 (gcp/dns.go); per-component extractor (config map for panel) deferred pending zone-detail field reads (visibility, dnssec_config, record-count summary)",
 	"gcp_agent_engine": "[no-inspector] Agent Engine (#769) creates google_vertex_ai_reasoning_engine, which is deploy-only on provider >= 7.6 (repo discovery/import schema pinned 6.10); no reasoning-engine inspector or extractor lands yet. Surfaced via name-prefix scoping until the schema pin advances and a vertexai.list-reasoning-engines dispatcher ships",
+	"gcp_document_ai":  "[no-inspector] Document AI (#765) creates google_document_ai_processor; no documentai inspector or extractor lands yet. Surfaced via name-prefix scoping until a documentai.list-processors dispatcher ships",
+	"gcp_model_armor":  "[no-inspector] Model Armor (#766) creates google_model_armor_template; the resource is newer/region-limited and absent from the repo discovery/import schema pin (6.10), so no modelarmor inspector or extractor lands yet. Surfaced via name-prefix scoping until the pin advances and a modelarmor.list-templates dispatcher ships",
 }
 
 // extractorFixtures are minimal SDK-shape fixtures that exercise each

--- a/tests/lint-gcp-project-pin.sh
+++ b/tests/lint-gcp-project-pin.sh
@@ -66,8 +66,10 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 # scoped by a parent reference. Keep sorted alphabetically with a
 # one-line rationale identifying the parent attribute.
 EXEMPT_PROJECT_PIN_GCP=(
+  google_document_ai_processor_default_version  # parent: processor (gcp/document_ai/main.tf; no project attr in provider schema)
   google_kms_crypto_key                 # parent: key_ring (gcp/kms/main.tf:82,103)
   google_kms_crypto_key_iam_binding     # parent: crypto_key_id (gcp/kms/main.tf:126)
+  google_model_armor_floorsetting       # parent: parent=projects/<id>/locations/<loc> (gcp/model_armor/main.tf; no project attr in provider schema)
   google_secret_manager_secret_version  # parent: secret (gcp/cloud_build, gcp/secretmanager)
   google_service_account_iam_binding    # parent: service_account_id (gcp/github_actions/main.tf, #597)
   google_service_networking_connection  # parent: network (gcp/cloudsql/main.tf:41)

--- a/tests/lint-labelless-name-prefix.sh
+++ b/tests/lint-labelless-name-prefix.sh
@@ -100,6 +100,20 @@ EXEMPT_LABELLESS_GCP=(
   google_secret_manager_secret_version
   google_storage_bucket_object
   google_service_networking_connection
+  #   google_document_ai_processor_default_version → processor = google_document_ai_processor.<X>.id
+  google_document_ai_processor_default_version
+  # google_model_armor_floorsetting — project/location SINGLETON keyed by its
+  # parent (projects/<id>/locations/<loc>); it has no name field of its own.
+  # Attribution flows through the project-scoped Model Armor API path.
+  google_model_armor_floorsetting
+  # google_model_armor_template — its canonical id attribute is `template_id`
+  # (not name/account_id/display_name, which this lint scans), and the preset
+  # sets template_id = "${var.project}-armor" for name-prefix scoping. It is
+  # also label-capable and carries labels = merge({project=var.project}, ...),
+  # but is NOT added to lint-project-label.sh's LABEL_CAPABLE_GCP because that
+  # array is drift-checked (TestUntaggableAllowlistsMatchLintScripts) against
+  # the typed registry pinned at provider 6.10, which predates Model Armor.
+  google_model_armor_template
   # google_dns_record_set — Cloud DNS record sets have semantic DNS
   # names (e.g. "www.example.com.") and cannot legally carry var.project
   # in the name field. Attribution flows through the parent managed_zone


### PR DESCRIPTION
## Summary

Closes the remaining Phase-1 GCP AI-stack sub-issues plus the VPC follow-up surfaced by #764.

Closes #765
Closes #766
Closes #774

With #765 and #766 landing, every sub-issue tracked by #756 (#764, #765, #766, #767, #768, #769) is complete, and #767 (GPU on gcp_gke + gcp_compute) is already implemented on main (#817).

## #765 — gcp_document_ai (L2, RAG ingestion)

- `google_document_ai_processor` (always-on) + optional `google_document_ai_processor_default_version`.
- Location is the DocAI multi-region (`us`|`eu`), NOT a GCP region: the mapper translates the stack region's continent and the preset never passes an arbitrary region through.
- Full composer registration + `Config.GCPDocumentAI` (processor type / location).

## #766 — gcp_model_armor (L6, safety)

- `google_model_armor_template` (PI/jailbreak + malicious-URI + responsible-AI filters at a configurable confidence floor).
- Optional, off-by-default `google_model_armor_floorsetting`. The floor setting is a project/org SINGLETON — documented and gated behind `manage_floorsetting`.
- Full composer registration + `Config.GCPModelArmor`.

## #774 — gcp/vpc Private Services Access

- `gcp/vpc` gains an optional reserved `VPC_PEERING` range + `google_service_networking_connection`, gated on `enable_service_networking` (default off), with `service_networking_connection_id` / `service_networking_peering_range` outputs.
- `gcp/vertex_ai` consumes the connection id on the private-endpoint path: it orders the index endpoint after the peering and fails loud at plan time if a private endpoint is requested without it.
- Composer `DefaultWiring` wires the connection into `gcp_vertex_ai` when a VPC is selected.

## Tests / CI

- `terraform test` shape coverage for `gcp/document_ai` (9), `gcp/model_armor` (8), and the `gcp/vertex_ai` #774 precondition (29 total).
- `gcp/vpc` wraps the community network module, which `terraform test` cannot plan under `mock_provider` in TF 1.7.5 (same reason `vpc`/`cloudsql` carry no tftests) — the testable #774 contract lives on the `vertex_ai` side.
- Lint allowlist updates for the new parent-scoped / labelless resource types, with rationale (model-armor template kept out of `lint-project-label.sh`'s `LABEL_CAPABLE_GCP` because that array is drift-checked against the 6.10 typed registry that predates Model Armor).
- Verified green end-to-end: CI run all checks success — `go build/vet/test -race`, `gofmt`, `verify-gen`, `verify-supported-resources`, all GCP lint scripts, `tflint`, `golden-stack-hcl`, every `test-presets`, `validate-presets`, `validate-presets-as-child`, and `validate-examples`.

## Out of scope — #777 (deliberate)

#777 (GCP closure-discovery parent-scope parity) is intentionally NOT in this PR. It is explicitly deferred parity hardening ("not a live bug" — correctness is already preserved by the engine's `mergeClosureResources` filter), and a correct implementation is a ~750-line refactor of the reverse-import discovery path plus live-creds validation. A partial pre-filter in `gcpdiscover` would be *riskier* than the status quo (it would have to replicate `mergeClosureResources`' authoritative matching, and a miss would drop resources). It deserves its own focused PR rather than riding alongside this component work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)