### PR TITLE
fix(cloud): bake codex auth + plugins into setup script (SessionStart hook doesn't run in the sandbox)

### DIFF
--- a/scripts/cloud-web-setup.sh
+++ b/scripts/cloud-web-setup.sh
@@ -64,6 +64,54 @@ install_npm_clis() {
   vercel --version
 }
 
+install_codex_auth_and_plugins() {
+  # Codex auth + Claude plugins, baked into the cached snapshot.
+  #
+  # WHY HERE and not scripts/cloud-session-start.sh: the project's SessionStart hook
+  # (.claude/settings.json) does NOT run in the Claude-Code-on-the-web / remote-execution
+  # sandbox -- only the harness's own launcher hooks do (verified: ~/.claude.json carries no
+  # trusted-project entry and the harness launcher-settings.json wires only git-identity). So
+  # the codex auth + plugin install that live in that hook never execute on a fresh session:
+  # codex 401s (no ~/.codex/auth.json) and `/codex:review` is missing (no
+  # installed_plugins.json). This setup script's filesystem output IS snapshotted, so doing it
+  # here makes the result present at the start of every new session with no hook required.
+  # All best-effort: this runs under `set -e`, so each step is guarded to never poison the cache.
+
+  # Codex ChatGPT-subscription auth (flat-rate). auth.json is a 1Password document (a
+  # `codex login` on a workstation, re-uploaded when its refresh token rotates).
+  if [ -n "${OP_SERVICE_ACCOUNT_TOKEN:-}" ] && command -v op >/dev/null 2>&1; then
+    mkdir -p "${HOME}/.codex"
+    printf 'preferred_auth_method = "chatgpt"\n' > "${HOME}/.codex/config.toml"
+    if op read "op://Reliable-Dev/codex-auth-json/auth.json" > "${HOME}/.codex/auth.json" 2>/dev/null; then
+      chmod 600 "${HOME}/.codex/auth.json"
+      log "codex: installed ChatGPT-subscription auth.json (snapshot)"
+    else
+      log "WARNING: codex auth.json fetch failed (non-fatal)"
+    fi
+  else
+    log "OP_SERVICE_ACCOUNT_TOKEN / op missing -- skipping codex auth"
+  fi
+
+  # Claude Code plugins: codex (=> /codex:review), claude-config (=> qa-professor / pr),
+  # firecrawl. Best-effort: `claude` is a harness binary that may not be on PATH during the
+  # cached setup phase. When it is, this bakes installed_plugins.json into the snapshot so the
+  # plugins load at session start; when it isn't, this is a no-op and `codex review` from the
+  # CLI (authed above) still works.
+  if command -v claude >/dev/null 2>&1; then
+    claude plugin marketplace add openai/codex-plugin-cc      >/dev/null 2>&1 || true
+    claude plugin marketplace add sam-at-luther/claude-config >/dev/null 2>&1 || true
+    for p in codex@openai-codex claude-config@claude-config firecrawl@claude-plugins-official; do
+      if claude plugin install "$p" >/dev/null 2>&1; then
+        log "plugin installed: $p"
+      else
+        log "WARNING: plugin install failed: $p (non-fatal; claude CLI may be unavailable at setup)"
+      fi
+    done
+  else
+    log "claude CLI not on PATH at setup -- skipping plugin install (codex CLI auth above still applies)"
+  fi
+}
+
 install_playwright_deps() {
   # OS libraries for Playwright's chromium (root/apt). The browser BINARY is fetched
   # per-session in the hook. Best-effort: only reliable's `make test-mock` needs it.
@@ -153,8 +201,9 @@ fi
 # and so the Go toolchain is guaranteed present (gopls). Both best-effort.
 install_playwright_deps || true
 install_gopls
+install_codex_auth_and_plugins || log "codex auth / plugin setup failed (non-fatal)"
 
 # Docker is preinstalled but its daemon won't be running in a fresh session VM. If a task
 # needs it, start it on demand: `sudo service docker start`. Not required for the standard
 # build/lint/test flow (Postgres is reached via POSTGRES_URL).
-log "setup complete: terraform, tflint, golangci-lint, gopls, go, codex, firecrawl-cli, vercel, op, gh, git-lfs, bubblewrap installed"
+log "setup complete: terraform, tflint, golangci-lint, gopls, go, codex, firecrawl-cli, vercel, op, gh, git-lfs, bubblewrap installed; codex auth + plugins baked"


### PR DESCRIPTION
## Problem

Follow-up to #818. After merging that, new sessions still had no codex auth and no `/codex:review`. The deeper cause: the project's SessionStart hook (`.claude/settings.json` → `scripts/cloud-session-start.sh`) does not execute at all in the Claude-Code-on-the-web / remote-execution sandbox — only the harness's own launcher hooks run.

Verified in two independent sessions:

- `~/.claude.json` has no `projects` (trusted-project) entry
- the harness `~/.claude/launcher-settings.json` wires only its git-identity / git-check hooks — never `cloud-session-start.sh`
- the hook left zero side-effects: no injected secrets, no `~/.codex/auth.json`

So the codex auth + plugin-install steps that live in that hook never run on a fresh session: codex 401s (no `~/.codex/auth.json`) and `/codex:review` is absent (no `installed_plugins.json`).

## Fix

Mirror of luthersystems/reliable#2132. Move the codex auth (and best-effort plugin install) into `scripts/cloud-web-setup.sh`, whose filesystem output is snapshotted and which provably runs:

- `op read op://Reliable-Dev/codex-auth-json/auth.json` → `~/.codex/auth.json` (+ `config.toml`). Reliable part — makes `codex review` work in every new session.
- best-effort `claude plugin install` of codex / claude-config / firecrawl (bakes `installed_plugins.json` into the snapshot when `claude` is on PATH at setup).

All steps guarded so they never fail the `set -e` setup. The `install_codex_auth_and_plugins` function is byte-identical to reliable's.

## Action required (one-time)

After merge: open the shared Claude Code environment → Setup script → re-paste the updated `scripts/cloud-web-setup.sh` (it's the same shared script across both repos). That busts the cache; from then on every new session has codex auth + plugins from the snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4YtSBZtcpcKFDbKWL5o4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4YtSBZtcpcKFDbKWL5o4S)_