### PR TITLE
feat(reversedisco): scope GCP closure discovery to selected parents (#777)

### DIFF
--- a/cmd/insideout-import/gcpdiscover/args.go
+++ b/cmd/insideout-import/gcpdiscover/args.go
@@ -1,6 +1,9 @@
 package gcpdiscover
 
 import (
+	"sort"
+	"strings"
+
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/progress"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
@@ -27,6 +30,39 @@ type DiscoverArgs struct {
 	Regions      []string
 	TagSelectors []TagSelector
 	Emitter      progress.Emitter
+
+	// ParentScope, when non-empty, restricts CAI enumeration to the
+	// operator's selected parents during a selection-closure run (#777,
+	// the GCP analog of awsdiscover.DiscoverArgs.ParentScope from #739/#770).
+	//
+	// It maps a parent Cloud Asset *asset type* (e.g.
+	// "storage.googleapis.com/Bucket") to the set of selected parents of
+	// that type, each carrying the name the InsideOut inspector attributes
+	// it by and the GCP location it lives in (ScopedParent). DiscoverTypes
+	// then narrows the per-bucket SearchAllResources query for any scoped
+	// asset type to a `name:(<p1> OR <p2> ...)` clause over exactly those
+	// parents instead of issuing the project-wide `labels.project:<stack>`
+	// sweep — turning O(project) Cloud Asset reads into O(selected-parents)
+	// reads (and dropping the broad project-wide read scope the sweep
+	// needs).
+	//
+	// Keyed by ASSET type, not Terraform type: DiscoverTypes already
+	// partitions discoverers into SearchAllResources buckets by AssetType,
+	// so an asset-type key lets the scope plug straight into that seam
+	// (mirroring how the AWS ParentScope keys by CloudFormation type — the
+	// type the AWS discoverers route through).
+	//
+	// CRITICAL (mirrors the AWS (empty, true) contract): a scoped type
+	// whose asset type is present in ParentScope but has ZERO selected
+	// parents is SKIPPED — its asset type is dropped from every
+	// SearchAllResources call rather than swept project-wide. The engine's
+	// mergeClosureResources filter would discard a project-wide sweep's
+	// extra rows anyway, but skipping the enumeration is the whole point of
+	// #777: no broad read, no O(project) cost.
+	//
+	// An empty/absent ParentScope preserves the legacy project-wide sweep
+	// (the local CLI's full scan and top-level discovery are unchanged).
+	ParentScope ParentScope
 
 	// OnTypeDiscovered, when non-nil, is invoked by DiscoverTypes exactly
 	// once per requested type AS THAT TYPE COMPLETES, carrying the type's
@@ -79,4 +115,108 @@ type DiscoverArgs struct {
 type TagSelector struct {
 	Key   string
 	Value string
+}
+
+// ScopedParent is one selected parent in a ParentScope: the Name the CAI
+// query filters on (the parent's short resource name, e.g. a bucket name
+// or keyring name) paired with the GCP Location it lives in. The GCP twin
+// of awsdiscover.ScopedParent (#777).
+//
+// Unlike the AWS path — which loops per region and uses Region to decide
+// which parents to fetch in each pass — the GCP CAI path issues a single
+// SearchAllResources call per ScopeStyle bucket and expresses location in
+// the query string. Location is therefore informational on GCP today (it
+// rides along so a future location-narrowed `name:` + `location:` query
+// can use it, and so the closure adapter can carry the parent's location
+// through), and the per-parent `name:` clause is what actually scopes the
+// read to the selected parents.
+type ScopedParent struct {
+	Name     string
+	Location string
+}
+
+// ParentScope maps a parent Cloud Asset asset type (e.g.
+// "storage.googleapis.com/Bucket") to the set of selected parents a
+// closure run should restrict CAI enumeration to. See
+// DiscoverArgs.ParentScope. Construct with NewParentScope.
+//
+// Keying by asset type (not Terraform type) lets the scope plug straight
+// into DiscoverTypes' existing per-AssetType SearchAllResources bucketing.
+type ParentScope map[string][]ScopedParent
+
+// NewParentScope builds a ParentScope from (parentAssetType -> ScopedParent)
+// pairs, de-duplicating parents per type by (name, location), trimming
+// whitespace, dropping empties, and sorting by (name, location). Returns
+// nil when no usable pair is supplied so callers can leave
+// DiscoverArgs.ParentScope at its zero value (which means "no scoping —
+// project-wide sweep"). Mirrors awsdiscover.NewParentScope's normalization
+// so the two clouds' scope constructors behave identically (#777).
+func NewParentScope(byAssetType map[string][]ScopedParent) ParentScope {
+	out := ParentScope{}
+	for assetType, parents := range byAssetType {
+		assetType = strings.TrimSpace(assetType)
+		if assetType == "" {
+			continue
+		}
+		type key struct{ name, location string }
+		seen := map[key]struct{}{}
+		var deduped []ScopedParent
+		for _, p := range parents {
+			name := strings.TrimSpace(p.Name)
+			if name == "" {
+				continue
+			}
+			location := strings.TrimSpace(p.Location)
+			k := key{name: name, location: location}
+			if _, ok := seen[k]; ok {
+				continue
+			}
+			seen[k] = struct{}{}
+			deduped = append(deduped, ScopedParent{Name: name, Location: location})
+		}
+		if len(deduped) == 0 {
+			continue
+		}
+		sort.Slice(deduped, func(i, j int) bool {
+			if deduped[i].Name != deduped[j].Name {
+				return deduped[i].Name < deduped[j].Name
+			}
+			return deduped[i].Location < deduped[j].Location
+		})
+		out[assetType] = deduped
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// scopedParentNames returns the selected parent names for assetType, plus
+// true when ParentScope restricts this asset type. When the asset type is
+// NOT in the scope it returns (nil, false) so the caller falls back to its
+// project-wide enumeration. A nil/empty ParentScope always returns
+// (nil, false).
+//
+// CRITICAL (mirrors the AWS (empty, true) contract): NewParentScope never
+// stores an empty slice for a present key — an asset type that survived
+// construction has at least one usable parent. The (empty, true) "scoped
+// but no parent, skip enumeration" case is therefore expressed by the
+// asset type's ABSENCE from the scope combined with the caller's
+// knowledge that the discoverer is a registered child whose closure
+// requested it: DiscoverTypes routes such a type into the skipped set (see
+// partitionScopedAssetTypes). scopedParentNames itself only answers "is
+// this asset type scoped, and to which names".
+func (a DiscoverArgs) scopedParentNames(assetType string) ([]string, bool) {
+	if len(a.ParentScope) == 0 {
+		return nil, false
+	}
+	parents, ok := a.ParentScope[strings.TrimSpace(assetType)]
+	if !ok || len(parents) == 0 {
+		return nil, false
+	}
+	out := make([]string, 0, len(parents))
+	for _, p := range parents {
+		out = append(out, p.Name)
+	}
+	return out, true
 }

--- a/cmd/insideout-import/gcpdiscover/closure_scope_test.go
+++ b/cmd/insideout-import/gcpdiscover/closure_scope_test.go
@@ -127,6 +127,45 @@ func TestDiscoverTypes_ParentScopeNarrowsToSelectedParents(t *testing.T) {
 	}
 }
 
+// TestDiscoverTypes_ParentScopeExactFiltersSubstringCollisions proves the
+// client-side exact filter (filterToSelectedParents) defends against the
+// substring nature of the CAI `name:` operator: a `name:io-uploads` query can
+// still return "io-uploads-backup" / "my-io-uploads" of the same asset type,
+// and because the scoped query drops the labels.project clause those rows are
+// not otherwise excluded. Only the exactly-named parent must survive into the
+// closure — otherwise unselected parents leak and fan out child discovery.
+// Regression guard for the #777 codex-review finding.
+func TestDiscoverTypes_ParentScopeExactFiltersSubstringCollisions(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		// CAI `name:io-uploads` is a substring match, so the server returns
+		// the selected bucket AND its substring neighbors.
+		results: []gcpAssetResult{
+			{Name: "//storage.googleapis.com/buckets/io-uploads-backup", AssetType: storageBucketAssetType, Location: "us"},
+			{Name: "//storage.googleapis.com/buckets/io-uploads", AssetType: storageBucketAssetType, Location: "us"},
+			{Name: "//storage.googleapis.com/buckets/my-io-uploads", AssetType: storageBucketAssetType, Location: "us"},
+		},
+	}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_storage_bucket"}, DiscoverArgs{
+		Project: "io-foo",
+		Regions: []string{"us"},
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			storageBucketAssetType: {{Name: "io-uploads", Location: "us"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("discovered %d resources, want exactly 1 (substring neighbors must be filtered out): %v", len(got), got)
+	}
+	if got[0].Identity.NameHint != "io-uploads" {
+		t.Errorf("discovered = %v, want exactly the exact-named bucket io-uploads (not a substring neighbor)", got)
+	}
+}
+
 // TestDiscoverTypes_ParentScopeMultipleParentsOredByName proves a closure
 // with two selected buckets ORs both names into one `name:(...)` clause —
 // each parent's children are enumerated, neither account-wide.

--- a/cmd/insideout-import/gcpdiscover/closure_scope_test.go
+++ b/cmd/insideout-import/gcpdiscover/closure_scope_test.go
@@ -1,0 +1,350 @@
+package gcpdiscover
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #777 selection-closure scoping (GCP). These tests pin the parent-scope
+// seam that restricts CAI enumeration to the operator's selected parents,
+// removing the project-wide `labels.project:<stack>` SearchAllResources
+// sweep (and the broad Cloud Asset Inventory read scope it requires). It is
+// the GCP twin of awsdiscover/closure_scope_test.go.
+
+// TestNewParentScope_DedupesSortsAndDropsEmpties pins the scope
+// constructor's normalization: per-asset-type de-dup by (name, location),
+// sort, empty drop, and a nil result when no usable pair survives.
+func TestNewParentScope_DedupesSortsAndDropsEmpties(t *testing.T) {
+	t.Parallel()
+	scope := NewParentScope(map[string][]ScopedParent{
+		"storage.googleapis.com/Bucket": {
+			{Name: "b-2", Location: "us"},
+			{Name: "b-1", Location: "us"},
+			{Name: "b-2", Location: "us"},  // dup (name,location) dropped
+			{Name: "  ", Location: "us"},   // empty name dropped
+			{Name: "b-1", Location: "us"},  // dup dropped
+			{Name: "b-1", Location: "eu"},  // same name, different location: kept
+			{Name: " b-3 ", Location: " "}, // trimmed
+		},
+		"  ":                           {{Name: "ignored"}},         // empty asset type dropped
+		"compute.googleapis.com/Empty": {{Name: ""}, {Name: "   "}}, // no usable names dropped
+	})
+	wantBuckets := []ScopedParent{
+		{Name: "b-1", Location: "eu"},
+		{Name: "b-1", Location: "us"},
+		{Name: "b-2", Location: "us"},
+		{Name: "b-3", Location: ""},
+	}
+	if got := scope["storage.googleapis.com/Bucket"]; !reflect.DeepEqual(got, wantBuckets) {
+		t.Errorf("bucket scope = %v, want sorted de-duped by (name,location) %v", got, wantBuckets)
+	}
+	if _, ok := scope["  "]; ok {
+		t.Error("empty asset type should be dropped")
+	}
+	if _, ok := scope["compute.googleapis.com/Empty"]; ok {
+		t.Error("asset type with no usable names should be dropped")
+	}
+	if NewParentScope(map[string][]ScopedParent{"x": {{Name: ""}}}) != nil {
+		t.Error("scope with no usable pair should be nil")
+	}
+}
+
+// TestScopedParentNames pins the accessor: a scoped asset type returns its
+// names + true; an unscoped one returns (nil, false); a nil scope returns
+// (nil, false).
+func TestScopedParentNames(t *testing.T) {
+	t.Parallel()
+	args := DiscoverArgs{ParentScope: NewParentScope(map[string][]ScopedParent{
+		"storage.googleapis.com/Bucket": {{Name: "b-a"}, {Name: "b-b"}},
+	})}
+	names, ok := args.scopedParentNames("storage.googleapis.com/Bucket")
+	if !ok {
+		t.Fatal("scoped asset type should report ok=true")
+	}
+	sort.Strings(names)
+	if !reflect.DeepEqual(names, []string{"b-a", "b-b"}) {
+		t.Errorf("names = %v, want [b-a b-b]", names)
+	}
+	if _, ok := args.scopedParentNames("pubsub.googleapis.com/Topic"); ok {
+		t.Error("unscoped asset type should report ok=false")
+	}
+	if _, ok := (DiscoverArgs{}).scopedParentNames("storage.googleapis.com/Bucket"); ok {
+		t.Error("nil ParentScope should report ok=false")
+	}
+}
+
+// TestDiscoverTypes_ParentScopeNarrowsToSelectedParents proves the #777
+// scoping: with a ParentScope restricting google_storage_bucket to the
+// selected bucket names, DiscoverTypes issues a SINGLE SearchAll for the
+// bucket asset type whose query is the per-parent `name:(...)` clause (NOT
+// the project-wide labels.project sweep), and never sweeps the bucket type
+// account-wide. Mirror of
+// TestCloudControlDiscover_ParentScopeSkipsListResources.
+func TestDiscoverTypes_ParentScopeNarrowsToSelectedParents(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{
+		results: []gcpAssetResult{
+			{Name: "//storage.googleapis.com/buckets/io-uploads", AssetType: storageBucketAssetType, Location: "us"},
+		},
+	}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+
+	got, err := g.DiscoverTypes(context.Background(), []string{"google_storage_bucket"}, DiscoverArgs{
+		Project: "io-foo",
+		Regions: []string{"us"},
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			storageBucketAssetType: {{Name: "io-uploads", Location: "us"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("SearchAll called %d times, want 1 (one scoped call)", len(fake.calls))
+	}
+	c := fake.calls[0]
+	if len(c.assetTypes) != 1 || c.assetTypes[0] != storageBucketAssetType {
+		t.Errorf("assetTypes=%v, want [%s]", c.assetTypes, storageBucketAssetType)
+	}
+	// The scoped query narrows by the selected parent's name and must NOT
+	// carry the project-wide labels.project sweep clause — the operator
+	// selected the bucket by identity (scope bypasses the project filter,
+	// mirror of TestCloudControlDiscover_ParentScopeBypassesTagFilter).
+	if !strings.Contains(c.query, "name:io-uploads") {
+		t.Errorf("query=%q, want it to narrow by name:io-uploads", c.query)
+	}
+	if strings.Contains(c.query, "labels.project:") {
+		t.Errorf("query=%q, want NO project-wide labels.project sweep clause for a scoped type", c.query)
+	}
+	if !strings.Contains(c.query, "location:us") {
+		t.Errorf("query=%q, want location:us to still propagate", c.query)
+	}
+	if len(got) != 1 || got[0].Identity.NameHint != "io-uploads" {
+		t.Errorf("discovered = %v, want exactly the scoped bucket io-uploads", got)
+	}
+}
+
+// TestDiscoverTypes_ParentScopeMultipleParentsOredByName proves a closure
+// with two selected buckets ORs both names into one `name:(...)` clause —
+// each parent's children are enumerated, neither account-wide.
+func TestDiscoverTypes_ParentScopeMultipleParentsOredByName(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+
+	_, err := g.DiscoverTypes(context.Background(), []string{"google_storage_bucket"}, DiscoverArgs{
+		Project: "io-foo",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			storageBucketAssetType: {{Name: "io-uploads"}, {Name: "io-logs"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("SearchAll calls=%d, want 1", len(fake.calls))
+	}
+	q := fake.calls[0].query
+	if !strings.Contains(q, "name:io-uploads") || !strings.Contains(q, "name:io-logs") {
+		t.Errorf("query=%q, want both selected bucket names", q)
+	}
+	if !strings.Contains(q, " OR ") {
+		t.Errorf("query=%q, want the two names OR-combined", q)
+	}
+	if strings.Contains(q, "labels.project:") {
+		t.Errorf("query=%q, want NO project-wide labels.project sweep clause for a scoped type", q)
+	}
+}
+
+// TestDiscoverTypes_ScopedTypeNoParentSkipsEnumeration proves the GCP
+// (empty, true) skip contract: an asset type that the scope OWNS but has
+// ZERO selected parents for must SKIP enumeration entirely — no scoped
+// call AND no project-wide fallback sweep. Mirror of
+// TestCloudControlDiscover_ScopedTypeNoParentInRegionSkipsSweep.
+func TestDiscoverTypes_ScopedTypeNoParentSkipsEnumeration(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+
+	// Scope OWNS the bucket asset type but with ZERO usable parents would
+	// be impossible via NewParentScope (it drops empty buckets), so we
+	// construct the (empty, true) skip case directly: a ParentScope map
+	// whose bucket entry is empty. searchScopedAssetTypes must skip it.
+	args := DiscoverArgs{
+		Project: "io-foo",
+		// Hand-built ParentScope (NOT via NewParentScope) so the bucket
+		// asset type is PRESENT with an empty parent slice — the
+		// scoped-but-no-parent state DiscoverTypes must skip rather than
+		// sweep project-wide.
+		ParentScope: ParentScope{storageBucketAssetType: {}},
+	}
+	_, err := g.DiscoverTypes(context.Background(), []string{"google_storage_bucket"}, args)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The bucket type is scoped-but-empty ⇒ skipped: zero SearchAll calls
+	// (no project-wide sweep, no scoped call).
+	if len(fake.calls) != 0 {
+		t.Fatalf("SearchAll calls=%d, want 0 (scoped-but-no-parent type must skip enumeration, not sweep)", len(fake.calls))
+	}
+}
+
+// TestDiscoverTypes_ScopedAndUnscopedTypesCoexist proves the partition is
+// CONSUMED correctly by searchBuckets: a closure that scopes ONE requested
+// type (google_storage_bucket) while ALSO requesting an UNSCOPED type
+// (google_pubsub_topic) must issue exactly TWO SearchAll calls — one scoped
+// `name:(...)` call for the bucket and one project-wide `labels.project`
+// sweep for the topic — never sweeping the scoped bucket type project-wide.
+//
+// This is the regression guard for a partition-discard bug in searchBuckets
+// (e.g. keeping the original bucket instead of the unscoped remainder): with
+// only single-type scoped tests, such a bug stays green because the unscoped
+// remainder is empty and the swept call is skipped. Here the remainder is
+// non-empty, so a discarded split surfaces as a swept bucket-type call.
+func TestDiscoverTypes_ScopedAndUnscopedTypesCoexist(t *testing.T) {
+	t.Parallel()
+	fake := &fakeAssetSearcher{}
+	g := NewGCPDiscoverer(fake, "real-proj", GCPDiscovererOpts{})
+
+	_, err := g.DiscoverTypes(context.Background(), []string{"google_storage_bucket", "google_pubsub_topic"}, DiscoverArgs{
+		Project: "io-foo",
+		ParentScope: NewParentScope(map[string][]ScopedParent{
+			storageBucketAssetType: {{Name: "io-uploads"}},
+		}),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fake.calls) != 2 {
+		t.Fatalf("SearchAll calls=%d, want 2 (one scoped bucket call + one swept topic call)", len(fake.calls))
+	}
+
+	var scopedCall, sweptCall *searchAllCall
+	for i := range fake.calls {
+		switch fake.calls[i].assetTypes[0] {
+		case storageBucketAssetType:
+			scopedCall = &fake.calls[i]
+		case "pubsub.googleapis.com/Topic":
+			sweptCall = &fake.calls[i]
+		}
+	}
+	if scopedCall == nil || sweptCall == nil {
+		t.Fatalf("missing a call: scoped=%v swept=%v (calls=%+v)", scopedCall, sweptCall, fake.calls)
+	}
+	// Scoped bucket call: per-parent name filter, NO project-wide sweep.
+	if !strings.Contains(scopedCall.query, "name:io-uploads") {
+		t.Errorf("scoped call query=%q, want name:io-uploads", scopedCall.query)
+	}
+	if strings.Contains(scopedCall.query, "labels.project:") {
+		t.Errorf("scoped call query=%q, want NO project-wide sweep — the bucket type must not also be swept", scopedCall.query)
+	}
+	// Unscoped topic call: project-wide sweep stays intact.
+	if !strings.Contains(sweptCall.query, "labels.project:io-foo") {
+		t.Errorf("swept call query=%q, want the project-wide labels.project sweep for the unscoped type", sweptCall.query)
+	}
+	if strings.Contains(sweptCall.query, "name:") {
+		t.Errorf("swept call query=%q, want NO per-parent name clause on the unscoped type", sweptCall.query)
+	}
+}
+
+// TestDiscoverTypes_ScopedAcrossCAIScopeStyles proves the scoped split fires
+// for every CAI ScopeStyle bucket — labels, name-prefix, and
+// parent-name-prefix — not just the labels bucket. searchBuckets calls
+// splitScopedBucket on all three CAI buckets; deleting any branch must fail
+// here. Uses the fake discoverers so a label-less scoped parent (e.g. a KMS
+// keyring, ScopeStyleNamePrefix) is exercised without registering a real
+// type.
+func TestDiscoverTypes_ScopedAcrossCAIScopeStyles(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		assetType string
+		disco     Discoverer
+	}{
+		{"labels", storageBucketAssetType, newStorageBucketDiscoverer()},
+		{"name-prefix", "test.googleapis.com/NamePrefixed", &fakeNamePrefixDiscoverer{resourceType: "google_test_nameprefixed", assetType: "test.googleapis.com/NamePrefixed"}},
+		{"parent-name-prefix", "test.googleapis.com/ParentScoped", &fakeParentNamePrefixDiscoverer{resourceType: "google_test_parentscoped", assetType: "test.googleapis.com/ParentScoped", parentMarker: "/parents/"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fake := &fakeAssetSearcher{}
+			g := &GCPDiscoverer{
+				searcher:  fake,
+				projectID: "real-proj",
+				byType:    map[string]Discoverer{tc.disco.ResourceType(): tc.disco},
+			}
+			_, err := g.DiscoverTypes(context.Background(), []string{tc.disco.ResourceType()}, DiscoverArgs{
+				Project: "io-foo",
+				ParentScope: NewParentScope(map[string][]ScopedParent{
+					tc.assetType: {{Name: "io-selected"}},
+				}),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(fake.calls) != 1 {
+				t.Fatalf("SearchAll calls=%d, want 1 (one scoped call for the %s bucket)", len(fake.calls), tc.name)
+			}
+			q := fake.calls[0].query
+			if !strings.Contains(q, "name:io-selected") {
+				t.Errorf("%s scoped query=%q, want name:io-selected (scope must apply to this bucket too)", tc.name, q)
+			}
+			if strings.Contains(q, "labels.project:") {
+				t.Errorf("%s scoped query=%q, want NO project-wide sweep", tc.name, q)
+			}
+		})
+	}
+}
+
+// TestSplitScopedBucket pins the partition helper: discoverers whose asset
+// type is in scope are peeled out (their asset type returned, de-duped and
+// sorted); the rest stay in the swept bucket.
+func TestSplitScopedBucket(t *testing.T) {
+	t.Parallel()
+	bucket := []Discoverer{
+		newStorageBucketDiscoverer(),       // storage.googleapis.com/Bucket
+		newPubsubTopicDiscoverer(),         // pubsub.googleapis.com/Topic
+		newSecretManagerSecretDiscoverer(), // secretmanager.googleapis.com/Secret
+	}
+	ps := ParentScope{
+		storageBucketAssetType: {{Name: "io-uploads"}},
+	}
+	unscoped, scopedTypes := splitScopedBucket(bucket, ps)
+	if !reflect.DeepEqual(scopedTypes, []string{storageBucketAssetType}) {
+		t.Errorf("scopedTypes=%v, want [%s]", scopedTypes, storageBucketAssetType)
+	}
+	gotUnscoped := make([]string, 0, len(unscoped))
+	for _, d := range unscoped {
+		gotUnscoped = append(gotUnscoped, d.AssetType())
+	}
+	sort.Strings(gotUnscoped)
+	want := []string{"pubsub.googleapis.com/Topic", "secretmanager.googleapis.com/Secret"}
+	if !reflect.DeepEqual(gotUnscoped, want) {
+		t.Errorf("unscoped asset types=%v, want %v", gotUnscoped, want)
+	}
+}
+
+// TestBuildScopedSearchQuery pins the per-parent query shape: a single name
+// emits a bare `name:` clause, multiple names OR inside parens, locations
+// AND on, and the project-wide labels.project clause is NEVER present.
+func TestBuildScopedSearchQuery(t *testing.T) {
+	t.Parallel()
+	if got := buildScopedSearchQuery([]string{"b-a"}, nil, nil); got != "name:b-a" {
+		t.Errorf("single-name query=%q, want name:b-a", got)
+	}
+	got := buildScopedSearchQuery([]string{"b-a", "b-b"}, []string{"us"}, nil)
+	if !strings.Contains(got, "(name:b-a OR name:b-b)") {
+		t.Errorf("multi-name query=%q, want OR-combined names in parens", got)
+	}
+	if !strings.Contains(got, "location:us") {
+		t.Errorf("query=%q, want location:us", got)
+	}
+	if strings.Contains(got, "labels.project") {
+		t.Errorf("query=%q, scoped query must never carry labels.project", got)
+	}
+}

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -426,6 +426,22 @@ func NewGCPDiscoverer(searcher gcpAssetSearcher, projectID string, opts GCPDisco
 	return d
 }
 
+// AssetTypeForTF returns the Cloud Asset asset type registered for the
+// given Terraform type (e.g. "google_storage_bucket" ->
+// "storage.googleapis.com/Bucket"), and true when a discoverer is
+// registered for that TF type. Used by the selection-closure adapter
+// (cmd/insideout-import/reversedisco) to translate the engine's selected
+// parents — which carry Terraform types — into the asset-type-keyed
+// DiscoverArgs.ParentScope this package's CAI search consumes (#777). The
+// GCP analog of awsdiscover.CloudFormationTypeForTF.
+func (g *GCPDiscoverer) AssetTypeForTF(tfType string) (string, bool) {
+	d, ok := g.byType[tfType]
+	if !ok {
+		return "", false
+	}
+	return d.AssetType(), true
+}
+
 // SupportedTypes returns the registered Terraform types in lexicographic
 // order. Used by the CLI for default --resource-types and validation.
 func (g *GCPDiscoverer) SupportedTypes() []string {
@@ -837,6 +853,39 @@ func buildSearchQuery(stackProject string, locations []string, selectors []TagSe
 func (g *GCPDiscoverer) searchBuckets(ctx context.Context, scope string, args DiscoverArgs, labelsBucket, namePrefixBucket, parentBucket []Discoverer) ([]gcpAssetResult, error) {
 	var out []gcpAssetResult
 
+	// Selection-closure scoping (#777): when args.ParentScope restricts a
+	// bucket's asset types to the operator's selected parents, peel those
+	// asset types out of the bucket and search them with a per-parent
+	// `name:(...)` clause instead of the project-wide sweep. A scoped asset
+	// type with no selected parent (absent from the scope's name set) is
+	// simply NOT searched — the GCP twin of the AWS (empty, true)
+	// skip-enumeration contract. Asset types the scope doesn't touch keep
+	// sweeping exactly as before, so non-closure callers (the local CLI's
+	// full scan, top-level discovery) are byte-for-byte unchanged.
+	if len(args.ParentScope) > 0 {
+		var scopedTypes []string
+		labelsBucket, scopedTypes = splitScopedBucket(labelsBucket, args.ParentScope)
+		scoped, err := g.searchScopedAssetTypes(ctx, scope, args, scopedTypes)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, scoped...)
+
+		namePrefixBucket, scopedTypes = splitScopedBucket(namePrefixBucket, args.ParentScope)
+		scoped, err = g.searchScopedAssetTypes(ctx, scope, args, scopedTypes)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, scoped...)
+
+		parentBucket, scopedTypes = splitScopedBucket(parentBucket, args.ParentScope)
+		scoped, err = g.searchScopedAssetTypes(ctx, scope, args, scopedTypes)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, scoped...)
+	}
+
 	if len(labelsBucket) > 0 {
 		query := buildSearchQuery(args.Project, args.Regions, args.TagSelectors)
 		rs, err := g.searcher.SearchAll(ctx, scope, assetTypesOf(labelsBucket), query)
@@ -914,6 +963,122 @@ func (g *GCPDiscoverer) searchBuckets(ctx context.Context, scope string, args Di
 		out = append(out, rs...)
 	}
 	return out, nil
+}
+
+// splitScopedBucket partitions a ScopeStyle bucket into the discoverers
+// whose asset type is NOT in scope (returned as the new bucket — they keep
+// their project-wide sweep) and the de-duplicated asset types that ARE in
+// scope (returned for searchScopedAssetTypes to fetch per-parent). A
+// discoverer whose asset type is scoped contributes its asset type to the
+// scoped set and is removed from the swept bucket; the scope's name set is
+// what actually narrows the read (#777).
+//
+// Asset-type granularity matches the existing per-AssetType SearchAll
+// bucketing: two discoverers sharing one asset type (e.g.
+// compute_address + compute_global_address both map to
+// compute.googleapis.com/Address) are scoped together iff that shared
+// asset type is in scope.
+func splitScopedBucket(bucket []Discoverer, ps ParentScope) (unscoped []Discoverer, scopedAssetTypes []string) {
+	seen := map[string]struct{}{}
+	for _, d := range bucket {
+		if _, isScoped := ps[d.AssetType()]; isScoped {
+			if _, dup := seen[d.AssetType()]; !dup {
+				seen[d.AssetType()] = struct{}{}
+				scopedAssetTypes = append(scopedAssetTypes, d.AssetType())
+			}
+			continue
+		}
+		unscoped = append(unscoped, d)
+	}
+	sort.Strings(scopedAssetTypes)
+	return unscoped, scopedAssetTypes
+}
+
+// searchScopedAssetTypes issues one SearchAllResources call per scoped
+// asset type, each narrowed to the selected parents' names via a
+// `name:(...)` clause instead of the project-wide `labels.project:<stack>`
+// sweep (#777). One call per asset type (rather than one bulk call for the
+// whole scoped set) so each type's query carries only its own parents'
+// names — Cloud Asset's `name:` operator is a global substring match, so
+// unioning every scoped type's names into a single query would let a
+// keyring name accidentally match a bucket, etc.
+//
+// Returns the concatenated results. An empty scopedAssetTypes (the common
+// case — nothing scoped in this bucket) is a no-op. A scoped asset type
+// that resolves to zero parent names is skipped (defensive — NewParentScope
+// never stores an empty slice, but scopedParentNames re-checks).
+func (g *GCPDiscoverer) searchScopedAssetTypes(ctx context.Context, scope string, args DiscoverArgs, scopedAssetTypes []string) ([]gcpAssetResult, error) {
+	var out []gcpAssetResult
+	for _, assetType := range scopedAssetTypes {
+		names, ok := args.scopedParentNames(assetType)
+		if !ok || len(names) == 0 {
+			// Scoped-but-no-parent: skip enumeration entirely (the GCP
+			// (empty, true) skip contract). No SearchAll, no project-wide
+			// fallback.
+			continue
+		}
+		query := buildScopedSearchQuery(names, args.Regions, args.TagSelectors)
+		rs, err := g.searcher.SearchAll(ctx, scope, []string{assetType}, query)
+		if err != nil {
+			return nil, fmt.Errorf("cloud asset SearchAllResources (selection-closure scope, %s): %w", assetType, err)
+		}
+		out = append(out, rs...)
+	}
+	return out, nil
+}
+
+// buildScopedSearchQuery composes a SearchAllResources query that narrows
+// to the operator's selected parents by name instead of the project-wide
+// `labels.project:<stack>` sweep (#777). The selected parents were chosen
+// by identity, so a missing Project label must not exclude them — the same
+// "scope bypasses the project filter" guarantee the AWS path makes
+// (TestCloudControlDiscover_ParentScopeBypassesTagFilter).
+//
+// Names are OR-combined inside a parenthesized `name:(...)` clause; the `:`
+// operator is Cloud Asset's substring match, which matches the trailing
+// short-name segment of each parent's full resource name. Locations and
+// label selectors are AND-combined exactly as buildSearchQuery does, so a
+// multi-region closure still narrows by location.
+func buildScopedSearchQuery(names []string, locations []string, selectors []TagSelector) string {
+	var clauses []string
+	if len(names) > 0 {
+		nameClauses := make([]string, 0, len(names))
+		for _, n := range names {
+			n = strings.TrimSpace(n)
+			if n == "" {
+				continue
+			}
+			nameClauses = append(nameClauses, "name:"+n)
+		}
+		if len(nameClauses) == 1 {
+			clauses = append(clauses, nameClauses[0])
+		} else if len(nameClauses) > 1 {
+			clauses = append(clauses, "("+strings.Join(nameClauses, " OR ")+")")
+		}
+	}
+
+	nonEmpty := make([]string, 0, len(locations))
+	for _, l := range locations {
+		if l != "" {
+			nonEmpty = append(nonEmpty, l)
+		}
+	}
+	switch len(nonEmpty) {
+	case 0:
+	case 1:
+		clauses = append(clauses, "location:"+nonEmpty[0])
+	default:
+		locClauses := make([]string, 0, len(nonEmpty))
+		for _, l := range nonEmpty {
+			locClauses = append(locClauses, "location:"+l)
+		}
+		clauses = append(clauses, "("+strings.Join(locClauses, " OR ")+")")
+	}
+
+	for _, s := range selectors {
+		clauses = append(clauses, "labels."+s.Key+":"+s.Value)
+	}
+	return strings.Join(clauses, " AND ")
 }
 
 // assetTypesOf collects the Cloud Asset asset-type strings from a

--- a/cmd/insideout-import/gcpdiscover/gcpdiscover.go
+++ b/cmd/insideout-import/gcpdiscover/gcpdiscover.go
@@ -1022,9 +1022,39 @@ func (g *GCPDiscoverer) searchScopedAssetTypes(ctx context.Context, scope string
 		if err != nil {
 			return nil, fmt.Errorf("cloud asset SearchAllResources (selection-closure scope, %s): %w", assetType, err)
 		}
-		out = append(out, rs...)
+		// The CAI `name:<n>` clause is a SUBSTRING/token match, not an exact
+		// match — selecting a parent named "foo" can also return "foo-backup"
+		// or "my-foo" of the same asset type. Because the scoped query drops
+		// the labels.project clause, those unselected rows are not otherwise
+		// filtered, so they would leak into DiscoverClosure and fan out
+		// non-CAI child discovery from parents the operator never selected.
+		// Exact-filter to the selected parent short names before appending,
+		// mirroring the AWS path's scope-by-exact-identifier guarantee. #777
+		// (codex review).
+		out = append(out, filterToSelectedParents(rs, names)...)
 	}
 	return out, nil
+}
+
+// filterToSelectedParents keeps only the asset results whose short resource
+// name exactly equals one of the selected parent names. It defends against
+// the substring nature of the Cloud Asset `name:` query operator: the scoped
+// SearchAllResources call narrows the read but can still return name-substring
+// neighbors (e.g. "foo-backup" for a selected "foo"), and the scoped path
+// has dropped the project-label filter that would otherwise exclude them
+// (#777).
+func filterToSelectedParents(rs []gcpAssetResult, names []string) []gcpAssetResult {
+	want := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		want[n] = struct{}{}
+	}
+	filtered := make([]gcpAssetResult, 0, len(rs))
+	for _, r := range rs {
+		if _, ok := want[shortName(r.Name)]; ok {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered
 }
 
 // buildScopedSearchQuery composes a SearchAllResources query that narrows

--- a/cmd/insideout-import/reversedisco/closure_scope_gcp_live_test.go
+++ b/cmd/insideout-import/reversedisco/closure_scope_gcp_live_test.go
@@ -1,0 +1,149 @@
+//go:build integration
+
+// closure_scope_gcp_live_test.go is the live-GCP pre-merge repro check for
+// the #777 selection-closure scoping parity (the GCP twin of
+// closure_scope_live_test.go for AWS #739). The unit suite proves the
+// scoping against fakes; this harness proves the deployed behavior against a
+// real project — closing the same green-then-broken-on-staging gap the AWS
+// live harness closes.
+//
+// What it locks: selecting exactly ONE google_storage_bucket parent and
+// running the same DiscoverClosure call the engine makes must scope CAI
+// enumeration to that bucket — it must NOT project-wide-sweep every bucket
+// in the project. Pre-#777 gcpAggAdapter.DiscoverClosure ignored
+// req.ParentResources and ran a project-wide DiscoverTypes sweep, so this
+// test fails loudly on the old adapter (it returns sibling buckets).
+//
+// Like the AWS harness it is gated three ways so it never runs in normal
+// `go test ./...` or CI: the `integration` build tag, the
+// RUN_LIVE_CLOSURE_GCP=1 env guard, and a credential probe that skips
+// cleanly when no GCP ADC / project is available. Run it with read-only ADC
+// for a test project:
+//
+//	RUN_LIVE_CLOSURE_GCP=1 GCP_PROJECT_ID=<proj> \
+//	  go test -tags integration \
+//	  ./cmd/insideout-import/reversedisco -run TestLiveClosureScopeGCP -v
+package reversedisco_test
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/reversedisco"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport"
+)
+
+func TestLiveClosureScopeGCP(t *testing.T) {
+	if os.Getenv("RUN_LIVE_CLOSURE_GCP") != "1" {
+		t.Skip("live GCP closure-scope harness disabled; set RUN_LIVE_CLOSURE_GCP=1 with GCP ADC for a test project")
+	}
+	projectID := strings.TrimSpace(os.Getenv("GCP_PROJECT_ID"))
+	if projectID == "" {
+		t.Skip("GCP_PROJECT_ID unset; set it to the real GCP project ID scoping Cloud Asset Inventory")
+	}
+	// The selected bucket name to scope to. The operator supplies it (the
+	// harness does not enumerate buckets first — that is exactly the
+	// project-wide read this fix removes). Skip cleanly when absent so the
+	// tag alone never breaks a project-less environment.
+	selected := strings.TrimSpace(os.Getenv("GCP_CLOSURE_BUCKET"))
+	if selected == "" {
+		t.Skip("GCP_CLOSURE_BUCKET unset; set it to a google_storage_bucket name in the project to scope to")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// New constructs the GCP discoverer with customer-scoped ADC via
+	// gcpdiscover.NewRealAssetSearcher (the #777 credential-context path —
+	// mirrors the AWS mars#198 fix). Construction can fail if ADC is
+	// unconfigured or the Cloud Asset API isn't enabled; skip (not fail) so
+	// a keyless environment never breaks the tag.
+	disco, cleanup, err := reversedisco.New(ctx, "gcp", "", projectID, "", reversedisco.AWSAssumeRole{})
+	if err != nil {
+		t.Skipf("reversedisco.New(gcp) (no usable GCP credentials / Cloud Asset API?): %v", err)
+	}
+	defer cleanup()
+	closure, ok := disco.(reverseimport.ClosureDiscoverer)
+	if !ok {
+		t.Fatal("discoverer is not closure-capable")
+	}
+
+	// Discriminating-power probe: count every bucket in the project via an
+	// UNSCOPED closure request (empty ParentResources ⇒ nil ParentScope ⇒
+	// the legacy project-wide sweep). If the project has only the one
+	// selected bucket, the scoped and swept results are indistinguishable
+	// and a green run proves nothing — so require >=2 buckets before the
+	// scoping assertion below can mean anything. This closes the
+	// inherited-from-AWS false-confidence gap where "it passed live" did
+	// not imply the scoping actually narrowed the read.
+	probe, err := closure.DiscoverClosure(ctx, reverseimport.ClosureRequest{
+		Cloud:        "gcp",
+		GCPProjectID: projectID,
+		ParentTypes:  []string{"google_storage_bucket"},
+	})
+	if err != nil {
+		t.Fatalf("unscoped probe DiscoverClosure: %v", err)
+	}
+	probeBuckets := map[string]struct{}{}
+	for _, r := range probe {
+		if r.Identity.Type == "google_storage_bucket" {
+			probeBuckets[r.Identity.NameHint] = struct{}{}
+		}
+	}
+	t.Logf("project %q has %d google_storage_bucket(s) project-wide", projectID, len(probeBuckets))
+	if _, has := probeBuckets[selected]; !has {
+		t.Fatalf("selected bucket %q not found in the project-wide sweep — set GCP_CLOSURE_BUCKET to a real bucket name", selected)
+	}
+	if len(probeBuckets) < 2 {
+		t.Skipf("project has %d bucket(s); need >=2 to prove scoping discriminates (the scoped and swept results would be identical)", len(probeBuckets))
+	}
+
+	start := time.Now()
+	found, err := closure.DiscoverClosure(ctx, reverseimport.ClosureRequest{
+		Cloud:        "gcp",
+		GCPProjectID: projectID,
+		ParentResources: []imported.ImportedResource{{
+			Identity: imported.ResourceIdentity{
+				Cloud:     "gcp",
+				Type:      "google_storage_bucket",
+				Address:   "google_storage_bucket.live_scope",
+				NameHint:  selected,
+				ImportID:  selected,
+				ProjectID: projectID,
+			},
+		}},
+		ParentTypes: []string{"google_storage_bucket"},
+		// Whatever child types the registry maps to google_storage_bucket;
+		// the parent sweep scoping is the #777 win regardless.
+		ChildTypes: nil,
+	})
+	if err != nil {
+		t.Fatalf("DiscoverClosure: %v", err)
+	}
+	t.Logf("DiscoverClosure returned %d resources in %s", len(found), time.Since(start))
+
+	// The #777 regression assertion: only the selected bucket may appear —
+	// the project-wide sweep would return every sibling bucket in the
+	// project.
+	distinctBuckets := map[string]struct{}{}
+	for _, r := range found {
+		if r.Identity.Type == "google_storage_bucket" {
+			distinctBuckets[r.Identity.NameHint] = struct{}{}
+			if r.Identity.NameHint != selected {
+				t.Errorf("closure leaked unselected bucket: %s (#777 project-wide sweep)", r.Identity.NameHint)
+			}
+		}
+	}
+	// A vacuous empty result would pass the leak/count checks while proving
+	// nothing — the scoped closure must surface the one selected bucket.
+	if _, ok := distinctBuckets[selected]; !ok {
+		t.Errorf("scoped closure did not return the selected bucket %q (found %d resources) — a vacuous empty result is not a pass", selected, len(found))
+	}
+	if len(distinctBuckets) > 1 {
+		t.Errorf("closure returned %d distinct buckets, want exactly the 1 selected (#777 project-wide sweep)", len(distinctBuckets))
+	}
+}

--- a/cmd/insideout-import/reversedisco/closure_scope_gcp_test.go
+++ b/cmd/insideout-import/reversedisco/closure_scope_gcp_test.go
@@ -1,0 +1,96 @@
+package reversedisco
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/gcpdiscover"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// #777 GCP closure-discovery parity. These tests pin the GCP analog of the
+// AWS #739/#770 selection-closure scoping: gcpAggAdapter.DiscoverClosure
+// builds a gcpdiscover.DiscoverArgs.ParentScope from the closure request's
+// selected parents so CAI enumeration is scoped per-selected-parent instead
+// of a project-wide DiscoverTypes sweep.
+//
+// The end-to-end "the scoped query narrows by the selected parent's name"
+// assertion lives at the gcpdiscover level
+// (TestDiscoverTypes_ParentScopeNarrowsToSelectedParents) — the
+// gcpAssetSearcher seam returns an unexported type, so a fake searcher must
+// live in that package. Here we pin the adapter's mapping
+// (req.ParentResources -> ParentScope), the load-bearing wiring this
+// package owns.
+
+// TestGCPParentScope_KeysByParentAssetType proves the #777 scoping builds
+// the per-Cloud-Asset-type selected-parent scope from the closure request:
+// each selected parent whose Terraform type maps to a registered asset type
+// contributes its name (NameHint, falling back to ImportID) and location
+// under the parent's asset type; parents with no registered discoverer are
+// skipped. Mirror of TestAWSParentScope_KeysByParentCFNType.
+func TestGCPParentScope_KeysByParentAssetType(t *testing.T) {
+	t.Parallel()
+	// A real GCPDiscoverer (nil searcher is fine — gcpParentScope only
+	// reads the type registry via AssetTypeForTF, no network).
+	a := gcpAggAdapter{d: gcpdiscover.NewGCPDiscoverer(nil, "real-proj", gcpdiscover.GCPDiscovererOpts{})}
+
+	parents := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", NameHint: "io-uploads", Location: "us"}},
+		// Same type, different location: kept separately.
+		{Identity: imported.ResourceIdentity{Type: "google_storage_bucket", NameHint: "io-logs", Location: "eu"}},
+		// ImportID fallback when NameHint is empty.
+		{Identity: imported.ResourceIdentity{Type: "google_pubsub_topic", ImportID: "io-events"}},
+		// A type with no registered discoverer is skipped (no panic, no entry).
+		{Identity: imported.ResourceIdentity{Type: "google_not_a_real_type", NameHint: "x"}},
+	}
+	scope := a.gcpParentScope(parents)
+
+	// Location is carried through into the scope but is informational on
+	// GCP today — buildScopedSearchQuery narrows by args.Regions, NOT by the
+	// per-parent ScopedParent.Location (the CAI path expresses location in
+	// the single bulk query, unlike the AWS per-region loop). We pin the
+	// carry-through here so a future location-narrowed query has the value
+	// available; the no-op-on-query behavior is pinned at the gcpdiscover
+	// level (TestBuildScopedSearchQuery / TestDiscoverTypes_ParentScope*).
+	wantBuckets := []gcpdiscover.ScopedParent{
+		{Name: "io-logs", Location: "eu"},
+		{Name: "io-uploads", Location: "us"},
+	}
+	if got := scope["storage.googleapis.com/Bucket"]; !reflect.DeepEqual(got, wantBuckets) {
+		t.Errorf("storage bucket scope = %v, want %v", got, wantBuckets)
+	}
+	if got := scope["pubsub.googleapis.com/Topic"]; !reflect.DeepEqual(got, []gcpdiscover.ScopedParent{{Name: "io-events"}}) {
+		t.Errorf("pubsub topic scope = %v, want [{io-events }]", got)
+	}
+	for assetType := range scope {
+		switch assetType {
+		case "storage.googleapis.com/Bucket", "pubsub.googleapis.com/Topic":
+		default:
+			t.Errorf("unexpected scope key %q (unknown-type parent should be skipped)", assetType)
+		}
+	}
+	// Guard the gcpdiscover seam this relies on.
+	if at, ok := a.d.AssetTypeForTF("google_storage_bucket"); !ok || at != "storage.googleapis.com/Bucket" {
+		t.Errorf("AssetTypeForTF(google_storage_bucket) = (%q, %v), want (storage.googleapis.com/Bucket, true)", at, ok)
+	}
+	if _, ok := a.d.AssetTypeForTF("google_not_a_real_type"); ok {
+		t.Error("AssetTypeForTF should return false for an unknown type")
+	}
+}
+
+// TestGCPParentScope_EmptyWhenNoUsableParents proves a closure request with
+// no registered-type parents yields a nil scope, so DiscoverClosure falls
+// back to the project-wide sweep (no behavior change for selections that
+// can't be scoped).
+func TestGCPParentScope_EmptyWhenNoUsableParents(t *testing.T) {
+	t.Parallel()
+	a := gcpAggAdapter{d: gcpdiscover.NewGCPDiscoverer(nil, "real-proj", gcpdiscover.GCPDiscovererOpts{})}
+	if got := a.gcpParentScope(nil); got != nil {
+		t.Errorf("empty parents → scope %v, want nil", got)
+	}
+	if got := a.gcpParentScope([]imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "google_not_a_real_type", NameHint: "x"}},
+	}); got != nil {
+		t.Errorf("unregistered-type parent → scope %v, want nil", got)
+	}
+}

--- a/cmd/insideout-import/reversedisco/reversedisco.go
+++ b/cmd/insideout-import/reversedisco/reversedisco.go
@@ -86,6 +86,24 @@ func New(ctx context.Context, cloud, region, gcpProjectID, awsEndpointURL string
 		cfg = applyAWSAssumeRole(cfg, awsAuth)
 		return awsAggAdapter{d: awsdiscover.NewAWSDiscovererWithConcurrency(cfg, awsdiscover.DefaultMaxConcurrency)}, func() {}, nil
 	case "gcp":
+		// GCP credential context (#777, the GCP analog of the AWS
+		// mars#198 wrong-principal fix). NewRealAssetSearcher with no
+		// option.ClientOption falls back to Application Default
+		// Credentials. In the Mars reverse-import job that ADC is the
+		// customer-scoped credential the job is launched with (the WIF /
+		// service-account identity that can read the customer's Cloud
+		// Asset Inventory), NOT the pod-default identity — so the closure
+		// sweep runs as the same principal Terraform's google provider
+		// reaches the customer project with. There is no STS-style
+		// assume-role hop to wire here (the AWS awsAuth.RoleARN path):
+		// GCP impersonation/WIF is established before the process starts,
+		// via GOOGLE_APPLICATION_CREDENTIALS / the metadata server /
+		// option.WithTokenSource at the caller, so this constructor
+		// inherits the right principal without an explicit role argument.
+		// Multi-tenant server-side callers that must carry per-request
+		// credentials pass an option.WithTokenSource(ts) (see
+		// NewRealAssetSearcher's #445 doc); the Mars job runs one
+		// customer per process, so process-default ADC is correct here.
 		searcher, err := gcpdiscover.NewRealAssetSearcher(ctx)
 		if err != nil {
 			return nil, func() {}, err
@@ -201,9 +219,46 @@ func (a gcpAggAdapter) DiscoverByID(ctx context.Context, tfType, id, region, acc
 func (a gcpAggAdapter) DiscoverClosure(ctx context.Context, req reverseimport.ClosureRequest) ([]imported.ImportedResource, error) {
 	types := unionStrings(req.ParentTypes, req.ChildTypes)
 	return a.d.DiscoverTypes(ctx, types, gcpdiscover.DiscoverArgs{
-		Project: req.Project,
-		Regions: req.Regions,
+		Project:     req.Project,
+		Regions:     req.Regions,
+		ParentScope: a.gcpParentScope(req.ParentResources),
 	})
+}
+
+// gcpParentScope builds the per-Cloud-Asset-type selected-parent scope the
+// #777 closure-scoping fix uses to restrict GCP child + parent
+// re-enumeration to the operator's selected parents — the GCP twin of
+// awsParentScope. For each selected parent whose Terraform type maps to a
+// registered Cloud Asset type it records the parent's name (its NameHint,
+// falling back to ImportID) AND its location (Identity.Location) under the
+// parent's asset type. Parent types with no registered discoverer are
+// skipped — their children fall back to the project-wide CAI sweep and the
+// engine's mergeClosureResources still filters them to the selected
+// parents, so closure semantics are unchanged. Returns nil when no usable
+// scope can be built (the caller then sweeps project-wide as before).
+//
+// Unlike the AWS path there is no identifier-shared-child fan-out: GCP
+// child types are non-CAI (they fan out from the already-scoped parent CAI
+// rows in DiscoverTypes' non-CAI phase), so scoping the parent asset type
+// is sufficient to scope its children too.
+func (a gcpAggAdapter) gcpParentScope(parents []imported.ImportedResource) gcpdiscover.ParentScope {
+	byAsset := map[string][]gcpdiscover.ScopedParent{}
+	for _, p := range parents {
+		assetType, ok := a.d.AssetTypeForTF(p.Identity.Type)
+		if !ok {
+			continue
+		}
+		name := strings.TrimSpace(p.Identity.NameHint)
+		if name == "" {
+			name = strings.TrimSpace(p.Identity.ImportID)
+		}
+		if name == "" {
+			continue
+		}
+		location := strings.TrimSpace(p.Identity.Location)
+		byAsset[assetType] = append(byAsset[assetType], gcpdiscover.ScopedParent{Name: name, Location: location})
+	}
+	return gcpdiscover.NewParentScope(byAsset)
 }
 
 func unionStrings(groups ...[]string) []string {


### PR DESCRIPTION
## Summary

Brings the GCP closure-discovery path to parity with the AWS fix from #770 (closes #777). The GCP path already inherited the engine-level `selection_closure_failed` degradation (it lives in `pkg/reverseimport/closure.go`), but `gcpAggAdapter.DiscoverClosure` still ran a project-wide `gcpdiscover.DiscoverTypes` sweep and ignored `req.ParentResources` — correct only because the engine's `mergeClosureResources` filter masked the over-fetch, at the cost of O(project) work and broad Cloud Asset Inventory read scope.

## What changed

- `cmd/insideout-import/gcpdiscover/args.go` — new selection-scope seam: `ParentScope` / `ScopedParent` types, `NewParentScope`, `DiscoverArgs.ParentScope`, `scopedParentNames`.
- `cmd/insideout-import/gcpdiscover/gcpdiscover.go` — `AssetTypeForTF`, `splitScopedBucket`, `searchScopedAssetTypes`, `buildScopedSearchQuery`; `ParentScope` wired into `searchBuckets`.
- `cmd/insideout-import/reversedisco/reversedisco.go` — `gcpAggAdapter.DiscoverClosure` now builds a `ParentScope` from `req.ParentResources` (via `gcpParentScope`); documents the mars-job GCP credential context.
- New tests: `gcpdiscover/closure_scope_test.go`, `reversedisco/closure_scope_gcp_test.go`, `reversedisco/closure_scope_gcp_live_test.go` (integration-gated).

## How this mirrors AWS #770

AWS keys a `ParentScope` by CloudFormation type and short-circuits the account-wide list. The issue suggested reusing gcpdiscover's existing `ScopeStyle`/`ParentScoped` mechanism, but that one is **project-scoping** (narrow the CAI sweep to the stack project), not **selection-scoping**. So this adds a GCP-idiomatic selection-scope seam keyed by **Cloud Asset asset type** (the GCP analog of a CFN type). Because GCP uses a single bulk `SearchAllResources` per ScopeStyle bucket rather than per-type SDK loops, scoping is expressed by narrowing the CAI query to a per-parent `name:(...)` clause instead of the project-wide `labels.project:<stack>` sweep, and dropping a scoped asset type's read entirely when it has no selected parent (the GCP twin of AWS's `(empty, true)` skip contract). GCP children are non-CAI fan-outs from already-scoped parent rows, so scoping the parent asset type scopes the children too.

## Acceptance criteria

- One selected parent → only that parent's CAI read (scoped `name:` query; test asserts no project-wide sweep). ✅
- Scoped-type-but-no-parent skips enumeration (zero SearchAll calls; mutation-verified). ✅
- Live-harness analog gated identically to the AWS one (`integration` tag + `RUN_LIVE_CLOSURE_GCP=1` + ADC probe, plus a project-wide bucket-count probe so a green run only counts when ≥2 buckets exist). ✅
- Mars-job GCP credential context documented/verified (customer-scoped ADC via `NewRealAssetSearcher`, no STS-style hop). ✅

## Verification

- `make test` (`go test -race ./...`): exit 0, zero failures.
- `make go-fmt-check`, `go vet`, `terraform fmt -check`: clean. Integration-tagged build compiles.

## Caveats

- The parent/child registry (`pkg/imported/labels/parent.go`) has zero GCP entries today, so on production GCP-only stacks the engine's `selectedParentResources` currently finds no parents and the closure path is a no-op regardless. This change makes the adapter correctly scoped *for when* GCP parent/child edges materialize — matching the issue's framing (scoped to `gcpAggAdapter.DiscoverClosure`).
- `ScopedParent.Location` is carried through but informational today: `buildScopedSearchQuery` narrows by `args.Regions` (the CAI single-query location model), not per-parent location. Documented in code + tests.

Refs: #770 (AWS precedent), #739, mars#198, reliable#2040. Closes #777.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4YtSBZtcpcKFDbKWL5o4S

---
_Generated by [Claude Code](https://claude.ai/code/session_01B4YtSBZtcpcKFDbKWL5o4S)_