### PR TITLE
feat(imported): ConfigReadback on ComponentMetricsBinding (reliable#1479)

### DIFF
--- a/pkg/imported/bindings/bindings.go
+++ b/pkg/imported/bindings/bindings.go
@@ -43,6 +43,41 @@ type ComponentMetricsBinding struct {
 	DimensionKey   string
 	DimensionFrom  string
 	DefaultMetrics []string
+
+	// ConfigReadback, when non-nil, describes how a consumer reads the
+	// resource's LIVE config from an inspector list action and remaps it
+	// onto the consumer's config keys. Optional — most types have no config
+	// overlay. Moved upstream from reliable so the per-type vocabulary lives
+	// with the other binding data instead of in a downstream map
+	// (reliable#1479 "zero per-type code").
+	ConfigReadback *ConfigReadback
+}
+
+// ConfigReadback describes how to read one imported resource type's live
+// configuration from an inspector list action and remap it onto a consumer's
+// config keys. The consumer owns the actual extraction + dispatch plumbing;
+// this struct is just the per-type data that plumbing needs.
+type ConfigReadback struct {
+	// Service / Action name the inspector list call (e.g. "s3" /
+	// "list-buckets"). Opaque to presets — the consumer interprets them.
+	Service string
+	Action  string
+	// ComponentKey selects the consumer's shared live-config extractor, in
+	// the managed component-key namespace (e.g. "aws_s3", "gcp_gcs").
+	ComponentKey string
+	// EnvelopeKey is the list-result envelope holding the per-resource
+	// records (e.g. "Buckets" for AWS, "buckets" for GCP).
+	EnvelopeKey string
+	// MatchAttr is the per-record attribute matched against the resource id
+	// (e.g. "Name" / "name").
+	MatchAttr string
+	// MatchFrom is the DimensionFrom-style source for the resource id.
+	MatchFrom string
+	// KeyMap translates extractor output keys onto the consumer's config
+	// keys (e.g. {"versioning": "versioning.enabled"}). Managed and imported
+	// deliberately use different config-key namespaces, so this is a real
+	// translation, not a cosmetic rename.
+	KeyMap map[string]string
 }
 
 var (

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -158,6 +158,15 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "BucketName",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"NumberOfObjects", "BucketSizeBytes"},
+		ConfigReadback: &ConfigReadback{
+			Service:      "s3",
+			Action:       "list-buckets",
+			ComponentKey: "aws_s3",
+			EnvelopeKey:  "Buckets",
+			MatchAttr:    "Name",
+			MatchFrom:    "name",
+			KeyMap:       map[string]string{"versioning": "versioning.enabled"},
+		},
 	},
 	"aws_dynamodb_table": {
 		Service:        "dynamodb",
@@ -228,6 +237,15 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "bucket_name",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"storage.googleapis.com/storage/total_bytes", "storage.googleapis.com/storage/object_count"},
+		ConfigReadback: &ConfigReadback{
+			Service:      "gcs",
+			Action:       "list-buckets",
+			ComponentKey: "gcp_gcs",
+			EnvelopeKey:  "buckets",
+			MatchAttr:    "name",
+			MatchFrom:    "name",
+			KeyMap:       map[string]string{"versioning": "versioning.enabled"},
+		},
 	},
 	"google_pubsub_topic": {
 		Service:        "pubsub",

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -97,3 +97,30 @@ func TestSeededBindings(t *testing.T) {
 		})
 	}
 }
+
+// TestSeed_ConfigReadback pins the config-readback descriptors moved upstream
+// from reliable (#1479). S3 and GCS carry a per-bucket versioning overlay; the
+// EnvelopeKey/MatchAttr casing differs by cloud and must be preserved exactly,
+// since the downstream consumer scopes the inspector list result on them.
+func TestSeed_ConfigReadback(t *testing.T) {
+	reseed(t)
+
+	s3, ok := Binding("aws_s3_bucket")
+	require.True(t, ok)
+	require.NotNil(t, s3.ConfigReadback, "aws_s3_bucket must carry a ConfigReadback")
+	assert.Equal(t, "s3", s3.ConfigReadback.Service)
+	assert.Equal(t, "list-buckets", s3.ConfigReadback.Action)
+	assert.Equal(t, "aws_s3", s3.ConfigReadback.ComponentKey)
+	assert.Equal(t, "Buckets", s3.ConfigReadback.EnvelopeKey)
+	assert.Equal(t, "Name", s3.ConfigReadback.MatchAttr)
+	assert.Equal(t, "name", s3.ConfigReadback.MatchFrom)
+	assert.Equal(t, map[string]string{"versioning": "versioning.enabled"}, s3.ConfigReadback.KeyMap)
+
+	gcs, ok := Binding("google_storage_bucket")
+	require.True(t, ok)
+	require.NotNil(t, gcs.ConfigReadback, "google_storage_bucket must carry a ConfigReadback")
+	assert.Equal(t, "gcs", gcs.ConfigReadback.Service)
+	assert.Equal(t, "buckets", gcs.ConfigReadback.EnvelopeKey)
+	assert.Equal(t, "name", gcs.ConfigReadback.MatchAttr)
+	assert.Equal(t, "gcp_gcs", gcs.ConfigReadback.ComponentKey)
+}

--- a/pkg/imported/types.go
+++ b/pkg/imported/types.go
@@ -71,6 +71,12 @@ type Capabilities struct {
 // pkg/imported see one canonical name without an extra import.
 type ComponentMetricsBinding = bindings.ComponentMetricsBinding
 
+// ConfigReadback is the optional live-config readback descriptor on a
+// ComponentMetricsBinding. Re-exported as a type alias from
+// pkg/imported/bindings so callers depending on pkg/imported see one
+// canonical name without an extra import.
+type ConfigReadback = bindings.ConfigReadback
+
 // FieldMismatch describes a single drifted attribute returned by
 // Provider.CompareDrift. Snapshot is the value carried in the sealed
 // snapshot (what Terraform expects); Cloud is the value the live


### PR DESCRIPTION
Upstream half of reliable's #1479 "zero per-type code" move for the imported metrics path.

## What
- Add an optional `ConfigReadback` descriptor to `ComponentMetricsBinding` (and re-export `imported.ConfigReadback` as a type alias, mirroring `ComponentMetricsBinding`).
- Seed it for the two types that have a live-config overlay today — `aws_s3_bucket` and `google_storage_bucket` (per-bucket versioning) — preserving the cloud-specific envelope/attr casing (`Buckets`/`Name` vs `buckets`/`name`) that the consumer scopes on.

## Why
reliable hardcoded these per-type readback descriptors in `internal/agentapi/imported_metrics.go` (`importedAWSConfigReadbacks` / `importedGCPConfigReadbacks`). That vocabulary is presets-owned; this moves it next to the other binding data so reliable can read `binding.ConfigReadback` and delete its local maps. The extraction + inspector-dispatch plumbing stays in reliable.

## Consumer
reliable PR luthersystems/reliable#2138 consumes this (`importedConfigReadbackFor` → `provider.MetricsBinding(t).ConfigReadback`) and drops `imported_metrics.go` from its zero-per-type-code allowlist.

## Tests
`TestSeed_ConfigReadback` pins the S3/GCS descriptors (service/action/componentKey/envelope/match/keyMap). `go build ./...`, `go vet ./pkg/imported/...`, and `go test ./pkg/imported/bindings/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEWLCgTptUkjNwLA3TDMn5)_