### PR TITLE
feat(observability): SDK-free leaf types + ConfigReadback + checkout v7 (consolidated)

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -14,7 +14,7 @@ jobs:
       presets_with_tests: ${{ steps.find-testable.outputs.dirs }}
       examples: ${{ steps.find-examples.outputs.dirs }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - id: find-presets
         name: Discover preset modules
@@ -62,7 +62,7 @@ jobs:
       matrix:
         dir: ${{ fromJson(needs.discover.outputs.presets) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -84,7 +84,7 @@ jobs:
       matrix:
         dir: ${{ fromJson(needs.discover.outputs.examples) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -107,7 +107,7 @@ jobs:
       matrix:
         dir: ${{ fromJson(needs.discover.outputs.presets_with_tests) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -138,7 +138,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Lint sensitive-in-for_each
         run: bash tests/lint-sensitive-for-each.sh
@@ -175,7 +175,7 @@ jobs:
   verify-phantom-schema:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -192,7 +192,7 @@ jobs:
   tflint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93  # v6.2.2
         with:
@@ -224,7 +224,7 @@ jobs:
       matrix:
         dir: ${{ fromJson(needs.discover.outputs.presets) }}
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -236,7 +236,7 @@ jobs:
   format-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
         with:
@@ -251,7 +251,7 @@ jobs:
   go-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
@@ -261,7 +261,7 @@ jobs:
   go-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
@@ -271,7 +271,7 @@ jobs:
   go-vet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
@@ -286,7 +286,7 @@ jobs:
     # the job was cancelled at the boundary with every step green.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
@@ -329,7 +329,7 @@ jobs:
   verify-gen:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
@@ -342,7 +342,7 @@ jobs:
   verify-supported-resources:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
@@ -359,7 +359,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod

--- a/pkg/imported/bindings/bindings.go
+++ b/pkg/imported/bindings/bindings.go
@@ -43,6 +43,41 @@ type ComponentMetricsBinding struct {
 	DimensionKey   string
 	DimensionFrom  string
 	DefaultMetrics []string
+
+	// ConfigReadback, when non-nil, describes how a consumer reads the
+	// resource's LIVE config from an inspector list action and remaps it
+	// onto the consumer's config keys. Optional — most types have no config
+	// overlay. Moved upstream from reliable so the per-type vocabulary lives
+	// with the other binding data instead of in a downstream map
+	// (reliable#1479 "zero per-type code").
+	ConfigReadback *ConfigReadback
+}
+
+// ConfigReadback describes how to read one imported resource type's live
+// configuration from an inspector list action and remap it onto a consumer's
+// config keys. The consumer owns the actual extraction + dispatch plumbing;
+// this struct is just the per-type data that plumbing needs.
+type ConfigReadback struct {
+	// Service / Action name the inspector list call (e.g. "s3" /
+	// "list-buckets"). Opaque to presets — the consumer interprets them.
+	Service string
+	Action  string
+	// ComponentKey selects the consumer's shared live-config extractor, in
+	// the managed component-key namespace (e.g. "aws_s3", "gcp_gcs").
+	ComponentKey string
+	// EnvelopeKey is the list-result envelope holding the per-resource
+	// records (e.g. "Buckets" for AWS, "buckets" for GCP).
+	EnvelopeKey string
+	// MatchAttr is the per-record attribute matched against the resource id
+	// (e.g. "Name" / "name").
+	MatchAttr string
+	// MatchFrom is the DimensionFrom-style source for the resource id.
+	MatchFrom string
+	// KeyMap translates extractor output keys onto the consumer's config
+	// keys (e.g. {"versioning": "versioning.enabled"}). Managed and imported
+	// deliberately use different config-key namespaces, so this is a real
+	// translation, not a cosmetic rename.
+	KeyMap map[string]string
 }
 
 var (

--- a/pkg/imported/bindings/seed.go
+++ b/pkg/imported/bindings/seed.go
@@ -158,6 +158,15 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "BucketName",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"NumberOfObjects", "BucketSizeBytes"},
+		ConfigReadback: &ConfigReadback{
+			Service:      "s3",
+			Action:       "list-buckets",
+			ComponentKey: "aws_s3",
+			EnvelopeKey:  "Buckets",
+			MatchAttr:    "Name",
+			MatchFrom:    "name",
+			KeyMap:       map[string]string{"versioning": "versioning.enabled"},
+		},
 	},
 	"aws_dynamodb_table": {
 		Service:        "dynamodb",
@@ -228,6 +237,15 @@ var seededBindings = map[string]ComponentMetricsBinding{
 		DimensionKey:   "bucket_name",
 		DimensionFrom:  "name",
 		DefaultMetrics: []string{"storage.googleapis.com/storage/total_bytes", "storage.googleapis.com/storage/object_count"},
+		ConfigReadback: &ConfigReadback{
+			Service:      "gcs",
+			Action:       "list-buckets",
+			ComponentKey: "gcp_gcs",
+			EnvelopeKey:  "buckets",
+			MatchAttr:    "name",
+			MatchFrom:    "name",
+			KeyMap:       map[string]string{"versioning": "versioning.enabled"},
+		},
 	},
 	"google_pubsub_topic": {
 		Service:        "pubsub",

--- a/pkg/imported/bindings/seed_test.go
+++ b/pkg/imported/bindings/seed_test.go
@@ -97,3 +97,30 @@ func TestSeededBindings(t *testing.T) {
 		})
 	}
 }
+
+// TestSeed_ConfigReadback pins the config-readback descriptors moved upstream
+// from reliable (#1479). S3 and GCS carry a per-bucket versioning overlay; the
+// EnvelopeKey/MatchAttr casing differs by cloud and must be preserved exactly,
+// since the downstream consumer scopes the inspector list result on them.
+func TestSeed_ConfigReadback(t *testing.T) {
+	reseed(t)
+
+	s3, ok := Binding("aws_s3_bucket")
+	require.True(t, ok)
+	require.NotNil(t, s3.ConfigReadback, "aws_s3_bucket must carry a ConfigReadback")
+	assert.Equal(t, "s3", s3.ConfigReadback.Service)
+	assert.Equal(t, "list-buckets", s3.ConfigReadback.Action)
+	assert.Equal(t, "aws_s3", s3.ConfigReadback.ComponentKey)
+	assert.Equal(t, "Buckets", s3.ConfigReadback.EnvelopeKey)
+	assert.Equal(t, "Name", s3.ConfigReadback.MatchAttr)
+	assert.Equal(t, "name", s3.ConfigReadback.MatchFrom)
+	assert.Equal(t, map[string]string{"versioning": "versioning.enabled"}, s3.ConfigReadback.KeyMap)
+
+	gcs, ok := Binding("google_storage_bucket")
+	require.True(t, ok)
+	require.NotNil(t, gcs.ConfigReadback, "google_storage_bucket must carry a ConfigReadback")
+	assert.Equal(t, "gcs", gcs.ConfigReadback.Service)
+	assert.Equal(t, "buckets", gcs.ConfigReadback.EnvelopeKey)
+	assert.Equal(t, "name", gcs.ConfigReadback.MatchAttr)
+	assert.Equal(t, "gcp_gcs", gcs.ConfigReadback.ComponentKey)
+}

--- a/pkg/imported/types.go
+++ b/pkg/imported/types.go
@@ -71,6 +71,12 @@ type Capabilities struct {
 // pkg/imported see one canonical name without an extra import.
 type ComponentMetricsBinding = bindings.ComponentMetricsBinding
 
+// ConfigReadback is the optional live-config readback descriptor on a
+// ComponentMetricsBinding. Re-exported as a type alias from
+// pkg/imported/bindings so callers depending on pkg/imported see one
+// canonical name without an extra import.
+type ConfigReadback = bindings.ConfigReadback
+
 // FieldMismatch describes a single drifted attribute returned by
 // Provider.CompareDrift. Snapshot is the value carried in the sealed
 // snapshot (what Terraform expects); Cloud is the value the live

--- a/pkg/observability/component_observability.go
+++ b/pkg/observability/component_observability.go
@@ -578,6 +578,19 @@ var gcpServiceMetrics = map[string]GCPObs{
 	},
 }
 
+// AWSObsForService returns the AWS metric-catalog group for a service
+// key (e.g. "ec2", "s3"), or nil if the service has no catalog. It is
+// the exported, SDK-free accessor consumers should use to resolve a
+// service to its CloudWatch namespace/dimension/metric spec instead of
+// re-walking the Observability registry themselves (reliable#2153 — the
+// ui-core /observability/metrics handler consumes this). The returned
+// record owns its Metrics slice header, so callers that flip Alarmed
+// per-key won't mutate the shared catalog.
+func AWSObsForService(service string) *AWSObs { return awsObsFor(service) }
+
+// GCPObsForService is the GCP twin of AWSObsForService.
+func GCPObsForService(service string) *GCPObs { return gcpObsFor(service) }
+
 // awsObsFor copies an AWSObs entry by service name. Returns nil if the
 // service has no metric catalog. The copy is shallow over Metrics so the
 // returned record has its own slice header — callers that flip Alarmed

--- a/pkg/observability/component_observability_accessor_test.go
+++ b/pkg/observability/component_observability_accessor_test.go
@@ -1,0 +1,32 @@
+package observability
+
+import "testing"
+
+// TestAWSObsForService_ReturnsIsolatedCopy pins the copy-semantics
+// contract the exported accessor promises (reliable#2153): a caller that
+// flips Alarmed on a returned record must NOT mutate the shared catalog,
+// so a second lookup returns the original value. Guards the catalog from
+// the now-external consumer (ui-core) and future refactors of awsObsFor.
+func TestAWSObsForService_ReturnsIsolatedCopy(t *testing.T) {
+	first := AWSObsForService("ec2")
+	if first == nil || len(first.Metrics) == 0 {
+		t.Fatalf("AWSObsForService(\"ec2\") returned no catalog; cannot exercise copy semantics")
+	}
+	orig := first.Metrics[0].Alarmed
+	first.Metrics[0].Alarmed = !orig
+
+	second := AWSObsForService("ec2")
+	if second.Metrics[0].Alarmed != orig {
+		t.Errorf("AWSObsForService shares the Metrics slice with the package catalog: mutation leaked (got %v, want %v)", second.Metrics[0].Alarmed, orig)
+	}
+}
+
+// TestAWSObsForService_UnknownReturnsNil documents the not-found contract.
+func TestAWSObsForService_UnknownReturnsNil(t *testing.T) {
+	if got := AWSObsForService("definitely-not-a-service"); got != nil {
+		t.Errorf("AWSObsForService(unknown) = %v, want nil", got)
+	}
+	if got := GCPObsForService("definitely-not-a-service"); got != nil {
+		t.Errorf("GCPObsForService(unknown) = %v, want nil", got)
+	}
+}

--- a/pkg/observability/inspect/inspecttypes/sdkfree_test.go
+++ b/pkg/observability/inspect/inspecttypes/sdkfree_test.go
@@ -1,0 +1,35 @@
+package inspecttypes_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// forbiddenSDKImportPrefixes — see the metricstypes twin. The inspect
+// wire types must stay SDK-free so reliable's thin proxy (reliable#2153)
+// can deserialize a BatchResponse without dragging in the AWS / GCP SDK
+// clients the parent inspect.Dispatcher pulls in.
+var forbiddenSDKImportPrefixes = []string{
+	"github.com/aws/aws-sdk-go",
+	"cloud.google.com/go",
+	"google.golang.org/api",
+	"google.golang.org/genproto",
+}
+
+// TestInspectTypesSDKFree fails if any cloud SDK leaks into the leaf
+// package's transitive dependencies.
+func TestInspectTypesSDKFree(t *testing.T) {
+	t.Parallel()
+	out, err := exec.Command("go", "list", "-deps", ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps: %v\n%s", err, out)
+	}
+	for _, dep := range strings.Fields(string(out)) {
+		for _, bad := range forbiddenSDKImportPrefixes {
+			if dep == bad || strings.HasPrefix(dep, bad+"/") {
+				t.Errorf("inspecttypes must stay SDK-free but transitively imports %q (matched %q)", dep, bad)
+			}
+		}
+	}
+}

--- a/pkg/observability/inspect/inspecttypes/sdkfree_test.go
+++ b/pkg/observability/inspect/inspecttypes/sdkfree_test.go
@@ -11,7 +11,8 @@ import (
 // can deserialize a BatchResponse without dragging in the AWS / GCP SDK
 // clients the parent inspect.Dispatcher pulls in.
 var forbiddenSDKImportPrefixes = []string{
-	"github.com/aws/aws-sdk-go",
+	"github.com/aws/aws-sdk-go",    // SDK v1
+	"github.com/aws/aws-sdk-go-v2", // SDK v2 — the "-v2" suffix is NOT matched by the v1 prefix.
 	"cloud.google.com/go",
 	"google.golang.org/api",
 	"google.golang.org/genproto",
@@ -21,7 +22,7 @@ var forbiddenSDKImportPrefixes = []string{
 // package's transitive dependencies.
 func TestInspectTypesSDKFree(t *testing.T) {
 	t.Parallel()
-	out, err := exec.Command("go", "list", "-deps", ".").CombinedOutput()
+	out, err := exec.Command("go", "list", "-deps", ".").Output()
 	if err != nil {
 		t.Fatalf("go list -deps: %v\n%s", err, out)
 	}

--- a/pkg/observability/inspect/inspecttypes/types.go
+++ b/pkg/observability/inspect/inspecttypes/types.go
@@ -1,0 +1,89 @@
+// Package inspecttypes holds the SDK-free wire-envelope types for the
+// inspect batch surface (SubRequest, SubResult, BatchRequest,
+// BatchResponse) plus the MaxBatchSubs cap. It is a leaf package with
+// ZERO cloud-SDK imports so a consumer that only needs to (de)serialize
+// the inspect wire shape — e.g. luthersystems/reliable's thin proxy
+// after the cloud reads moved into ui-core (reliable#2153) — can do so
+// without dragging the AWS / GCP SDK clients pulled in by the parent
+// inspect package's Dispatcher into its binary.
+//
+// The parent pkg/observability/inspect package re-exports every type
+// here as a Go type alias, so existing callers of inspect.SubResult etc.
+// are unaffected and the wire shape is byte-for-byte identical.
+//
+// JSON shapes are wire-stable. Changing a field name or json tag is a
+// wire-breaking change and requires coordinated rollout across the
+// reliable handler, the ui-core /observability surface, and every
+// MCP-server callsite. Tests in inspect/types_test.go pin the exact
+// json tags and `omitempty` semantics so drift surfaces at unit-test
+// time rather than at HTTP-decode time.
+package inspecttypes
+
+// MaxBatchSubs caps the number of sub-probes per batch request. The
+// dispatcher rejects requests with len(Subs) > MaxBatchSubs. The number
+// is wire-coupled — both the client (MCP server / reliable HTTP handler)
+// and the server (batch dispatcher) read this same constant, so changing
+// it requires coordinated rollout.
+const MaxBatchSubs = 32
+
+// SubRequest is one probe within a batch. Service is a registry name
+// recognized by pkg/observability/service_actions.go's AWSServiceNames
+// or GCPServiceNames; Action is a registry-defined verb. Filters carries
+// arbitrary JSON the per-service handler interprets — left empty for
+// actions that need no filter.
+//
+// Detail / raw flags are deliberately NOT exposed: batch always returns
+// summarized results. Callers needing detail or raw output should use
+// the singular awsinspect / gcpinspect tools.
+//
+// The `jsonschema:"..."` tags are read by MCP clients via
+// github.com/google/jsonschema-go reflection to publish per-property
+// descriptions on tools/list. They are inert for encoding/json.
+type SubRequest struct {
+	Service string `json:"service" jsonschema:"Cloud service to query (e.g. 'ec2', 'rds', 's3' for AWS; 'compute', 'storage', 'cloudsql' for GCP). Use the singular awsinspect/gcpinspect tool with action='list-actions' to discover supported services."`
+	Action  string `json:"action" jsonschema:"Operation on the service (e.g. 'describe-instances', 'list-buckets', 'list-actions' for discovery, 'list-metrics' / 'get-metrics' for time-series)."`
+	Filters string `json:"filters,omitempty" jsonschema:"Optional JSON-encoded filter object passed through to the underlying API. Examples: '{\"hours\":6}' for metric windows, '{\"days\":7}' for cost queries."`
+}
+
+// SubResult is one probe's outcome. Index pins the result back to the
+// SubRequest at the same index in the original Subs slice — the fan-out
+// dispatcher may complete out of order. OK is true iff Error is empty;
+// Result is set iff OK is true; Error is set iff OK is false. DurationMS
+// captures the per-probe latency in milliseconds and is always emitted
+// (even when zero) for observability.
+type SubResult struct {
+	Index      int    `json:"index"`
+	Service    string `json:"service"`
+	Action     string `json:"action"`
+	OK         bool   `json:"ok"`
+	Result     any    `json:"result,omitempty"`
+	Error      string `json:"error,omitempty"`
+	DurationMS int64  `json:"duration_ms"`
+}
+
+// BatchRequest is the wire envelope for both
+// POST /api/v2/aws/inspect/batch and POST /api/v2/gcp/inspect/batch.
+// SessionID identifies the calling reliable session; the dispatcher
+// resolves it to credentials + project context.
+//
+// A single shape covers both clouds because the request shape is
+// cloud-agnostic — the route the request lands on (`/aws/...` vs
+// `/gcp/...`) carries the cloud selection.
+type BatchRequest struct {
+	SessionID string       `json:"session_id"`
+	Subs      []SubRequest `json:"subs"`
+}
+
+// BatchResponse is the wire envelope returned by the same two endpoints.
+// OK is the HTTP-envelope success bit — true iff the dispatcher itself
+// ran to completion (HTTP 200 path). Per-sub success/failure is encoded
+// in Results[i].OK and Results[i].Error, NOT aggregated into this outer
+// OK: a partial-failure batch (some Results[i].OK == false) still
+// returns outer OK == true.
+//
+// Results is index-aligned with the original Subs slice:
+// Results[i].Index == i.
+type BatchResponse struct {
+	OK      bool        `json:"ok"`
+	Results []SubResult `json:"results"`
+}

--- a/pkg/observability/inspect/types.go
+++ b/pkg/observability/inspect/types.go
@@ -1,102 +1,42 @@
-// Package inspect holds the session-aware AWS / GCP inspect
-// dispatcher and the wire envelope types for the
-// /api/v2/aws/inspect/batch and /api/v2/gcp/inspect/batch endpoints.
-// The package is the canonical contract between the Vercel-hosted
-// reliable handlers and the MCP server (currently
-// luthersystems/reliable/mcp-server/, future
-// luthersystems/insideout-agent-skills).
+// Package inspect holds the session-aware AWS / GCP inspect dispatcher
+// and the wire envelope types for the /api/v2/aws/inspect/batch and
+// /api/v2/gcp/inspect/batch endpoints. The package is the canonical
+// contract between the Vercel-hosted reliable handlers, the ui-core
+// /observability surface (reliable#2153), and the MCP server.
 //
-// JSON shapes are wire-stable. Changing a field name or json tag is a
-// wire-breaking change and requires coordinated rollout across the
-// reliable handler and every MCP-server callsite. Tests in
-// types_test.go pin the exact json tags and `omitempty` semantics so
-// drift surfaces at unit-test time rather than at HTTP-decode time.
+// The wire-envelope TYPES (SubRequest, SubResult, BatchRequest,
+// BatchResponse) and the MaxBatchSubs cap moved into the SDK-free leaf
+// package pkg/observability/inspect/inspecttypes (reliable#2153) so a
+// proxy consumer can (de)serialize the inspect wire shape without
+// importing the AWS / GCP SDK clients the Dispatcher below pulls in. The
+// aliases here preserve the `inspect.SubResult` spelling for every
+// existing in-tree caller — a Go type alias is identical to the aliased
+// type, so the jsonschema/json tags and every existing signature are
+// unchanged.
 //
 // The Dispatcher (singular AWS/GCP + AWSBatch/GCPBatch) lifts the
 // reliable-internal logic from internal/agentapi/{aws,gcp}_inspect{,_batch}.go
-// into this repo (#276 Item 3) and abstracts the four reliable-owned
-// concerns behind the four interfaces declared in interfaces.go:
-// ProjectResolver, CredsProvider, DriftReporter, MetricsFetcher.
-// The MCP doc-render helpers (the four tool descriptions and two
-// service tables) live in render.go.
+// into this repo and abstracts the four reliable-owned concerns behind
+// the four interfaces declared in interfaces.go: ProjectResolver,
+// CredsProvider, DriftReporter, MetricsFetcher. The MCP doc-render
+// helpers live in render.go.
 package inspect
 
-// MaxBatchSubs caps the number of sub-probes per batch request. The
-// dispatcher rejects requests with len(Subs) > MaxBatchSubs. The
-// number is wire-coupled — both the client (MCP server / reliable
-// HTTP handler) and the server (batch dispatcher) read this same
-// constant, so changing it requires coordinated rollout.
-const MaxBatchSubs = 32
+import "github.com/luthersystems/insideout-terraform-presets/pkg/observability/inspect/inspecttypes"
 
-// SubRequest is one probe within a batch. Service is a registry name
-// recognized by pkg/observability/service_actions.go's AWSServiceNames
-// or GCPServiceNames; Action is a registry-defined verb. Filters
-// carries arbitrary JSON the per-service handler interprets — left
-// empty for actions that need no filter.
-//
-// Detail / raw flags are deliberately NOT exposed: batch always
-// returns summarized results. Callers needing detail or raw output
-// should use the singular awsinspect / gcpinspect tools.
-//
-// The `jsonschema:"..."` tags are read by MCP clients via
-// github.com/google/jsonschema-go reflection to publish per-property
-// descriptions on tools/list. They are inert for encoding/json.
-type SubRequest struct {
-	Service string `json:"service" jsonschema:"Cloud service to query (e.g. 'ec2', 'rds', 's3' for AWS; 'compute', 'storage', 'cloudsql' for GCP). Use the singular awsinspect/gcpinspect tool with action='list-actions' to discover supported services."`
-	Action  string `json:"action" jsonschema:"Operation on the service (e.g. 'describe-instances', 'list-buckets', 'list-actions' for discovery, 'list-metrics' / 'get-metrics' for time-series)."`
-	Filters string `json:"filters,omitempty" jsonschema:"Optional JSON-encoded filter object passed through to the underlying API. Examples: '{\"hours\":6}' for metric windows, '{\"days\":7}' for cost queries."`
-}
+// MaxBatchSubs caps the number of sub-probes per batch request. See
+// inspecttypes.MaxBatchSubs for the canonical definition.
+const MaxBatchSubs = inspecttypes.MaxBatchSubs
 
-// SubResult is one probe's outcome. Index pins the result back to the
-// SubRequest at the same index in the original Subs slice — the
-// fan-out dispatcher may complete out of order. OK is true iff Error
-// is empty; Result is set iff OK is true; Error is set iff OK is
-// false. DurationMS captures the per-probe latency in milliseconds
-// and is always emitted (even when zero) for observability.
-type SubResult struct {
-	Index      int    `json:"index"`
-	Service    string `json:"service"`
-	Action     string `json:"action"`
-	OK         bool   `json:"ok"`
-	Result     any    `json:"result,omitempty"`
-	Error      string `json:"error,omitempty"`
-	DurationMS int64  `json:"duration_ms"`
-}
-
-// BatchRequest is the wire envelope for both
-// POST /api/v2/aws/inspect/batch and POST /api/v2/gcp/inspect/batch.
-// SessionID identifies the calling reliable session; the dispatcher
-// resolves it to credentials + project context (via reliable's
-// session DB + Oracle credential broker today, via injected
-// credential-provider interfaces once #276 Item 3 lifts the
-// dispatcher).
-//
-// A single shape covers both clouds because the request shape is
-// cloud-agnostic — the route the request lands on (`/aws/...` vs
-// `/gcp/...`) carries the cloud selection. Reliable's legacy
-// AWSInspectBatchRequest / GCPInspectBatchRequest are
-// structurally-identical types (NOT Go aliases — separate named
-// declarations with the same fields and json tags); collapsing them
-// into a single canonical BatchRequest is part of the #276 cleanup.
-type BatchRequest struct {
-	SessionID string       `json:"session_id"`
-	Subs      []SubRequest `json:"subs"`
-}
-
-// BatchResponse is the wire envelope returned by the same two
-// endpoints. OK is the HTTP-envelope success bit — true iff the
-// dispatcher itself ran to completion (HTTP 200 path). Per-sub
-// success/failure is encoded in Results[i].OK and Results[i].Error,
-// NOT aggregated into this outer OK. This matches the legacy
-// reliable dispatcher semantics
-// (reliable/internal/agentapi/{aws,gcp}_inspect_batch.go:
-// `writeJSON(w, http.StatusOK, ...{OK: true, Results: results})`):
-// a partial-failure batch (some Results[i].OK == false) still
-// returns outer OK == true.
-//
-// Results is index-aligned with the original Subs slice:
-// Results[i].Index == i.
-type BatchResponse struct {
-	OK      bool        `json:"ok"`
-	Results []SubResult `json:"results"`
-}
+// SDK-free wire-envelope types, re-exported from inspecttypes. See that
+// package for the canonical definitions and JSON-tag contract.
+type (
+	// SubRequest is one probe within a batch.
+	SubRequest = inspecttypes.SubRequest
+	// SubResult is one probe's outcome.
+	SubResult = inspecttypes.SubResult
+	// BatchRequest is the wire envelope for the inspect batch endpoints.
+	BatchRequest = inspecttypes.BatchRequest
+	// BatchResponse is the wire envelope returned by the inspect batch endpoints.
+	BatchResponse = inspecttypes.BatchResponse
+)

--- a/pkg/observability/metrics/metricstypes/sdkfree_test.go
+++ b/pkg/observability/metrics/metricstypes/sdkfree_test.go
@@ -1,0 +1,41 @@
+package metricstypes_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// forbiddenSDKImportPrefixes are the heavy cloud-SDK import roots that
+// must never appear in this leaf package's transitive dependency set.
+// The whole point of metricstypes (reliable#2153) is that a proxy
+// consumer can deserialize a MetricsResult without pulling the
+// CloudWatch / Cloud Monitoring clients into its binary; a stray import
+// here silently reintroduces that weight at the consumer. Cite the
+// triggering example in the comment so the next author understands the
+// blast radius: reliable's cmd/api Vercel function is at the 250 MB hard
+// limit and these SDKs are the bulk of it.
+var forbiddenSDKImportPrefixes = []string{
+	"github.com/aws/aws-sdk-go",  // v1 and v2
+	"cloud.google.com/go",        // GCP client libraries
+	"google.golang.org/api",      // GCP discovery / REST clients
+	"google.golang.org/genproto", // dragged in by the GCP clients
+}
+
+// TestMetricsTypesSDKFree fails if any cloud SDK leaks into the leaf
+// package's transitive dependencies. Runs `go list -deps` on the
+// package under test — go is always present in CI.
+func TestMetricsTypesSDKFree(t *testing.T) {
+	t.Parallel()
+	out, err := exec.Command("go", "list", "-deps", ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go list -deps: %v\n%s", err, out)
+	}
+	for _, dep := range strings.Fields(string(out)) {
+		for _, bad := range forbiddenSDKImportPrefixes {
+			if dep == bad || strings.HasPrefix(dep, bad+"/") {
+				t.Errorf("metricstypes must stay SDK-free but transitively imports %q (matched %q)", dep, bad)
+			}
+		}
+	}
+}

--- a/pkg/observability/metrics/metricstypes/sdkfree_test.go
+++ b/pkg/observability/metrics/metricstypes/sdkfree_test.go
@@ -16,10 +16,11 @@ import (
 // blast radius: reliable's cmd/api Vercel function is at the 250 MB hard
 // limit and these SDKs are the bulk of it.
 var forbiddenSDKImportPrefixes = []string{
-	"github.com/aws/aws-sdk-go",  // v1 and v2
-	"cloud.google.com/go",        // GCP client libraries
-	"google.golang.org/api",      // GCP discovery / REST clients
-	"google.golang.org/genproto", // dragged in by the GCP clients
+	"github.com/aws/aws-sdk-go",    // SDK v1
+	"github.com/aws/aws-sdk-go-v2", // SDK v2 — this repo's only AWS SDK; the "-v2" suffix is NOT matched by the v1 prefix (a bare HasPrefix(dep, "aws-sdk-go"+"/") never fires on "aws-sdk-go-v2/...").
+	"cloud.google.com/go",          // GCP client libraries
+	"google.golang.org/api",        // GCP discovery / REST clients
+	"google.golang.org/genproto",   // dragged in by the GCP clients
 }
 
 // TestMetricsTypesSDKFree fails if any cloud SDK leaks into the leaf
@@ -27,7 +28,7 @@ var forbiddenSDKImportPrefixes = []string{
 // package under test — go is always present in CI.
 func TestMetricsTypesSDKFree(t *testing.T) {
 	t.Parallel()
-	out, err := exec.Command("go", "list", "-deps", ".").CombinedOutput()
+	out, err := exec.Command("go", "list", "-deps", ".").Output()
 	if err != nil {
 		t.Fatalf("go list -deps: %v\n%s", err, out)
 	}

--- a/pkg/observability/metrics/metricstypes/types.go
+++ b/pkg/observability/metrics/metricstypes/types.go
@@ -1,0 +1,93 @@
+// Package metricstypes holds the SDK-free result/data types for the
+// get-metrics path. It is a leaf package with ZERO cloud-SDK imports
+// (no aws-sdk-go-v2/*, no cloud.google.com/go/*) so a consumer that
+// only needs to *deserialize* a MetricsResult — e.g. luthersystems/
+// reliable's thin proxy after the observability reads moved into
+// ui-core (reliable#2153) — can do so without dragging the CloudWatch
+// / Cloud Monitoring clients into its binary.
+//
+// The parent pkg/observability/metrics package re-exports every type
+// here as a Go type alias, so existing callers of metrics.MetricsResult
+// etc. are unaffected and the wire shape is byte-for-byte identical.
+//
+// JSON tags below are bit-for-bit identical to the InsideOut backend's
+// original definitions so the wire shape returned to InsideOut / Oracle
+// frontends is preserved across the migration window. Do NOT change a
+// field name or json tag without a coordinated wire-breaking rollout
+// across reliable + ui-core.
+package metricstypes
+
+// MetricsFilter controls the time range and granularity of metric
+// queries. Defaults (Hours=6, Period=300) are applied by
+// metrics.ParseMetricsFilter; the public Fetch entry point assumes the
+// caller has already set them.
+type MetricsFilter struct {
+	Hours  int `json:"hours"`  // lookback window (default: 6)
+	Period int `json:"period"` // aggregation period in seconds (default: 300)
+
+	// AccountID is the caller's AWS account ID. It's the dimension VALUE
+	// for groups whose AWSObs.DimensionValueAccountID is set — today only
+	// the AOSS OCU group (AWS/AOSS publishes account-level OCU under a
+	// ClientId=<account-id> dimension, #778). The inspector that resolves
+	// the credential already knows the account (sts.GetCallerIdentity at
+	// dispatch); it rides here so Fetch need not make its own STS call.
+	// Empty for callers fetching only account-keyed-free services; the
+	// query builder then skips any account-keyed group rather than
+	// emitting an empty-value query.
+	AccountID string `json:"account_id,omitempty"`
+}
+
+// MetricsResult is the top-level response for a get-metrics action.
+type MetricsResult struct {
+	Service   string            `json:"service"`
+	TimeRange string            `json:"time_range"`
+	Period    int               `json:"period_seconds"`
+	Resources []ResourceMetrics `json:"resources"`
+}
+
+// ResourceMetrics holds metrics for a single resource (e.g. one EC2
+// instance).
+type ResourceMetrics struct {
+	ResourceID string         `json:"resource_id"`
+	Metrics    []MetricSeries `json:"metrics"`
+}
+
+// MetricSeries holds the data for a single metric.
+//
+// The JSON shape ("name", "unit", "datapoints") is preserved unchanged
+// for AWS; "labels" is the GCP-side breakdown surface. AWS callers
+// leave Labels nil and Unit string; GCP callers leave Unit empty and
+// populate Labels for breakdown metrics (e.g. cloudfunctions
+// execution_count by status=ok/error). Both shapes co-exist on the
+// wire with omitempty.
+type MetricSeries struct {
+	Name       string            `json:"name"`
+	Unit       string            `json:"unit,omitempty"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	Datapoints []Datapoint       `json:"datapoints"`
+}
+
+// Datapoint is a single metric value at a point in time. The field name
+// "Average" is a historical accident — the CloudWatch Stat (Average /
+// Sum / Maximum) is chosen per-metric in the spec table; this field
+// carries whichever statistic was requested. Renaming is a
+// downstream-API breaking change deferred indefinitely.
+type Datapoint struct {
+	Timestamp string  `json:"timestamp"`
+	Average   float64 `json:"average"`
+}
+
+// ResourceID is a resource identifier for the metric-fetch path. The
+// CloudWatch dimension name (e.g. "InstanceId", "DBInstanceIdentifier")
+// is carried alongside the value so a single Fetch call can serve a
+// service whose dimension name is service-fixed but whose dimension
+// values are caller-supplied.
+//
+// In practice every resource passed to a single Fetch invocation
+// shares the same DimensionName (the one declared on the AWSObs spec).
+// The struct keeps the pair colocated so callers don't have to thread
+// a parallel string through.
+type ResourceID struct {
+	ID            string
+	DimensionName string
+}

--- a/pkg/observability/metrics/types.go
+++ b/pkg/observability/metrics/types.go
@@ -1,93 +1,38 @@
-// Package metrics is the CloudWatch metric-fetch wrapper ported from
-// The InsideOut backend's internal/agentapi/aws_metrics.go. Per-service resource
-// discovery (DescribeInstances, ListFunctions, etc.) is intentionally
-// NOT included here — that surface lands in C14 alongside the AWS
-// inspector port. This package handles the slice of the pipeline that
-// runs after callers have already produced a list of resource IDs:
-// build CloudWatch GetMetricDataQuery slices, hand them to the
-// CloudWatch API, normalize the response into MetricsResult.
+// Package metrics is the CloudWatch / Cloud Monitoring metric-fetch
+// wrapper ported from the InsideOut backend's metric paths. Per-service
+// resource discovery (DescribeInstances, ListFunctions, etc.) is
+// intentionally NOT included here — that surface lives in
+// pkg/observability/discovery. This package handles the slice of the
+// pipeline that runs after callers have already produced a list of
+// resource IDs: build CloudWatch GetMetricDataQuery slices, hand them to
+// the CloudWatch / Monitoring API, normalize the response into
+// MetricsResult.
 //
-// JSON tags on every type below are bit-for-bit identical to the InsideOut backend's
-// so the wire shape returned to InsideOut/Oracle frontends is preserved
-// across the migration window.
+// The result/data TYPES (MetricsResult, ResourceMetrics, MetricSeries,
+// Datapoint, MetricsFilter, ResourceID) moved into the SDK-free leaf
+// package pkg/observability/metrics/metricstypes (reliable#2153) so a
+// proxy consumer can deserialize a MetricsResult without importing the
+// CloudWatch / Cloud Monitoring clients. The aliases below preserve the
+// `metrics.MetricsResult` spelling for every existing in-tree caller —
+// a Go type alias is identical to the aliased type, so signatures like
+// Fetch(...) (MetricsResult, error) keep their exact shape.
 package metrics
 
-// MetricsFilter controls the time range and granularity of metric
-// queries. Mirrors the InsideOut backend's MetricsFilter (aws_metrics.go:67).
-// Defaults (Hours=6, Period=300) are applied by ParseMetricsFilter; the
-// public Fetch entry point assumes the caller has already set them.
-type MetricsFilter struct {
-	Hours  int `json:"hours"`  // lookback window (default: 6)
-	Period int `json:"period"` // aggregation period in seconds (default: 300)
+import "github.com/luthersystems/insideout-terraform-presets/pkg/observability/metrics/metricstypes"
 
-	// AccountID is the caller's AWS account ID. It's the dimension VALUE
-	// for groups whose AWSObs.DimensionValueAccountID is set — today only
-	// the AOSS OCU group (AWS/AOSS publishes account-level OCU under a
-	// ClientId=<account-id> dimension, #778). The inspector that resolves
-	// the credential already knows the account (sts.GetCallerIdentity at
-	// dispatch); it rides here so Fetch need not make its own STS call.
-	// Empty for callers fetching only account-keyed-free services; the
-	// query builder then skips any account-keyed group rather than
-	// emitting an empty-value query.
-	AccountID string `json:"account_id,omitempty"`
-}
-
-// MetricsResult is the top-level response for a get-metrics action.
-// Mirrors the InsideOut backend's MetricsResult (aws_metrics.go:74).
-type MetricsResult struct {
-	Service   string            `json:"service"`
-	TimeRange string            `json:"time_range"`
-	Period    int               `json:"period_seconds"`
-	Resources []ResourceMetrics `json:"resources"`
-}
-
-// ResourceMetrics holds metrics for a single resource (e.g. one EC2
-// instance). Mirrors the InsideOut backend's ResourceMetrics (aws_metrics.go:81).
-type ResourceMetrics struct {
-	ResourceID string         `json:"resource_id"`
-	Metrics    []MetricSeries `json:"metrics"`
-}
-
-// MetricSeries holds the data for a single metric.
-//
-// Renamed from the InsideOut backend's MetricResult (aws_metrics.go:88) to disambiguate
-// from MetricsResult and from the Go convention that *Result implies a
-// type returned at the top of an API call. The JSON shape ("name",
-// "unit", "datapoints") is preserved unchanged for AWS; "labels" is
-// the GCP-side breakdown surface ported from the InsideOut backend's GCPMetricResult
-// (gcp_metrics.go:98). AWS callers leave Labels nil and Unit string;
-// GCP callers leave Unit empty and populate Labels for breakdown
-// metrics (e.g. cloudfunctions execution_count by status=ok/error).
-// Both shapes co-exist on the wire with omitempty.
-type MetricSeries struct {
-	Name       string            `json:"name"`
-	Unit       string            `json:"unit,omitempty"`
-	Labels     map[string]string `json:"labels,omitempty"`
-	Datapoints []Datapoint       `json:"datapoints"`
-}
-
-// Datapoint is a single metric value at a point in time. Mirrors
-// The InsideOut backend's Datapoint (aws_metrics.go:95). The field name "Average"
-// is a historical accident — the CloudWatch Stat (Average / Sum /
-// Maximum) is chosen per-metric in the spec table; this field carries
-// whichever statistic was requested. Renaming is a downstream-API
-// breaking change deferred indefinitely.
-type Datapoint struct {
-	Timestamp string  `json:"timestamp"`
-	Average   float64 `json:"average"`
-}
-
-// ResourceID is a resource identifier for the metric-fetch path. The
-// CloudWatch dimension name (e.g. "InstanceId", "DBInstanceIdentifier")
-// is carried alongside the value so a single Fetch call can serve a
-// service whose dimension name is service-fixed but whose dimension
-// values are caller-supplied.
-//
-// In practice every resource passed to a single Fetch invocation
-// shares the same DimensionName (the one declared on the AWSObs spec).
-// The struct keeps the pair colocated so callers don't have to thread
-// a parallel string through.
-type ResourceID struct {
-	ID            string
-	DimensionName string
-}
+// SDK-free result/data types, re-exported from metricstypes. See that
+// package for the canonical definitions and JSON-tag contract.
+type (
+	// MetricsFilter controls the time range and granularity of metric queries.
+	MetricsFilter = metricstypes.MetricsFilter
+	// MetricsResult is the top-level response for a get-metrics action.
+	MetricsResult = metricstypes.MetricsResult
+	// ResourceMetrics holds metrics for a single resource.
+	ResourceMetrics = metricstypes.ResourceMetrics
+	// MetricSeries holds the data for a single metric.
+	MetricSeries = metricstypes.MetricSeries
+	// Datapoint is a single metric value at a point in time.
+	Datapoint = metricstypes.Datapoint
+	// ResourceID is a resource identifier for the metric-fetch path.
+	ResourceID = metricstypes.ResourceID
+)


### PR DESCRIPTION
Consolidated PR — supersedes and folds in all other open presets PRs so a single PR resolves the lot. Merge commits preserve original authorship.

## Folded-in PRs
- #822 — feat(imported): ConfigReadback on ComponentMetricsBinding (reliable#1479) — @sam-at-luther
- #823 — chore(deps): bump actions/checkout 6.0.3 → 7.0.0 — dependabot

---

## 1. SDK-free leaf type packages (reliable#2153, anchor #2 of #2141)

Prerequisite for letting reliable become a thin proxy that deserializes ui-core's responses without importing the AWS/GCP SDK service packages (reliable's `cmd/api` is at the 250 MB Vercel limit).

- `pkg/observability/metrics/metricstypes` (new): `MetricsResult`, `ResourceMetrics`, `MetricSeries`, `Datapoint`, `MetricsFilter`, `ResourceID`.
- `pkg/observability/inspect/inspecttypes` (new): `SubRequest`, `SubResult`, `BatchRequest`, `BatchResponse`, `MaxBatchSubs`.
- Parent `metrics` / `inspect` packages re-export every type as a Go type alias — all in-tree callers and the wire shape unchanged.
- Exported `observability.AWSObsForService` / `GCPObsForService` accessors so the ui-core metrics handler resolves a service to its catalog group without re-walking the registry.
- Each leaf package ships a `go list -deps` poka-yoke that fails if any `aws-sdk-go` / `aws-sdk-go-v2` / `cloud.google.com/go` / `google.golang.org/api` dep leaks back in. (Review fix: the guard now matches `aws-sdk-go-v2`, the repo's only AWS SDK — the bare `aws-sdk-go` prefix didn't.)

## 2. ConfigReadback on ComponentMetricsBinding (from #822)

Optional `ConfigReadback` descriptor on `ComponentMetricsBinding` (+ `imported.ConfigReadback` alias), seeded for `aws_s3_bucket` / `google_storage_bucket` (per-bucket versioning overlay), preserving the cloud-specific envelope/attr casing. Moves the per-type readback vocabulary out of reliable's `imported_metrics.go`. Pinned by `TestSeed_ConfigReadback`.

## 3. actions/checkout v7 (from #823)

Bumps `actions/checkout` 6.0.3 → 7.0.0 in `.github/workflows/terraform-validate.yml`.

## Tests
`go build ./...`, `go vet ./pkg/...`, and `go test ./pkg/imported/... ./pkg/observability/...` all pass.

Refs: reliable#2153 (anchor #2), reliable#2141, reliable#1479, reliable#1722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)