### PR TITLE
fix(reverseimport): dedupe imported resources by address (Duplicate import configuration)

### DIFF
--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -109,6 +109,23 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 	// the plain `aws.imported` alias (byte-identical to prior output).
 	awsRegions := ImportedAWSRegions(irs)
 
+	// Dedup by Terraform address. Two IRs that share an Address are the
+	// same logical resource — GenerateAddress's `_<8hex>` collision suffix
+	// is a slice of identityHash (Cloud|AccountID|ProjectID|Region|Location|
+	// Type|ImportID|ProviderIdentity), so an identical suffixed address
+	// implies an identical identity tuple. Emitting both would write two
+	// `import { to = <addr> }` blocks (and two `resource` blocks) for one
+	// address, which Terraform rejects with
+	//   Error: Duplicate import configuration for "<addr>"
+	// — the prod reverse-import failure in sess_v2_Jok8JjJhzJER, where the
+	// same aws_iam_role_policy_attachment (AdministratorAccess on
+	// platform-test-admin) reached the emitter twice after the
+	// closure/genconfig/depchase pipeline (whose resourceKey-based dedup
+	// keys on identity, not address). This is the final HCL gate, so it is
+	// the right place to guarantee the invariant regardless of upstream
+	// duplication. First occurrence wins (entries are address-sorted below,
+	// so the choice is deterministic).
+	seenAddr := make(map[string]struct{}, len(irs))
 	var entries []entry
 	for i := range irs {
 		ir := &irs[i]
@@ -127,6 +144,10 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 		if addr == "" {
 			continue
 		}
+		if _, dup := seenAddr[addr]; dup {
+			continue
+		}
+		seenAddr[addr] = struct{}{}
 
 		e := entry{address: addr}
 		switch mode {

--- a/pkg/composer/imported_emit_dupaddr_test.go
+++ b/pkg/composer/imported_emit_dupaddr_test.go
@@ -1,0 +1,65 @@
+package composer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// TestEmitImportedTF_DuplicateAddressDeduped reproduces the prod
+// reverse-import failure (sess_v2_Jok8JjJhzJER):
+//
+//	Error: Duplicate import configuration for
+//	"aws_iam_role_policy_attachment.arn_aws_iam_aws_policy_administratoraccess_1e6a3817"
+//
+// When two ImportedResources carrying the SAME Terraform address reach
+// EmitImportedTF, the emitter must NOT write two `import {}` (and two
+// `resource {}`) blocks for that address — Terraform rejects a second
+// `import { to = <addr> }` for an address already targeted by another
+// import block. Two IRs sharing an Address are, by construction, the same
+// logical resource: GenerateAddress's `_<8hex>` collision suffix is a
+// slice of identityHash, which folds in Cloud/AccountID/Region/Type/
+// ImportID — so an identical suffixed address implies an identical
+// identity tuple. Collapsing to the first occurrence is therefore lossless.
+func TestEmitImportedTF_DuplicateAddressDeduped(t *testing.T) {
+	t.Parallel()
+
+	const addr = "aws_iam_role_policy_attachment.arn_aws_iam_aws_policy_administratoraccess_1e6a3817"
+	mk := func() imported.ImportedResource {
+		return imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_iam_role_policy_attachment",
+				Address:  addr,
+				ImportID: "platform-test-admin/arn:aws:iam::aws:policy/AdministratorAccess",
+				NativeIDs: map[string]string{
+					"role":       "platform-test-admin",
+					"policy_arn": "arn:aws:iam::aws:policy/AdministratorAccess",
+				},
+			},
+			Tier: imported.TierImportedFlat,
+			Attrs: []byte(`{"role":{"literal":"platform-test-admin"},` +
+				`"policy_arn":{"literal":"arn:aws:iam::aws:policy/AdministratorAccess"}}`),
+		}
+	}
+
+	out, used := EmitImportedTF("aws", []imported.ImportedResource{mk(), mk()}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	require.True(t, used["aws"])
+	s := string(out)
+
+	// Exactly one import block and one resource block for the shared address.
+	require.Equalf(t, 1, strings.Count(s, "to = "+addr),
+		"expected a single import block for %s, got duplicates:\n%s", addr, s)
+	require.Equalf(t, 1, strings.Count(s, `resource "aws_iam_role_policy_attachment" "arn_aws_iam_aws_policy_administratoraccess_1e6a3817"`),
+		"expected a single resource block for %s, got duplicates:\n%s", addr, s)
+
+	// And the emitted HCL must parse.
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.False(t, diags.HasErrors(), "imported.tf must parse: %s", diags.Error())
+}

--- a/pkg/reverseimport/dedupe_test.go
+++ b/pkg/reverseimport/dedupe_test.go
@@ -1,0 +1,52 @@
+package reverseimport
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// TestDedupeByAddress is the source-of-truth guard for the prod reverse-import
+// failure (session sess_v2_Jok8JjJhzJER): a duplicate-address resource must be
+// dropped from the canonical set so it appears once in imported.json (the
+// reliable-persisted/counted set) and once in /imported.tf — never producing
+// Terraform's "Duplicate import configuration" error or a phantom UI count.
+func TestDedupeByAddress(t *testing.T) {
+	t.Parallel()
+
+	mk := func(addr, importID string) imported.ImportedResource {
+		return imported.ImportedResource{Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_iam_role_policy_attachment",
+			Address:  addr,
+			ImportID: importID,
+		}}
+	}
+	const dupAddr = "aws_iam_role_policy_attachment.arn_aws_iam_aws_policy_administratoraccess_1e6a3817"
+
+	in := []imported.ImportedResource{
+		mk("aws_iam_role.platform_test_admin", "platform-test-admin"),
+		mk(dupAddr, "platform-test-admin/arn:aws:iam::aws:policy/AdministratorAccess"),
+		mk(dupAddr, "platform-test-admin/arn:aws:iam::aws:policy/AdministratorAccess"),
+	}
+
+	out := dedupeByAddress(in)
+	require.Len(t, out, 2, "duplicate address must collapse to one entry")
+	require.Equal(t, "aws_iam_role.platform_test_admin", out[0].Identity.Address, "first-occurrence order preserved")
+	require.Equal(t, dupAddr, out[1].Identity.Address)
+}
+
+// TestDedupeByAddress_KeepsEmptyAddresses ensures address-less resources (which
+// can't be keyed) are all preserved rather than collapsed onto each other.
+func TestDedupeByAddress_KeepsEmptyAddresses(t *testing.T) {
+	t.Parallel()
+
+	in := []imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Cloud: "aws", ImportID: "a"}},
+		{Identity: imported.ResourceIdentity{Cloud: "aws", ImportID: "b"}},
+	}
+	out := dedupeByAddress(in)
+	require.Len(t, out, 2, "empty-address resources must not collapse")
+}

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -70,7 +70,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	if err != nil {
 		return result, err
 	}
-	resources = closure.resources
+	resources = dedupeByAddress(closure.resources)
 	result.Diagnostics = append(result.Diagnostics, closure.diagnostics...)
 	dependenciesByAddress := closure.dependencies
 	opts.progressf("reverse-import: selection closure complete (%d resource(s))\n", len(resources))
@@ -119,7 +119,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 	// Fold genconfig's own skip manifest (with reason codes) in first, then
 	// safety-net any dropped identity the manifest missed.
 	skips.addOrphanImports(preGenconfigIdentities, gcRes.Skipped)
-	resources = gcRes.Resources
+	resources = dedupeByAddress(gcRes.Resources)
 	opts.progressf("reverse-import: terraform config generated\n")
 
 	if !opts.SkipDriftFix {
@@ -168,7 +168,7 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			return result, fmt.Errorf("depchase: %w", err)
 		}
 		if dcRes != nil {
-			resources = dcRes.Resources
+			resources = dedupeByAddress(dcRes.Resources)
 			appendDepChaseDependencies(dependenciesByAddress, resources, dcRes.Edges)
 		}
 		opts.progressf("reverse-import: dependency chase complete (%d resource(s) total)\n", len(resources))
@@ -583,6 +583,40 @@ func populateArtifacts(result *job.Result, outputDir, generatedPath string, dcRe
 		}
 	}
 	return nil
+}
+
+// dedupeByAddress removes resources that repeat a Terraform address already
+// seen earlier in the slice, preserving first-occurrence order. Two resources
+// sharing an Address are the same logical resource — GenerateAddress's
+// `_<8hex>` collision suffix is a slice of identityHash (Cloud|AccountID|
+// ProjectID|Region|Location|Type|ImportID|ProviderIdentity), so an identical
+// address implies an identical identity tuple — making the drop lossless.
+//
+// This is the single source-of-truth dedupe for the reverse-import resource
+// set: it feeds BOTH imported.json (which reliable persists and counts for the
+// imported-resources UI) and EmitImportedTF (which writes /imported.tf). The
+// upstream closure/depchase dedupe keys on the identity TUPLE (resourceKey),
+// not the rendered address, so a duplicate that survives a pass with a
+// different identity projection but the same address still reaches here. Left
+// unguarded it produces two `import { to = <addr> }` blocks and the Terraform
+// failure "Duplicate import configuration for <addr>" (prod reverse-import of
+// role platform-test-admin, session sess_v2_Jok8JjJhzJER) AND a phantom
+// double-count in the management UI. composer.EmitImportedTF dedupes again as a
+// final HCL gate; this point additionally keeps the persisted/count set clean.
+func dedupeByAddress(resources []imported.ImportedResource) []imported.ImportedResource {
+	seen := make(map[string]struct{}, len(resources))
+	out := resources[:0:0]
+	for _, r := range resources {
+		addr := strings.TrimSpace(r.Identity.Address)
+		if addr != "" {
+			if _, dup := seen[addr]; dup {
+				continue
+			}
+			seen[addr] = struct{}{}
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 func appendDepChaseDependencies(dependenciesByAddress map[string][]imported.ResourceIdentity, resources []imported.ImportedResource, edges []depchase.GraphEdge) {


### PR DESCRIPTION
## Summary

Fixes the prod reverse-import failure in session `sess_v2_Jok8JjJhzJER` (importing role `platform-test-admin`):

```
Error: Duplicate import configuration for
"aws_iam_role_policy_attachment.arn_aws_iam_aws_policy_administratoraccess_1e6a3817"
```

Root cause: two `ImportedResource`s sharing the **same Terraform address** reached the emitter, so `EmitImportedTF` wrote two `import { to = <addr> }` blocks (and two `resource` blocks) for one address — which Terraform rejects. Two IRs with an identical address are by construction the same logical resource: `GenerateAddress`'s `_<8hex>` collision suffix is a slice of `identityHash` (folds in Cloud/AccountID/Region/Type/ImportID), so the duplicate-suffix collision is a true duplicate, not two distinct roles. The upstream closure/depchase dedupe keys on the identity *tuple* (`resourceKey`), not the rendered address, so a same-address duplicate could slip through.

Two layers of fix:

- `pkg/composer/imported_emit.go` — `EmitImportedTF` now dedupes entries by address (final HCL gate; guarantees valid `/imported.tf` for any consumer, including already-persisted dirty rows).
- `pkg/reverseimport/run.go` — dedupe the canonical resource set once at each pipeline-stage boundary (closure → genconfig → depchase). This is the single source-of-truth dedupe: it feeds **both** `imported.json` (which reliable persists and *counts* for the imported-resources UI) and `EmitImportedTF`. Without it, the emit-gate alone would still leave a phantom double-count in the management UI, since the count is sourced from `imported.json`, not the emitted HCL.

First-occurrence wins; the drop is lossless.

## Test plan
- [x] `TestEmitImportedTF_DuplicateAddressDeduped` reproduces the exact prod address against the real emitter (fails before, passes after)
- [x] `TestDedupeByAddress` / `TestDedupeByAddress_KeepsEmptyAddresses` cover the engine-boundary helper
- [x] `go test ./pkg/composer/ -run 'Imported|Compose|Import'` passes (no regressions)
- [x] `go test ./pkg/reverseimport/...` passes
- [x] `go vet` clean on both packages
- [ ] No `.tf` files touched — terraform fmt/validate unaffected

## Notes
- This needs a presets version bump in `reliable`'s `go.mod` to take effect in the apply path and the imported-count UI.
- The existing dirty `sess_v2_Jok8JjJhzJER` row stays double-counted until re-imported; the emit-gate lets its apply succeed regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017ooqjnbBWHzY7VommBQHYJ)_