### PR TITLE
fix(metrics): empty datapoints/resources marshal to [] not null (#255)

### DIFF
--- a/pkg/observability/metrics/aws.go
+++ b/pkg/observability/metrics/aws.go
@@ -148,7 +148,10 @@ func Fetch(
 	startTime := endTime.Add(-time.Duration(hours) * time.Hour)
 	clampedPeriod := max(min(period, 86400), 1)
 
-	var out []ResourceMetrics
+	// Non-nil so an all-skipped loop still marshals Resources to [] not
+	// null (#255 Pattern A — the reliable metrics panel gates on array
+	// shape).
+	out := []ResourceMetrics{}
 	for _, res := range resources {
 		queries := BuildGetMetricDataQueries(groups, res, service, mf.AccountID)
 		series, err := getMetricData(ctx, cw, queries, startTime, endTime, int32(clampedPeriod)) //nolint:gosec // clamped to [1, 86400]
@@ -319,7 +322,9 @@ func getMetricData(
 
 	results := make([]MetricSeries, 0, len(out.MetricDataResults))
 	for _, r := range out.MetricDataResults {
-		series := MetricSeries{Name: aws.ToString(r.Label)}
+		// Datapoints non-nil so an empty metric window marshals to [] not
+		// null (#255 Pattern A).
+		series := MetricSeries{Name: aws.ToString(r.Label), Datapoints: []Datapoint{}}
 		for i, ts := range r.Timestamps {
 			if i >= len(r.Values) {
 				break

--- a/pkg/observability/metrics/aws_test.go
+++ b/pkg/observability/metrics/aws_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -608,6 +609,40 @@ func TestFetch_ZeroResources(t *testing.T) {
 	assert.NotNil(t, result.Resources, "Resources must be non-nil empty slice for JSON wire shape")
 	assert.Empty(t, result.Resources)
 	assert.Equal(t, 0, mock.calls, "no resources → no GetMetricData calls")
+}
+
+// TestFetch_EmptyDatapointsMarshalToArray pins the #255 contract for the
+// metric path: a resource that CloudWatch returns with zero samples in the
+// window must serialize its `datapoints` as [] (not null), since the
+// reliable metrics panel gates on array shape. assert.Empty alone is
+// insufficient — it accepts both nil and [] — so we marshal and compare.
+func TestFetch_EmptyDatapointsMarshalToArray(t *testing.T) {
+	t.Parallel()
+	mock := &fakeCloudWatch{
+		output: &cloudwatch.GetMetricDataOutput{
+			MetricDataResults: []cwtypes.MetricDataResult{
+				// Label present, but no Timestamps/Values: an empty window.
+				{Label: aws.String("CPUUtilization")},
+			},
+		},
+	}
+	c := clientsWithCW(mock)
+	obs := awsSpec(t, composer.KeyAWSEC2)
+	result, err := Fetch(context.Background(), c, "ec2", oneGroup(obs),
+		[]ResourceID{{ID: "i-abc", DimensionName: "InstanceId"}},
+		MetricsFilter{Hours: 6, Period: 300})
+	require.NoError(t, err)
+
+	require.Len(t, result.Resources, 1)
+	require.Len(t, result.Resources[0].Metrics, 1)
+	dp := result.Resources[0].Metrics[0].Datapoints
+	require.NotNil(t, dp, "Datapoints must be a non-nil empty slice")
+	assert.Empty(t, dp)
+
+	// The wire-shape pin: the field marshals to [] not null.
+	b, err := json.Marshal(dp)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
 }
 
 // TestFetch_S3PeriodAndHoursOverride mirrors the InsideOut backend's

--- a/pkg/observability/metrics/gcp.go
+++ b/pkg/observability/metrics/gcp.go
@@ -325,8 +325,9 @@ func shapeGCPSeries(
 		entry, exists := resourceMetrics[resID][key]
 		if !exists {
 			entry = &MetricSeries{
-				Name:   spec.DisplayName,
-				Labels: labels, // nil for non-breakdown metrics; map otherwise.
+				Name:       spec.DisplayName,
+				Labels:     labels,        // nil for non-breakdown metrics; map otherwise.
+				Datapoints: []Datapoint{}, // non-nil so empty windows marshal to [] not null (#255 Pattern A).
 			}
 			resourceMetrics[resID][key] = entry
 		}


### PR DESCRIPTION
Drive-by fix found while testing the ui-core `/observability/metrics` proxy live (reliable#2153): an empty-window S3 bucket came back as `"datapoints": null`.

## Problem
The metric-fetch path emitted JSON `null` for empty slices — the same null-vs-empty-array class as the discovery #255 rule, which the downstream reliable metrics panel gates on:
- AWS: a `MetricSeries` with no samples left `Datapoints` nil; an all-skipped resource loop left `MetricsResult.Resources` nil (`var out []ResourceMetrics`).
- GCP: the per-key `MetricSeries` entry had the same nil-`Datapoints` gap.

## Fix
Construction-site fix (#255 Pattern A — non-nil composite literal):
- `aws.go`: `out := []ResourceMetrics{}`, and each `MetricSeries{… Datapoints: []Datapoint{}}`.
- `gcp.go`: seed the per-key `MetricSeries` entry with `Datapoints: []Datapoint{}` (its result/series slices were already `make()`'d).

## Tests
- `TestFetch_ZeroResources` already pins `Resources` non-nil.
- New `TestFetch_EmptyDatapointsMarshalToArray` pins the datapoints wire shape (`require.NotNil` + `json.Marshal == "[]"`), per the #255 test-contract convention.
- `go test ./pkg/observability/metrics/...` passes.

Refs: #255, reliable#2153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JWHx8xoM3QRzofSVd2bbqS)_