### PR TITLE
feat(observability): metrics DiscoverAndFetch (parity port of reliable getServiceMetrics)

### DIFF
--- a/pkg/observability/metrics/discover_and_fetch.go
+++ b/pkg/observability/metrics/discover_and_fetch.go
@@ -1,0 +1,478 @@
+// discover_and_fetch.go
+//
+// DiscoverAndFetch is the in-process orchestrator that reproduces — byte
+// for byte — the InsideOut backend's getServiceMetrics
+// (internal/agentapi/aws_metrics.go). It is the entry point ui-core
+// calls when its /observability/metrics endpoint receives an empty
+// `resources` list: the caller hands over (service, filters) and this
+// function performs the whole "discover the account's resources for the
+// service, then fetch their CloudWatch series" pipeline that previously
+// lived in reliable.
+//
+// The pieces this file owns are exactly the pieces reliable kept
+// reliable-side after the metric-fetch core moved upstream:
+//
+//   - The orchestration branches (kms/secretsmanager health vs the
+//     CloudWatch catalog; the #2035 resource-scoped fast path; the
+//     discover-then-fetch tail).
+//   - The KMS / Secrets Manager operational-health envelopes — these are
+//     not CloudWatch time-series and the JSON shape is reliable-defined.
+//   - The service-keyed view over upstream's observability.Observability
+//     registry (metricDefinitions).
+//
+// The metric catalog (observability.AWSObs), the CloudWatch fetch
+// (metrics.Fetch), and the per-service discovery (discovery/aws.Inspect,
+// reached via runMetricsDiscovery in discover_and_fetch_discovery.go)
+// already live in this repo — DiscoverAndFetch reuses them. The
+// per-service ID extractors and the KMS/SM readers ported here keep
+// their exact behavior so the wire result is identical to what reliable
+// returned in-process.
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability/filter"
+)
+
+// UnsupportedServiceMetricsError signals "this AWS service has no entry
+// in our metric catalog yet" — a known UX gap, not an AWS operation
+// failure. Surfaced by DiscoverAndFetch when a service is missing from
+// metricDefinitions (e.g. CloudWatch Logs / `logs`). Reliable's call
+// sites converted this into a typed empty-state envelope
+// (`empty_reason=no_metrics_catalog`, `service=<svc>`) so the UI renders
+// clean copy with the resource name instead of the misleading
+// `aws_operation_failed: no metric definitions for service: <svc>`
+// banner the user saw in reliable#1789. ui-core consumers should detect
+// it via AsUnsupportedServiceMetricsError and emit the same envelope.
+//
+// Ported from reliable's unexported unsupportedServiceMetricsError; it is
+// exported here because it crosses the repo boundary (ui-core needs to
+// detect it).
+type UnsupportedServiceMetricsError struct {
+	Service string
+}
+
+func (e *UnsupportedServiceMetricsError) Error() string {
+	return fmt.Sprintf("no metric definitions for service: %s", e.Service)
+}
+
+// AsUnsupportedServiceMetricsError extracts the sentinel from err. Because
+// upstream `observability/inspect/dispatcher.go` wraps inner errors with
+// `%v` (not `%w`) it breaks the error chain, so `errors.As` alone is not
+// sufficient at the wire boundary — we also pattern-match the verbatim
+// error string the dispatcher prefixes with `aws_operation_failed:`. The
+// service name is captured from the trailing `service: <svc>` segment so
+// the caller can populate `Service` on the response envelope without
+// re-parsing.
+//
+// Returns (svc, true) when the error wraps an
+// UnsupportedServiceMetricsError (direct call), or when the error's
+// string matches the upstream-wrapped shape; (zero, false) otherwise.
+// Ported verbatim from reliable's asUnsupportedServiceMetricsError.
+func AsUnsupportedServiceMetricsError(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	var sentinel *UnsupportedServiceMetricsError
+	if errors.As(err, &sentinel) {
+		return sentinel.Service, true
+	}
+	// String-fallback: upstream wraps with `aws_operation_failed: %v`, so
+	// the chain is broken but the message text is stable. Match on the
+	// suffix so the upstream prefix (or any other wrap layer that uses
+	// `%v`) doesn't defeat detection.
+	const marker = "no metric definitions for service: "
+	msg := err.Error()
+	idx := strings.LastIndex(msg, marker)
+	if idx < 0 {
+		return "", false
+	}
+	svc := strings.TrimSpace(msg[idx+len(marker):])
+	// Guard against trailing fragments — the upstream wrap doesn't add
+	// any, but defend in depth so a future wrap that does (e.g.
+	// `... (request id %s)`) cleanly truncates at the first whitespace
+	// rather than capturing the trailing junk as the service name.
+	if cut := strings.IndexAny(svc, " \t\r\n"); cut >= 0 {
+		svc = svc[:cut]
+	}
+	if svc == "" {
+		return "", false
+	}
+	return svc, true
+}
+
+// --- KMS/Secrets Manager operational health types ---
+//
+// JSON tags are identical to reliable's so consumers see the same field
+// names + tag spellings as before the cross-repo move.
+
+// KeyHealthResult holds operational health data for KMS keys.
+type KeyHealthResult struct {
+	Service string          `json:"service"`
+	Note    string          `json:"note"`
+	Keys    []KeyHealthInfo `json:"keys"`
+}
+
+// KeyHealthInfo holds health data for a single KMS key.
+type KeyHealthInfo struct {
+	KeyID           string `json:"key_id"`
+	Alias           string `json:"alias,omitempty"`
+	KeyState        string `json:"key_state"`
+	KeyManager      string `json:"key_manager"`
+	RotationEnabled bool   `json:"rotation_enabled"`
+	CreationDate    string `json:"creation_date,omitempty"`
+	Description     string `json:"description,omitempty"`
+}
+
+// SecretHealthResult holds operational health data for Secrets Manager secrets.
+type SecretHealthResult struct {
+	Service string             `json:"service"`
+	Note    string             `json:"note"`
+	Secrets []SecretHealthInfo `json:"secrets"`
+}
+
+// SecretHealthInfo holds health data for a single secret.
+type SecretHealthInfo struct {
+	Name             string `json:"name"`
+	ARN              string `json:"arn,omitempty"`
+	RotationEnabled  bool   `json:"rotation_enabled"`
+	LastRotatedDate  string `json:"last_rotated_date,omitempty"`
+	LastAccessedDate string `json:"last_accessed_date,omitempty"`
+	NextRotationDate string `json:"next_rotation_date,omitempty"`
+	VersionCount     int    `json:"version_count"`
+	CreatedDate      string `json:"created_date,omitempty"`
+}
+
+func buildSecretsManagerListInput(project string) *secretsmanager.ListSecretsInput {
+	input := &secretsmanager.ListSecretsInput{}
+	if project != "" {
+		input.Filters = []smtypes.Filter{
+			{Key: smtypes.FilterNameStringTypeTagValue, Values: []string{project}},
+		}
+	}
+	return input
+}
+
+// --- Metric Definitions ---
+
+// metricDefinitions maps service names to upstream's AWSObs spec.
+// Reliable kept a service-keyed view because observability.Observability
+// is keyed by composer.ComponentKey; the inspector dispatch path joins on
+// the service tag (obs.Service). The values are pointers into upstream's
+// catalog — single source of truth, no copy. Ported from reliable's
+// metricDefinitions (aws_metrics.go).
+var metricDefinitions = func() map[string]*observability.AWSObs {
+	out := make(map[string]*observability.AWSObs)
+	for _, obs := range observability.Observability {
+		if obs.AWS == nil || obs.Service == "" {
+			continue
+		}
+		if _, seen := out[obs.Service]; seen {
+			continue
+		}
+		out[obs.Service] = obs.AWS
+	}
+	return out
+}()
+
+// --- Main Entry Point ---
+
+// DiscoverAndFetch retrieves CloudWatch metrics (or operational health
+// data) for a service, discovering the account's resources first.
+// Reproduces reliable's getServiceMetrics (aws_metrics.go) behavior
+// exactly: discovery is delegated to runMetricsDiscovery (see
+// discover_and_fetch_discovery.go); the metric fetch itself is delegated
+// to Fetch. KMS and SecretsManager return operational-health envelopes,
+// not CloudWatch time-series.
+//
+// The return value is `any` to mirror reliable: the CloudWatch path holds
+// a MetricsResult (value), the kms path a *KeyHealthResult, the
+// secretsmanager path a *SecretHealthResult.
+//
+// Resource-scoped fast path (reliable#2035): when the filter already
+// names the service's CloudWatch dimension value (e.g.
+// `{"BucketName":"<bucket>"}` for s3, keyed on obs.DimensionName), the
+// resource is already resolved — we query that dimension directly and
+// SKIP account-wide discovery entirely. This is the imported-resource
+// path: an imported S3 bucket lives in the user's pre-existing account
+// and is NOT tagged with our session's project, so the project-tag-scoped
+// runMetricsDiscovery would return zero buckets and the panel would
+// render "no recent samples yet". The managed/designed path passes a
+// project filter (no resource-dimension key), so it keeps going through
+// discovery unchanged.
+func DiscoverAndFetch(ctx context.Context, cfg aws.Config, service, filters string) (any, error) {
+	project := filter.Project(filters)
+
+	switch service {
+	case "kms":
+		return getKMSKeyHealth(ctx, cfg, project)
+	case "secretsmanager":
+		return getSecretHealth(ctx, cfg, project)
+	}
+
+	obs, ok := metricDefinitions[service]
+	if !ok {
+		// Typed sentinel — caller converts to a `no_metrics_catalog`
+		// empty-state envelope so the UI renders clean copy with the
+		// resource name (reliable#1789) instead of the misleading
+		// `aws_operation_failed: ...` banner.
+		return nil, &UnsupportedServiceMetricsError{Service: service}
+	}
+
+	// Resource-scoped fast path: the dimension value is already in the
+	// filter (imported get-metrics, reliable#2035). Skip discovery.
+	if dim := resourceDimensionFromFilter(filters, obs.DimensionName); dim != "" {
+		return fetchServiceMetricsForResources(ctx, cfg, service, obs, []string{dim}, filters)
+	}
+
+	resourceIDs, err := runMetricsDiscovery(ctx, cfg, service, project)
+	if err != nil {
+		return nil, fmt.Errorf("auto-discover failed for %s: %w", service, err)
+	}
+	return fetchServiceMetricsForResources(ctx, cfg, service, obs, resourceIDs, filters)
+}
+
+// clientsFromConfigForFetch is the seam fetchServiceMetricsForResourcesImpl
+// uses to build a *Clients. Defaults to NewClientsFromConfig; tests swap
+// it so the fetch tail runs against a mocked CloudWatch client instead of
+// constructing a real SDK client from cfg.
+var clientsFromConfigForFetch = NewClientsFromConfig
+
+// fetchServiceMetricsForResources is the shared metric-fetch tail: it
+// wraps the given dimension values as ResourceID (all carrying
+// obs.DimensionName) and delegates the CloudWatch query to Fetch, which
+// applies the per-service overrides (S3 daily period + StorageType dims,
+// CloudFront us-east-1 routing). Split out so both the discovery path and
+// the resource-scoped fast path (reliable#2035) share identical fetch
+// semantics.
+//
+// Declared as a seam var so tests can assert which dimension values the
+// resource-scoped fast path forwards, without a real CloudWatch call.
+// Ported from reliable's fetchServiceMetricsForResources.
+var fetchServiceMetricsForResources = fetchServiceMetricsForResourcesImpl
+
+func fetchServiceMetricsForResourcesImpl(ctx context.Context, cfg aws.Config, service string, obs *observability.AWSObs, dimensionValues []string, filters string) (any, error) {
+	resources := make([]ResourceID, 0, len(dimensionValues))
+	for _, id := range dimensionValues {
+		resources = append(resources, ResourceID{ID: id, DimensionName: obs.DimensionName})
+	}
+
+	clients, err := clientsFromConfigForFetch(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("metrics clients: %w", err)
+	}
+
+	mf := ParseMetricsFilter(filters)
+	// presets#778: Fetch takes the full namespace group list; this path
+	// always queries a single component namespace.
+	return Fetch(ctx, clients, service, []*observability.AWSObs{obs}, resources, mf)
+}
+
+// resourceDimensionFromFilter returns the resource's CloudWatch
+// dimension value when the filter explicitly names it under dimensionName
+// (e.g. `{"BucketName":"my-bucket"}` for s3) — the shape the imported
+// get-metrics path produces from a binding's DimensionKey (reliable#2035).
+// Returns "" when the key is absent, empty, non-string, or the filter is
+// not a JSON object, in which case the caller falls back to account-wide
+// discovery. dimensionName=="" (a service with no dimension) never
+// matches. Ported verbatim from reliable.
+func resourceDimensionFromFilter(filters, dimensionName string) string {
+	if filters == "" || dimensionName == "" {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(filters), &m); err != nil {
+		return ""
+	}
+	if v, ok := m[dimensionName].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
+// --- KMS Key Health ---
+
+// kmsHealthAPI is the subset of the KMS client getKMSKeyHealth invokes.
+// Narrowed to a seam so tests inject a fake without standing up the SDK
+// client (which would try real AWS auth). *kms.Client satisfies it.
+type kmsHealthAPI interface {
+	ListKeys(ctx context.Context, params *kms.ListKeysInput, optFns ...func(*kms.Options)) (*kms.ListKeysOutput, error)
+	ListAliases(ctx context.Context, params *kms.ListAliasesInput, optFns ...func(*kms.Options)) (*kms.ListAliasesOutput, error)
+	DescribeKey(ctx context.Context, params *kms.DescribeKeyInput, optFns ...func(*kms.Options)) (*kms.DescribeKeyOutput, error)
+	ListResourceTags(ctx context.Context, params *kms.ListResourceTagsInput, optFns ...func(*kms.Options)) (*kms.ListResourceTagsOutput, error)
+	GetKeyRotationStatus(ctx context.Context, params *kms.GetKeyRotationStatusInput, optFns ...func(*kms.Options)) (*kms.GetKeyRotationStatusOutput, error)
+}
+
+// newKMSClient is the seam getKMSKeyHealth uses to obtain its client.
+var newKMSClient = func(cfg aws.Config) kmsHealthAPI { return kms.NewFromConfig(cfg) }
+
+// getKMSKeyHealth reports per-key health (rotation, state, manager, age)
+// for KMS keys scoped to the caller's project. When project=="" (demo
+// sessions) every key is reported — including AWS-managed keys that we
+// cannot tag. When project!="" only customer-managed keys tagged
+// Project=<project> survive; AWS-managed keys are filtered out because
+// they cannot carry our tags. Ported verbatim from reliable's
+// getKMSKeyHealth (reliable#1112 fail-closed behavior preserved).
+func getKMSKeyHealth(ctx context.Context, cfg aws.Config, project string) (*KeyHealthResult, error) {
+	kmsClient := newKMSClient(cfg)
+
+	listOut, err := kmsClient.ListKeys(ctx, &kms.ListKeysInput{})
+	if err != nil {
+		return nil, fmt.Errorf("kms ListKeys: %w", err)
+	}
+
+	aliasOut, err := kmsClient.ListAliases(ctx, &kms.ListAliasesInput{})
+	if err != nil {
+		return nil, fmt.Errorf("kms ListAliases: %w", err)
+	}
+	aliasMap := make(map[string]string)
+	for _, a := range aliasOut.Aliases {
+		if a.TargetKeyId != nil {
+			aliasMap[aws.ToString(a.TargetKeyId)] = aws.ToString(a.AliasName)
+		}
+	}
+
+	var keys []KeyHealthInfo
+	for _, key := range listOut.Keys {
+		keyID := aws.ToString(key.KeyId)
+
+		descOut, descErr := kmsClient.DescribeKey(ctx, &kms.DescribeKeyInput{KeyId: key.KeyId})
+		if descErr != nil {
+			log.Printf("[kms DescribeKey] skip key=%s: %v", keyID, descErr)
+			continue
+		}
+		meta := descOut.KeyMetadata
+		if meta == nil {
+			continue
+		}
+
+		// Project-tag gate. Customer-managed keys check their tags;
+		// aws-managed keys short-circuit to "not ours" — they can't
+		// carry our Project tag. For demo sessions (project==""), keep
+		// everything including aws-managed keys for visibility.
+		if project != "" {
+			if meta.KeyManager != kmstypes.KeyManagerTypeCustomer {
+				continue
+			}
+			tagsOut, tagErr := kmsClient.ListResourceTags(ctx, &kms.ListResourceTagsInput{KeyId: key.KeyId})
+			if tagErr != nil {
+				log.Printf("[kms ListResourceTags] skip key=%s: %v", keyID, tagErr)
+				continue
+			}
+			if !hasProjectTagKMS(tagsOut.Tags, project) {
+				continue
+			}
+		}
+
+		info := KeyHealthInfo{
+			KeyID:       keyID,
+			Alias:       aliasMap[keyID],
+			KeyState:    string(meta.KeyState),
+			KeyManager:  string(meta.KeyManager),
+			Description: aws.ToString(meta.Description),
+		}
+		if meta.CreationDate != nil {
+			info.CreationDate = meta.CreationDate.Format(time.RFC3339)
+		}
+		if meta.KeyManager == kmstypes.KeyManagerTypeCustomer {
+			rotOut, rotErr := kmsClient.GetKeyRotationStatus(ctx, &kms.GetKeyRotationStatusInput{KeyId: key.KeyId})
+			if rotErr == nil {
+				info.RotationEnabled = rotOut.KeyRotationEnabled
+			}
+		}
+		keys = append(keys, info)
+	}
+
+	return &KeyHealthResult{
+		Service: "kms",
+		Note:    "Key health: rotation status, key state, creation date. Use list-keys/list-aliases for full metadata.",
+		Keys:    keys,
+	}, nil
+}
+
+// hasProjectTagKMS checks a KMS tag slice for Project=<project>. KMS is
+// the outlier — the SDK field names are TagKey/TagValue, not the Key/Value
+// pattern every other service uses.
+func hasProjectTagKMS(tags []kmstypes.Tag, project string) bool {
+	for _, t := range tags {
+		if aws.ToString(t.TagKey) == "Project" && aws.ToString(t.TagValue) == project {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Secrets Manager Secret Health ---
+
+// smHealthAPI is the subset of the Secrets Manager client getSecretHealth
+// invokes. Seam for test injection; *secretsmanager.Client satisfies it.
+type smHealthAPI interface {
+	ListSecrets(ctx context.Context, params *secretsmanager.ListSecretsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error)
+	ListSecretVersionIds(ctx context.Context, params *secretsmanager.ListSecretVersionIdsInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretVersionIdsOutput, error)
+}
+
+// newSecretsManagerClient is the seam getSecretHealth uses to obtain its
+// client.
+var newSecretsManagerClient = func(cfg aws.Config) smHealthAPI { return secretsmanager.NewFromConfig(cfg) }
+
+// getSecretHealth reports per-secret operational health scoped to the
+// caller's project. Ported verbatim from reliable's getSecretHealth.
+func getSecretHealth(ctx context.Context, cfg aws.Config, project string) (*SecretHealthResult, error) {
+	smClient := newSecretsManagerClient(cfg)
+
+	listOut, err := smClient.ListSecrets(ctx, buildSecretsManagerListInput(project))
+	if err != nil {
+		return nil, fmt.Errorf("list secrets: %w", err)
+	}
+
+	var secrets []SecretHealthInfo
+	for _, s := range listOut.SecretList {
+		info := SecretHealthInfo{
+			Name:            aws.ToString(s.Name),
+			ARN:             aws.ToString(s.ARN),
+			RotationEnabled: aws.ToBool(s.RotationEnabled),
+		}
+		if s.LastRotatedDate != nil {
+			info.LastRotatedDate = s.LastRotatedDate.Format(time.RFC3339)
+		}
+		if s.LastAccessedDate != nil {
+			info.LastAccessedDate = s.LastAccessedDate.Format(time.RFC3339)
+		}
+		if s.NextRotationDate != nil {
+			info.NextRotationDate = s.NextRotationDate.Format(time.RFC3339)
+		}
+		if s.CreatedDate != nil {
+			info.CreatedDate = s.CreatedDate.Format(time.RFC3339)
+		}
+
+		// Get version count
+		versOut, versErr := smClient.ListSecretVersionIds(ctx, &secretsmanager.ListSecretVersionIdsInput{
+			SecretId: s.ARN,
+		})
+		if versErr == nil && versOut.Versions != nil {
+			info.VersionCount = len(versOut.Versions)
+		}
+
+		secrets = append(secrets, info)
+	}
+
+	return &SecretHealthResult{
+		Service: "secretsmanager",
+		Note:    "Secret health: rotation status, last accessed/rotated dates. Use list-secrets for full metadata.",
+		Secrets: secrets,
+	}, nil
+}

--- a/pkg/observability/metrics/discover_and_fetch_discovery.go
+++ b/pkg/observability/metrics/discover_and_fetch_discovery.go
@@ -1,0 +1,509 @@
+// discover_and_fetch_discovery.go
+//
+// Per-service ID extraction for the DiscoverAndFetch path. Ported from
+// reliable's internal/agentapi/aws_metrics_discovery.go. Every
+// service-specific SDK call + project-tag filter pair lives upstream in
+// pkg/observability/discovery/aws; this file contributes only the
+// CloudWatch-dimension ID shape: each upstream discovery action returns a
+// typed slice (or, for the few services that delegate to filter.Match, a
+// []map[string]any), and the extractor walks the shape pulling out the
+// field that CloudWatch keys on.
+//
+// Special cases consolidated here:
+//
+//   - ALB: the CloudWatch dimension value is the ARN suffix
+//     ("app/<name>/<hash>"), not the full ARN.
+//   - SQS: the dimension is the queue name (last URL segment), not the
+//     full queue URL.
+//   - EC2: only running instances participate in metrics. Stopped /
+//     terminated instances either have no metrics or stale data we don't
+//     want to chart.
+//   - Bedrock: no project-scoped model enumeration is possible
+//     (foundation models are account-wide); the extractor returns nil to
+//     keep the panel empty without erroring.
+//   - VPC: AWS/NATGateway is the metric namespace, so we extract NAT
+//     gateway IDs from the describe-nat-gateways result, not VPC IDs.
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	apigatewayv2types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
+	cloudfronttypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	cwlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	cognitoidptypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
+
+	awsdiscovery "github.com/luthersystems/insideout-terraform-presets/pkg/observability/discovery/aws"
+)
+
+// metricsDiscoverySpec pairs a service with the upstream discovery
+// action whose result feeds metric ID extraction. Each spec's Extract
+// hands back the CloudWatch dimension values for that service.
+type metricsDiscoverySpec struct {
+	// Action is the upstream awsdiscovery.Inspect action name (e.g.
+	// "describe-instances", "list-functions"). Selected to be the
+	// cheapest call that returns the field CloudWatch keys on.
+	Action string
+
+	// Extract walks the upstream result and returns the CloudWatch
+	// dimension values. Returns nil for an empty result. Must accept
+	// both the typed-slice shape (project=="" branch) and the
+	// []map[string]any shape (project!="" branch routed through
+	// filter.Match) where applicable — RDS, MSK, APIGateway, OpenSearch.
+	Extract func(any) []string
+}
+
+// metricsDiscoveryActions maps service tag → discovery spec. Keep in
+// sync with metricDefinitions (the metric-spec catalog) — every key
+// here must have an entry there, and vice versa, except for KMS and
+// SecretsManager which take the operational-health path instead of
+// CloudWatch.
+var metricsDiscoveryActions = map[string]metricsDiscoverySpec{
+	"ec2": {
+		Action:  "describe-instances",
+		Extract: extractEC2RunningInstanceIDs,
+	},
+	"lambda": {
+		Action:  "list-functions",
+		Extract: extractLambdaFunctionNames,
+	},
+	"alb": {
+		Action:  "describe-load-balancers",
+		Extract: extractALBDimensionIDs,
+	},
+	"rds": {
+		Action:  "describe-db-instances",
+		Extract: extractRDSInstanceIdentifiers,
+	},
+	"cloudfront": {
+		Action:  "list-distributions",
+		Extract: extractCloudFrontDistributionIDs,
+	},
+	"apigateway": {
+		Action:  "get-apis",
+		Extract: extractAPIGatewayIDs,
+	},
+	"vpc": {
+		Action:  "describe-nat-gateways",
+		Extract: extractNATGatewayIDs,
+	},
+	"s3": {
+		Action:  "list-buckets",
+		Extract: extractS3BucketNames,
+	},
+	"sqs": {
+		Action:  "list-queues",
+		Extract: extractSQSQueueNames,
+	},
+	"dynamodb": {
+		Action:  "list-tables",
+		Extract: extractStringSlice,
+	},
+	"cloudwatchlogs": {
+		Action:  "describe-log-groups",
+		Extract: extractCloudWatchLogGroupNames,
+	},
+	"cognito": {
+		Action:  "list-user-pools",
+		Extract: extractCognitoUserPoolIDs,
+	},
+	"opensearch": {
+		Action:  "describe-domains",
+		Extract: extractOpenSearchDomainNames,
+	},
+	"bedrock": {
+		Action:  "list-knowledge-bases",
+		Extract: extractBedrockNoMetrics,
+	},
+	"eks": {
+		Action:  "list-clusters",
+		Extract: extractStringSlice,
+	},
+	"elasticache": {
+		Action:  "describe-cache-clusters",
+		Extract: extractElastiCacheClusterIDs,
+	},
+	"msk": {
+		Action:  "list-clusters",
+		Extract: extractMSKClusterARNs,
+	},
+	"waf": {
+		Action:  "list-web-acls",
+		Extract: extractWAFWebACLIDs,
+	},
+	"ecs": {
+		Action:  "list-clusters",
+		Extract: extractECSClusterNames,
+	},
+}
+
+// runMetricsDiscovery dispatches to the upstream Inspect for the given
+// service and returns the CloudWatch dimension values. Project filter
+// is encoded as JSON `{"project":"<p>"}` for upstream's filter.Project
+// reader. Empty project means session-wide (demo); upstream skips the
+// project tag check on empty.
+//
+// Declared as a seam var so tests can assert the resource-scoped fast
+// path (reliable#2035) bypasses account-wide discovery without a real AWS
+// round trip. Ported from reliable's runMetricsDiscovery.
+var runMetricsDiscovery = runMetricsDiscoveryImpl
+
+func runMetricsDiscoveryImpl(ctx context.Context, cfg aws.Config, service, project string) ([]string, error) {
+	spec, ok := metricsDiscoveryActions[service]
+	if !ok {
+		return nil, fmt.Errorf("no auto-discovery for service: %s", service)
+	}
+	filters := ""
+	if project != "" {
+		if b, err := json.Marshal(map[string]string{"project": project}); err == nil {
+			filters = string(b)
+		}
+	}
+	raw, err := awsdiscovery.Inspect(ctx, cfg, service, spec.Action, filters)
+	if err != nil {
+		return nil, err
+	}
+	return spec.Extract(raw), nil
+}
+
+// --- Per-service extractors ---
+//
+// Each extractor takes the upstream Inspect result and returns the
+// CloudWatch dimension values. Where upstream may return either a typed
+// slice or a []map[string]any (project-filtered via filter.Match), the
+// extractor handles both with type assertions.
+
+func extractEC2RunningInstanceIDs(raw any) []string {
+	reservations, ok := raw.([]ec2types.Reservation)
+	if !ok {
+		return nil
+	}
+	var ids []string
+	for _, r := range reservations {
+		for _, inst := range r.Instances {
+			if inst.State == nil || inst.State.Name != ec2types.InstanceStateNameRunning {
+				continue
+			}
+			if id := aws.ToString(inst.InstanceId); id != "" {
+				ids = append(ids, id)
+			}
+		}
+	}
+	return ids
+}
+
+func extractLambdaFunctionNames(raw any) []string {
+	fns, ok := raw.([]lambdatypes.FunctionConfiguration)
+	if !ok {
+		return nil
+	}
+	var names []string
+	for _, f := range fns {
+		if name := aws.ToString(f.FunctionName); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func extractALBDimensionIDs(raw any) []string {
+	lbs, ok := raw.([]elbv2types.LoadBalancer)
+	if !ok {
+		return nil
+	}
+	var ids []string
+	for _, lb := range lbs {
+		arn := aws.ToString(lb.LoadBalancerArn)
+		if id := albDimensionFromARN(arn); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// albDimensionFromARN trims an ALB ARN to its CloudWatch dimension
+// suffix. Example:
+//
+//	arn:aws:elasticloadbalancing:us-east-1:123:loadbalancer/app/my-lb/abc
+//	→ app/my-lb/abc
+func albDimensionFromARN(arn string) string {
+	if _, suffix, ok := strings.Cut(arn, "loadbalancer/"); ok {
+		return suffix
+	}
+	return ""
+}
+
+func extractRDSInstanceIdentifiers(raw any) []string {
+	if dbs, ok := raw.([]rdstypes.DBInstance); ok {
+		ids := make([]string, 0, len(dbs))
+		for _, db := range dbs {
+			if id := aws.ToString(db.DBInstanceIdentifier); id != "" {
+				ids = append(ids, id)
+			}
+		}
+		return ids
+	}
+	// project!="" path returns []map[string]any after filter.Match.
+	return extractStringField(raw, "DBInstanceIdentifier")
+}
+
+func extractCloudFrontDistributionIDs(raw any) []string {
+	if dists, ok := raw.([]cloudfronttypes.DistributionSummary); ok {
+		ids := make([]string, 0, len(dists))
+		for _, d := range dists {
+			if id := aws.ToString(d.Id); id != "" {
+				ids = append(ids, id)
+			}
+		}
+		return ids
+	}
+	return extractStringField(raw, "Id")
+}
+
+func extractAPIGatewayIDs(raw any) []string {
+	if apis, ok := raw.([]apigatewayv2types.Api); ok {
+		ids := make([]string, 0, len(apis))
+		for _, a := range apis {
+			if id := aws.ToString(a.ApiId); id != "" {
+				ids = append(ids, id)
+			}
+		}
+		return ids
+	}
+	return extractStringField(raw, "ApiId")
+}
+
+func extractNATGatewayIDs(raw any) []string {
+	gws, ok := raw.([]ec2types.NatGateway)
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(gws))
+	for _, gw := range gws {
+		if id := aws.ToString(gw.NatGatewayId); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func extractS3BucketNames(raw any) []string {
+	buckets, ok := raw.([]s3types.Bucket)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(buckets))
+	for _, b := range buckets {
+		if name := aws.ToString(b.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func extractSQSQueueNames(raw any) []string {
+	urls, ok := raw.([]string)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(urls))
+	for _, u := range urls {
+		if name := sqsQueueNameFromURL(u); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// sqsQueueNameFromURL extracts the queue name from a queue URL.
+// Example: https://sqs.us-east-1.amazonaws.com/123/my-queue → my-queue.
+func sqsQueueNameFromURL(queueURL string) string {
+	idx := strings.LastIndex(queueURL, "/")
+	if idx < 0 || idx == len(queueURL)-1 {
+		return ""
+	}
+	return queueURL[idx+1:]
+}
+
+func extractStringSlice(raw any) []string {
+	if names, ok := raw.([]string); ok {
+		return names
+	}
+	return nil
+}
+
+func extractCloudWatchLogGroupNames(raw any) []string {
+	groups, ok := raw.([]cwlogstypes.LogGroup)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(groups))
+	for _, g := range groups {
+		if name := aws.ToString(g.LogGroupName); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func extractCognitoUserPoolIDs(raw any) []string {
+	pools, ok := raw.([]cognitoidptypes.UserPoolDescriptionType)
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(pools))
+	for _, p := range pools {
+		if id := aws.ToString(p.Id); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+// extractOpenSearchDomainNames handles upstream's union return —
+// describe-domains may yield typed []opensearchtypes.DomainStatus or
+// []map[string]any depending on the project filter path. Both shapes
+// carry "DomainName" / "domain_name" / similar keys.
+func extractOpenSearchDomainNames(raw any) []string {
+	// Try the maps path first since upstream's project-filtered branch
+	// JSON-roundtrips through []map[string]any.
+	if names := extractStringField(raw, "DomainName"); len(names) > 0 {
+		return names
+	}
+	// Typed shape: []opensearchtypes.DomainStatus has DomainName too,
+	// but reflecting on it would pull in another dep — fall through to
+	// extractStringField after one more pass via JSON marshal/unmarshal.
+	return extractStringFieldViaJSON(raw, "DomainName")
+}
+
+// extractBedrockNoMetrics returns nil regardless of the upstream
+// payload — Bedrock CloudWatch metrics are per-foundation-model and
+// foundation models aren't project-scoped. Keeping the empty panel
+// matches the pre-Phase-H discoverer behaviour. See reliable#1017 / #1018.
+func extractBedrockNoMetrics(_ any) []string {
+	return nil
+}
+
+func extractElastiCacheClusterIDs(raw any) []string {
+	clusters, ok := raw.([]elasticachetypes.CacheCluster)
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(clusters))
+	for _, c := range clusters {
+		if id := aws.ToString(c.CacheClusterId); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func extractMSKClusterARNs(raw any) []string {
+	if clusters, ok := raw.([]kafkatypes.Cluster); ok {
+		arns := make([]string, 0, len(clusters))
+		for _, c := range clusters {
+			if arn := aws.ToString(c.ClusterArn); arn != "" {
+				arns = append(arns, arn)
+			}
+		}
+		return arns
+	}
+	return extractStringField(raw, "ClusterArn")
+}
+
+func extractWAFWebACLIDs(raw any) []string {
+	acls, ok := raw.([]wafv2types.WebACLSummary)
+	if !ok {
+		return nil
+	}
+	ids := make([]string, 0, len(acls))
+	for _, a := range acls {
+		if id := aws.ToString(a.Id); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func extractECSClusterNames(raw any) []string {
+	clusters, ok := raw.([]ecstypes.Cluster)
+	if !ok {
+		return nil
+	}
+	names := make([]string, 0, len(clusters))
+	for _, c := range clusters {
+		// AWS/ECS metrics are keyed on ClusterName (short), not ARN.
+		// Walk the ARN suffix when ClusterName is absent on the SDK
+		// response.
+		if name := aws.ToString(c.ClusterName); name != "" {
+			names = append(names, name)
+			continue
+		}
+		arn := aws.ToString(c.ClusterArn)
+		if idx := strings.LastIndex(arn, "/"); idx >= 0 && idx < len(arn)-1 {
+			names = append(names, arn[idx+1:])
+		}
+	}
+	return names
+}
+
+// extractStringField pulls a single string field out of a
+// []map[string]any payload (upstream's filter.Match return shape). Used
+// for the project-filtered branches on RDS / MSK / APIGateway. Returns
+// nil if raw isn't []map[string]any or the field is absent / non-string
+// on every entry.
+func extractStringField(raw any, field string) []string {
+	maps, ok := raw.([]map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(maps))
+	for _, m := range maps {
+		v, present := m[field]
+		if !present {
+			continue
+		}
+		if s, ok := v.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// extractStringFieldViaJSON is a fallback for typed shapes the
+// extractor doesn't statically know about. Marshals raw → JSON →
+// []map[string]any then runs extractStringField. Only used for
+// OpenSearch's typed describe-domains return shape, which carries
+// DomainName under the same key after JSON encoding.
+func extractStringFieldViaJSON(raw any, field string) []string {
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var maps []map[string]any
+	if err := json.Unmarshal(b, &maps); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(maps))
+	for _, m := range maps {
+		if v, ok := m[field]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}

--- a/pkg/observability/metrics/discover_and_fetch_discovery_test.go
+++ b/pkg/observability/metrics/discover_and_fetch_discovery_test.go
@@ -1,0 +1,264 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	apigatewayv2types "github.com/aws/aws-sdk-go-v2/service/apigatewayv2/types"
+	cloudfronttypes "github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
+	cwlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
+	cognitoidptypes "github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	elasticachetypes "github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+	elbv2types "github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2/types"
+	kafkatypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
+	lambdatypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	wafv2types "github.com/aws/aws-sdk-go-v2/service/wafv2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the per-service CloudWatch-dimension extractors that
+// DiscoverAndFetch's auto-discovery path depends on. Reliable did not
+// unit-test these (the extraction was implicitly covered by the
+// discovery/aws Inspect tests + integration tests), but porting the
+// behavior across repos warrants direct coverage of the
+// special-case shape handling (running-only EC2, ALB ARN suffix, SQS
+// URL tail, ECS ClusterName-vs-ARN, Bedrock no-metrics, and the
+// typed-vs-map dual paths).
+
+// TestExtractEC2RunningInstanceIDs_OnlyRunning verifies stopped /
+// terminated instances are excluded — only running instances publish the
+// metrics we chart.
+func TestExtractEC2RunningInstanceIDs_OnlyRunning(t *testing.T) {
+	t.Parallel()
+	raw := []ec2types.Reservation{
+		{Instances: []ec2types.Instance{
+			{InstanceId: aws.String("i-running"), State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning}},
+			{InstanceId: aws.String("i-stopped"), State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameStopped}},
+		}},
+		{Instances: []ec2types.Instance{
+			{InstanceId: aws.String("i-running2"), State: &ec2types.InstanceState{Name: ec2types.InstanceStateNameRunning}},
+			{InstanceId: aws.String("i-nostate")}, // nil State → skipped
+		}},
+	}
+	assert.Equal(t, []string{"i-running", "i-running2"}, extractEC2RunningInstanceIDs(any(raw)))
+
+	// Wrong underlying type → nil (defensive, matches reliable).
+	assert.Nil(t, extractEC2RunningInstanceIDs(any([]string{"x"})))
+}
+
+func TestExtractLambdaFunctionNames(t *testing.T) {
+	t.Parallel()
+	raw := []lambdatypes.FunctionConfiguration{
+		{FunctionName: aws.String("fn-a")},
+		{FunctionName: aws.String("")}, // empty → skipped
+		{FunctionName: aws.String("fn-b")},
+	}
+	assert.Equal(t, []string{"fn-a", "fn-b"}, extractLambdaFunctionNames(any(raw)))
+}
+
+// TestExtractALBDimensionIDs pins the ARN→suffix trim: AWS keys
+// AWS/ApplicationELB on "app/<name>/<hash>", not the full ARN.
+func TestExtractALBDimensionIDs(t *testing.T) {
+	t.Parallel()
+	raw := []elbv2types.LoadBalancer{
+		{LoadBalancerArn: aws.String("arn:aws:elasticloadbalancing:eu-west-2:111:loadbalancer/app/my-lb/abc123")},
+		{LoadBalancerArn: aws.String("not-an-arn")}, // no "loadbalancer/" → skipped
+	}
+	assert.Equal(t, []string{"app/my-lb/abc123"}, extractALBDimensionIDs(any(raw)))
+}
+
+// TestExtractRDSInstanceIdentifiers_BothShapes covers the typed-slice
+// (project=="") path and the []map[string]any (project!="", filter.Match)
+// path.
+func TestExtractRDSInstanceIdentifiers_BothShapes(t *testing.T) {
+	t.Parallel()
+	typed := []rdstypes.DBInstance{{DBInstanceIdentifier: aws.String("db-1")}, {DBInstanceIdentifier: aws.String("db-2")}}
+	assert.Equal(t, []string{"db-1", "db-2"}, extractRDSInstanceIdentifiers(any(typed)))
+
+	maps := []map[string]any{{"DBInstanceIdentifier": "db-3"}, {"OtherField": "x"}, {"DBInstanceIdentifier": "db-4"}}
+	assert.Equal(t, []string{"db-3", "db-4"}, extractRDSInstanceIdentifiers(any(maps)))
+}
+
+func TestExtractCloudFrontDistributionIDs_BothShapes(t *testing.T) {
+	t.Parallel()
+	typed := []cloudfronttypes.DistributionSummary{{Id: aws.String("E123")}}
+	assert.Equal(t, []string{"E123"}, extractCloudFrontDistributionIDs(any(typed)))
+	maps := []map[string]any{{"Id": "E456"}}
+	assert.Equal(t, []string{"E456"}, extractCloudFrontDistributionIDs(any(maps)))
+}
+
+func TestExtractAPIGatewayIDs_BothShapes(t *testing.T) {
+	t.Parallel()
+	typed := []apigatewayv2types.Api{{ApiId: aws.String("api-1")}}
+	assert.Equal(t, []string{"api-1"}, extractAPIGatewayIDs(any(typed)))
+	maps := []map[string]any{{"ApiId": "api-2"}}
+	assert.Equal(t, []string{"api-2"}, extractAPIGatewayIDs(any(maps)))
+}
+
+func TestExtractNATGatewayIDs(t *testing.T) {
+	t.Parallel()
+	raw := []ec2types.NatGateway{{NatGatewayId: aws.String("nat-1")}, {NatGatewayId: aws.String("nat-2")}}
+	assert.Equal(t, []string{"nat-1", "nat-2"}, extractNATGatewayIDs(any(raw)))
+}
+
+func TestExtractS3BucketNames(t *testing.T) {
+	t.Parallel()
+	raw := []s3types.Bucket{{Name: aws.String("bucket-a")}, {Name: aws.String("bucket-b")}}
+	assert.Equal(t, []string{"bucket-a", "bucket-b"}, extractS3BucketNames(any(raw)))
+}
+
+// TestExtractSQSQueueNames pins the URL→name tail extraction (AWS/SQS
+// keys QueueName, not the full URL).
+func TestExtractSQSQueueNames(t *testing.T) {
+	t.Parallel()
+	raw := []string{
+		"https://sqs.eu-west-2.amazonaws.com/111/my-queue",
+		"https://sqs.eu-west-2.amazonaws.com/111/",   // trailing slash → skipped
+		"https://sqs.eu-west-2.amazonaws.com/111/q2", //
+	}
+	assert.Equal(t, []string{"my-queue", "q2"}, extractSQSQueueNames(any(raw)))
+}
+
+func TestExtractStringSlice(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, []string{"t1", "t2"}, extractStringSlice(any([]string{"t1", "t2"})))
+	assert.Nil(t, extractStringSlice(any(123)))
+}
+
+func TestExtractCloudWatchLogGroupNames(t *testing.T) {
+	t.Parallel()
+	raw := []cwlogstypes.LogGroup{{LogGroupName: aws.String("/aws/lambda/fn")}}
+	assert.Equal(t, []string{"/aws/lambda/fn"}, extractCloudWatchLogGroupNames(any(raw)))
+}
+
+func TestExtractCognitoUserPoolIDs(t *testing.T) {
+	t.Parallel()
+	raw := []cognitoidptypes.UserPoolDescriptionType{{Id: aws.String("eu-west-2_ABC")}}
+	assert.Equal(t, []string{"eu-west-2_ABC"}, extractCognitoUserPoolIDs(any(raw)))
+}
+
+// TestExtractOpenSearchDomainNames covers the map path and the
+// typed-via-JSON fallback path.
+func TestExtractOpenSearchDomainNames(t *testing.T) {
+	t.Parallel()
+	maps := []map[string]any{{"DomainName": "search-1"}}
+	assert.Equal(t, []string{"search-1"}, extractOpenSearchDomainNames(any(maps)))
+
+	// A typed shape that JSON-marshals to objects carrying "DomainName".
+	type domainStatus struct {
+		DomainName string `json:"DomainName"`
+	}
+	typed := []domainStatus{{DomainName: "search-2"}}
+	assert.Equal(t, []string{"search-2"}, extractOpenSearchDomainNames(any(typed)))
+}
+
+// TestExtractBedrockNoMetrics always returns nil — Bedrock metrics are
+// per-foundation-model and not project-scoped (reliable#1017/#1018).
+func TestExtractBedrockNoMetrics(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, extractBedrockNoMetrics(any([]string{"anything"})))
+	assert.Nil(t, extractBedrockNoMetrics(nil))
+}
+
+func TestExtractElastiCacheClusterIDs(t *testing.T) {
+	t.Parallel()
+	raw := []elasticachetypes.CacheCluster{{CacheClusterId: aws.String("redis-001")}}
+	assert.Equal(t, []string{"redis-001"}, extractElastiCacheClusterIDs(any(raw)))
+}
+
+func TestExtractMSKClusterARNs_BothShapes(t *testing.T) {
+	t.Parallel()
+	typed := []kafkatypes.Cluster{{ClusterArn: aws.String("arn:aws:kafka:...:cluster/io-kafka/x")}}
+	assert.Equal(t, []string{"arn:aws:kafka:...:cluster/io-kafka/x"}, extractMSKClusterARNs(any(typed)))
+	maps := []map[string]any{{"ClusterArn": "arn:map"}}
+	assert.Equal(t, []string{"arn:map"}, extractMSKClusterARNs(any(maps)))
+}
+
+func TestExtractWAFWebACLIDs(t *testing.T) {
+	t.Parallel()
+	raw := []wafv2types.WebACLSummary{{Id: aws.String("acl-1")}}
+	assert.Equal(t, []string{"acl-1"}, extractWAFWebACLIDs(any(raw)))
+}
+
+// TestExtractECSClusterNames pins the ClusterName-preferred,
+// ARN-suffix-fallback behavior (AWS/ECS keys ClusterName, not ARN).
+func TestExtractECSClusterNames(t *testing.T) {
+	t.Parallel()
+	raw := []ecstypes.Cluster{
+		{ClusterName: aws.String("named-cluster")},
+		{ClusterArn: aws.String("arn:aws:ecs:eu-west-2:111:cluster/arn-only-cluster")}, // ClusterName empty → ARN tail
+	}
+	assert.Equal(t, []string{"named-cluster", "arn-only-cluster"}, extractECSClusterNames(any(raw)))
+}
+
+func TestExtractStringField_NonMapReturnsNil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, extractStringField(any([]string{"x"}), "Field"))
+	assert.Equal(t, []string{"v"}, extractStringField(any([]map[string]any{{"Field": "v"}, {"Field": 5}}), "Field"))
+}
+
+// TestMetricsDiscoveryActions_AllMetricServicesCovered is the reliable
+// drift guard: every service in metricDefinitions must have a discovery
+// action, except the allowlisted services whose upstream inspect handler
+// exposes no list-enumeration action usable to resolve a CloudWatch
+// dimension value. kms / secretsmanager are excluded by construction
+// (operational-health path, not in metricDefinitions).
+//
+// IMPORTANT (parity note): the allowlisted services below have a metric
+// CATALOG entry (observability.AWSObs) but NO account-wide discovery
+// action. DiscoverAndFetch's auto-discovery path therefore errors with
+// "no auto-discovery for service: <svc>" for them — exactly as reliable's
+// getServiceMetrics does today (reliable's metricsDiscoveryActions never
+// covered these). The resource-scoped fast path (#2035) still works since
+// it bypasses discovery. This allowlist can only SHRINK: add a discovery
+// row upstream and delete the entry here.
+func TestMetricsDiscoveryActions_AllMetricServicesCovered(t *testing.T) {
+	t.Parallel()
+	exempt := map[string]bool{
+		// presets#797: sagemaker inspect exposes no endpoint-listing
+		// action, so account-wide discovery of the EndpointName dimension
+		// is impossible. Binding-scoped fast path (#2035) still works.
+		"sagemaker": true,
+		// kendra / agentcore: upstream grew AWS metric specs for these
+		// after reliable's metricsDiscoveryActions was written; their
+		// inspect handlers expose no list action that yields the metric
+		// dimension value, so account-wide discovery is unavailable — same
+		// situation as sagemaker. Auto-discovery errors; fast path works.
+		"kendra":    true,
+		"agentcore": true,
+	}
+	for svc := range metricDefinitions {
+		if exempt[svc] {
+			continue
+		}
+		_, ok := metricsDiscoveryActions[svc]
+		assert.True(t, ok, "service %s has metric definitions but no discovery action", svc)
+	}
+}
+
+// TestMetricDefinitions_KMSAndSMExcluded confirms the catalog view skips
+// kms / secretsmanager (they take the operational-health path), matching
+// reliable.
+func TestMetricDefinitions_KMSAndSMExcluded(t *testing.T) {
+	t.Parallel()
+	_, hasKMS := metricDefinitions["kms"]
+	_, hasSM := metricDefinitions["secretsmanager"]
+	assert.False(t, hasKMS, "kms must not be in metricDefinitions")
+	assert.False(t, hasSM, "secretsmanager must not be in metricDefinitions")
+
+	// And the canonical EC2 service must be present with its AWSObs spec
+	// sourced from the upstream observability registry. (Pointer identity
+	// against a specific component key is intentionally NOT asserted —
+	// several component keys map to Service=="ec2" and map iteration order
+	// picks the first-seen, matching reliable's metricDefinitions build.)
+	ec2Obs, ok := metricDefinitions["ec2"]
+	require.True(t, ok, "ec2 must be in metricDefinitions")
+	require.NotNil(t, ec2Obs)
+	assert.Equal(t, "AWS/EC2", ec2Obs.Namespace)
+	assert.Equal(t, "InstanceId", ec2Obs.DimensionName)
+}

--- a/pkg/observability/metrics/discover_and_fetch_gcp.go
+++ b/pkg/observability/metrics/discover_and_fetch_gcp.go
@@ -1,0 +1,238 @@
+// discover_and_fetch_gcp.go
+//
+// GCP Cloud Monitoring twin of DiscoverAndFetch. Ported from reliable's
+// internal/agentapi/gcp_metrics.go::getGCPServiceMetrics. Unlike AWS,
+// there is no per-service resource discovery on the GCP path: Cloud
+// Monitoring's ListTimeSeries returns every resource in the project that
+// publishes the metric, so the "discover" half is implicit and FetchGCP
+// is called with a nil resource list. The bastion→compute alias and the
+// Secret Manager operational-health envelope are the two reliable-side
+// behaviors ported here; the metric fetch itself is FetchGCP (already in
+// this repo).
+//
+// Required IAM permissions (or predefined roles) on the GCP project:
+//
+//	Monitoring Viewer (roles/monitoring.viewer)
+//	  monitoring.timeSeries.list — all metric services.
+//	Secret Manager Viewer (roles/secretmanager.viewer)
+//	  secretmanager.secrets.list / versions.list — secretmanager health.
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
+)
+
+// GCPSecretHealthResult holds operational health data for Secret Manager secrets.
+type GCPSecretHealthResult struct {
+	Service string                `json:"service"`
+	Note    string                `json:"note"`
+	Secrets []GCPSecretHealthInfo `json:"secrets"`
+}
+
+// GCPSecretHealthInfo holds health data for a single secret.
+type GCPSecretHealthInfo struct {
+	Name            string `json:"name"`
+	VersionCount    int    `json:"version_count"`
+	ReplicationType string `json:"replication_type,omitempty"`
+	CreateTime      string `json:"create_time,omitempty"`
+}
+
+// gcpMetricDefinitions maps service names to upstream's GCPObs spec.
+// Reliable kept a service-keyed view because observability.Observability
+// is keyed by composer.ComponentKey; the inspector dispatch path joins on
+// the service tag (obs.Service). The values are pointers into upstream's
+// catalog — single source of truth, no copy. Ported from reliable's
+// gcpMetricDefinitions.
+var gcpMetricDefinitions = func() map[string]*observability.GCPObs {
+	out := make(map[string]*observability.GCPObs)
+	for _, obs := range observability.Observability {
+		if obs.GCP == nil || obs.Service == "" {
+			continue
+		}
+		if _, seen := out[obs.Service]; seen {
+			continue
+		}
+		out[obs.Service] = obs.GCP
+	}
+	return out
+}()
+
+// newGCPClientsForFetch is the seam DiscoverAndFetchGCP uses to build a
+// *GCPClients. Defaults to NewGCPClients; tests swap it so the fetch tail
+// runs against a mocked Cloud Monitoring client.
+var newGCPClientsForFetch = func(ctx context.Context, projectID string, opts ...option.ClientOption) (*GCPClients, error) {
+	return NewGCPClients(ctx, projectID, opts...)
+}
+
+// DiscoverAndFetchGCP retrieves Cloud Monitoring metrics (or operational
+// health data) for a GCP service. Reproduces reliable's
+// getGCPServiceMetrics (gcp_metrics.go) behavior exactly.
+//
+// projectID scopes the query; filters carries the hours/period window
+// (the project scope on GCP comes from projectID, not the filters tag).
+// opts carry the broker-issued credentials — the same role
+// createGCPClientOption played reliable-side. The return value is `any`
+// to mirror reliable: the Cloud Monitoring path holds a MetricsResult
+// (value), the secretmanager path a *GCPSecretHealthResult.
+//
+// The bastion alias resolves to the compute spec; the GCS daily-period
+// override and label-breakdown grouping are owned by FetchGCP. Secret
+// Manager returns an operational-health envelope, not Cloud Monitoring
+// time-series. Note FetchGCP receives the ORIGINAL service (so the
+// result's Service field and the gcs override key on the caller's
+// service) while obs is the resolved spec — matching reliable.
+func DiscoverAndFetchGCP(ctx context.Context, projectID, service, filters string, opts ...option.ClientOption) (any, error) {
+	if service == "secretmanager" {
+		return getGCPSecretHealth(ctx, projectID, opts...)
+	}
+
+	resolvedService := service
+	if service == "bastion" {
+		resolvedService = "compute"
+	}
+	obs, ok := gcpMetricDefinitions[resolvedService]
+	if !ok {
+		return nil, fmt.Errorf("no metric definitions for GCP service: %s", service)
+	}
+
+	clients, err := newGCPClientsForFetch(ctx, projectID, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("metrics gcp clients: %w", err)
+	}
+	defer func() { _ = clients.Close() }()
+
+	mf := ParseMetricsFilter(filters)
+	return FetchGCP(ctx, clients, service, obs, nil, mf)
+}
+
+// --- Secret Manager Operational Health ---
+
+// gcpSecretIterator / gcpSecretVersionIterator are the minimal Next()
+// surfaces the secret-health reader consumes. The concrete gapic
+// iterators (*secretmanager.SecretIterator, *secretmanager.SecretVersionIterator)
+// satisfy them structurally, so the real adapter returns them directly.
+type gcpSecretIterator interface {
+	Next() (*secretmanagerpb.Secret, error)
+}
+
+type gcpSecretVersionIterator interface {
+	Next() (*secretmanagerpb.SecretVersion, error)
+}
+
+// gcpSecretManagerAPI is the subset of the Secret Manager client
+// getGCPSecretHealth invokes. Seam for test injection; the real
+// *secretmanager.Client is wrapped by realGCPSecretClient.
+type gcpSecretManagerAPI interface {
+	ListSecrets(ctx context.Context, req *secretmanagerpb.ListSecretsRequest) gcpSecretIterator
+	ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest) gcpSecretVersionIterator
+	Close() error
+}
+
+// realGCPSecretClient adapts *secretmanager.Client to gcpSecretManagerAPI.
+// The gapic iterators are returned as-is — they satisfy the narrow
+// iterator interfaces structurally.
+type realGCPSecretClient struct {
+	client *secretmanager.Client
+}
+
+func (r *realGCPSecretClient) ListSecrets(ctx context.Context, req *secretmanagerpb.ListSecretsRequest) gcpSecretIterator {
+	return r.client.ListSecrets(ctx, req)
+}
+
+func (r *realGCPSecretClient) ListSecretVersions(ctx context.Context, req *secretmanagerpb.ListSecretVersionsRequest) gcpSecretVersionIterator {
+	return r.client.ListSecretVersions(ctx, req)
+}
+
+func (r *realGCPSecretClient) Close() error { return r.client.Close() }
+
+// newGCPSecretClient is the seam getGCPSecretHealth uses to obtain its
+// client.
+var newGCPSecretClient = func(ctx context.Context, opts ...option.ClientOption) (gcpSecretManagerAPI, error) {
+	c, err := secretmanager.NewClient(ctx, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &realGCPSecretClient{client: c}, nil
+}
+
+// getGCPSecretHealth returns operational health data for Secret Manager
+// secrets. Ported verbatim from reliable's getGCPSecretHealth (the creds
+// argument is replaced by the option.ClientOption opts the caller
+// supplies, same as the rest of the GCP path).
+func getGCPSecretHealth(ctx context.Context, projectID string, opts ...option.ClientOption) (*GCPSecretHealthResult, error) {
+	client, err := newGCPSecretClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create secret manager client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	it := client.ListSecrets(ctx, &secretmanagerpb.ListSecretsRequest{
+		Parent: fmt.Sprintf("projects/%s", projectID),
+	})
+
+	var secrets []GCPSecretHealthInfo
+	for {
+		s, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("list secrets: %w", err)
+		}
+
+		info := GCPSecretHealthInfo{
+			Name: s.Name,
+		}
+
+		// Replication type
+		if s.Replication != nil {
+			switch s.Replication.Replication.(type) {
+			case *secretmanagerpb.Replication_Automatic_:
+				info.ReplicationType = "automatic"
+			case *secretmanagerpb.Replication_UserManaged_:
+				info.ReplicationType = "user-managed"
+			}
+		}
+
+		// Create time
+		if s.CreateTime != nil {
+			info.CreateTime = s.CreateTime.AsTime().Format(time.RFC3339)
+		}
+
+		// Count versions
+		versIt := client.ListSecretVersions(ctx, &secretmanagerpb.ListSecretVersionsRequest{
+			Parent: s.Name,
+		})
+		versionCount := 0
+		for {
+			_, vErr := versIt.Next()
+			if vErr == iterator.Done {
+				break
+			}
+			if vErr != nil {
+				log.Printf("[gcp-metrics] warning: list versions for %s: %v", s.Name, vErr)
+				break
+			}
+			versionCount++
+		}
+		info.VersionCount = versionCount
+
+		secrets = append(secrets, info)
+	}
+
+	return &GCPSecretHealthResult{
+		Service: "secretmanager",
+		Note:    "Secret health: version count, replication type, create time. Use list-secrets for full metadata.",
+		Secrets: secrets,
+	}, nil
+}

--- a/pkg/observability/metrics/discover_and_fetch_gcp_test.go
+++ b/pkg/observability/metrics/discover_and_fetch_gcp_test.go
@@ -1,0 +1,239 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
+	"cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+)
+
+// =============================================================================
+// DiscoverAndFetchGCP — parity port of reliable's getGCPServiceMetrics
+// tests (internal/agentapi/gcp_metrics_test.go).
+// =============================================================================
+
+// withGCPClients swaps the GCP monitoring-client constructor so
+// DiscoverAndFetchGCP's metric path runs against a mocked Cloud
+// Monitoring client (fakeMonitoring lives in gcp_test.go).
+func withGCPClients(t *testing.T, mon MonitoringAPI) {
+	t.Helper()
+	orig := newGCPClientsForFetch
+	t.Cleanup(func() { newGCPClientsForFetch = orig })
+	newGCPClientsForFetch = func(_ context.Context, projectID string, _ ...option.ClientOption) (*GCPClients, error) {
+		return &GCPClients{ProjectID: projectID, Monitoring: mon}, nil
+	}
+}
+
+// TestDiscoverAndFetchGCP_Compute drives the Cloud Monitoring path end to
+// end with a mocked monitoring client and asserts reliable's MetricsResult
+// wire shape. Cloud Monitoring returns every resource publishing the
+// metric, so there is no per-service discovery — DiscoverAndFetchGCP
+// passes a nil resource list to FetchGCP (parity with reliable).
+func TestDiscoverAndFetchGCP_Compute(t *testing.T) {
+	now := time.Now().UTC()
+	ts1 := timestamppb.New(now.Add(-10 * time.Minute))
+	mon := &fakeMonitoring{
+		responses: map[string][]*monitoringpb.TimeSeries{
+			"cpu/utilization": {
+				{
+					Resource: &monitoredrespb.MonitoredResource{
+						Type:   "gce_instance",
+						Labels: map[string]string{"instance_id": "i-abc123", "zone": "us-central1-a"},
+					},
+					Points: []*monitoringpb.Point{
+						{Interval: &monitoringpb.TimeInterval{EndTime: ts1}, Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{DoubleValue: 0.45}}},
+					},
+				},
+			},
+		},
+	}
+	withGCPClients(t, mon)
+
+	got, err := DiscoverAndFetchGCP(context.Background(), "test-project", "compute", `{"hours":12,"period":600}`)
+	require.NoError(t, err)
+
+	mr, ok := got.(MetricsResult)
+	require.True(t, ok, "Cloud Monitoring path must return a MetricsResult value (reliable parity)")
+	assert.Equal(t, "compute", mr.Service)
+	assert.Equal(t, 600, mr.Period)
+	assert.Contains(t, mr.TimeRange, "12")
+	require.Len(t, mr.Resources, 1)
+	assert.Equal(t, "i-abc123", mr.Resources[0].ResourceID)
+
+	// One ListTimeSeries call per metric in the compute spec.
+	obs := gcpSpec(t, composer.KeyGCPCompute)
+	assert.Len(t, mon.calls, len(obs.Metrics))
+}
+
+// TestDiscoverAndFetchGCP_BastionAlias pins the bastion→compute alias:
+// the bastion service resolves to the compute spec, yet the result's
+// Service field carries the caller's original "bastion" (reliable
+// passes service, not resolvedService, to FetchGCP).
+func TestDiscoverAndFetchGCP_BastionAlias(t *testing.T) {
+	now := time.Now().UTC()
+	mon := &fakeMonitoring{
+		responses: map[string][]*monitoringpb.TimeSeries{
+			"cpu/utilization": {
+				{
+					Resource: &monitoredrespb.MonitoredResource{
+						Type:   "gce_instance",
+						Labels: map[string]string{"instance_id": "bastion-vm"},
+					},
+					Points: []*monitoringpb.Point{
+						{Interval: &monitoringpb.TimeInterval{EndTime: timestamppb.New(now)}, Value: &monitoringpb.TypedValue{Value: &monitoringpb.TypedValue_DoubleValue{DoubleValue: 0.1}}},
+					},
+				},
+			},
+		},
+	}
+	withGCPClients(t, mon)
+
+	got, err := DiscoverAndFetchGCP(context.Background(), "test-project", "bastion", "")
+	require.NoError(t, err)
+	mr, ok := got.(MetricsResult)
+	require.True(t, ok)
+	assert.Equal(t, "bastion", mr.Service, "result Service must echo the caller's service, not the resolved alias")
+	// The compute metric set was queried (alias resolved to compute spec).
+	obs := gcpSpec(t, composer.KeyGCPCompute)
+	assert.Len(t, mon.calls, len(obs.Metrics))
+	require.Len(t, mr.Resources, 1)
+	assert.Equal(t, "bastion-vm", mr.Resources[0].ResourceID)
+}
+
+// TestDiscoverAndFetchGCP_UnknownService pins the error for a GCP service
+// with no metric catalog entry.
+func TestDiscoverAndFetchGCP_UnknownService(t *testing.T) {
+	t.Parallel()
+	got, err := DiscoverAndFetchGCP(context.Background(), "test-project", "totally-unknown", "")
+	require.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "no metric definitions for GCP service: totally-unknown")
+}
+
+// --- GCP Secret Manager health ---
+
+// sliceSecretIterator / sliceVersionIterator are minimal in-memory
+// iterators satisfying the narrow iterator interfaces.
+type sliceSecretIterator struct {
+	items []*secretmanagerpb.Secret
+	i     int
+}
+
+func (s *sliceSecretIterator) Next() (*secretmanagerpb.Secret, error) {
+	if s.i >= len(s.items) {
+		return nil, iterator.Done
+	}
+	v := s.items[s.i]
+	s.i++
+	return v, nil
+}
+
+type sliceVersionIterator struct {
+	n int
+	i int
+}
+
+func (s *sliceVersionIterator) Next() (*secretmanagerpb.SecretVersion, error) {
+	if s.i >= s.n {
+		return nil, iterator.Done
+	}
+	s.i++
+	return &secretmanagerpb.SecretVersion{}, nil
+}
+
+type fakeGCPSecretClient struct {
+	secrets        []*secretmanagerpb.Secret
+	versionsByName map[string]int
+	closed         bool
+}
+
+func (f *fakeGCPSecretClient) ListSecrets(_ context.Context, _ *secretmanagerpb.ListSecretsRequest) gcpSecretIterator {
+	return &sliceSecretIterator{items: f.secrets}
+}
+
+func (f *fakeGCPSecretClient) ListSecretVersions(_ context.Context, req *secretmanagerpb.ListSecretVersionsRequest) gcpSecretVersionIterator {
+	return &sliceVersionIterator{n: f.versionsByName[req.Parent]}
+}
+
+func (f *fakeGCPSecretClient) Close() error { f.closed = true; return nil }
+
+func withGCPSecretClient(t *testing.T, f gcpSecretManagerAPI) {
+	t.Helper()
+	orig := newGCPSecretClient
+	t.Cleanup(func() { newGCPSecretClient = orig })
+	newGCPSecretClient = func(_ context.Context, _ ...option.ClientOption) (gcpSecretManagerAPI, error) {
+		return f, nil
+	}
+}
+
+// TestDiscoverAndFetchGCP_SecretManagerHealth asserts the secretmanager
+// branch returns a *GCPSecretHealthResult with reliable's field shape
+// (replication-type dispatch, RFC3339 create time, version count).
+func TestDiscoverAndFetchGCP_SecretManagerHealth(t *testing.T) {
+	created := time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC)
+	f := &fakeGCPSecretClient{
+		secrets: []*secretmanagerpb.Secret{
+			{
+				Name:        "projects/test-project/secrets/auto-secret",
+				CreateTime:  timestamppb.New(created),
+				Replication: &secretmanagerpb.Replication{Replication: &secretmanagerpb.Replication_Automatic_{Automatic: &secretmanagerpb.Replication_Automatic{}}},
+			},
+			{
+				Name:        "projects/test-project/secrets/usermanaged-secret",
+				Replication: &secretmanagerpb.Replication{Replication: &secretmanagerpb.Replication_UserManaged_{UserManaged: &secretmanagerpb.Replication_UserManaged{}}},
+			},
+		},
+		versionsByName: map[string]int{
+			"projects/test-project/secrets/auto-secret":        3,
+			"projects/test-project/secrets/usermanaged-secret": 1,
+		},
+	}
+	withGCPSecretClient(t, f)
+
+	got, err := DiscoverAndFetchGCP(context.Background(), "test-project", "secretmanager", "")
+	require.NoError(t, err)
+
+	res, ok := got.(*GCPSecretHealthResult)
+	require.True(t, ok, "secretmanager path must return *GCPSecretHealthResult (reliable parity)")
+	assert.Equal(t, "secretmanager", res.Service)
+	assert.NotEmpty(t, res.Note)
+	require.Len(t, res.Secrets, 2)
+
+	byName := map[string]GCPSecretHealthInfo{}
+	for _, s := range res.Secrets {
+		byName[s.Name] = s
+	}
+	auto := byName["projects/test-project/secrets/auto-secret"]
+	assert.Equal(t, "automatic", auto.ReplicationType)
+	assert.Equal(t, 3, auto.VersionCount)
+	assert.Equal(t, created.Format(time.RFC3339), auto.CreateTime)
+
+	um := byName["projects/test-project/secrets/usermanaged-secret"]
+	assert.Equal(t, "user-managed", um.ReplicationType)
+	assert.Equal(t, 1, um.VersionCount)
+
+	assert.True(t, f.closed, "the secret manager client must be closed")
+}
+
+func TestDiscoverAndFetchGCP_SecretManager_ClientError(t *testing.T) {
+	t.Parallel()
+	orig := newGCPSecretClient
+	t.Cleanup(func() { newGCPSecretClient = orig })
+	newGCPSecretClient = func(_ context.Context, _ ...option.ClientOption) (gcpSecretManagerAPI, error) {
+		return nil, errors.New("PermissionDenied")
+	}
+	_, err := DiscoverAndFetchGCP(context.Background(), "test-project", "secretmanager", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "PermissionDenied")
+}

--- a/pkg/observability/metrics/discover_and_fetch_test.go
+++ b/pkg/observability/metrics/discover_and_fetch_test.go
@@ -1,0 +1,529 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	cwtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	kmstypes "github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/observability"
+)
+
+// =============================================================================
+// DiscoverAndFetch orchestration — parity port of reliable's
+// getServiceMetrics tests (internal/agentapi/aws_metrics_test.go).
+// =============================================================================
+
+// TestDiscoverAndFetch_UnsupportedService pins the typed sentinel for a
+// service with no metric catalog entry (reliable#1789). ui-core detects
+// this via AsUnsupportedServiceMetricsError and emits a clean empty-state
+// envelope instead of an `aws_operation_failed` banner.
+func TestDiscoverAndFetch_UnsupportedService(t *testing.T) {
+	t.Parallel()
+	got, err := DiscoverAndFetch(context.Background(), aws.Config{}, "totally-unknown-service", "")
+	require.Error(t, err)
+	assert.Nil(t, got)
+
+	svc, ok := AsUnsupportedServiceMetricsError(err)
+	assert.True(t, ok, "must be detectable as the unsupported-service sentinel")
+	assert.Equal(t, "totally-unknown-service", svc)
+
+	var sentinel *UnsupportedServiceMetricsError
+	require.True(t, errors.As(err, &sentinel))
+	assert.Equal(t, "no metric definitions for service: totally-unknown-service", sentinel.Error())
+}
+
+// TestAsUnsupportedServiceMetricsError_StringFallback covers the
+// wire-boundary case reliable guards: the dispatcher wraps with `%v`
+// (breaking the chain), so detection falls back to matching the stable
+// message suffix. Ported from reliable's coverage of the same helper.
+func TestAsUnsupportedServiceMetricsError_StringFallback(t *testing.T) {
+	t.Parallel()
+	// %v-wrapped (chain broken) — must still be detected via the suffix.
+	wrapped := errors.New("aws_operation_failed: no metric definitions for service: logs")
+	svc, ok := AsUnsupportedServiceMetricsError(wrapped)
+	assert.True(t, ok)
+	assert.Equal(t, "logs", svc)
+
+	// Unrelated error — must not match.
+	_, ok = AsUnsupportedServiceMetricsError(errors.New("throttled"))
+	assert.False(t, ok)
+
+	// nil — must not match.
+	_, ok = AsUnsupportedServiceMetricsError(nil)
+	assert.False(t, ok)
+}
+
+// TestResourceDimensionFromFilter is the reliable#2035 dimension-parse
+// table, ported verbatim from reliable's aws_metrics_test.go.
+func TestResourceDimensionFromFilter(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		filters   string
+		dimension string
+		want      string
+	}{
+		{"s3 bucket name resolved", `{"BucketName":"my-bucket"}`, "BucketName", "my-bucket"},
+		{"trims whitespace", `{"BucketName":"  padded  "}`, "BucketName", "padded"},
+		{"sibling keys ignored", `{"BucketName":"b","hours":6}`, "BucketName", "b"},
+		{"project-only filter does not match", `{"project":"io-sess"}`, "BucketName", ""},
+		{"empty filter", "", "BucketName", ""},
+		{"empty dimension never matches", `{"BucketName":"b"}`, "", ""},
+		{"key present but empty", `{"BucketName":""}`, "BucketName", ""},
+		{"key present but non-string", `{"BucketName":123}`, "BucketName", ""},
+		{"non-object filter", `["BucketName"]`, "BucketName", ""},
+		{"malformed json", `{not json`, "BucketName", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, resourceDimensionFromFilter(tc.filters, tc.dimension))
+		})
+	}
+}
+
+// TestDiscoverAndFetch_ResourceScopedSkipsDiscovery is the reliable#2035
+// regression guard, ported from reliable's
+// TestGetServiceMetrics_ResourceScopedSkipsDiscovery. An IMPORTED S3
+// bucket lives in the user's pre-existing account and is NOT tagged
+// Project=io-<session>, so project-tag-scoped account-wide discovery
+// returns zero resources. When the get-metrics filter already names the
+// resolved CloudWatch dimension value ({"BucketName":"<bucket>"}),
+// DiscoverAndFetch MUST query that dimension directly and MUST NOT run
+// account-wide discovery.
+//
+// MUST NOT run in parallel: it swaps the package-level seam vars.
+func TestDiscoverAndFetch_ResourceScopedSkipsDiscovery(t *testing.T) {
+	origDiscovery := runMetricsDiscovery
+	origFetch := fetchServiceMetricsForResources
+	defer func() {
+		runMetricsDiscovery = origDiscovery
+		fetchServiceMetricsForResources = origFetch
+	}()
+
+	t.Run("resolved dimension queries directly without discovery", func(t *testing.T) {
+		discoveryCalled := false
+		runMetricsDiscovery = func(_ context.Context, _ aws.Config, _, _ string) ([]string, error) {
+			discoveryCalled = true
+			// An untagged imported bucket is invisible to project-scoped
+			// discovery — return nothing, as production would.
+			return nil, nil
+		}
+		var fetched []string
+		fetchServiceMetricsForResources = func(_ context.Context, _ aws.Config, service string, _ *observability.AWSObs, dims []string, _ string) (any, error) {
+			fetched = dims
+			res := make([]ResourceMetrics, 0, len(dims))
+			for _, d := range dims {
+				res = append(res, ResourceMetrics{ResourceID: d})
+			}
+			return MetricsResult{Service: service, Resources: res}, nil
+		}
+
+		got, err := DiscoverAndFetch(context.Background(), aws.Config{}, "s3", `{"BucketName":"imported-bucket"}`)
+		require.NoError(t, err)
+		assert.False(t, discoveryCalled,
+			"resource-scoped get-metrics must NOT run account-wide discovery (#2035)")
+		assert.Equal(t, []string{"imported-bucket"}, fetched,
+			"the resolved BucketName must be queried directly")
+
+		mr, ok := got.(MetricsResult)
+		require.True(t, ok)
+		require.Len(t, mr.Resources, 1,
+			"the named imported bucket must produce a series even though discovery would drop it")
+		assert.Equal(t, "imported-bucket", mr.Resources[0].ResourceID)
+	})
+
+	t.Run("project-scoped filter still routes through discovery", func(t *testing.T) {
+		discoveryCalled := false
+		runMetricsDiscovery = func(_ context.Context, _ aws.Config, _, project string) ([]string, error) {
+			discoveryCalled = true
+			assert.Equal(t, "io-managed", project,
+				"managed path must thread the project through to discovery")
+			return []string{"managed-bucket"}, nil
+		}
+		var fetched []string
+		fetchServiceMetricsForResources = func(_ context.Context, _ aws.Config, service string, _ *observability.AWSObs, dims []string, _ string) (any, error) {
+			fetched = dims
+			return MetricsResult{Service: service}, nil
+		}
+
+		_, err := DiscoverAndFetch(context.Background(), aws.Config{}, "s3", `{"project":"io-managed"}`)
+		require.NoError(t, err)
+		assert.True(t, discoveryCalled,
+			"the managed/designed path (no resource-dimension key) must keep using discovery")
+		assert.Equal(t, []string{"managed-bucket"}, fetched,
+			"discovered resources must flow to the fetch tail unchanged")
+	})
+}
+
+// TestDiscoverAndFetch_EC2_AutoDiscoveryPath drives DiscoverAndFetch end
+// to end through the auto-discovery branch (no resource-dimension key in
+// the filter): discovery resolves an instance ID, then the REAL fetch
+// tail (fetchServiceMetricsForResourcesImpl → Fetch) runs against a
+// mocked CloudWatch client, producing reliable's MetricsResult wire
+// shape. This proves the discover→fetch orchestration for the canonical
+// service.
+//
+// MUST NOT run in parallel: swaps package-level seam vars.
+func TestDiscoverAndFetch_EC2_AutoDiscoveryPath(t *testing.T) {
+	origDiscovery := runMetricsDiscovery
+	origClients := clientsFromConfigForFetch
+	defer func() {
+		runMetricsDiscovery = origDiscovery
+		clientsFromConfigForFetch = origClients
+	}()
+
+	now := time.Now().UTC()
+
+	// Discovery returns the running instance the account holds for the
+	// project. We assert it received the project parsed from the filter.
+	discoveryCalled := false
+	runMetricsDiscovery = func(_ context.Context, _ aws.Config, service, project string) ([]string, error) {
+		discoveryCalled = true
+		assert.Equal(t, "ec2", service)
+		assert.Equal(t, "io-projx", project, "project must be parsed from the filter and threaded to discovery")
+		return []string{"i-abc123"}, nil
+	}
+
+	// The fetch tail builds a *Clients from cfg — swap the constructor so
+	// it returns a mocked CloudWatch client instead of a real SDK client.
+	cwMock := &fakeCloudWatch{
+		output: &cloudwatch.GetMetricDataOutput{
+			MetricDataResults: []cwtypes.MetricDataResult{
+				{Label: aws.String("CPUUtilization"), Timestamps: []time.Time{now}, Values: []float64{42.5}},
+			},
+		},
+	}
+	clientsFromConfigForFetch = func(_ aws.Config) (*Clients, error) {
+		return clientsWithCW(cwMock), nil
+	}
+
+	got, err := DiscoverAndFetch(context.Background(), aws.Config{}, "ec2", `{"project":"io-projx","hours":12,"period":600}`)
+	require.NoError(t, err)
+	assert.True(t, discoveryCalled, "auto-discovery branch must run when no resource-dimension key is present")
+
+	mr, ok := got.(MetricsResult)
+	require.True(t, ok, "CloudWatch path must return a MetricsResult value (reliable parity)")
+	assert.Equal(t, "ec2", mr.Service)
+	assert.Equal(t, 600, mr.Period)
+	assert.Contains(t, mr.TimeRange, "12")
+	require.Len(t, mr.Resources, 1)
+	assert.Equal(t, "i-abc123", mr.Resources[0].ResourceID, "discovered instance must be fetched")
+	require.NotEmpty(t, mr.Resources[0].Metrics)
+	assert.Equal(t, "CPUUtilization", mr.Resources[0].Metrics[0].Name)
+	require.Len(t, mr.Resources[0].Metrics[0].Datapoints, 1)
+	assert.InDelta(t, 42.5, mr.Resources[0].Metrics[0].Datapoints[0].Average, 0.001)
+
+	// The instance ID must reach CloudWatch under the EC2 dimension.
+	require.NotNil(t, cwMock.lastInput)
+	dims := cwMock.lastInput.MetricDataQueries[0].MetricStat.Metric.Dimensions
+	require.NotEmpty(t, dims)
+	assert.Equal(t, "InstanceId", aws.ToString(dims[0].Name))
+	assert.Equal(t, "i-abc123", aws.ToString(dims[0].Value))
+}
+
+// TestDiscoverAndFetch_ResourceScoped_EC2_RealFetchTail exercises the
+// #2035 fast path through the REAL fetch tail with a mocked CloudWatch
+// client, asserting discovery is never consulted. Complements the
+// seam-swapped fast-path test above by validating the actual fetch
+// produces the wire shape.
+//
+// MUST NOT run in parallel: swaps package-level seam vars.
+func TestDiscoverAndFetch_ResourceScoped_EC2_RealFetchTail(t *testing.T) {
+	origDiscovery := runMetricsDiscovery
+	origClients := clientsFromConfigForFetch
+	defer func() {
+		runMetricsDiscovery = origDiscovery
+		clientsFromConfigForFetch = origClients
+	}()
+
+	discoveryCalled := false
+	runMetricsDiscovery = func(_ context.Context, _ aws.Config, _, _ string) ([]string, error) {
+		discoveryCalled = true
+		return nil, nil
+	}
+	cwMock := &fakeCloudWatch{
+		output: &cloudwatch.GetMetricDataOutput{
+			MetricDataResults: []cwtypes.MetricDataResult{
+				{Label: aws.String("CPUUtilization"), Timestamps: []time.Time{time.Now().UTC()}, Values: []float64{7}},
+			},
+		},
+	}
+	clientsFromConfigForFetch = func(_ aws.Config) (*Clients, error) { return clientsWithCW(cwMock), nil }
+
+	got, err := DiscoverAndFetch(context.Background(), aws.Config{}, "ec2", `{"InstanceId":"i-imported"}`)
+	require.NoError(t, err)
+	assert.False(t, discoveryCalled, "resource-scoped fast path must skip discovery (#2035)")
+
+	mr, ok := got.(MetricsResult)
+	require.True(t, ok)
+	require.Len(t, mr.Resources, 1)
+	assert.Equal(t, "i-imported", mr.Resources[0].ResourceID)
+	require.NotNil(t, cwMock.lastInput)
+	assert.Equal(t, "i-imported", aws.ToString(cwMock.lastInput.MetricDataQueries[0].MetricStat.Metric.Dimensions[0].Value))
+}
+
+// =============================================================================
+// KMS / Secrets Manager operational-health readers — parity port.
+// =============================================================================
+
+// --- KMS fake ---
+
+type fakeKMS struct {
+	listKeys     *kms.ListKeysOutput
+	listKeysErr  error
+	listAliases  *kms.ListAliasesOutput
+	describeKeys map[string]*kms.DescribeKeyOutput
+	tags         map[string]*kms.ListResourceTagsOutput
+	rotation     map[string]*kms.GetKeyRotationStatusOutput
+}
+
+func (f *fakeKMS) ListKeys(_ context.Context, _ *kms.ListKeysInput, _ ...func(*kms.Options)) (*kms.ListKeysOutput, error) {
+	if f.listKeysErr != nil {
+		return nil, f.listKeysErr
+	}
+	if f.listKeys == nil {
+		return &kms.ListKeysOutput{}, nil
+	}
+	return f.listKeys, nil
+}
+
+func (f *fakeKMS) ListAliases(_ context.Context, _ *kms.ListAliasesInput, _ ...func(*kms.Options)) (*kms.ListAliasesOutput, error) {
+	if f.listAliases == nil {
+		return &kms.ListAliasesOutput{}, nil
+	}
+	return f.listAliases, nil
+}
+
+func (f *fakeKMS) DescribeKey(_ context.Context, in *kms.DescribeKeyInput, _ ...func(*kms.Options)) (*kms.DescribeKeyOutput, error) {
+	out, ok := f.describeKeys[aws.ToString(in.KeyId)]
+	if !ok {
+		return &kms.DescribeKeyOutput{}, nil
+	}
+	return out, nil
+}
+
+func (f *fakeKMS) ListResourceTags(_ context.Context, in *kms.ListResourceTagsInput, _ ...func(*kms.Options)) (*kms.ListResourceTagsOutput, error) {
+	out, ok := f.tags[aws.ToString(in.KeyId)]
+	if !ok {
+		return &kms.ListResourceTagsOutput{}, nil
+	}
+	return out, nil
+}
+
+func (f *fakeKMS) GetKeyRotationStatus(_ context.Context, in *kms.GetKeyRotationStatusInput, _ ...func(*kms.Options)) (*kms.GetKeyRotationStatusOutput, error) {
+	out, ok := f.rotation[aws.ToString(in.KeyId)]
+	if !ok {
+		return &kms.GetKeyRotationStatusOutput{}, nil
+	}
+	return out, nil
+}
+
+func withKMS(t *testing.T, f kmsHealthAPI) {
+	t.Helper()
+	orig := newKMSClient
+	t.Cleanup(func() { newKMSClient = orig })
+	newKMSClient = func(_ aws.Config) kmsHealthAPI { return f }
+}
+
+// TestDiscoverAndFetch_KMSHealth_DemoSession asserts the kms branch of
+// DiscoverAndFetch returns a *KeyHealthResult and that with project==""
+// every key (customer- AND aws-managed) is surfaced. Ported from
+// reliable's getKMSKeyHealth behavior.
+func TestDiscoverAndFetch_KMSHealth_DemoSession(t *testing.T) {
+	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	f := &fakeKMS{
+		listKeys: &kms.ListKeysOutput{Keys: []kmstypes.KeyListEntry{
+			{KeyId: aws.String("key-cust")},
+			{KeyId: aws.String("key-aws")},
+		}},
+		listAliases: &kms.ListAliasesOutput{Aliases: []kmstypes.AliasListEntry{
+			{AliasName: aws.String("alias/my-key"), TargetKeyId: aws.String("key-cust")},
+		}},
+		describeKeys: map[string]*kms.DescribeKeyOutput{
+			"key-cust": {KeyMetadata: &kmstypes.KeyMetadata{
+				KeyId: aws.String("key-cust"), KeyState: kmstypes.KeyStateEnabled,
+				KeyManager: kmstypes.KeyManagerTypeCustomer, Description: aws.String("app key"),
+				CreationDate: &created,
+			}},
+			"key-aws": {KeyMetadata: &kmstypes.KeyMetadata{
+				KeyId: aws.String("key-aws"), KeyState: kmstypes.KeyStateEnabled,
+				KeyManager: kmstypes.KeyManagerTypeAws,
+			}},
+		},
+		rotation: map[string]*kms.GetKeyRotationStatusOutput{
+			"key-cust": {KeyRotationEnabled: true},
+		},
+	}
+	withKMS(t, f)
+
+	got, err := DiscoverAndFetch(context.Background(), aws.Config{}, "kms", "")
+	require.NoError(t, err)
+
+	res, ok := got.(*KeyHealthResult)
+	require.True(t, ok, "kms path must return *KeyHealthResult (reliable parity)")
+	assert.Equal(t, "kms", res.Service)
+	assert.NotEmpty(t, res.Note)
+	require.Len(t, res.Keys, 2, "demo session (project=='') surfaces aws-managed keys too")
+
+	byID := map[string]KeyHealthInfo{}
+	for _, k := range res.Keys {
+		byID[k.KeyID] = k
+	}
+	cust := byID["key-cust"]
+	assert.Equal(t, "alias/my-key", cust.Alias)
+	assert.Equal(t, "Enabled", cust.KeyState)
+	assert.Equal(t, "CUSTOMER", cust.KeyManager)
+	assert.True(t, cust.RotationEnabled, "customer key rotation status must be read")
+	assert.Equal(t, "app key", cust.Description)
+	assert.Equal(t, created.Format(time.RFC3339), cust.CreationDate)
+
+	awsKey := byID["key-aws"]
+	assert.Equal(t, "AWS", awsKey.KeyManager)
+	assert.False(t, awsKey.RotationEnabled, "aws-managed key rotation is never queried")
+}
+
+// TestDiscoverAndFetch_KMSHealth_ProjectScopedFailClosed pins reliable's
+// #1112 fail-closed gate: with a non-empty project, aws-managed keys are
+// dropped and customer keys without the Project tag are dropped.
+func TestDiscoverAndFetch_KMSHealth_ProjectScopedFailClosed(t *testing.T) {
+	f := &fakeKMS{
+		listKeys: &kms.ListKeysOutput{Keys: []kmstypes.KeyListEntry{
+			{KeyId: aws.String("key-tagged")},
+			{KeyId: aws.String("key-untagged")},
+			{KeyId: aws.String("key-aws")},
+		}},
+		describeKeys: map[string]*kms.DescribeKeyOutput{
+			"key-tagged":   {KeyMetadata: &kmstypes.KeyMetadata{KeyId: aws.String("key-tagged"), KeyManager: kmstypes.KeyManagerTypeCustomer, KeyState: kmstypes.KeyStateEnabled}},
+			"key-untagged": {KeyMetadata: &kmstypes.KeyMetadata{KeyId: aws.String("key-untagged"), KeyManager: kmstypes.KeyManagerTypeCustomer, KeyState: kmstypes.KeyStateEnabled}},
+			"key-aws":      {KeyMetadata: &kmstypes.KeyMetadata{KeyId: aws.String("key-aws"), KeyManager: kmstypes.KeyManagerTypeAws, KeyState: kmstypes.KeyStateEnabled}},
+		},
+		tags: map[string]*kms.ListResourceTagsOutput{
+			"key-tagged": {Tags: []kmstypes.Tag{{TagKey: aws.String("Project"), TagValue: aws.String("io-projx")}}},
+			// key-untagged: no Project tag.
+			"key-untagged": {Tags: []kmstypes.Tag{{TagKey: aws.String("Name"), TagValue: aws.String("other")}}},
+		},
+	}
+	withKMS(t, f)
+
+	got, err := getKMSKeyHealth(context.Background(), aws.Config{}, "io-projx")
+	require.NoError(t, err)
+	require.Len(t, got.Keys, 1, "only the Project-tagged customer key survives the fail-closed gate")
+	assert.Equal(t, "key-tagged", got.Keys[0].KeyID)
+}
+
+func TestDiscoverAndFetch_KMSHealth_ListKeysError(t *testing.T) {
+	withKMS(t, &fakeKMS{listKeysErr: errors.New("AccessDenied")})
+	_, err := DiscoverAndFetch(context.Background(), aws.Config{}, "kms", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDenied")
+}
+
+// --- Secrets Manager fake ---
+
+type fakeSM struct {
+	listSecrets    *secretsmanager.ListSecretsOutput
+	listSecretsErr error
+	versions       map[string]*secretsmanager.ListSecretVersionIdsOutput
+}
+
+func (f *fakeSM) ListSecrets(_ context.Context, in *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretsOutput, error) {
+	if f.listSecretsErr != nil {
+		return nil, f.listSecretsErr
+	}
+	if f.listSecrets == nil {
+		return &secretsmanager.ListSecretsOutput{}, nil
+	}
+	return f.listSecrets, nil
+}
+
+func (f *fakeSM) ListSecretVersionIds(_ context.Context, in *secretsmanager.ListSecretVersionIdsInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+	out, ok := f.versions[aws.ToString(in.SecretId)]
+	if !ok {
+		return &secretsmanager.ListSecretVersionIdsOutput{}, nil
+	}
+	return out, nil
+}
+
+func withSM(t *testing.T, f smHealthAPI) {
+	t.Helper()
+	orig := newSecretsManagerClient
+	t.Cleanup(func() { newSecretsManagerClient = orig })
+	newSecretsManagerClient = func(_ aws.Config) smHealthAPI { return f }
+}
+
+// TestDiscoverAndFetch_SecretHealth asserts the secretsmanager branch of
+// DiscoverAndFetch returns a *SecretHealthResult with the reliable field
+// shape, including the version-count second round trip.
+func TestDiscoverAndFetch_SecretHealth(t *testing.T) {
+	rotated := time.Date(2024, 5, 1, 0, 0, 0, 0, time.UTC)
+	f := &fakeSM{
+		listSecrets: &secretsmanager.ListSecretsOutput{SecretList: []smtypes.SecretListEntry{
+			{
+				Name:            aws.String("io-projx/db-password"),
+				ARN:             aws.String("arn:aws:secretsmanager:eu-west-2:111:secret:io-projx/db-password-AbCdEf"),
+				RotationEnabled: aws.Bool(true),
+				LastRotatedDate: &rotated,
+			},
+		}},
+		versions: map[string]*secretsmanager.ListSecretVersionIdsOutput{
+			"arn:aws:secretsmanager:eu-west-2:111:secret:io-projx/db-password-AbCdEf": {
+				Versions: []smtypes.SecretVersionsListEntry{{}, {}, {}},
+			},
+		},
+	}
+	withSM(t, f)
+
+	got, err := DiscoverAndFetch(context.Background(), aws.Config{}, "secretsmanager", `{"project":"io-projx"}`)
+	require.NoError(t, err)
+
+	res, ok := got.(*SecretHealthResult)
+	require.True(t, ok, "secretsmanager path must return *SecretHealthResult (reliable parity)")
+	assert.Equal(t, "secretsmanager", res.Service)
+	assert.NotEmpty(t, res.Note)
+	require.Len(t, res.Secrets, 1)
+
+	s := res.Secrets[0]
+	assert.Equal(t, "io-projx/db-password", s.Name)
+	assert.True(t, s.RotationEnabled)
+	assert.Equal(t, rotated.Format(time.RFC3339), s.LastRotatedDate)
+	assert.Equal(t, 3, s.VersionCount, "version count comes from the second ListSecretVersionIds call")
+}
+
+// TestBuildSecretsManagerListInput pins the project-tag-scoped list
+// filter, ported from reliable.
+func TestBuildSecretsManagerListInput(t *testing.T) {
+	t.Parallel()
+	t.Run("empty project has no filters", func(t *testing.T) {
+		t.Parallel()
+		input := buildSecretsManagerListInput("")
+		require.NotNil(t, input)
+		assert.Empty(t, input.Filters)
+	})
+	t.Run("project scopes by tag value", func(t *testing.T) {
+		t.Parallel()
+		input := buildSecretsManagerListInput("io-projx")
+		require.Len(t, input.Filters, 1)
+		assert.Equal(t, smtypes.FilterNameStringTypeTagValue, input.Filters[0].Key)
+		assert.Equal(t, []string{"io-projx"}, input.Filters[0].Values)
+	})
+}
+
+func TestDiscoverAndFetch_SecretHealth_ListError(t *testing.T) {
+	withSM(t, &fakeSM{listSecretsErr: errors.New("AccessDenied")})
+	_, err := DiscoverAndFetch(context.Background(), aws.Config{}, "secretsmanager", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "AccessDenied")
+}


### PR DESCRIPTION
## What

Adds an in-process orchestrator to `pkg/observability/metrics` that reproduces — with byte-for-byte parity — reliable's `getServiceMetrics` (`internal/agentapi/aws_metrics.go`) and `getGCPServiceMetrics` (`gcp_metrics.go`).

- `DiscoverAndFetch(ctx, cfg, service, filters) (any, error)` — AWS path
- `DiscoverAndFetchGCP(ctx, projectID, service, filters, opts...) (any, error)` — GCP path

The principle is "same behavior as reliable today, just running in presets/ui-core instead of reliable."

## Why

ui-core's `/observability/metrics` endpoint will call `DiscoverAndFetch` when it receives an **empty `resources` list** — i.e. it does the account-wide "discover the service's resources, then fetch their CloudWatch / Cloud Monitoring series" pipeline itself instead of relying on reliable. Once this lands and ui-core consumes it, reliable can DELETE its in-process copy.

Refs reliable#2141, reliable#2153.

## What was ported

The metric catalog (`observability.AWSObs`/`GCPObs`), the fetch (`metrics.Fetch` / `FetchGCP`), and the discovery (`discovery/aws.Inspect`) already live in this repo and are reused unchanged. This PR adds only the orchestration and the pieces reliable kept reliable-side:

| New file | Contents |
|---|---|
| `discover_and_fetch.go` | `DiscoverAndFetch` orchestrator (kms/secretsmanager branches, #2035 resource-scoped fast path, discover→fetch tail), KMS + Secrets Manager operational-health readers and envelope types, `metricDefinitions` service-keyed catalog view, `UnsupportedServiceMetricsError` (exported for ui-core detection) |
| `discover_and_fetch_discovery.go` | `runMetricsDiscovery` + the `metricsDiscoveryActions` map + all per-service CloudWatch-dimension extractors |
| `discover_and_fetch_gcp.go` | `DiscoverAndFetchGCP` orchestrator (secretmanager branch, bastion→compute alias, FetchGCP), GCP Secret Manager health envelope |

Wire shapes are preserved exactly: the time-series paths return `MetricsResult`; the health paths return the same `*KeyHealthResult` / `*SecretHealthResult` / `*GCPSecretHealthResult` JSON shapes reliable defined. SDK client construction is behind seams so the readers are unit-tested with mocked AWS/GCP clients.

## Tests

39 new test functions; `go test ./pkg/observability/... -count=1` passes (1467 total). Parity cases include:

- EC2 auto-discovery orchestration (discovery → real fetch tail → mocked CloudWatch → `MetricsResult`)
- #2035 resource-scoped fast path (named dimension queries directly, discovery skipped) — both seam-level and through the real fetch tail
- KMS health: demo-session (all keys) vs project-scoped fail-closed gate (#1112)
- Secrets Manager health envelope incl. version-count round trip
- GCP Cloud Monitoring path + bastion→compute alias + Secret Manager health envelope
- All per-service extractors (running-only EC2, ALB ARN suffix, SQS URL tail, ECS ClusterName-vs-ARN, Bedrock no-metrics, typed-vs-map dual paths)
- `UnsupportedServiceMetricsError` detection incl. the `%v`-wrapped string-fallback

## Parity note for reviewers

`agentcore` / `kendra` / `sagemaker` have AWS metric-catalog entries but **no account-wide discovery action** (their upstream inspect handlers expose no usable list action). The auto-discovery path therefore errors for them — exactly as reliable's `getServiceMetrics` does today, since reliable's `metricsDiscoveryActions` never covered them. The resource-scoped fast path (#2035) still works. This is captured in an allowlist in `TestMetricsDiscoveryActions_AllMetricServicesCovered` that can only shrink.