### PR TITLE
refactor(observability): keep filter pkg SDK-free (move ProjectTagFilter to discovery/aws)

### DIFF
--- a/pkg/observability/discovery/aws/compute.go
+++ b/pkg/observability/discovery/aws/compute.go
@@ -31,7 +31,7 @@ import (
 
 func inspectEC2(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
 	client := ec2.NewFromConfig(cfg)
-	tagFilters := filter.ProjectTagFilter(filter.Project(filters))
+	tagFilters := ProjectTagFilter(filter.Project(filters))
 
 	switch action {
 	case "describe-instances":
@@ -85,7 +85,7 @@ func inspectEC2(ctx context.Context, cfg aws.Config, action, filters string) (an
 
 func inspectEBS(ctx context.Context, cfg aws.Config, action, filters string) (any, error) {
 	client := ec2.NewFromConfig(cfg)
-	tagFilters := filter.ProjectTagFilter(filter.Project(filters))
+	tagFilters := ProjectTagFilter(filter.Project(filters))
 
 	switch action {
 	case "describe-volumes":

--- a/pkg/observability/discovery/aws/network.go
+++ b/pkg/observability/discovery/aws/network.go
@@ -61,7 +61,7 @@ func inspectVPC(ctx context.Context, cfg aws.Config, action, filters string) (an
 	case "describe-nat-gateways":
 		client := ec2.NewFromConfig(cfg)
 		input := &ec2.DescribeNatGatewaysInput{}
-		if tagFilters := filter.ProjectTagFilter(filter.Project(filters)); len(tagFilters) > 0 {
+		if tagFilters := ProjectTagFilter(filter.Project(filters)); len(tagFilters) > 0 {
 			// NAT gateway DescribeNatGatewaysInput uses Filter (singular),
 			// not Filters — peculiarity of the EC2 SDK's NAT API.
 			input.Filter = tagFilters
@@ -103,7 +103,7 @@ func inspectVPC(ctx context.Context, cfg aws.Config, action, filters string) (an
 // Mirrors the InsideOut backend's inspectVPCWithIGW (aws_inspect.go:507).
 func inspectVPCWithIGW(ctx context.Context, client vpcDescribeAPI, project string) ([]vpcWithIGW, error) {
 	vpcInput := &ec2.DescribeVpcsInput{}
-	if tagFilters := filter.ProjectTagFilter(project); len(tagFilters) > 0 {
+	if tagFilters := ProjectTagFilter(project); len(tagFilters) > 0 {
 		vpcInput.Filters = tagFilters
 	}
 	vpcOut, err := client.DescribeVpcs(ctx, vpcInput)

--- a/pkg/observability/discovery/aws/project_tag_filter.go
+++ b/pkg/observability/discovery/aws/project_tag_filter.go
@@ -1,0 +1,29 @@
+// Project-tag → EC2 filter helper.
+//
+// This lives here, in the AWS discovery package, rather than in
+// pkg/observability/filter so that the filter package stays free of the
+// AWS SDK. reliable imports filter.{Project,EnsureProject} in its thin
+// observability-via-oracle proxy (reliable#2141 / #2153) and must NOT drag
+// in aws-sdk-go-v2/service/ec2/types — its cmd/api Vercel function is at
+// the 250 MB size limit, and every imported SDK service package carries an
+// irreducible linker baseline. The only callers of ProjectTagFilter are
+// the AWS discovery inspectors in this package, which already import the
+// EC2 SDK, so moving it here costs nothing and keeps `filter` SDK-free.
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// ProjectTagFilter returns EC2-style tag filters for the Project tag.
+// Used by EC2, VPC, and other services that share the EC2 filter API.
+func ProjectTagFilter(project string) []ec2types.Filter {
+	if project == "" {
+		return nil
+	}
+	return []ec2types.Filter{{
+		Name:   aws.String("tag:Project"),
+		Values: []string{project},
+	}}
+}

--- a/pkg/observability/discovery/aws/project_tag_filter_test.go
+++ b/pkg/observability/discovery/aws/project_tag_filter_test.go
@@ -1,0 +1,26 @@
+// Tests for ProjectTagFilter, relocated here from
+// pkg/observability/filter so the filter package stays SDK-free
+// (reliable#2141 / #2153 — see project_tag_filter.go).
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProjectTagFilter(t *testing.T) {
+	t.Parallel()
+	t.Run("empty project returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, ProjectTagFilter(""))
+	})
+	t.Run("non-empty project returns tag:Project filter", func(t *testing.T) {
+		t.Parallel()
+		filters := ProjectTagFilter("io-myproject")
+		assert.Len(t, filters, 1)
+		assert.Equal(t, "tag:Project", *filters[0].Name)
+		assert.Equal(t, []string{"io-myproject"}, filters[0].Values)
+	})
+}

--- a/pkg/observability/filter/project.go
+++ b/pkg/observability/filter/project.go
@@ -11,8 +11,6 @@ package filter
 
 import (
 	"encoding/json"
-
-	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 )
 
 // Project extracts the "project" value from a JSON filters string.
@@ -77,20 +75,6 @@ func EnsureProject(filters, project string) string {
 	b, _ := json.Marshal(m)
 	return string(b)
 }
-
-// ProjectTagFilter returns EC2-style tag filters for the Project tag.
-// Used by EC2, VPC, and other services that share the EC2 filter API.
-func ProjectTagFilter(project string) []ec2types.Filter {
-	if project == "" {
-		return nil
-	}
-	return []ec2types.Filter{{
-		Name:   strPtr("tag:Project"),
-		Values: []string{project},
-	}}
-}
-
-func strPtr(s string) *string { return &s }
 
 // TagFormat declares how project membership is encoded on a resource.
 type TagFormat string

--- a/pkg/observability/filter/project_test.go
+++ b/pkg/observability/filter/project_test.go
@@ -177,21 +177,6 @@ func TestEnsureProject(t *testing.T) {
 	}
 }
 
-func TestProjectTagFilter(t *testing.T) {
-	t.Parallel()
-	t.Run("empty project returns nil", func(t *testing.T) {
-		t.Parallel()
-		assert.Nil(t, ProjectTagFilter(""))
-	})
-	t.Run("non-empty project returns tag:Project filter", func(t *testing.T) {
-		t.Parallel()
-		filters := ProjectTagFilter("io-myproject")
-		assert.Len(t, filters, 1)
-		assert.Equal(t, "tag:Project", *filters[0].Name)
-		assert.Equal(t, []string{"io-myproject"}, filters[0].Values)
-	})
-}
-
 func TestMatch_KVFormat(t *testing.T) {
 	t.Parallel()
 	resources := []map[string]any{


### PR DESCRIPTION
## What

Moves `ProjectTagFilter` out of `pkg/observability/filter` into `pkg/observability/discovery/aws`, so the `filter` package no longer imports the AWS SDK.

## Why

`ProjectTagFilter` was the only symbol in `filter` that imported `aws-sdk-go-v2/service/ec2/types`, which made the whole `filter` package transitively depend on the EC2 SDK.

reliable imports `filter.Project` / `filter.EnsureProject` from its thin observability-via-oracle proxy (reliable#2141 / #2153) and must not drag in any AWS SDK service package — its `cmd/api` Vercel function is at the 250 MB limit, and every imported SDK service carries an irreducible linker baseline. This was the one loose thread keeping `filter` from being importable by the slimmed-down reliable proxy.

## What changed

- New `pkg/observability/discovery/aws/project_tag_filter.go` holds `ProjectTagFilter` (the discovery inspectors are its only callers and already import the EC2 SDK).
- Removed `ProjectTagFilter` + the `strPtr` helper + the `ec2types` import from `filter/project.go`.
- Updated the four call sites in `discovery/aws/{compute,network}.go` to the local identifier.
- Moved `TestProjectTagFilter` alongside the relocated function.

Pure relocation — no behavior change.

## Verification

- `go build ./...`, `go vet`, and `go test ./pkg/observability/... ./pkg/imported/...` pass.
- `go list -deps ./pkg/observability/filter | grep -E 'aws-sdk-go-v2/service/|cloud.google.com/go/'` is now empty (was `aws-sdk-go-v2/service/ec2/types`).

Refs: reliable#2141, reliable#2153.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NP8JFEvnjuAEzaKLMTB8kV)_