### PR TITLE
fix(composer): pin composed AWS provider to 6.52.0 (satisfy eks module floor)

### DIFF
--- a/cmd/insideout-import/genconfig/testdata/providers_aws.golden
+++ b/cmd/insideout-import/genconfig/testdata/providers_aws.golden
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 6.46.0"
+      version = "= 6.52.0"
     }
   }
 }

--- a/pkg/composer/compose_bedrock_aoss_test.go
+++ b/pkg/composer/compose_bedrock_aoss_test.go
@@ -358,7 +358,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 		// Every aws/<module>/main.tf preset declares `version = ">= 6.0"`,
 		// which lands in Discovered["aws"]. The composed archive must NOT
 		// inherit that open range — it must keep the exact pin matching the
-		// mars provider-mirror bake (= 6.46.0) so terraform init hits the
+		// mars provider-mirror bake (= 6.52.0) so terraform init hits the
 		// cache instead of resolving "newest at runtime" (#786).
 		withAWSDiscovered := map[string]*tfconfig.ProviderRequirement{
 			"aws":  {Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
@@ -370,7 +370,7 @@ func TestGenerateProvidersTF_DiscoveryUnion(t *testing.T) {
 			Selected:   map[ComponentKey]bool{},
 			Discovered: withAWSDiscovered,
 		}))
-		require.Contains(t, got, `version = "= 6.46.0"`,
+		require.Contains(t, got, `version = "= 6.52.0"`,
 			"aws base provider must stay exactly pinned to the mars-baked version, not the discovered >= 6.0 range")
 		require.NotContains(t, got, `version = ">= 6.0"`,
 			"the open >= 6.0 range must never reach the composed archive")
@@ -623,8 +623,8 @@ func TestPinBaseProviders(t *testing.T) {
 		required := map[string]*tfconfig.ProviderRequirement{
 			"aws": {Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
 		}
-		pinBaseProviders(required, map[string]string{"aws": "= 6.46.0"})
-		require.Equal(t, []string{"= 6.46.0"}, required["aws"].VersionConstraints,
+		pinBaseProviders(required, map[string]string{"aws": "= 6.52.0"})
+		require.Equal(t, []string{"= 6.52.0"}, required["aws"].VersionConstraints,
 			"the open range must be replaced by the exact pin")
 		require.Equal(t, "hashicorp/aws", required["aws"].Source)
 	})
@@ -637,10 +637,10 @@ func TestPinBaseProviders(t *testing.T) {
 		required := map[string]*tfconfig.ProviderRequirement{
 			"aws": {Source: "registry.example.com/hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
 		}
-		pinBaseProviders(required, map[string]string{"aws": "= 6.46.0"})
+		pinBaseProviders(required, map[string]string{"aws": "= 6.52.0"})
 		require.Equal(t, "registry.example.com/hashicorp/aws", required["aws"].Source,
 			"a non-default Source must survive the version pin")
-		require.Equal(t, []string{"= 6.46.0"}, required["aws"].VersionConstraints)
+		require.Equal(t, []string{"= 6.52.0"}, required["aws"].VersionConstraints)
 	})
 
 	t.Run("synthesizes hashicorp/<name> Source when the provider is absent", func(t *testing.T) {
@@ -656,7 +656,7 @@ func TestPinBaseProviders(t *testing.T) {
 			"aws":  {Source: "hashicorp/aws", VersionConstraints: []string{">= 6.0"}},
 			"time": {Source: "hashicorp/time", VersionConstraints: []string{">= 0.9"}},
 		}
-		pinBaseProviders(required, map[string]string{"aws": "= 6.46.0"})
+		pinBaseProviders(required, map[string]string{"aws": "= 6.52.0"})
 		require.Equal(t, []string{">= 0.9"}, required["time"].VersionConstraints,
 			"a provider not named in the pin set must be left as-is")
 	})

--- a/pkg/composer/imported/provider_pins.go
+++ b/pkg/composer/imported/provider_pins.go
@@ -23,7 +23,7 @@ import "strings"
 //
 // The versions MUST equal the luthersystems/mars provider-mirror bake
 // (mars/Dockerfile `AWS_PROVIDER_VERSION` / `GOOGLE_PROVIDER_VERSION`). As of
-// mars v0.123.0 that bake is aws 6.46.0 and google/google-beta 6.10.0. Bump
+// mars v0.125.0 that bake is aws 6.52.0 and google/google-beta 6.10.0. Bump
 // these AND the mars bake together; the cross-emitter drift guards
 // (TestBaseProviderPins_* and the per-emitter pin tests) fail if either side
 // drifts back to an open range. Note this is intentionally DISTINCT from
@@ -31,7 +31,7 @@ import "strings"
 // schemas/providers.tf and need not equal the runtime deploy pin.
 var baseProviderPins = map[string]map[string]string{
 	"aws": {
-		"aws": "= 6.46.0",
+		"aws": "= 6.52.0",
 	},
 	"gcp": {
 		"google":      "= 6.10.0",
@@ -39,7 +39,7 @@ var baseProviderPins = map[string]map[string]string{
 	},
 }
 
-// BaseProviderPin returns the exact version constraint (e.g. "= 6.46.0") this
+// BaseProviderPin returns the exact version constraint (e.g. "= 6.52.0") this
 // repo pins for a cloud's base Terraform provider, matching the
 // luthersystems/mars provider-mirror bake so terraform init hits the cache.
 // cloud is "aws" or "gcp"; provider is the required_providers key ("aws",
@@ -68,7 +68,7 @@ func BaseProviderPins(cloud string) map[string]string {
 }
 
 // AllBaseProviderPins returns a flattened provider-name → exact-constraint map
-// across every cloud (aws, gcp), e.g. {"aws": "= 6.46.0", "google": "= 6.10.0",
+// across every cloud (aws, gcp), e.g. {"aws": "= 6.52.0", "google": "= 6.10.0",
 // "google-beta": "= 6.10.0"}. The composer's pre-init provider-conflict
 // validator seeds these into its constraint union so a preset pinning a range
 // incompatible with the exact emitted pin is caught before terraform init —

--- a/pkg/composer/imported/provider_pins_test.go
+++ b/pkg/composer/imported/provider_pins_test.go
@@ -17,8 +17,8 @@ import (
 // together.
 func TestBaseProviderPins_ExactAndMatchMars(t *testing.T) {
 	t.Parallel()
-	// As of mars v0.123.0: aws 6.46.0, google/google-beta 6.10.0.
-	assert.Equal(t, "= 6.46.0", BaseProviderPin("aws", "aws"))
+	// As of mars v0.125.0: aws 6.52.0, google/google-beta 6.10.0.
+	assert.Equal(t, "= 6.52.0", BaseProviderPin("aws", "aws"))
 	assert.Equal(t, "= 6.10.0", BaseProviderPin("gcp", "google"))
 	assert.Equal(t, "= 6.10.0", BaseProviderPin("gcp", "google-beta"))
 }
@@ -55,7 +55,7 @@ func TestBaseProviderPins_ReturnsCopy(t *testing.T) {
 	t.Parallel()
 	got := BaseProviderPins("aws")
 	got["aws"] = "= 9.9.9"
-	assert.Equal(t, "= 6.46.0", BaseProviderPin("aws", "aws"),
+	assert.Equal(t, "= 6.52.0", BaseProviderPin("aws", "aws"),
 		"mutating the returned map must not affect the source of truth")
 }
 
@@ -66,12 +66,12 @@ func TestBaseProviderPins_ReturnsCopy(t *testing.T) {
 func TestAllBaseProviderPins(t *testing.T) {
 	t.Parallel()
 	all := AllBaseProviderPins()
-	assert.Equal(t, "= 6.46.0", all["aws"])
+	assert.Equal(t, "= 6.52.0", all["aws"])
 	assert.Equal(t, "= 6.10.0", all["google"])
 	assert.Equal(t, "= 6.10.0", all["google-beta"],
 		"google-beta must be seeded — the emitter pins it, so the validator must too")
 	assert.Len(t, all, 3, "exactly the three base providers across aws+gcp")
 	// Returned map is a fresh copy; mutating it must not affect the source.
 	all["aws"] = "= 9.9.9"
-	assert.Equal(t, "= 6.46.0", AllBaseProviderPins()["aws"])
+	assert.Equal(t, "= 6.52.0", AllBaseProviderPins()["aws"])
 }

--- a/pkg/composer/imported_tfvalidate_test.go
+++ b/pkg/composer/imported_tfvalidate_test.go
@@ -43,7 +43,7 @@ import (
 // truth the real reverse-import emitter feeds into its providers.tf
 // (pkg/reverseimport/providers.go). Hand-pinning it (the pre-#796 `~> 5.0`)
 // let this harness validate the imported.tf codegen against a different AWS
-// provider major than production emits (`= 6.46.0`), because the shared
+// provider major than production emits (`= 6.52.0`), because the shared
 // TF_PLUGIN_CACHE_DIR resolved each constraint to a different cached major.
 // A v6-only schema change to an imported resource body would therefore pass
 // the v5-pinned harness. Deriving the pin from BaseProviderPin closes that
@@ -83,7 +83,7 @@ provider "aws" {
 // emitter ships — the canonical imported.BaseProviderPin("aws", "aws"),
 // also consumed by pkg/reverseimport/providers.go — and never against a
 // stale hand-pinned major. Pre-#796 the fixture hand-pinned `~> 5.0` while
-// production emitted `= 6.46.0`; this test fails on that skew. Unlike
+// production emitted `= 6.52.0`; this test fails on that skew. Unlike
 // TestImportedTF_TerraformValidate it needs no `terraform` binary, so it
 // runs everywhere the tfvalidate tag is built.
 func TestImportedTF_ProvidersFixtureMatchesEmitterPin(t *testing.T) {

--- a/pkg/composer/validate_providers.go
+++ b/pkg/composer/validate_providers.go
@@ -2,6 +2,7 @@ package composer
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -9,6 +10,12 @@ import (
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// exactPinRe pulls 3-segment versions out of a constraint string (matches the
+// version in `= X.Y.Z`, `>= X.Y.Z`, `<= X.Y.Z`, etc.) so findSatisfyingVersion
+// can test the actual pinned/boundary versions directly instead of relying
+// solely on the bounded candidate sweep.
+var exactPinRe = regexp.MustCompile(`=\s*(\d+\.\d+\.\d+)`)
 
 // providerSeeds represents the cloud-level required_provider entry that
 // generateProvidersTF stamps on every emitted root, regardless of what the
@@ -131,21 +138,27 @@ func findProviderConflicts(perProvider map[string]map[string][]string) []Validat
 	return issues
 }
 
-// findSatisfyingVersion sweeps a representative set of candidate versions and
-// returns true if any of them satisfy the combined constraint set. We need
-// to test enough of the version space that pessimistic three-segment
-// constraints like `~> 5.7.0` (= [5.7.0, 5.8.0)) don't slip through as
-// false negatives.
+// findSatisfyingVersion returns true if any version satisfies the combined
+// constraint set. It first tests the exact 3-segment versions named in the
+// constraints themselves (so an exact base pin like `= 6.52.0` is always
+// checked directly), then falls back to a bounded candidate sweep for
+// range-only constraints.
 //
-// Strategy: every major 0-50, every minor 0-50, with .0 and .99 patches.
-// That's 5,202 candidates — plenty to land inside any realistic
-// constraint window without being meaningfully expensive (each Check is
-// O(constraints)). Coverage assumption: providers don't ship version
-// numbers above 50.50.x, which is true for every Terraform provider in
-// existence today.
+// The direct exact-pin check exists because the sweep is bounded: it used to
+// stop at minor 50, which produced a *bogus* conflict once aws shipped 6.52.0
+// (minor 52 was outside the sweep, so the genuine `= 6.52.0` pin looked
+// unsatisfiable). Testing the named versions removes that whole class of
+// false negative; the sweep is kept (and widened to minor 99) only to cover
+// pessimistic range constraints like `~> 5.7.0` that name no exact version.
 func findSatisfyingVersion(c version.Constraints) bool {
+	// Exact/boundary versions named in the constraints, checked directly.
+	for _, m := range exactPinRe.FindAllStringSubmatch(c.String(), -1) {
+		if v, err := version.NewVersion(m[1]); err == nil && c.Check(v) {
+			return true
+		}
+	}
 	for major := 0; major <= 50; major++ {
-		for minor := 0; minor <= 50; minor++ {
+		for minor := 0; minor <= 99; minor++ {
 			for _, patch := range []int{0, 99} {
 				v, err := version.NewVersion(fmt.Sprintf("%d.%d.%d", major, minor, patch))
 				if err != nil {

--- a/pkg/composer/validate_providers.go
+++ b/pkg/composer/validate_providers.go
@@ -14,7 +14,7 @@ import (
 // generateProvidersTF stamps on every emitted root, regardless of what the
 // presets declare. ValidateProviderConstraints unions these into the
 // per-provider constraint set so a preset that pins (e.g.) `aws ~> 6.40`
-// surfaces as a conflict against the seed's exact `= 6.46.0` instead of
+// surfaces as a conflict against the seed's exact `= 6.52.0` instead of
 // slipping through to terraform init.
 //
 // These mirror the EXACT pins generateProvidersTF emits (#786): the composed

--- a/pkg/composer/validate_providers_test.go
+++ b/pkg/composer/validate_providers_test.go
@@ -123,7 +123,7 @@ func TestProviderSeedsMirrorComposer(t *testing.T) {
 	// constraints: a value change is then a deliberate diff, and the
 	// imported-package guard (TestBaseProviderPins_ExactAndMatchMars) separately
 	// asserts these equal the mars bake.
-	require.Equal(t, "= 6.46.0", providerSeeds["aws"])
+	require.Equal(t, "= 6.52.0", providerSeeds["aws"])
 	require.Equal(t, "= 6.10.0", providerSeeds["google"])
 	// google-beta MUST be seeded: the emitter pins it (pinBaseProviders
 	// re-asserts google-beta), so a GCP preset pinning an incompatible

--- a/pkg/composer/validate_providers_test.go
+++ b/pkg/composer/validate_providers_test.go
@@ -104,6 +104,12 @@ func TestFindSatisfyingVersion_AcceptsCompatibleAndRejectsImpossible(t *testing.
 	require.False(t, findSatisfyingVersion(mustParse("< 6.0,>= 6.1")))
 	// "< 5.0" AND ">= 7.0" cannot intersect.
 	require.False(t, findSatisfyingVersion(mustParse("< 5.0,>= 7.0")))
+	// Exact pin above the bounded sweep's old minor ceiling must still be found
+	// directly — aws 6.52.0 exposed this (minor 52 was outside the old <= 50
+	// sweep, producing a bogus conflict). Mirrors the real composed union:
+	// base pin = 6.52.0 plus a preset range >= 6.0.
+	require.True(t, findSatisfyingVersion(mustParse("= 6.52.0,>= 6.0")),
+		"an exact pin beyond the sweep ceiling must be tested directly")
 }
 
 // TestProviderSeedsMirrorComposer locks the providerSeeds constant against

--- a/pkg/reverseimport/providers_test.go
+++ b/pkg/reverseimport/providers_test.go
@@ -71,7 +71,7 @@ func TestRenderImportedProvidersTF_ExactProviderPins(t *testing.T) {
 			t.Fatalf("renderImportedProvidersTF() error = %v", err)
 		}
 		s := string(body)
-		want := imported.BaseProviderPin("aws", "aws") // "= 6.46.0"
+		want := imported.BaseProviderPin("aws", "aws") // "= 6.52.0"
 		if !strings.Contains(s, `version = "`+want+`"`) {
 			t.Fatalf("aws provider must be exactly pinned to %q, got:\n%s", want, s)
 		}

--- a/pkg/reverseimport/testdata/providers_imported_aws.golden
+++ b/pkg/reverseimport/testdata/providers_imported_aws.golden
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 6.46.0"
+      version = "= 6.52.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

(Repurposed from the earlier — and wrong — google 7.16.0 change; see history.)

`terraform-aws-modules/eks` 21.24.0 (resolved by the aws presets) requires **`aws >= 6.52`**, but the composer's `baseProviderPins` pinned `= 6.46.0`. So composed AWS stacks fail `terraform init` with `no available releases match the given constraints = 6.46.0, >= 6.52.0`. (Reproduced locally against the real upstream `versions.tf`.)

Bump the aws base pin to **`6.52.0`** so it satisfies the eks floor and matches the mars provider-mirror bake (mars#206).

**Google stays `= 6.10.0`** — `terraform-google-modules` (network/kubernetes-engine) cap `google < 7`, so v7 isn't usable for composed GCP stacks. (This is why the original google 7.16.0 idea on this branch was dropped.)

## Changes
- `baseProviderPins` aws `= 6.46.0` → `= 6.52.0`.
- Cross-emitter drift guard (`TestBaseProviderPins_*`) + composer/reverseimport pin assertions + the reverse-import `providers.tf` golden updated in lockstep.
- Schema codegen aws version (`generated.*`; `5.70.0`) intentionally untouched.

## Test plan
- [x] `go test ./pkg/composer/imported/... ./pkg/reverseimport/...` + composer pin/seed/bedrock tests green; `gofmt` clean.
- [ ] The composer `*_TerraformInit` / `*_TerraformValidate` tests need public-registry module egress (CI) — will run there. Note: the **separate** community-drift fragility (exact pins vs rising floors) is worth hardening by pinning the community module versions; out of scope here.

## Pairs with
mars#206 (bake aws 6.52.0 + google 6.10.0) and the sandbox-infrastructure-template stage locks.

Refs #148