### PR TITLE
fix(reverse-import): accept behavioral attrs (publish) on first-import plan

### DIFF
--- a/docs/reverse-import-contract.md
+++ b/docs/reverse-import-contract.md
@@ -31,6 +31,21 @@ The authoritative validator is **`pkg/composer/plan_acceptance.go:ValidateFirstI
 - `create` / `destroy` / `replace` on any resource is rejected;
 - it checks `importCount == ExpectedImports` (a count of **imports**, not changes).
 
+Two narrow, schema-guarded exceptions also pass without flagging, because
+the diff is not real drift:
+
+- **optional zero-default** — an `Optional` attribute going from `null`
+  (before) to its zero provider default (e.g. `force_destroy: false`)
+  (`allowedFirstImportOptionalZeroDefault`);
+- **behavioral / deploy-directive attrs** — a hand-curated per-type
+  allowlist (`firstImportBehavioralAttrs`) of write-only / non-round-trippable
+  attributes whose generated value is an apply-time instruction rather than a
+  faithful read-back of remote state. Current entries: `publish` on
+  `aws_cloudfront_function`, `aws_lambda_function`, and `aws_sfn_state_machine`
+  (issue #833). The allowlist is conservative by design and CI-guarded
+  (`TestFirstImportBehavioralAttrsAreRealOptionalSchemaFields`) so it can only
+  name real, configurable schema fields.
+
 ### Invariant: `change_count <= import_count`, NOT `==`
 
 Many AWS resource types **have no `tags` attribute at all** (e.g.

--- a/pkg/composer/plan_acceptance.go
+++ b/pkg/composer/plan_acceptance.go
@@ -358,6 +358,18 @@ func allowedFirstImportOptionalZeroDefault(resourceType, path string, before, af
 // failed at `terraform plan` because 4 aws_cloudfront_function resources
 // (e.g. aws_cloudfront_function.a2ae0703_ln_default_luther_api_cf_site157d)
 // produced an `imported_plan_unauthorized_change` on path "publish".
+//
+// CONSIDERED AND DELIBERATELY EXCLUDED (do not add without evidence of a real
+// first-import partial-failure, to avoid masking drift):
+//   - aws_db_instance / aws_rds_cluster `apply_immediately`, `skip_final_snapshot`:
+//     Optional workflow switches, but the policy layer tracks them as faithful
+//     drift (DriftSemanticExact) and the common null->false shape is already
+//     forgiven by allowedFirstImportOptionalZeroDefault. Only revisit if genconfig
+//     starts emitting a non-zero value (e.g. skip_final_snapshot=true) that
+//     partial-fails an RDS slice the way #833 did for CloudFront.
+//   - aws_lambda_function `source_code_hash` (Optional+Computed): genuinely
+//     non-round-trippable, BUT it is real redeploy signal — a first-plan diff
+//     there means the deployed package differs, which we must NOT hide.
 var firstImportBehavioralAttrs = map[string]map[string]struct{}{
 	// `publish` controls whether the provider publishes the LIVE stage on
 	// apply. It defaults to true and is not a faithful read-back of remote

--- a/pkg/composer/plan_acceptance.go
+++ b/pkg/composer/plan_acceptance.go
@@ -295,6 +295,9 @@ func unauthorizedChangeIssues(field, resourceType string, change *tfjson.Change,
 		if allowedFirstImportOptionalZeroDefault(resourceType, p, change.Before, change.After) {
 			continue
 		}
+		if isFirstImportBehavioralAttr(resourceType, p) {
+			continue
+		}
 		issues = append(issues, ValidationIssue{
 			Field:  field + "." + p,
 			Code:   "imported_plan_unauthorized_change",
@@ -325,6 +328,71 @@ func allowedFirstImportOptionalZeroDefault(resourceType, path string, before, af
 	}
 	afterValue, afterOK := valueAtPath(after, path)
 	return afterOK && isZeroProviderDefault(afterValue)
+}
+
+// firstImportBehavioralAttrs is a hand-curated allowlist of
+// (resourceType -> attribute-path) pairs that are DEPLOY-DIRECTIVE /
+// WRITE-ONLY / NON-ROUND-TRIPPABLE attributes. Their value in the
+// generated config is an instruction to the provider at apply time, NOT
+// a faithful read-back of remote state, so a first-import `terraform
+// plan` legitimately shows an in-place diff on them even though nothing
+// real has drifted. The first-import contract (decision #34) otherwise
+// only permits provenance tag/label repair, which would reject these
+// benign diffs and fail the whole-account import (job ends `partial`).
+//
+// This is intentionally distinct from allowedFirstImportOptionalZeroDefault,
+// which only forgives the narrow null-before -> zero-provider-default-after
+// shape. A behavioral attr may diff to a NON-zero value (e.g.
+// aws_cloudfront_function.publish defaults to true and round-trips as a
+// true->true or null->true first-plan diff), so the zero-default helper
+// cannot cover it.
+//
+// CONSERVATIVE BY DESIGN: only attributes that are unambiguously a deploy
+// directive or a provider write-only field belong here. A normal config
+// attribute that should faithfully match remote state must NEVER be added
+// — doing so would silently mask real drift on first import. Each entry
+// is justified inline; when in doubt, leave it out.
+//
+// Triggering example: issue #833 — whole-account reverse-import of account
+// 141812438321 (staging session sess_v2_fvZSf5IfhLCb, job ri-897a6c4e-kff6g)
+// failed at `terraform plan` because 4 aws_cloudfront_function resources
+// (e.g. aws_cloudfront_function.a2ae0703_ln_default_luther_api_cf_site157d)
+// produced an `imported_plan_unauthorized_change` on path "publish".
+var firstImportBehavioralAttrs = map[string]map[string]struct{}{
+	// `publish` controls whether the provider publishes the LIVE stage on
+	// apply. It defaults to true and is not a faithful read-back of remote
+	// state, so genconfig's emitted value yields a benign first-plan diff.
+	// (#833 — the exact prod-failing case.)
+	"aws_cloudfront_function": {
+		"publish": {},
+	},
+	// `publish` is a deploy directive: when true, the provider publishes a
+	// new immutable Lambda version on apply. It is an apply-time action,
+	// not round-trippable readback state. The narrow null->false shape was
+	// already forgiven by allowedFirstImportOptionalZeroDefault; this
+	// covers the remaining behavioral shapes (e.g. genconfig emitting true,
+	// or a function with a published version) for class consistency (#833).
+	"aws_lambda_function": {
+		"publish": {},
+	},
+	// `publish` is a deploy directive: when true, the provider publishes a
+	// new state-machine version on apply. Same write-only/apply-time
+	// semantics as the Lambda case (#833 sweep).
+	"aws_sfn_state_machine": {
+		"publish": {},
+	},
+}
+
+// isFirstImportBehavioralAttr reports whether path on resourceType is a
+// curated deploy-directive / write-only attribute that the first-import
+// contract permits to differ. See firstImportBehavioralAttrs.
+func isFirstImportBehavioralAttr(resourceType, path string) bool {
+	paths, ok := firstImportBehavioralAttrs[resourceType]
+	if !ok {
+		return false
+	}
+	_, ok = paths[path]
+	return ok
 }
 
 func isZeroProviderDefault(v any) bool {

--- a/pkg/composer/plan_acceptance_test.go
+++ b/pkg/composer/plan_acceptance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
 )
 
 // importChange builds a tfjson.ResourceChange that represents an
@@ -143,7 +144,12 @@ func TestValidateFirstImportPlan_Contract(t *testing.T) {
 			wantCodes: nil,
 		},
 		{
-			name: "aws lambda import publish true still fails",
+			// #833: `publish` is a behavioral deploy directive on
+			// aws_lambda_function (publishes a new version on apply), not
+			// round-trippable readback state. Even the non-zero false->true
+			// shape is a benign first-plan diff and must be accepted.
+			// (Previously asserted to fail; corrected by the #833 sweep.)
+			name: "aws lambda import publish true passes (behavioral attr)",
 			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
 				typedImportChange("aws_lambda_function", "aws_lambda_function.fn",
 					tfjson.Actions{tfjson.ActionUpdate},
@@ -152,7 +158,97 @@ func TestValidateFirstImportPlan_Contract(t *testing.T) {
 				),
 			}},
 			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: nil,
+		},
+		{
+			// Guard: a non-behavioral optional attr (memory_size) that
+			// genuinely diverges from imported state is still real drift
+			// and must fail — the behavioral allowlist must not over-reach.
+			name: "aws lambda import non-behavioral memory_size change still fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_lambda_function", "aws_lambda_function.fn",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"memory_size": float64(128)},
+					map[string]any{"memory_size": float64(256)},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
 			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			// #833 EXACT PROD REPRO. Whole-account reverse-import of account
+			// 141812438321 (staging session sess_v2_fvZSf5IfhLCb, job
+			// ri-897a6c4e-kff6g) failed at `terraform plan` because
+			// aws_cloudfront_function.a2ae0703_ln_default_luther_api_cf_site157d
+			// (and 3 siblings) produced a first-plan diff on `publish`, which
+			// the contract rejected with imported_plan_unauthorized_change.
+			// `publish` is a deploy directive (defaults true), not real drift.
+			name: "aws cloudfront_function first-import publish diff passes (#833)",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_cloudfront_function",
+					"aws_cloudfront_function.a2ae0703_ln_default_luther_api_cf_site157d",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": false, "code": "function handler(){}"},
+					map[string]any{"publish": true, "code": "function handler(){}"},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: nil,
+		},
+		{
+			// #833 sweep: aws_sfn_state_machine.publish is the same class of
+			// deploy directive (publishes a new version on apply).
+			name: "aws sfn_state_machine first-import publish diff passes (#833 sweep)",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_sfn_state_machine", "aws_sfn_state_machine.sm",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": false},
+					map[string]any{"publish": true},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: nil,
+		},
+		{
+			// Guard: the behavioral allowlist is per-type. `publish` on a
+			// type NOT in firstImportBehavioralAttrs must still flag, so the
+			// allowlist can never silently widen to every `publish` field.
+			name: "publish diff on an unlisted type still fails",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_s3_bucket", "aws_s3_bucket.b",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": false},
+					map[string]any{"publish": true},
+				),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 1, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: []string{"imported_plan_unauthorized_change"},
+		},
+		{
+			// #833 multi-resource shape: the exact 4-cloudfront-function
+			// account slice (all `publish` diffs) is accepted as a clean
+			// import-only plan — no partial drop.
+			name: "aws four cloudfront_function publish diffs all pass (#833 account slice)",
+			plan: &tfjson.Plan{ResourceChanges: []*tfjson.ResourceChange{
+				typedImportChange("aws_cloudfront_function",
+					"aws_cloudfront_function.a2ae0703_ln_default_luther_api_cf_site157d",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": false}, map[string]any{"publish": true}),
+				typedImportChange("aws_cloudfront_function",
+					"aws_cloudfront_function.a2ae0703_ln_default_luther_api_cf_site157d_d3681487",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": false}, map[string]any{"publish": true}),
+				typedImportChange("aws_cloudfront_function",
+					"aws_cloudfront_function.fcc86a23_ln_default_luther_api_cf_site157d",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": false}, map[string]any{"publish": true}),
+				typedImportChange("aws_cloudfront_function",
+					"aws_cloudfront_function.fcc86a23_ln_default_luther_api_cf_site157d_94986f5a",
+					tfjson.Actions{tfjson.ActionUpdate},
+					map[string]any{"publish": false}, map[string]any{"publish": true}),
+			}},
+			opts:      ValidateFirstImportPlanOpts{ExpectedImports: 4, ProvenanceLabelKeys: FirstImportProvenanceKeys("aws")},
+			wantCodes: nil,
 		},
 		{
 			name: "required field null to zero still fails",
@@ -638,4 +734,27 @@ func TestDiffPaths_LeafLevel(t *testing.T) {
 	// Scalar change at top-level.
 	got = diffPaths("STANDARD", "NEARLINE", "")
 	assert.Equal(t, []string{"<root>"}, got)
+}
+
+// TestFirstImportBehavioralAttrsAreRealOptionalSchemaFields is a
+// class-level poka-yoke (#833): every (resourceType, path) the
+// first-import contract forgives as "behavioral" must name a real,
+// configurable (Optional or Required) attribute in the generated provider
+// schema. This fails on a typo'd type/path and — more importantly —
+// refuses to let anyone allowlist a Computed-only field (which is never a
+// deploy directive the genconfig writes) or a non-existent attribute, both
+// of which would mask the wrong thing rather than fix a benign first-plan
+// diff. It keeps the allowlist honest as new entries are added.
+func TestFirstImportBehavioralAttrsAreRealOptionalSchemaFields(t *testing.T) {
+	t.Parallel()
+	for resourceType, paths := range firstImportBehavioralAttrs {
+		_, schema, ok := generated.Lookup(resourceType)
+		require.Truef(t, ok, "behavioral allowlist names unknown resource type %q", resourceType)
+		for path := range paths {
+			fs, ok := schema[path]
+			require.Truef(t, ok, "%s: behavioral path %q is not in the generated schema", resourceType, path)
+			assert.Truef(t, fs.Configurable(),
+				"%s.%s: behavioral allowlist entries must be configurable (Optional/Required); a Computed-only field is never a deploy directive", resourceType, path)
+		}
+	}
 }


### PR DESCRIPTION
Closes #833

## Problem

A whole-account reverse-import PLAN failed at Mars `terraform plan` because the first-import contract guard (`ValidateFirstImportPlan`) rejected 4 `aws_cloudfront_function` resources with:

```
imported_plan_unauthorized_change
first-import plan must only repair provenance tags/labels; path "publish" is not in the allowed set
```

`publish` on `aws_cloudfront_function` is a deploy-time directive (defaults `true`, not a faithful read-back of remote state), so the generated config produces a benign first-plan diff on `publish`. The contract — which only allows provenance tag/label repair — treated it as drift, so the job ended `status: partial`, exit 1 → `JOB_STATUS_FAILURE`.

## Fix (issue option (a))

Add a hand-curated, schema-guarded per-type allowlist `firstImportBehavioralAttrs` in `pkg/composer/plan_acceptance.go`, consulted in `unauthorizedChangeIssues` right next to the existing `allowedFirstImportOptionalZeroDefault` helper. A behavioral / write-only / non-round-trippable attribute is forgiven on the first-import plan.

This is intentionally distinct from `allowedFirstImportOptionalZeroDefault`, which only forgives the narrow `null`-before → zero-provider-default-after shape. A behavioral attr can diff to a non-zero value (e.g. `publish: true`), so the zero-default helper cannot cover it.

## Allowlisted (resource type, attribute) — all deploy directives

| Resource type | Attr | Justification |
|---|---|---|
| `aws_cloudfront_function` | `publish` | Controls whether the provider publishes the LIVE stage on apply (defaults true); not a faithful readback. **The exact #833 prod-failing case.** |
| `aws_lambda_function` | `publish` | Apply-time action: publishes a new immutable Lambda version. The narrow `null→false` shape was already covered by the zero-default helper; this covers the remaining shapes for class consistency. |
| `aws_sfn_state_machine` | `publish` | Apply-time action: publishes a new state-machine version on apply. Same write-only semantics. |

### Candidates deliberately left out

The issue floated several `aws_lambda_function` fields. I kept the allowlist to `publish` only and did **not** add the others, to avoid masking real drift:

- `source_code_hash`, `filename`, `s3_bucket` / `s3_key` / `s3_object_version`, `image_uri` — genuine config inputs that *should* faithfully match the deployed package; a first-plan diff on them is real signal (a redeploy mismatch), not a benign deploy directive. Allowlisting them could hide an out-of-band code change.
- `last_modified`, `version`, `qualified_arn`, `source_code_size`, `code_sha256` — Computed-only in the provider schema, so the composer never emits them and they can't produce a config-vs-state first-plan diff in the first place. (The new CI guard would also reject them as non-configurable.)

Only `publish` is an unambiguous apply-time directive across these three types, so it's the only attribute added.

## Poka-yoke / tests (`pkg/composer/plan_acceptance_test.go`)

- **Exact prod repro** — first-import plan whose only diff is `publish` on `aws_cloudfront_function.a2ae0703_ln_default_luther_api_cf_site157d` is accepted (cites #833 + the account/job).
- **Account slice** — all 4 prod cloudfront-function `publish` diffs accepted as a clean import-only plan (no partial drop).
- **Swept attrs** — `aws_lambda_function.publish` and `aws_sfn_state_machine.publish` accepted.
- **Negatives (no over-reach):** a non-behavioral `memory_size` change still fails; `publish` on an **unlisted** type (`aws_s3_bucket`) still fails.
- **Class-level guard** — `TestFirstImportBehavioralAttrsAreRealOptionalSchemaFields` fails if any allowlist entry names a non-existent or Computed-only (non-configurable) attribute, so the allowlist can only ever name real deploy-directive fields and can't silently widen.
- Updated the previously-too-strict `aws lambda import publish true still fails` case (which encoded the assumption #833 corrects).

Also documented the exception in `docs/reverse-import-contract.md`.

## Test plan

- `gofmt -l` clean on changed files
- `go build ./...` OK
- `go vet ./pkg/composer/... ./pkg/reverseimport/...` OK
- `go test ./pkg/composer/... ./pkg/reverseimport/...` — all pass except two pre-existing network-bound tests (`TestComposeStack_TerraformInit`, `TestComposeGCPVPC_PlanHasNoForEachUnknownKey`) that download Terraform modules and 403 in the sandbox; confirmed identical failures on stock `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_