### PR TITLE
fix(composer): drop dangling-parent orphans in ComposeStackWithIssues

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -693,16 +693,37 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// Build /imported.tf for resources observed via reverse-Terraform
 	// (issue #148). This must happen before generateProvidersTF so that
 	// importedClouds tells the provider emitter which alias to declare.
-	issues = append(issues, ValidateImportedResources(cloud, opts.Imported)...)
+	// Drop orphaned children — a child whose Identity.ParentAddress references a
+	// resource not present in the import set — BEFORE validation/emit. Such a
+	// child can never render a valid block (its parent reference points
+	// nowhere), and ValidateImportedResources would flag it
+	// imported_resource_dangling_parent, which callers escalate to a fatal that
+	// aborts the WHOLE compose (the reliable reverse-import apply 500). This is
+	// the same philosophy as dropUncomposable below: one un-emittable resource
+	// must not fail the entire stack. Canonical case (#736): the InsideOut
+	// management state bucket is excluded from import, but RGT/Cloud Control
+	// surfaces its ownership_controls/versioning/sse/public_access_block children
+	// independently, each pointing at the now-absent bucket. DropOrphanedChildren
+	// runs to a fixed point (a dropped parent cascades to grandchildren). The
+	// drop is intentionally silent — it only REMOVES a would-be-fatal issue, so
+	// it cannot break any caller; callers wanting an audit trail call
+	// DropOrphanedChildren themselves first (reliable's apply leg logs the
+	// dropped addresses).
+	importedResources := opts.Imported
+	if kept, dropped := imported.DropOrphanedChildren(opts.Imported); len(dropped) > 0 {
+		importedResources = kept
+	}
+
+	issues = append(issues, ValidateImportedResources(cloud, importedResources)...)
 	// Emit-readiness checks (required-argument completeness) run here —
 	// at compose time, on the final ready-to-emit resource set — not in
 	// the discovery manifest writer, which validates a still-enriching
 	// intermediate snapshot. See ValidateImportedEmitReadiness.
-	emitReadiness := ValidateImportedEmitReadiness(cloud, opts.Imported)
+	emitReadiness := ValidateImportedEmitReadiness(cloud, importedResources)
 	issues = append(issues, emitReadiness...)
-	issues = append(issues, ValidateImportedResourceAuthorization(cloud, opts.Imported)...)
+	issues = append(issues, ValidateImportedResourceAuthorization(cloud, importedResources)...)
 	provOpts := ProvenanceOpts{ImportProjectID: opts.ImportProjectID, ImportSessionID: opts.ImportSessionID}
-	issues = append(issues, ValidateProvenanceConflicts(cloud, opts.Imported, provOpts)...)
+	issues = append(issues, ValidateProvenanceConflicts(cloud, importedResources, provOpts)...)
 	emitOpts := EmitImportedOpts{
 		ImportProjectID: opts.ImportProjectID,
 		ImportSessionID: opts.ImportSessionID,
@@ -715,7 +736,7 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// already recorded above, so the caller still learns which resource
 	// was dropped and why; emitting it anyway would turn a one-resource
 	// gap into a stack-wide planning failure.
-	composable := dropUncomposable(opts.Imported, emitReadiness)
+	composable := dropUncomposable(importedResources, emitReadiness)
 	importedTF, importedClouds := EmitImportedTF(cloud, composable, emitOpts)
 	if len(importedTF) > 0 {
 		files["/imported.tf"] = importedTF
@@ -769,8 +790,8 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	issues = append(issues, ValidateValueTypes(moduleToVals, presetPaths)...)
 	issues = append(issues, ValidateModuleWiring(blocks, presetPaths)...)
 	issues = append(issues, ValidateNoModuleCycles(blocks)...)
-	issues = append(issues, ValidateNoUnionCycles(blocks, opts.Imported)...)
-	issues = append(issues, ValidateCrossTierWiring(blocks, opts.Imported)...)
+	issues = append(issues, ValidateNoUnionCycles(blocks, importedResources)...)
+	issues = append(issues, ValidateCrossTierWiring(blocks, importedResources)...)
 	issues = append(issues, ValidateProviderConstraints(presetPaths)...)
 	issues = append(issues, ValidateSensitivePropagation(blocks, presetPaths)...)
 	issues = append(issues, ValidateComposedRoot(files)...)

--- a/pkg/composer/imported_orphan_compose_test.go
+++ b/pkg/composer/imported_orphan_compose_test.go
@@ -1,0 +1,69 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// TestComposeStack_DropsDanglingParentOrphans is the composer-side fix for the
+// reverse-import apply 500 (#736 sweep): a child whose ParentAddress points at a
+// resource excluded from the import set must not abort the whole compose with a
+// fatal imported_resource_dangling_parent. ComposeStackWithIssues now drops such
+// orphans (via imported.DropOrphanedChildren) before validation, the same way
+// dropUncomposable refuses emit-unready resources — so one un-importable child
+// never fails the stack.
+//
+// Canonical case: the InsideOut management state bucket is excluded from import,
+// but RGT/Cloud Control surfaces its ownership_controls/versioning/... children
+// pointing at the now-absent bucket. Triggering data: reliable account
+// 536892739526 / the luther-948e8133-…-tfstate-s3-… bucket's 4 children.
+func TestComposeStack_DropsDanglingParentOrphans(t *testing.T) {
+	t.Parallel()
+
+	irs := []imported.ImportedResource{
+		// Parent bucket PRESENT → its child is kept.
+		{Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_s3_bucket",
+			Address: "aws_s3_bucket.keep", ImportID: "keep-bucket",
+		}, Tier: imported.TierImportedFlat},
+		{Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_s3_bucket_versioning",
+			Address: "aws_s3_bucket_versioning.keep_v", ParentAddress: "aws_s3_bucket.keep",
+			ImportID: "keep-bucket",
+		}, Tier: imported.TierImportedFlat},
+		// Parent bucket ABSENT (excluded as the InsideOut state bucket) → orphan.
+		{Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_s3_bucket_versioning",
+			Address: "aws_s3_bucket_versioning.orphan_v", ParentAddress: "aws_s3_bucket.absent_tfstate",
+			ImportID: "absent-tfstate-bucket",
+		}, Tier: imported.TierImportedFlat},
+	}
+
+	res, err := newTestClient().ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "io-orphan-test",
+		Region:       "us-east-1",
+		Imported:     irs,
+	})
+	require.NoError(t, err)
+
+	// The orphan must NOT produce a (fatal) dangling-parent issue — it was
+	// dropped before validation.
+	for _, is := range res.Issues {
+		assert.NotEqualf(t, CodeImportedDanglingParent, is.Code,
+			"orphan should be dropped, not flagged dangling: %+v", is)
+	}
+
+	// The orphan child must not be emitted; the valid resource (whose parent is
+	// present) must survive so the rest of the stack still composes.
+	tf := string(res.Files["/imported.tf"])
+	assert.NotContains(t, tf, "orphan_v", "orphaned child (absent parent) must be dropped from imported.tf")
+	assert.Contains(t, tf, `resource "aws_s3_bucket" "keep"`, "the in-set parent bucket must still be emitted")
+}


### PR DESCRIPTION
## Summary

Moves the dangling-parent orphan handling into the composer itself, so **every** consumer of `ComposeStackWithIssues` is covered — not just callers that remember to pre-drop.

A child whose `Identity.ParentAddress` references a resource **excluded from the import set** (e.g. the InsideOut management state bucket is excluded, but RGT/Cloud Control surfaces its `ownership_controls` / `versioning` / `sse` / `public_access_block` children independently) trips the **fatal** `imported_resource_dangling_parent` validation, which callers escalate into an aborted compose. That was the reliable reverse-import **apply** 500 (account `536892739526`, the `luther-948e8133-…-tfstate-s3-…` bucket's 4 children).

`ComposeStackWithIssues` now runs `imported.DropOrphanedChildren` (#736) on `opts.Imported` before validation/emit and uses the pruned set throughout (`ValidateImportedResources`, emit-readiness, authorization, provenance, `dropUncomposable`, wiring checks). Same philosophy as the existing `dropUncomposable`: one un-emittable resource must not fail the whole stack.

## Why silent (no new issue)

`ValidationIssue` has no severity field — callers treat any non-allowlisted code as fatal. Emitting a *new* advisory code would be fatal-by-default for existing consumers. So the drop is intentionally silent: it only **removes** a would-be-fatal issue, so it cannot break any caller. Callers that want an audit trail call `DropOrphanedChildren` themselves first (reliable's apply leg already logs the dropped addresses). A structured advisory is a future enhancement gated on adding a severity field to `ValidationIssue`.

## Relationship to the reliable fix

reliable#2197 already calls `DropOrphanedChildren` before compose (ships the fix now, against the current pin). This PR makes the composer self-healing so the next consumer (or reliable after #2197's explicit call is eventually removed) is covered for free. Both consume the same `imported.DropOrphanedChildren` (#736) — no duplicated logic.

## Test plan

- `go build ./...` OK
- `TestComposeStack_DropsDanglingParentOrphans` (new): orphan child (absent parent) is dropped → no `imported_resource_dangling_parent` fatal; orphan absent from `/imported.tf`; in-set parent bucket still emitted
- `DropOrphanedChildren` itself covered by `orphans_test.go`
- Full `pkg/composer` suite green except two pre-existing `terraform init`-network tests (`TestComposeStack_TerraformInit`, `TestComposeGCPVPC_PlanHasNoForEachUnknownKey`) that also fail on the unmodified tree in this sandbox (no provider-download network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_