### PR TITLE
fix(composer): exempt forget-mode resources from dangling-parent drop/flag (code-review follow-up to #836)

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -709,10 +709,7 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// it cannot break any caller; callers wanting an audit trail call
 	// DropOrphanedChildren themselves first (reliable's apply leg logs the
 	// dropped addresses).
-	importedResources := opts.Imported
-	if kept, dropped := imported.DropOrphanedChildren(opts.Imported); len(dropped) > 0 {
-		importedResources = kept
-	}
+	importedResources, _ := imported.DropOrphanedChildren(opts.Imported)
 
 	issues = append(issues, ValidateImportedResources(cloud, importedResources)...)
 	// Emit-readiness checks (required-argument completeness) run here —

--- a/pkg/composer/imported/orphans.go
+++ b/pkg/composer/imported/orphans.go
@@ -11,6 +11,17 @@ import "strings"
 // dependency cycle — composer imports imported, not the reverse).
 const DanglingParentReason = "imported_resource_dangling_parent"
 
+// emitsRemovedBlock reports whether ir is the forget projection that renders a
+// Terraform `removed { from = ... lifecycle { destroy = false } }` block rather
+// than an import/resource block. Mirrors the composer's classifyEmitMode
+// `emitModeRemovedBlock` case (TierImportedMissing + ActionRemoveFromInsideOut).
+// Such a block references only the resource's own address, never its parent, so
+// it can never be a dangling-parent orphan — DropOrphanedChildren must not drop
+// it (and ValidateImportedResources must not flag it dangling).
+func emitsRemovedBlock(ir ImportedResource) bool {
+	return ir.Tier == TierImportedMissing && ir.Remediation == ActionRemoveFromInsideOut
+}
+
 // DropOrphanedChildren removes every resource whose Identity.ParentAddress
 // transitively references a resource that is not present in the kept set, and
 // returns the surviving resources plus the dropped orphans (each unchanged).
@@ -70,6 +81,17 @@ func DropOrphanedChildren(irs []ImportedResource) (kept []ImportedResource, drop
 				continue
 			}
 			if present[parent] {
+				continue
+			}
+			// Forget-mode resources are NEVER dangling orphans. A
+			// TierImportedMissing + ActionRemoveFromInsideOut resource renders a
+			// `removed { from = <addr> lifecycle { destroy = false } }` block,
+			// which references only its OWN address — never its parent. Dropping
+			// it would strip that protective block and leave the address in
+			// Terraform state exposed to deletion on the next apply/destroy
+			// (reliable #2048's fail-closed forget guard). So keep it (and keep
+			// its address present), even when its parent is absent from the set.
+			if emitsRemovedBlock(ir) {
 				continue
 			}
 			// Orphan: parent is absent (never discovered or already

--- a/pkg/composer/imported/orphans_test.go
+++ b/pkg/composer/imported/orphans_test.go
@@ -122,3 +122,28 @@ func TestDropOrphanedChildren_OrderPreserved(t *testing.T) {
 	assert.Equal(t, []string{"aws_z.last", "aws_a.first"}, addrsOf(kept),
 		"kept preserves input order; the orphan in the middle is removed")
 }
+
+// TestDropOrphanedChildren_KeepsForgetBlockOrphan pins the reliable #2048
+// data-loss fix: a forget projection (TierImportedMissing +
+// ActionRemoveFromInsideOut) renders a `removed {}` block that references only
+// its own address, never its parent. Even when its parent is ABSENT from the
+// set (the destroy path projects every adopted resource to forget-mode and an
+// excluded parent is common), it must NOT be dropped — dropping it strips the
+// protective removed{destroy=false} block and exposes the resource to deletion.
+func TestDropOrphanedChildren_KeepsForgetBlockOrphan(t *testing.T) {
+	in := []ImportedResource{
+		// Forget-mode orphan: parent absent, but emits removed{} → keep.
+		{Identity: ResourceIdentity{Address: "aws_s3_bucket_versioning.forget_v", ParentAddress: "aws_s3_bucket.absent"},
+			Tier: TierImportedMissing, Remediation: ActionRemoveFromInsideOut},
+		// Import-mode orphan: parent absent → still dropped.
+		{Identity: ResourceIdentity{Address: "aws_s3_bucket_versioning.import_v", ParentAddress: "aws_s3_bucket.absent"},
+			Tier: TierImportedFlat},
+	}
+	kept, dropped := DropOrphanedChildren(in)
+	if len(kept) != 1 || kept[0].Identity.Address != "aws_s3_bucket_versioning.forget_v" {
+		t.Fatalf("kept = %+v, want only the forget-mode orphan", kept)
+	}
+	if len(dropped) != 1 || dropped[0].Identity.Address != "aws_s3_bucket_versioning.import_v" {
+		t.Fatalf("dropped = %+v, want only the import-mode orphan", dropped)
+	}
+}

--- a/pkg/composer/imported_orphan_compose_test.go
+++ b/pkg/composer/imported_orphan_compose_test.go
@@ -54,16 +54,21 @@ func TestComposeStack_DropsDanglingParentOrphans(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// The orphan must NOT produce a (fatal) dangling-parent issue — it was
-	// dropped before validation.
+	// PRIMARY guard: the orphan must NOT produce the fatal dangling-parent issue
+	// — it was dropped before validation. (Without the drop, ValidateImportedResources
+	// emits imported_resource_dangling_parent for orphan_v and the gated caller
+	// aborts the whole compose.) This assertion fails if the fix regresses.
 	for _, is := range res.Issues {
 		assert.NotEqualf(t, CodeImportedDanglingParent, is.Code,
 			"orphan should be dropped, not flagged dangling: %+v", is)
 	}
 
-	// The orphan child must not be emitted; the valid resource (whose parent is
-	// present) must survive so the rest of the stack still composes.
+	// Secondary sanity on the emitted stack. NOTE: the present-parent child
+	// keep_v is NOT asserted present — a minimal aws_s3_bucket_versioning has no
+	// emit-ready body, so emit-readiness (dropUncomposable) drops it regardless
+	// of orphan logic; only the in-set parent bucket reliably emits. So these two
+	// are weak sanity checks, not the guard (the dangling-code assertion above is).
 	tf := string(res.Files["/imported.tf"])
-	assert.NotContains(t, tf, "orphan_v", "orphaned child (absent parent) must be dropped from imported.tf")
-	assert.Contains(t, tf, `resource "aws_s3_bucket" "keep"`, "the in-set parent bucket must still be emitted")
+	assert.NotContains(t, tf, "orphan_v", "orphaned child (absent parent) must not reach imported.tf")
+	assert.Contains(t, tf, `resource "aws_s3_bucket" "keep"`, "the in-set parent bucket must still be emitted (cascade didn't over-drop)")
 }

--- a/pkg/composer/imported_validate.go
+++ b/pkg/composer/imported_validate.go
@@ -173,6 +173,14 @@ func ValidateImportedResources(cloud string, irs []imported.ImportedResource) []
 		if _, ok := addressIndex[parent]; ok {
 			continue
 		}
+		// A forget projection renders a `removed {}` block that references only
+		// its own address, never its parent, so an absent parent is not a
+		// dangling reference for it — don't flag it. Mirrors the emitsRemovedBlock
+		// skip in imported.DropOrphanedChildren (reliable #2048: dropping/flagging
+		// a forget block would strip its protective removed{} and risk deletion).
+		if classifyEmitMode(irs[i]) == emitModeRemovedBlock {
+			continue
+		}
 		issues = append(issues, ValidationIssue{
 			Field:  importedField(irs[i], i),
 			Value:  parent,


### PR DESCRIPTION
## Summary

Code-review follow-up to #836. The orphan handling was **mode-agnostic**, which created a **data-loss risk on the destroy path**.

A forget projection (`TierImportedMissing` + `ActionRemoveFromInsideOut`) renders a `removed { from = <addr> lifecycle { destroy = false } }` block that references **only its own address, never its parent** — so an absent parent is *not* a dangling reference for it. But:

- `DropOrphanedChildren` dropped it anyway, and
- `ValidateImportedResources` flagged it `imported_resource_dangling_parent`.

On the **destroy** path, reliable projects every adopted resource to forget-mode via `projectImportedForDestroy` (which preserves `Identity.ParentAddress`). So an adopted child whose parent is absent from the destroy set would be **silently dropped** → its protective `removed{destroy=false}` block is never emitted → the resource stays in Terraform state **exposed to deletion**, defeating reliable's #2048 fail-closed forget guard.

## Fix

Both sides now skip forget-mode resources:
- `imported.DropOrphanedChildren` — new `emitsRemovedBlock` predicate (`TierImportedMissing` + `ActionRemoveFromInsideOut`); forget-mode orphans are kept (and stay "present" for their own children).
- the dangling-parent validator — skips `classifyEmitMode(ir) == emitModeRemovedBlock`.

Import-mode orphans are still dropped/flagged exactly as before. This is a **no-op everywhere except the destroy path**, since forget-mode projection only happens at destroy time.

## Also (other code-review nits)

- Simplify the `compose.go` drop call: `importedResources, _ := imported.DropOrphanedChildren(opts.Imported)` (the `len(dropped)>0` guard was over-clever).
- Fix a misleading comment in the orphan compose test: the minimal present-parent child is dropped by emit-readiness, not orphan logic — the `imported_resource_dangling_parent`-absent assertion is the real guard.

## Test plan

- `go build ./...` OK
- `TestDropOrphanedChildren_KeepsForgetBlockOrphan` (new): forget-mode orphan kept, import-mode orphan dropped
- existing `DropOrphanedChildren` + composer dangling tests green

## Found by

The reliable-side code-review pass on this work flagged the destroy-path data-loss (the drop sat in the shared compose bottleneck). This puts the mode-aware fix at the source so every consumer (reliable apply + the management-button/compose path + destroy) is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_