### PR TITLE
chore: bump actions/setup-go to 6.5.0 + install rsync in cloud-web setup

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -272,7 +272,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -287,7 +287,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -330,7 +330,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -343,7 +343,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go.mod
           cache: true
@@ -360,7 +360,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
           go-version-file: go.mod
           cache: true

--- a/scripts/cloud-web-setup.sh
+++ b/scripts/cloud-web-setup.sh
@@ -190,12 +190,16 @@ ensure_go() {
 # Phase 1 (sync): base packages the parallel installers depend on. git-lfs is needed by
 # reliable's go tests (LFS-tracked tokenizer model); 'git lfs install' is system-wide here.
 # bubblewrap is codex's sandbox runtime -- without it on PATH codex warns on every invocation
-# and falls back to its bundled copy. Installed in this single synchronous transaction (not the
-# parallel phase) to avoid dpkg-lock contention with install_apt_extras.
-log "installing base apt packages (incl. git-lfs, bubblewrap)"
+# and falls back to its bundled copy. rsync drives reliable's `make export-mock` /
+# `make verify-mock` (mock-ui/scripts/export-mock.sh rsyncs the shared component tree into the
+# insideout-app-mock export); without it that target dies with "rsync: command not found".
+# This setup script is committed identically in both repos, so rsync ships here too even though
+# presets has no mock-ui. Installed in this single synchronous transaction (not the parallel
+# phase) to avoid dpkg-lock contention with install_apt_extras.
+log "installing base apt packages (incl. git-lfs, bubblewrap, rsync)"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y --no-install-recommends unzip jq ca-certificates curl gnupg git-lfs bubblewrap
+apt-get install -y --no-install-recommends unzip jq ca-certificates curl gnupg git-lfs bubblewrap rsync
 git lfs install --system || true
 
 # Phase 2 (parallel): non-apt installers PLUS the single apt user (install_apt_extras).
@@ -225,7 +229,7 @@ install_codex_auth_and_plugins || log "codex auth / plugin setup failed (non-fat
 # Docker is preinstalled but its daemon won't be running in a fresh session VM. If a task
 # needs it, start it on demand: `sudo service docker start`. Not required for the standard
 # build/lint/test flow (Postgres is reached via POSTGRES_URL).
-log "setup complete: terraform, tflint, golangci-lint, gopls, go, codex, firecrawl-cli, vercel, op, gh, git-lfs, bubblewrap installed; codex auth + plugins baked"
+log "setup complete: terraform, tflint, golangci-lint, gopls, go, codex, firecrawl-cli, vercel, op, gh, git-lfs, bubblewrap, rsync installed; codex auth + plugins baked"
 # Explicit completion marker. If this line is ABSENT from the log, the script aborted partway
 # (look for the "ERROR: setup aborted at line N" breadcrumb above). To check what was skipped
 # vs failed, grep the log for: 'skipping plugin install' | 'plugin install failed' | 'WARNING' | 'ERROR'


### PR DESCRIPTION
Folds two housekeeping PRs into one so they land (and go green) together. No functional change to any preset.

## Changes

- **Bump `actions/setup-go` 6.4.0 → 6.5.0** (`.github/workflows/terraform-validate.yml`). Dependabot's actions-group update, SHA-pinned (`924ae3a` # v6.5.0). Supersedes #832.
- **Install `rsync` in the cloud-web setup script** (`scripts/cloud-web-setup.sh`). Mirrors reliable's matching change to keep the shared Claude-Code-on-the-web setup script identical across both repos — reliable needs `rsync` for `make export-mock` / `make verify-mock`; on a fresh VM that target dies with `rsync: command not found`. No-op for presets builds (presets has no mock-ui). Supersedes #830.

## Test plan

- Both hunks are disjoint single-file changes cherry-picked cleanly onto latest `main`.
- CI (`terraform-validate` + preset validation) runs on this PR and gates green.

Closes #832
Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_