### PR TITLE
fix(imported): drop Optional+Computed inline routes on aws_route_table import (odb_network_arn provider drift)

### DIFF
--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -285,6 +285,7 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 		ensureLambdaPlaceholderSource(typed)
 		ensureKeyPairPlaceholder(typed)
 		ensureSecurityGroupRuleLists(typed)
+		dropRouteTableComputedRoutes(typed)
 		// Pass the registered schema so computed-only attributes are
 		// dropped. Lookup returns a nil schema for unregistered types,
 		// which makes MarshalHCLConfigurable byte-identical to MarshalHCL.
@@ -332,6 +333,32 @@ func ensureSecurityGroupIngressRuleLists(rule *generated.AWSSecurityGroupIngress
 	}
 	if rule.SecurityGroups == nil {
 		rule.SecurityGroups = []*generated.Value[string]{}
+	}
+}
+
+// dropRouteTableComputedRoutes clears the inline `route` list on an imported
+// aws_route_table before emission.
+//
+// aws_route_table.route is Optional+Computed and is emitted as a nested-object
+// list literal (`route = [{ ... }]`). Terraform type-checks each object
+// element against the provider's full nested schema, so the moment the AWS
+// provider widens that schema with a new Required sub-attribute the emitter
+// doesn't know about, every element fails plan with `Inappropriate value for
+// attribute "route": element 0: attribute "<x>" is required`. AWS provider
+// v6.52.0 did exactly this — it added the Required `odb_network_arn` (Oracle
+// Database@AWS routing) to the route object — which broke every whole-account
+// reverse-import apply that discovered a route table with inline routes.
+//
+// Because `route` is Computed, terraform reads the route table's real routes
+// from the imported resource's refreshed state, so simply not declaring them
+// is a plan no-op — and it makes the emitter immune to this class of provider
+// nested-schema drift (the same failure mode ensureSecurityGroupRuleLists
+// hand-patches for aws_security_group's ingress/egress objects). We drop the
+// inline routes rather than re-declaring them; adopting a route table does not
+// require re-stating routes terraform can already read.
+func dropRouteTableComputedRoutes(typed any) {
+	if rt, ok := typed.(*generated.AWSRouteTable); ok {
+		rt.Route = nil
 	}
 }
 

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -320,6 +320,56 @@ func TestEmitImportedTF_SecurityGroupTypedAttrsRestoresEmptyRuleLists(t *testing
 	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
 }
 
+// TestEmitImportedTF_RouteTableDropsComputedInlineRoutes pins the fix for the
+// whole-account reverse-import apply break: aws_route_table.route is
+// Optional+Computed and was emitted as a nested-object list literal
+// (`route = [{...}]`). AWS provider v6.52.0 added the Required `odb_network_arn`
+// to the route object, so every emitted route element began failing plan with
+// `Inappropriate value for attribute "route": element 0: attribute
+// "odb_network_arn" is required`. Because route is Computed, terraform reads
+// the real routes from refreshed state, so the emitter drops inline routes —
+// a plan no-op that is immune to this provider nested-schema drift. The route
+// table itself (vpc_id, tags, import block) must still emit and parse.
+func TestEmitImportedTF_RouteTableDropsComputedInlineRoutes(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSRouteTable{
+		VPCID: generated.LiteralOf("vpc-123"),
+		Tags:  map[string]*generated.Value[string]{"Name": generated.LiteralOf("rtb-main")},
+		Route: []generated.AWSRouteTableRoute{{
+			CIDRBlock: generated.LiteralOf("0.0.0.0/0"),
+			GatewayID: generated.LiteralOf("igw-0abc"),
+		}},
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_route_table",
+			Address:  "aws_route_table.main",
+			ImportID: "rtb-02eb84aa4898e1f26",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+
+	// The Optional+Computed inline route list must be dropped (provider-drift
+	// guard): no `route = [...]` attribute and no route sub-attribute leakage.
+	assert.NotRegexp(t, `(?m)^\s*route\s*=`, s,
+		"inline computed route list must be dropped:\n%s", s)
+	assert.NotContains(t, s, "cidr_block",
+		"dropping route must drop its nested sub-attributes too:\n%s", s)
+
+	// The route table itself still adopts: import block + configurable attrs.
+	assert.Contains(t, s, `id = "rtb-02eb84aa4898e1f26"`, "import block must survive")
+	assert.Regexp(t, `(?m)^\s*vpc_id\s*=\s*"vpc-123"`, s, "vpc_id must survive:\n%s", s)
+
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
+}
+
 func TestEmitImportedTF_SecretsManagerPinsProviderDefaultDrift(t *testing.T) {
 	t.Parallel()
 	attrs, err := json.Marshal(&generated.AWSSecretsmanagerSecret{


### PR DESCRIPTION
## Symptom

Whole-account reverse-import **apply** (the leg that dispatches to Mars) failed at `terraform plan` on every route table with inline routes — 9 identical errors in one test account:

```
Error: Incorrect attribute value type
  on imported.tf, in resource "aws_route_table" "rtb_...":
  route = [{
Inappropriate value for attribute "route": element 0: attribute "odb_network_arn" is required.
```

Terraform `init` succeeded; this is a schema type-validation error thrown during `plan`, before any graph walk. Not a credential/infra failure, and **not** the compose/orphan class (that fix held — the archive was generated by the fixed binary and the apply dispatched fine).

## Root cause

`aws_route_table.route` is `Optional + Computed` and the imported-resource emitter renders it as a nested-object list literal (`route = [{...}]`). Terraform type-checks each object element against the provider's *full* nested schema, so the moment the provider widens that object with a new Required sub-attribute the emitter doesn't know about, every element fails plan.

AWS provider **v6.52.0** added the Required `odb_network_arn` (Oracle Database@AWS routing) to the route object — so every emitted route element broke.

## Fix

Because `route` is Computed, terraform reads a route table's real routes from the imported resource's refreshed state, so **not declaring them inline is a plan no-op**. Drop the inline route list on import via a typed mutator (`dropRouteTableComputedRoutes`), mirroring the existing `ensureSecurityGroupRuleLists` pattern — which hand-patches the identical "required nested sub-attribute" failure mode for `aws_security_group` ingress/egress. Adopting a route table doesn't require re-stating routes terraform can already read.

## Test

- `TestEmitImportedTF_RouteTableDropsComputedInlineRoutes` — asserts the inline route list is dropped, no route sub-attribute leaks, and the route table still adopts (import block + `vpc_id`) and parses.
- Full `pkg/composer/imported*` + `generated` suites pass. (Two pre-existing `TerraformInit`/`GCPVPC` failures in the package are environment-only — the sandbox proxy 403s the module registry — and are unrelated to this change.)

## How it was found

Ran the real reverse-import apply against staging on the exact session that previously 500'd (account `536892739526`). The compose/orphan fix let it dispatch; the Mars job then failed at plan with the error above. Diagnosed from the job's terraform logs.

## Follow-up (not in this PR)

The same class bites any `Optional+Computed` nested-object attribute the moment a provider adds a Required sub-attribute (`ensureSecurityGroupRuleLists` is the precedent whack-a-mole). A general emitter guard that drops Computed nested-object attributes on import would immunize the whole class, but it changes `aws_security_group` emission and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_