### PR TITLE
fix(composer): normalize emitted imported.tf on the composer path (adopted S3/ALB/ENI conflicting args)

### DIFF
--- a/cmd/insideout-import/genconfig/cleanup.go
+++ b/cmd/insideout-import/genconfig/cleanup.go
@@ -5,9 +5,10 @@ import (
 	"sort"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	tfjson "github.com/hashicorp/terraform-json"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/normalize"
 )
 
 // awsProviderKey and gcpProviderKey are the registry sources for the
@@ -115,80 +116,22 @@ func applySchemaToBlock(blk *hclwrite.Block, schema *tfjson.SchemaBlock) {
 	// Don't add a second lifecycle block if one already exists; merge into
 	// the existing one. terraform plan -generate-config-out doesn't emit
 	// lifecycle, so in practice this is purely defensive.
+	//
+	// The ignore_changes shape is owned by the shared normalize package so
+	// this schema-cleanup pass and the resource-type fixups emit byte-
+	// identical lifecycle blocks (they used to be two copies in this command).
 	for _, sub := range blk.Body().Blocks() {
 		if sub.Type() == "lifecycle" {
-			mergeIgnoreChanges(sub, sensitive)
+			normalize.MergeIgnoreChanges(sub, sensitive)
 			return
 		}
 	}
 	lc := blk.Body().AppendNewBlock("lifecycle", nil)
-	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(sensitive))
+	lc.Body().SetAttributeRaw("ignore_changes", normalize.IgnoreChangesTokens(sensitive))
 }
 
-// mergeIgnoreChanges unions `names` into the lifecycle block's existing
-// ignore_changes list, PRESERVING the entries already there and
-// de-duplicating. A resource that already pins some attributes (e.g.
-// `ignore_changes = [tags]` from a Sensitive-driven cleanup pass, or from an
-// earlier fixup) keeps them and gains the new ones —
-// e.g. [tags] + [egress, ingress] -> [tags, egress, ingress]. Builds the list
-// when no ignore_changes attribute is present yet. Bare-identifier (traversal)
-// form throughout, matching ignoreChangesTokens. Idempotent: re-merging the
-// same names is a no-op (so NormalizeImportedHCL re-runs are stable). If the
-// existing list is the catch-all `all`, it already covers everything and is
-// left untouched.
-func mergeIgnoreChanges(lc *hclwrite.Block, names []string) {
-	merged := existingIgnoreChangeNames(lc)
-	seen := make(map[string]struct{}, len(merged))
-	for _, n := range merged {
-		if n == "all" {
-			return // `all` already ignores every attribute
-		}
-		seen[n] = struct{}{}
-	}
-	for _, n := range names {
-		if _, ok := seen[n]; ok {
-			continue
-		}
-		seen[n] = struct{}{}
-		merged = append(merged, n)
-	}
-	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(merged))
-}
-
-// existingIgnoreChangeNames returns the bare-identifier names already present
-// in the lifecycle block's ignore_changes list (e.g. ["tags"]). Empty when the
-// attribute is absent. Only traversal (bare-identifier) entries are recognized
-// — the form this package always emits via ignoreChangesTokens; the quoted
-// terraform-<1.5 form is never produced here.
-func existingIgnoreChangeNames(lc *hclwrite.Block) []string {
-	attr := lc.Body().GetAttribute("ignore_changes")
-	if attr == nil {
-		return nil
-	}
-	var names []string
-	for _, tok := range attr.Expr().BuildTokens(nil) {
-		if tok.Type == hclsyntax.TokenIdent {
-			names = append(names, string(tok.Bytes))
-		}
-	}
-	return names
-}
-
-// ignoreChangesTokens emits the canonical `[name1, name2, ...]` form
-// (traversal references, NOT quoted strings). terraform 1.5+ deprecates
-// the quoted form with a warning at every plan; using traversal form
-// keeps generated.tf warning-free and matches what `terraform fmt`
-// would produce.
-func ignoreChangesTokens(names []string) hclwrite.Tokens {
-	tokens := hclwrite.Tokens{
-		{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
-	}
-	for i, n := range names {
-		if i > 0 {
-			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(", ")})
-		}
-		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(n)})
-	}
-	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")})
-	return tokens
-}
+// mergeIgnoreChanges / existingIgnoreChangeNames / ignoreChangesTokens moved to
+// the shared pkg/composer/imported/normalize package (exported as
+// MergeIgnoreChanges / IgnoreChangesTokens) so the resource-type fixups and this
+// schema-cleanup pass share one canonical ignore_changes shape instead of two
+// drifting copies. See applySchemaToBlock above.

--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/normalize"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -539,7 +540,7 @@ func cleanValidateExtract(ctx context.Context, opts Options, runner terraformRun
 	// over-emission, …). See fixups.go. The reported address list drives
 	// per-resource progress logging.
 	progressf(opts.Stdout, "genconfig: %s: applying resource type fixups…\n", scope)
-	fixed, err := applyResourceTypeFixupsReport(cleaned)
+	fixed, err := normalize.ApplyResourceTypeFixupsReport(cleaned)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resource-type fixups: %w", err)
 	}

--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -12,6 +12,7 @@ import (
 
 	terraformpresets "github.com/luthersystems/insideout-terraform-presets"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/normalize"
 )
 
 // insideoutManagedByValue is the value stamped into the `managed-by` tag on
@@ -735,6 +736,25 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// gap into a stack-wide planning failure.
 	composable := dropUncomposable(importedResources, emitReadiness)
 	importedTF, importedClouds := EmitImportedTF(cloud, composable, emitOpts)
+	// Normalize the emitted HCL through the shared resource-type fixups. This
+	// is the SAME pass the reverse-import pipeline runs over the FINAL
+	// imported.tf it emits (pkg/reverseimport/run.go): terraform import
+	// faithfully echoes a resource's live state, including pairs of attributes
+	// the provider marks mutually exclusive (e.g. aws_network_interface's
+	// private_ip_list alongside private_ips, aws_lb's subnet_mapping alongside
+	// subnets) and literal-zero / empty-list readbacks that fail per-field
+	// validators — all of which fail `terraform validate` before apply. Both
+	// emit paths go through EmitImportedTF, so both need the identical fix;
+	// running it here (not only in run.go) closes the composer path that
+	// ui-core/reliable use to compose stacks adopting existing resources.
+	// AWS only, mirroring run.go's gate — the fixups are AWS-specific. #708.
+	if len(importedTF) > 0 && strings.EqualFold(cloud, "aws") {
+		normalized, nerr := normalize.NormalizeImportedHCL(importedTF)
+		if nerr != nil {
+			return nil, fmt.Errorf("normalize imported.tf: %w", nerr)
+		}
+		importedTF = normalized
+	}
 	if len(importedTF) > 0 {
 		files["/imported.tf"] = importedTF
 	}

--- a/pkg/composer/imported/normalize/normalize.go
+++ b/pkg/composer/imported/normalize/normalize.go
@@ -1,4 +1,31 @@
-package genconfig
+// Package normalize is the shared engine that reconciles the
+// mutually-exclusive / invalid provider attributes that faithful
+// resource-adoption HCL carries. Both emit paths that adopt existing AWS
+// resources run it over their output:
+//
+//   - the reverse-import pipeline (pkg/reverseimport) runs it over the FINAL
+//     imported.tf the composer emits (was cmd/insideout-import/genconfig's
+//     NormalizeImportedHCL), and
+//   - the composer path (pkg/composer.composeStackImpl) runs it over the
+//     /imported.tf it writes into a composed stack that adopts existing
+//     resources.
+//
+// It lives here — a leaf package under pkg/composer/imported, importing only
+// pkg/composer/imported — so both consumers (pkg/composer and the
+// cmd/insideout-import/genconfig command) can share the one registry without
+// pkg/composer taking a dependency on a cmd/ package (issue #708 — originally
+// applied on the reverse-import path only; this package extends the same fix
+// to the composer path).
+//
+// terraform import (and `terraform plan -generate-config-out`) faithfully
+// echo back a resource's live state, including pairs of attributes the
+// provider schema marks mutually exclusive (e.g. aws_network_interface's
+// private_ip_list alongside private_ips, aws_lb's subnet_mapping alongside
+// subnets) and literal-zero / empty-list readbacks that fail the provider's
+// per-field validators. Left unresolved they fail `terraform validate` /
+// `plan` before apply. The resourceTypeFixups registry below reconciles each
+// known case; NormalizeImportedHCL is the entry point.
+package normalize
 
 import (
 	"fmt"
@@ -11,6 +38,12 @@ import (
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
 )
+
+// normalizeSourceName is the synthetic filename used in HCL parse
+// diagnostics for the config this package rewrites. It is a label only —
+// no file is read — so any stable name works; "imported.tf" reflects the
+// artifact both consumers feed in.
+const normalizeSourceName = "imported.tf"
 
 // applyResourceTypeFixups runs after schema cleanup. It plugs the gaps
 // where `terraform plan -generate-config-out` produces output that the
@@ -27,7 +60,7 @@ import (
 // methods that need re-emission) is a one-line addition to the table
 // rather than a refactor.
 func applyResourceTypeFixups(raw []byte) ([]byte, error) {
-	res, err := applyResourceTypeFixupsReport(raw)
+	res, err := ApplyResourceTypeFixupsReport(raw)
 	return res.HCL, err
 }
 
@@ -45,24 +78,26 @@ func NormalizeImportedHCL(raw []byte) ([]byte, error) {
 	return applyResourceTypeFixups(raw)
 }
 
-// fixupResult is the output of applyResourceTypeFixupsReport: the rewritten
+// FixupResult is the output of ApplyResourceTypeFixupsReport: the rewritten
 // HCL plus the "TYPE.NAME" addresses a registered fixup ran against.
-type fixupResult struct {
+type FixupResult struct {
 	// HCL is the post-fixup generated config.
 	HCL []byte
 	// Applied lists the addresses a registered fixup closure ran for, for
 	// per-resource progress logging. It reflects fixups ATTEMPTED (a
-	// registered closure ran for that block) — a useful "what did genconfig
-	// touch" signal even though a given closure may be a no-op on a block.
+	// registered closure ran for that block) — a useful "what did the fixup
+	// pass touch" signal even though a given closure may be a no-op on a block.
 	Applied []string
 }
 
-// applyResourceTypeFixupsReport is applyResourceTypeFixups plus the list of
-// addresses touched, returned together in a fixupResult.
-func applyResourceTypeFixupsReport(raw []byte) (fixupResult, error) {
-	f, diags := hclwrite.ParseConfig(raw, generatedFile, hcl.Pos{Line: 1, Column: 1})
+// ApplyResourceTypeFixupsReport is applyResourceTypeFixups plus the list of
+// addresses touched, returned together in a FixupResult. Exported so the
+// genconfig command's generated.tf pass can drive per-resource progress
+// logging off the Applied list.
+func ApplyResourceTypeFixupsReport(raw []byte) (FixupResult, error) {
+	f, diags := hclwrite.ParseConfig(raw, normalizeSourceName, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return fixupResult{}, fmt.Errorf("parse for fixups: %s", diags.Error())
+		return FixupResult{}, fmt.Errorf("parse for fixups: %s", diags.Error())
 	}
 	var applied []string
 	for _, blk := range f.Body().Blocks() {
@@ -80,7 +115,7 @@ func applyResourceTypeFixupsReport(raw []byte) (fixupResult, error) {
 		fix(blk)
 		applied = append(applied, labels[0]+"."+labels[1])
 	}
-	return fixupResult{HCL: f.Bytes(), Applied: applied}, nil
+	return FixupResult{HCL: f.Bytes(), Applied: applied}, nil
 }
 
 // resourceTypeFixups maps a Terraform resource type to its post-cleanup
@@ -152,12 +187,12 @@ func fixupDefaultNetworkACLIgnoreRules(blk *hclwrite.Block) {
 	body := blk.Body()
 	for _, sub := range body.Blocks() {
 		if sub.Type() == "lifecycle" {
-			mergeIgnoreChanges(sub, defaultNACLIgnoreChanges)
+			MergeIgnoreChanges(sub, defaultNACLIgnoreChanges)
 			return
 		}
 	}
 	lc := body.AppendNewBlock("lifecycle", nil)
-	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(defaultNACLIgnoreChanges))
+	lc.Body().SetAttributeRaw("ignore_changes", IgnoreChangesTokens(defaultNACLIgnoreChanges))
 }
 
 // defaultNACLIgnoreChanges are the nested rule blocks dropped by scalar-only
@@ -218,12 +253,12 @@ func fixupLambdaSource(blk *hclwrite.Block) {
 	// consistent across Sensitive-driven and fixup-driven entries.
 	for _, sub := range body.Blocks() {
 		if sub.Type() == "lifecycle" {
-			mergeIgnoreChanges(sub, lambdaIgnoreChanges)
+			MergeIgnoreChanges(sub, lambdaIgnoreChanges)
 			return
 		}
 	}
 	lc := body.AppendNewBlock("lifecycle", nil)
-	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(lambdaIgnoreChanges))
+	lc.Body().SetAttributeRaw("ignore_changes", IgnoreChangesTokens(lambdaIgnoreChanges))
 }
 
 // fixupKeyPairPublicKey is the aws_key_pair counterpart to
@@ -242,12 +277,12 @@ func fixupKeyPairPublicKey(blk *hclwrite.Block) {
 	}
 	for _, sub := range body.Blocks() {
 		if sub.Type() == "lifecycle" {
-			mergeIgnoreChanges(sub, imported.KeyPairPublicKeyAttr)
+			MergeIgnoreChanges(sub, imported.KeyPairPublicKeyAttr)
 			return
 		}
 	}
 	lc := body.AppendNewBlock("lifecycle", nil)
-	lc.Body().SetAttributeRaw("ignore_changes", ignoreChangesTokens(imported.KeyPairPublicKeyAttr))
+	lc.Body().SetAttributeRaw("ignore_changes", IgnoreChangesTokens(imported.KeyPairPublicKeyAttr))
 }
 
 // fixupKMSRotationPeriodZero drops aws_kms_key.rotation_period_in_days
@@ -1172,4 +1207,99 @@ func isAttrLiteralFalse(body *hclwrite.Body, name string) bool {
 		sb.Write(t.Bytes)
 	}
 	return strings.TrimSpace(sb.String()) == "false"
+}
+
+// MergeIgnoreChanges unions `names` into the lifecycle block's existing
+// ignore_changes list, PRESERVING the entries already there and
+// de-duplicating. A resource that already pins some attributes (e.g.
+// `ignore_changes = [tags]` from a Sensitive-driven cleanup pass, or from an
+// earlier fixup) keeps them and gains the new ones —
+// e.g. [tags] + [egress, ingress] -> [tags, egress, ingress]. Builds the list
+// when no ignore_changes attribute is present yet. Bare-identifier (traversal)
+// form throughout, matching IgnoreChangesTokens. Idempotent: re-merging the
+// same names is a no-op (so NormalizeImportedHCL re-runs are stable). If the
+// existing list is the catch-all `all`, it already covers everything and is
+// left untouched.
+//
+// Exported (with IgnoreChangesTokens) so the genconfig command's schema-cleanup
+// pass shares this exact ignore_changes shape rather than carrying a drifting
+// duplicate — the fixups here and cleanGenerated must emit byte-identical
+// lifecycle blocks.
+func MergeIgnoreChanges(lc *hclwrite.Block, names []string) {
+	merged := existingIgnoreChangeNames(lc)
+	seen := make(map[string]struct{}, len(merged))
+	for _, n := range merged {
+		if n == "all" {
+			return // `all` already ignores every attribute
+		}
+		seen[n] = struct{}{}
+	}
+	for _, n := range names {
+		if _, ok := seen[n]; ok {
+			continue
+		}
+		seen[n] = struct{}{}
+		merged = append(merged, n)
+	}
+	lc.Body().SetAttributeRaw("ignore_changes", IgnoreChangesTokens(merged))
+}
+
+// existingIgnoreChangeNames returns the bare-identifier names already present
+// in the lifecycle block's ignore_changes list (e.g. ["tags"]). Empty when the
+// attribute is absent. Only traversal (bare-identifier) entries are recognized
+// — the form this package always emits via IgnoreChangesTokens; the quoted
+// terraform-<1.5 form is never produced here.
+func existingIgnoreChangeNames(lc *hclwrite.Block) []string {
+	attr := lc.Body().GetAttribute("ignore_changes")
+	if attr == nil {
+		return nil
+	}
+	var names []string
+	for _, tok := range attr.Expr().BuildTokens(nil) {
+		if tok.Type == hclsyntax.TokenIdent {
+			names = append(names, string(tok.Bytes))
+		}
+	}
+	return names
+}
+
+// IgnoreChangesTokens emits the canonical `[name1, name2, ...]` form
+// (traversal references, NOT quoted strings). terraform 1.5+ deprecates
+// the quoted form with a warning at every plan; using traversal form
+// keeps generated config warning-free and matches what `terraform fmt`
+// would produce.
+func IgnoreChangesTokens(names []string) hclwrite.Tokens {
+	tokens := hclwrite.Tokens{
+		{Type: hclsyntax.TokenOBrack, Bytes: []byte("[")},
+	}
+	for i, n := range names {
+		if i > 0 {
+			tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenComma, Bytes: []byte(", ")})
+		}
+		tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenIdent, Bytes: []byte(n)})
+	}
+	tokens = append(tokens, &hclwrite.Token{Type: hclsyntax.TokenCBrack, Bytes: []byte("]")})
+	return tokens
+}
+
+// stringLitFromAttr extracts the value of a `name = "string-literal"`
+// attribute. Returns "" for any non-literal expression.
+//
+// This is a small, self-contained copy of the genconfig helper of the same
+// name (cmd/insideout-import/genconfig/orphan_imports.go). It is duplicated
+// rather than shared because the genconfig original is an imports.tf /
+// import-ID concern used across orphan/unimportable pruning; a single fixup
+// here (interface_type normalization) needs the same trivial extraction, and
+// inverting the genconfig dependency onto this leaf package for a 10-line pure
+// function would be the wrong direction.
+func stringLitFromAttr(attr *hclwrite.Attribute) string {
+	if attr == nil {
+		return ""
+	}
+	tokens := attr.Expr().BuildTokens(nil)
+	if len(tokens) != 3 {
+		return ""
+	}
+	// tokens: OQuote, QuotedLit, CQuote
+	return string(tokens[1].Bytes)
 }

--- a/pkg/composer/imported/normalize/normalize_test.go
+++ b/pkg/composer/imported/normalize/normalize_test.go
@@ -1,4 +1,4 @@
-package genconfig
+package normalize
 
 import (
 	"reflect"

--- a/pkg/composer/imported_conflicts_test.go
+++ b/pkg/composer/imported_conflicts_test.go
@@ -1,0 +1,167 @@
+package composer
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// loadConflictFixture reads testdata/imported_conflicts.json — a faithful
+// reduction of the real 86-resource whole-account manifest that produced the
+// conflicting-argument imported.tf. It carries the two resources whose live
+// state terraform import echoes back as mutually-exclusive provider
+// attributes:
+//
+//   - aws_network_interface with BOTH private_ip_list AND private_ips (the
+//     same IP): provider error "Conflicting configuration arguments".
+//   - aws_lb with BOTH a subnets list AND subnet_mapping blocks: provider
+//     error "Invalid combination of arguments".
+//
+// plus the dependency closure that makes the bundle a self-contained,
+// resolvable graph so `terraform validate` doesn't mask the ENI conflict
+// behind an unresolved reference: the two aws_subnet the ENIs sit in and the
+// two aws_vpc those subnets belong to. An aws_s3_bucket rides along as
+// realistic ballast (its inline server_side_encryption_configuration is only a
+// deprecation warning, not a conflict).
+func loadConflictFixture(t *testing.T) []imported.ImportedResource {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/imported_conflicts.json")
+	require.NoError(t, err)
+	var irs []imported.ImportedResource
+	require.NoError(t, json.Unmarshal(raw, &irs))
+	require.NotEmpty(t, irs)
+	return irs
+}
+
+// resourceBlocks parses imported.tf and returns every `resource "<wantType>"`
+// block body keyed by its resource name label.
+func resourceBlocks(t *testing.T, tf []byte, wantType string) map[string]*hclsyntax.Body {
+	t.Helper()
+	file, diags := hclsyntax.ParseConfig(tf, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), tf)
+	out := map[string]*hclsyntax.Body{}
+	for _, blk := range file.Body.(*hclsyntax.Body).Blocks {
+		if blk.Type != "resource" || len(blk.Labels) != 2 || blk.Labels[0] != wantType {
+			continue
+		}
+		out[blk.Labels[1]] = blk.Body
+	}
+	return out
+}
+
+func bodyHasAttr(b *hclsyntax.Body, name string) bool {
+	_, ok := b.Attributes[name]
+	return ok
+}
+
+func bodyHasBlock(b *hclsyntax.Body, typ string) bool {
+	for _, blk := range b.Blocks {
+		if blk.Type == typ {
+			return true
+		}
+	}
+	return false
+}
+
+// TestImportedConflicts_ComposePathNormalizes is the #708-composer-path
+// regression test. It runs the exact reduced manifest through the PUBLIC
+// composer entrypoint (ComposeStackWithIssues) and asserts the /imported.tf
+// the composer writes has been normalized — the mutually-exclusive provider
+// attributes are reconciled.
+//
+// The proof is before/after at the composer boundary: EmitImportedTF (the raw
+// emit both compose paths share) still produces the conflicting pairs, but the
+// composer's emitted /imported.tf — which now runs the shared
+// normalize.NormalizeImportedHCL over that emit, the same pass the
+// reverse-import pipeline runs — no longer does. Against main (before wiring
+// the composer path) the composed /imported.tf is byte-identical to the raw
+// emit and this test fails.
+//
+// Runs in normal CI: pure HCL parsing, no terraform binary.
+func TestImportedConflicts_ComposePathNormalizes(t *testing.T) {
+	t.Parallel()
+	irs := loadConflictFixture(t)
+
+	// Raw emit path (shared by both compose paths) — the un-normalized shape.
+	raw, used := EmitImportedTF("aws", irs, EmitImportedOpts{})
+	require.NotEmpty(t, raw)
+	require.True(t, used["aws"])
+
+	// Composer path — the artifact ui-core/reliable ship. This is what the
+	// fix normalizes.
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "io-f-v6e-hzw-zt",
+		Region:       "us-east-1",
+		Imported:     irs,
+	})
+	require.NoError(t, err)
+	composed := res.Files["/imported.tf"]
+	require.NotEmpty(t, composed, "composer must emit /imported.tf for the adopted resources")
+
+	// --- aws_network_interface: private_ip_list conflicts with private_ips ---
+	rawENIs := resourceBlocks(t, raw, "aws_network_interface")
+	require.NotEmpty(t, rawENIs, "fixture must emit aws_network_interface blocks")
+	sawRawConflict := false
+	for name, b := range rawENIs {
+		if bodyHasAttr(b, "private_ip_list") && bodyHasAttr(b, "private_ips") {
+			sawRawConflict = true
+			t.Logf("raw ENI %q carries both private_ip_list and private_ips (the bug)", name)
+		}
+	}
+	require.True(t, sawRawConflict,
+		"fixture no longer reproduces the ENI private_ip_list/private_ips conflict; "+
+			"the after-assertion would be vacuous")
+
+	composedENIs := resourceBlocks(t, composed, "aws_network_interface")
+	require.NotEmpty(t, composedENIs, "composer must emit the aws_network_interface blocks")
+	for name, b := range composedENIs {
+		assert.Falsef(t, bodyHasAttr(b, "private_ip_list") && bodyHasAttr(b, "private_ips"),
+			"composed aws_network_interface %q still emits BOTH private_ip_list and private_ips — "+
+				"the composer path did not normalize the imported.tf (#708)", name)
+		// The plural form carries the intent and must survive; the *_list form
+		// is the redundant alternative that fixupNetworkInterfaceProviderQuirks drops.
+		assert.Truef(t, bodyHasAttr(b, "private_ips"),
+			"composed aws_network_interface %q dropped private_ips; the normalizer must keep the plural form", name)
+		assert.Falsef(t, bodyHasAttr(b, "private_ip_list"),
+			"composed aws_network_interface %q kept the redundant private_ip_list", name)
+	}
+
+	// --- aws_lb: subnets conflicts with subnet_mapping ---
+	rawLBs := resourceBlocks(t, raw, "aws_lb")
+	require.NotEmpty(t, rawLBs, "fixture must emit an aws_lb block")
+	sawRawLBConflict := false
+	for name, b := range rawLBs {
+		if bodyHasAttr(b, "subnets") && bodyHasBlock(b, "subnet_mapping") {
+			sawRawLBConflict = true
+			t.Logf("raw LB %q carries both subnets and subnet_mapping (the bug)", name)
+		}
+	}
+	require.True(t, sawRawLBConflict,
+		"fixture no longer reproduces the aws_lb subnets/subnet_mapping conflict")
+
+	composedLBs := resourceBlocks(t, composed, "aws_lb")
+	require.NotEmpty(t, composedLBs, "composer must emit the aws_lb block")
+	for name, b := range composedLBs {
+		assert.Falsef(t, bodyHasAttr(b, "subnets") && bodyHasBlock(b, "subnet_mapping"),
+			"composed aws_lb %q still emits BOTH subnets and subnet_mapping — "+
+				"the composer path did not normalize the imported.tf (#708)", name)
+		// No static-IP pin in the fixture, so the canonical ALB shape keeps
+		// `subnets` and drops the subnet_mapping blocks.
+		assert.Truef(t, bodyHasAttr(b, "subnets"),
+			"composed aws_lb %q dropped subnets; with no static-IP pin the normalizer keeps subnets", name)
+		assert.Falsef(t, bodyHasBlock(b, "subnet_mapping"),
+			"composed aws_lb %q kept the redundant subnet_mapping blocks", name)
+	}
+}

--- a/pkg/composer/imported_conflicts_tfvalidate_test.go
+++ b/pkg/composer/imported_conflicts_tfvalidate_test.go
@@ -1,0 +1,129 @@
+//go:build tfvalidate
+
+// Build-tagged Terraform-validate harness proving the composer path no longer
+// ships the mutually-exclusive provider attributes that faithful
+// resource-adoption HCL carries (issue #708, composer path).
+//
+// Normal `go test` skips this file (it shells out to the `terraform` binary
+// and does a one-time provider download). Run it explicitly:
+//
+//	go test -tags tfvalidate -run TestImportedConflicts_ComposePathTerraformValidate -v ./pkg/composer/
+//
+// It exercises BOTH sides of the fix against the real AWS provider schema
+// (pinned to imported.BaseProviderPin("aws","aws"), = 6.46.0):
+//
+//   - the RAW EmitImportedTF output (shared by both compose paths, no
+//     normalization) still fails `terraform validate` with
+//     "Conflicting configuration arguments" — the bug reproduces at the pinned
+//     provider, so it is NOT provider-version-specific; and
+//   - the composer's emitted /imported.tf — now normalized in
+//     composeStackImpl — carries NEITHER "Conflicting configuration arguments"
+//     nor "Invalid combination of arguments".
+//
+// `terraform validate` is a pure provider-schema check — no AWS credentials
+// and no network beyond the one-time provider download (TF_PLUGIN_CACHE_DIR
+// keeps it warm). The reduced fixture is a complete, self-contained closure
+// (every referenced subnet/VPC is declared), so the normalized composer
+// /imported.tf validates clean with no residual `Error:` diagnostics.
+
+package composer
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// validateImportedTF drops hcl next to a minimal providers.tf declaring the
+// aws.imported alias and returns the combined `terraform validate` output.
+func validateImportedTF(t *testing.T, tfBin string, hcl []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "providers.tf"), []byte(tfValidateProvidersHCL(t)), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "imported.tf"), hcl, 0o644))
+
+	cache := filepath.Join(os.TempDir(), "tf-plugin-cache")
+	_ = os.MkdirAll(cache, 0o755)
+	env := append(os.Environ(), "TF_PLUGIN_CACHE_DIR="+cache, "TF_IN_AUTOMATION=1")
+	run := func(args ...string) (string, error) {
+		cmd := exec.Command(tfBin, args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		b, err := cmd.CombinedOutput()
+		return string(b), err
+	}
+	if out, err := run("init", "-backend=false", "-input=false", "-no-color"); err != nil {
+		t.Fatalf("terraform init failed: %v\n%s", err, out)
+	}
+	out, _ := run("validate", "-no-color") // non-nil err expected (undeclared subnet refs)
+	return out
+}
+
+const (
+	conflictErr     = "Conflicting configuration arguments"
+	invalidComboErr = "Invalid combination of arguments"
+)
+
+func TestImportedConflicts_ComposePathTerraformValidate(t *testing.T) {
+	tfBin, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skip("terraform binary not on PATH")
+	}
+
+	irs := loadConflictFixture(t)
+
+	// --- before: raw emit (un-normalized), shared by both compose paths ---
+	// The fixture is a self-contained dependency closure (ENI -> subnet -> vpc,
+	// plus the ALB and an S3 bucket), so the ENI attribute conflict is not
+	// masked by an unresolved subnet reference — both conflict classes surface.
+	raw, _ := EmitImportedTF("aws", irs, EmitImportedOpts{})
+	require.NotEmpty(t, raw)
+	rawOut := validateImportedTF(t, tfBin, raw)
+	t.Logf("=== validate(raw EmitImportedTF) ===\n%s", rawOut)
+	require.Containsf(t, rawOut, conflictErr,
+		"raw EmitImportedTF must reproduce the aws_network_interface "+
+			"private_ip_list/private_ips conflict at the pinned provider; if it does "+
+			"not, the fixture or emitter changed and the after-assertion is vacuous\n%s", rawOut)
+	require.Containsf(t, rawOut, invalidComboErr,
+		"raw EmitImportedTF must reproduce the aws_lb subnets/subnet_mapping conflict "+
+			"at the pinned provider\n%s", rawOut)
+
+	// --- after: composer path emitted /imported.tf (normalized) ---
+	c := newTestClient()
+	res, cerr := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "io-f-v6e-hzw-zt",
+		Region:       "us-east-1",
+		Imported:     irs,
+	})
+	require.NoError(t, cerr)
+	composed := res.Files["/imported.tf"]
+	require.NotEmpty(t, composed)
+
+	composedOut := validateImportedTF(t, tfBin, composed)
+	t.Logf("=== validate(composer /imported.tf) ===\n%s", composedOut)
+	if strings.Contains(composedOut, conflictErr) {
+		t.Errorf("composer /imported.tf still emits %q — the composer path did not normalize the imported.tf (#708):\n%s\n--- imported.tf ---\n%s",
+			conflictErr, composedOut, composed)
+	}
+	if strings.Contains(composedOut, invalidComboErr) {
+		t.Errorf("composer /imported.tf still emits %q — the composer path did not normalize the imported.tf (#708):\n%s\n--- imported.tf ---\n%s",
+			invalidComboErr, composedOut, composed)
+	}
+	// The complete closure validates clean once normalized (the provider is
+	// pinned at imported.BaseProviderPin, so this is not version-fragile): the
+	// only remaining diagnostics are S3 inline-block deprecation WARNINGS, which
+	// `terraform validate` reports as success. Any surviving `Error:` means the
+	// normalized composer artifact is still not deployable.
+	if strings.Contains(composedOut, "Error:") {
+		t.Errorf("composer /imported.tf still fails `terraform validate` after normalization:\n%s\n--- imported.tf ---\n%s",
+			composedOut, composed)
+	}
+}

--- a/pkg/composer/noselfimport_test.go
+++ b/pkg/composer/noselfimport_test.go
@@ -27,6 +27,12 @@ import (
 //     — Phase 2 Layer 2 field-policy registry (issue #147) used by
 //     cross-tier wiring validators (issue #150) to classify
 //     wiring vs scalar attributes.
+//   - github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/normalize
+//     — the shared resource-type fixup engine the composer runs over the
+//     /imported.tf it emits, so faithful resource-adoption HCL doesn't ship
+//     mutually-exclusive provider attributes that fail `terraform validate`
+//     (issue #708 / composer path). Composer-owned infrastructure, not a
+//     downstream consumer.
 //
 // Subpackages outside the allowlist (e.g. an "internal/" helper) must fail
 // so coupling can't accidentally leak in.
@@ -40,6 +46,7 @@ func TestNoForeignLutherImportsInNonTestFiles(t *testing.T) {
 		parentPkg + "/pkg/composer/imported/generated": {},
 		parentPkg + "/pkg/composer/imported/importid":  {},
 		parentPkg + "/pkg/composer/imported/policy":    {},
+		parentPkg + "/pkg/composer/imported/normalize": {},
 	}
 
 	entries, err := os.ReadDir(".")

--- a/pkg/composer/testdata/imported_conflicts.json
+++ b/pkg/composer/testdata/imported_conflicts.json
@@ -1,0 +1,1039 @@
+[
+  {
+    "attrs": {
+      "access_logs": [
+        {
+          "bucket": {
+            "literal": ""
+          },
+          "enabled": {
+            "literal": false
+          },
+          "prefix": {
+            "null": true
+          }
+        }
+      ],
+      "client_keep_alive": {
+        "literal": 3600
+      },
+      "connection_logs": [
+        {
+          "bucket": {
+            "literal": ""
+          },
+          "enabled": {
+            "literal": false
+          },
+          "prefix": {
+            "null": true
+          }
+        }
+      ],
+      "customer_owned_ipv4_pool": {
+        "null": true
+      },
+      "desync_mitigation_mode": {
+        "literal": "defensive"
+      },
+      "dns_record_client_routing_policy": {
+        "null": true
+      },
+      "drop_invalid_header_fields": {
+        "literal": false
+      },
+      "enable_cross_zone_load_balancing": {
+        "literal": true
+      },
+      "enable_deletion_protection": {
+        "literal": false
+      },
+      "enable_http2": {
+        "literal": true
+      },
+      "enable_tls_version_and_cipher_suite_headers": {
+        "literal": false
+      },
+      "enable_waf_fail_open": {
+        "literal": false
+      },
+      "enable_xff_client_port": {
+        "literal": false
+      },
+      "enable_zonal_shift": {
+        "literal": false
+      },
+      "health_check_logs": [
+        {
+          "bucket": {
+            "literal": ""
+          },
+          "enabled": {
+            "literal": false
+          },
+          "prefix": {
+            "null": true
+          }
+        }
+      ],
+      "idle_timeout": {
+        "literal": 60
+      },
+      "internal": {
+        "literal": false
+      },
+      "ip_address_type": {
+        "literal": "ipv4"
+      },
+      "ipam_pools": [],
+      "load_balancer_type": {
+        "literal": "application"
+      },
+      "minimum_load_balancer_capacity": [],
+      "name": {
+        "literal": "io-f-v6e-hzw-zt-alb"
+      },
+      "preserve_host_header": {
+        "literal": false
+      },
+      "region": {
+        "literal": "us-east-1"
+      },
+      "security_groups": [
+        {
+          "literal": "sg-05b33367d0263c42d"
+        }
+      ],
+      "subnet_mapping": [
+        {
+          "allocation_id": {
+            "literal": ""
+          },
+          "ipv6_address": {
+            "literal": ""
+          },
+          "outpost_id": {
+            "literal": ""
+          },
+          "private_ipv4_address": {
+            "literal": ""
+          },
+          "subnet_id": {
+            "literal": "subnet-08b4ceeaf7cbeccdb"
+          }
+        },
+        {
+          "allocation_id": {
+            "literal": ""
+          },
+          "ipv6_address": {
+            "literal": ""
+          },
+          "outpost_id": {
+            "literal": ""
+          },
+          "private_ipv4_address": {
+            "literal": ""
+          },
+          "subnet_id": {
+            "literal": "subnet-0a9e275a33c1d279f"
+          }
+        }
+      ],
+      "subnets": [
+        {
+          "literal": "subnet-08b4ceeaf7cbeccdb"
+        },
+        {
+          "literal": "subnet-0a9e275a33c1d279f"
+        }
+      ],
+      "tags": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "alb0"
+        },
+        "Name": {
+          "literal": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-alb-alb0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f-v6e-hzw-zt"
+        },
+        "Resource": {
+          "literal": "alb"
+        },
+        "Subcomponent": {
+          "literal": "alb"
+        }
+      },
+      "tags_all": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "alb0"
+        },
+        "Name": {
+          "literal": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-alb-alb0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f-v6e-hzw-zt"
+        },
+        "Resource": {
+          "literal": "alb"
+        },
+        "Subcomponent": {
+          "literal": "alb"
+        }
+      },
+      "xff_header_processing_mode": {
+        "literal": "append"
+      }
+    },
+    "identity": {
+      "account_id": "141812438321",
+      "address": "aws_lb.io_f_v6e_hzw_zt_alb",
+      "cloud": "aws",
+      "enrichment_status": "full",
+      "import_id": "arn:aws:elasticloadbalancing:us-east-1:141812438321:loadbalancer/app/io-f-v6e-hzw-zt-alb/bcda3f52ff22fa50",
+      "name_hint": "io-f-v6e-hzw-zt-alb",
+      "native_ids": {
+        "arn": "arn:aws:elasticloadbalancing:us-east-1:141812438321:loadbalancer/app/io-f-v6e-hzw-zt-alb/bcda3f52ff22fa50",
+        "name": "io-f-v6e-hzw-zt-alb"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0",
+      "region": "us-east-1",
+      "tags": {
+        "Component": "insideout",
+        "Environment": "prod",
+        "ID": "alb0",
+        "Name": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-alb-alb0",
+        "Organization": "luthersystems",
+        "Project": "io-f-v6e-hzw-zt",
+        "Resource": "alb",
+        "Subcomponent": "alb"
+      },
+      "type": "aws_lb"
+    },
+    "source": "importer",
+    "tier": "ImportedFlat"
+  },
+  {
+    "attrs": {
+      "attachment": [
+        {
+          "device_index": {
+            "literal": 0
+          },
+          "instance": {
+            "literal": "i-0f489bc60a257a4f3"
+          },
+          "network_card_index": {
+            "literal": 0
+          }
+        }
+      ],
+      "description": {
+        "null": true
+      },
+      "ena_srd_specification": [],
+      "ipv4_prefixes": [],
+      "ipv6_address_list": [],
+      "ipv6_addresses": [],
+      "ipv6_prefixes": [],
+      "private_ip": {
+        "literal": "10.1.134.121"
+      },
+      "private_ip_list": [
+        {
+          "literal": "10.1.134.121"
+        }
+      ],
+      "private_ips": [
+        {
+          "literal": "10.1.134.121"
+        }
+      ],
+      "region": {
+        "literal": "us-east-1"
+      },
+      "security_groups": [
+        {
+          "literal": "sg-07ab0fd93782eb359"
+        }
+      ],
+      "source_dest_check": {
+        "literal": true
+      },
+      "subnet_id": {
+        "expr": "aws_subnet.subnet_0e866663c4c5ad4d9.id"
+      },
+      "tags": {},
+      "tags_all": {}
+    },
+    "identity": {
+      "account_id": "141812438321",
+      "address": "aws_network_interface.eni_0071933677a6be65f",
+      "cloud": "aws",
+      "enrichment_status": "full",
+      "import_id": "eni-0071933677a6be65f",
+      "name_hint": "eni-0071933677a6be65f",
+      "native_ids": {
+        "name": "eni-0071933677a6be65f"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0",
+      "region": "us-east-1",
+      "type": "aws_network_interface"
+    },
+    "source": "importer",
+    "tier": "ImportedFlat"
+  },
+  {
+    "attrs": {
+      "attachment": [
+        {
+          "device_index": {
+            "literal": 1
+          },
+          "instance": {
+            "literal": ""
+          },
+          "network_card_index": {
+            "literal": 0
+          }
+        }
+      ],
+      "description": {
+        "literal": "ELB app/io-f-v6e-hzw-zt-alb/bcda3f52ff22fa50"
+      },
+      "ena_srd_specification": [],
+      "ipv4_prefixes": [],
+      "ipv6_address_list": [],
+      "ipv6_addresses": [],
+      "ipv6_prefixes": [],
+      "private_ip": {
+        "literal": "10.1.128.22"
+      },
+      "private_ip_list": [
+        {
+          "literal": "10.1.128.22"
+        }
+      ],
+      "private_ips": [
+        {
+          "literal": "10.1.128.22"
+        }
+      ],
+      "region": {
+        "literal": "us-east-1"
+      },
+      "security_groups": [
+        {
+          "literal": "sg-05b33367d0263c42d"
+        }
+      ],
+      "source_dest_check": {
+        "literal": true
+      },
+      "subnet_id": {
+        "expr": "aws_subnet.subnet_08b4ceeaf7cbeccdb.id"
+      },
+      "tags": {},
+      "tags_all": {}
+    },
+    "identity": {
+      "account_id": "141812438321",
+      "address": "aws_network_interface.eni_0d62bb4aa2988e052",
+      "cloud": "aws",
+      "enrichment_status": "full",
+      "import_id": "eni-0d62bb4aa2988e052",
+      "name_hint": "eni-0d62bb4aa2988e052",
+      "native_ids": {
+        "name": "eni-0d62bb4aa2988e052"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0",
+      "region": "us-east-1",
+      "type": "aws_network_interface"
+    },
+    "source": "importer",
+    "tier": "ImportedFlat"
+  },
+  {
+    "attrs": {
+      "bucket": {
+        "literal": "luther-55f50492-default-tfstate-s3-tbzt"
+      },
+      "bucket_namespace": {
+        "literal": "global"
+      },
+      "cors_rule": [],
+      "force_destroy": {
+        "literal": false
+      },
+      "grant": [
+        {
+          "id": {
+            "literal": "781ed559823c531af356257a8d8aab76cfb63f121d76a91261a95eef5663e2ae"
+          },
+          "permissions": [
+            {
+              "literal": "FULL_CONTROL"
+            }
+          ],
+          "type": {
+            "literal": "CanonicalUser"
+          },
+          "uri": {
+            "literal": ""
+          }
+        }
+      ],
+      "lifecycle_rule": [],
+      "logging": [],
+      "object_lock_configuration": [],
+      "object_lock_enabled": {
+        "literal": false
+      },
+      "region": {
+        "literal": "us-east-1"
+      },
+      "replication_configuration": [],
+      "server_side_encryption_configuration": [
+        {
+          "rule": [
+            {
+              "apply_server_side_encryption_by_default": [
+                {
+                  "kms_master_key_id": {
+                    "literal": "arn:aws:kms:us-east-1:141812438321:key/9b00e98c-0de7-480e-bd81-ed2e84a5f1b9"
+                  },
+                  "sse_algorithm": {
+                    "literal": "aws:kms"
+                  }
+                }
+              ],
+              "bucket_key_enabled": {
+                "literal": false
+              }
+            }
+          ]
+        }
+      ],
+      "tags": {
+        "Component": {
+          "literal": "tfstate"
+        },
+        "Environment": {
+          "literal": "default"
+        },
+        "ID": {
+          "literal": "tbzt"
+        },
+        "Name": {
+          "literal": "luther-55f50492-default-tfstate-s3-tbzt"
+        },
+        "Project": {
+          "literal": "55f50492"
+        },
+        "Resource": {
+          "literal": "s3"
+        }
+      },
+      "tags_all": {
+        "Component": {
+          "literal": "tfstate"
+        },
+        "Environment": {
+          "literal": "default"
+        },
+        "ID": {
+          "literal": "tbzt"
+        },
+        "Name": {
+          "literal": "luther-55f50492-default-tfstate-s3-tbzt"
+        },
+        "Project": {
+          "literal": "55f50492"
+        },
+        "Resource": {
+          "literal": "s3"
+        }
+      },
+      "versioning": [
+        {
+          "enabled": {
+            "literal": true
+          },
+          "mfa_delete": {
+            "literal": false
+          }
+        }
+      ],
+      "website": []
+    },
+    "identity": {
+      "account_id": "141812438321",
+      "address": "aws_s3_bucket.luther_55f50492_default_tfstate_s3_tbzt",
+      "cloud": "aws",
+      "enrichment_status": "full",
+      "import_id": "luther-55f50492-default-tfstate-s3-tbzt",
+      "name_hint": "luther-55f50492-default-tfstate-s3-tbzt",
+      "native_ids": {
+        "arn": "arn:aws:s3:::luther-55f50492-default-tfstate-s3-tbzt",
+        "name": "luther-55f50492-default-tfstate-s3-tbzt",
+        "region": "us-east-1"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0",
+      "region": "us-east-1",
+      "tags": {
+        "Component": "tfstate",
+        "Environment": "default",
+        "ID": "tbzt",
+        "Name": "luther-55f50492-default-tfstate-s3-tbzt",
+        "Project": "55f50492",
+        "Resource": "s3"
+      },
+      "type": "aws_s3_bucket"
+    },
+    "source": "importer",
+    "tier": "ImportedFlat"
+  },
+  {
+    "attrs": {
+      "assign_ipv6_address_on_creation": {
+        "literal": false
+      },
+      "availability_zone": {
+        "literal": "us-east-1a"
+      },
+      "cidr_block": {
+        "literal": "10.1.128.0/20"
+      },
+      "customer_owned_ipv4_pool": {
+        "null": true
+      },
+      "enable_dns64": {
+        "literal": false
+      },
+      "enable_resource_name_dns_a_record_on_launch": {
+        "literal": false
+      },
+      "enable_resource_name_dns_aaaa_record_on_launch": {
+        "literal": false
+      },
+      "ipv4_ipam_pool_id": {
+        "null": true
+      },
+      "ipv4_netmask_length": {
+        "null": true
+      },
+      "ipv6_ipam_pool_id": {
+        "null": true
+      },
+      "ipv6_native": {
+        "literal": false
+      },
+      "ipv6_netmask_length": {
+        "null": true
+      },
+      "map_public_ip_on_launch": {
+        "literal": true
+      },
+      "outpost_arn": {
+        "null": true
+      },
+      "private_dns_hostname_type_on_launch": {
+        "literal": "ip-name"
+      },
+      "region": {
+        "literal": "us-east-1"
+      },
+      "tags": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "vpc0"
+        },
+        "Name": {
+          "literal": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-vpc-vpc0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f-v6e-hzw-zt"
+        },
+        "Resource": {
+          "literal": "vpc"
+        },
+        "Subcomponent": {
+          "literal": "vpc"
+        },
+        "kubernetes.io/role/elb": {
+          "literal": "1"
+        }
+      },
+      "tags_all": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "vpc0"
+        },
+        "Name": {
+          "literal": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-vpc-vpc0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f-v6e-hzw-zt"
+        },
+        "Resource": {
+          "literal": "vpc"
+        },
+        "Subcomponent": {
+          "literal": "vpc"
+        },
+        "kubernetes.io/role/elb": {
+          "literal": "1"
+        }
+      },
+      "vpc_id": {
+        "expr": "aws_vpc.vpc_0328efde06fc443f8.id"
+      }
+    },
+    "identity": {
+      "account_id": "141812438321",
+      "address": "aws_subnet.subnet_08b4ceeaf7cbeccdb",
+      "cloud": "aws",
+      "enrichment_status": "full",
+      "import_id": "subnet-08b4ceeaf7cbeccdb",
+      "name_hint": "subnet-08b4ceeaf7cbeccdb",
+      "native_ids": {
+        "name": "subnet-08b4ceeaf7cbeccdb",
+        "vpc_id": "vpc-0328efde06fc443f8"
+      },
+      "parent_address": "aws_vpc.vpc_0328efde06fc443f8",
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0",
+      "region": "us-east-1",
+      "tags": {
+        "Component": "insideout",
+        "Environment": "prod",
+        "ID": "vpc0",
+        "Name": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-vpc-vpc0",
+        "Organization": "luthersystems",
+        "Project": "io-f-v6e-hzw-zt",
+        "Resource": "vpc",
+        "Subcomponent": "vpc",
+        "kubernetes.io/role/elb": "1"
+      },
+      "type": "aws_subnet"
+    },
+    "source": "importer",
+    "tier": "ImportedFlat"
+  },
+  {
+    "attrs": {
+      "assign_ipv6_address_on_creation": {
+        "literal": false
+      },
+      "availability_zone": {
+        "literal": "us-east-1a"
+      },
+      "cidr_block": {
+        "literal": "10.1.128.0/20"
+      },
+      "customer_owned_ipv4_pool": {
+        "null": true
+      },
+      "enable_dns64": {
+        "literal": false
+      },
+      "enable_resource_name_dns_a_record_on_launch": {
+        "literal": false
+      },
+      "enable_resource_name_dns_aaaa_record_on_launch": {
+        "literal": false
+      },
+      "ipv4_ipam_pool_id": {
+        "null": true
+      },
+      "ipv4_netmask_length": {
+        "null": true
+      },
+      "ipv6_ipam_pool_id": {
+        "null": true
+      },
+      "ipv6_native": {
+        "literal": false
+      },
+      "ipv6_netmask_length": {
+        "null": true
+      },
+      "map_public_ip_on_launch": {
+        "literal": true
+      },
+      "outpost_arn": {
+        "null": true
+      },
+      "private_dns_hostname_type_on_launch": {
+        "literal": "ip-name"
+      },
+      "region": {
+        "literal": "us-east-1"
+      },
+      "tags": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "vpc0"
+        },
+        "Name": {
+          "literal": "io-f0ttnkgjdvee-prod-luthersystems-insideout-vpc-vpc0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f0ttnkgjdvee"
+        },
+        "Resource": {
+          "literal": "vpc"
+        },
+        "Subcomponent": {
+          "literal": "vpc"
+        },
+        "kubernetes.io/role/elb": {
+          "literal": "1"
+        }
+      },
+      "tags_all": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "vpc0"
+        },
+        "Name": {
+          "literal": "io-f0ttnkgjdvee-prod-luthersystems-insideout-vpc-vpc0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f0ttnkgjdvee"
+        },
+        "Resource": {
+          "literal": "vpc"
+        },
+        "Subcomponent": {
+          "literal": "vpc"
+        },
+        "kubernetes.io/role/elb": {
+          "literal": "1"
+        }
+      },
+      "vpc_id": {
+        "expr": "aws_vpc.vpc_0b5b7a95d51782af5.id"
+      }
+    },
+    "identity": {
+      "account_id": "141812438321",
+      "address": "aws_subnet.subnet_0e866663c4c5ad4d9",
+      "cloud": "aws",
+      "enrichment_status": "full",
+      "import_id": "subnet-0e866663c4c5ad4d9",
+      "name_hint": "subnet-0e866663c4c5ad4d9",
+      "native_ids": {
+        "name": "subnet-0e866663c4c5ad4d9",
+        "vpc_id": "vpc-0b5b7a95d51782af5"
+      },
+      "parent_address": "aws_vpc.vpc_0b5b7a95d51782af5",
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0",
+      "region": "us-east-1",
+      "tags": {
+        "Component": "insideout",
+        "Environment": "prod",
+        "ID": "vpc0",
+        "Name": "io-f0ttnkgjdvee-prod-luthersystems-insideout-vpc-vpc0",
+        "Organization": "luthersystems",
+        "Project": "io-f0ttnkgjdvee",
+        "Resource": "vpc",
+        "Subcomponent": "vpc",
+        "kubernetes.io/role/elb": "1"
+      },
+      "type": "aws_subnet"
+    },
+    "source": "importer",
+    "tier": "ImportedFlat"
+  },
+  {
+    "attrs": {
+      "assign_generated_ipv6_cidr_block": {
+        "literal": false
+      },
+      "cidr_block": {
+        "literal": "10.1.0.0/16"
+      },
+      "enable_dns_hostnames": {
+        "literal": true
+      },
+      "enable_dns_support": {
+        "literal": true
+      },
+      "enable_network_address_usage_metrics": {
+        "literal": false
+      },
+      "instance_tenancy": {
+        "literal": "default"
+      },
+      "ipv4_ipam_pool_id": {
+        "null": true
+      },
+      "ipv4_netmask_length": {
+        "null": true
+      },
+      "ipv6_ipam_pool_id": {
+        "null": true
+      },
+      "region": {
+        "literal": "us-east-1"
+      },
+      "tags": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "vpc0"
+        },
+        "Name": {
+          "literal": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-vpc-vpc0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f-v6e-hzw-zt"
+        },
+        "Resource": {
+          "literal": "vpc"
+        },
+        "Subcomponent": {
+          "literal": "vpc"
+        }
+      },
+      "tags_all": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "vpc0"
+        },
+        "Name": {
+          "literal": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-vpc-vpc0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f-v6e-hzw-zt"
+        },
+        "Resource": {
+          "literal": "vpc"
+        },
+        "Subcomponent": {
+          "literal": "vpc"
+        }
+      }
+    },
+    "identity": {
+      "account_id": "141812438321",
+      "address": "aws_vpc.vpc_0328efde06fc443f8",
+      "cloud": "aws",
+      "enrichment_status": "full",
+      "import_id": "vpc-0328efde06fc443f8",
+      "name_hint": "vpc-0328efde06fc443f8",
+      "native_ids": {
+        "name": "vpc-0328efde06fc443f8"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0",
+      "region": "us-east-1",
+      "tags": {
+        "Component": "insideout",
+        "Environment": "prod",
+        "ID": "vpc0",
+        "Name": "io-f-v6e-hzw-zt-prod-luthersystems-insideout-vpc-vpc0",
+        "Organization": "luthersystems",
+        "Project": "io-f-v6e-hzw-zt",
+        "Resource": "vpc",
+        "Subcomponent": "vpc"
+      },
+      "type": "aws_vpc"
+    },
+    "source": "importer",
+    "tier": "ImportedFlat"
+  },
+  {
+    "attrs": {
+      "assign_generated_ipv6_cidr_block": {
+        "literal": false
+      },
+      "cidr_block": {
+        "literal": "10.1.0.0/16"
+      },
+      "enable_dns_hostnames": {
+        "literal": true
+      },
+      "enable_dns_support": {
+        "literal": true
+      },
+      "enable_network_address_usage_metrics": {
+        "literal": false
+      },
+      "instance_tenancy": {
+        "literal": "default"
+      },
+      "ipv4_ipam_pool_id": {
+        "null": true
+      },
+      "ipv4_netmask_length": {
+        "null": true
+      },
+      "ipv6_ipam_pool_id": {
+        "null": true
+      },
+      "region": {
+        "literal": "us-east-1"
+      },
+      "tags": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "vpc0"
+        },
+        "Name": {
+          "literal": "io-f0ttnkgjdvee-prod-luthersystems-insideout-vpc-vpc0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f0ttnkgjdvee"
+        },
+        "Resource": {
+          "literal": "vpc"
+        },
+        "Subcomponent": {
+          "literal": "vpc"
+        }
+      },
+      "tags_all": {
+        "Component": {
+          "literal": "insideout"
+        },
+        "Environment": {
+          "literal": "prod"
+        },
+        "ID": {
+          "literal": "vpc0"
+        },
+        "Name": {
+          "literal": "io-f0ttnkgjdvee-prod-luthersystems-insideout-vpc-vpc0"
+        },
+        "Organization": {
+          "literal": "luthersystems"
+        },
+        "Project": {
+          "literal": "io-f0ttnkgjdvee"
+        },
+        "Resource": {
+          "literal": "vpc"
+        },
+        "Subcomponent": {
+          "literal": "vpc"
+        }
+      }
+    },
+    "identity": {
+      "account_id": "141812438321",
+      "address": "aws_vpc.vpc_0b5b7a95d51782af5",
+      "cloud": "aws",
+      "enrichment_status": "full",
+      "import_id": "vpc-0b5b7a95d51782af5",
+      "name_hint": "vpc-0b5b7a95d51782af5",
+      "native_ids": {
+        "name": "vpc-0b5b7a95d51782af5"
+      },
+      "provider_config": "aws.imported",
+      "provider_source": "registry.terraform.io/hashicorp/aws",
+      "provider_version": "5.40.0",
+      "region": "us-east-1",
+      "tags": {
+        "Component": "insideout",
+        "Environment": "prod",
+        "ID": "vpc0",
+        "Name": "io-f0ttnkgjdvee-prod-luthersystems-insideout-vpc-vpc0",
+        "Organization": "luthersystems",
+        "Project": "io-f0ttnkgjdvee",
+        "Resource": "vpc",
+        "Subcomponent": "vpc"
+      },
+      "type": "aws_vpc"
+    },
+    "source": "importer",
+    "tier": "ImportedFlat"
+  }
+]

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/genconfig"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/normalize"
 	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
 )
 
@@ -456,7 +457,7 @@ func writeImportedTerraformArtifacts(outputDir, cloud, region, gcpProjectID, aws
 	// private_ip_list + private_ips, subnet_mapping + subnets) and fail the
 	// final `terraform validate`. AWS only — the fixups are AWS-specific. #708.
 	if cloud == "aws" {
-		normalized, err := genconfig.NormalizeImportedHCL(importedTF)
+		normalized, err := normalize.NormalizeImportedHCL(importedTF)
 		if err != nil {
 			return fmt.Errorf("normalize imported.tf: %w", err)
 		}


### PR DESCRIPTION
Closes #840.

## Symptom

When the composer adopts existing AWS resources (`ComposeStack`/`ComposeSingle` with `Imported:` set — the path ui-core/reliable use), the emitted `/imported.tf` fails `terraform validate` / `plan` before apply:

```
Error: Invalid combination of arguments
  aws_lb.<alb>: only one of `subnet_mapping,subnets` can be specified
Error: Conflicting configuration arguments
  aws_network_interface.<eni>: private_ip_list conflicts with private_ips
```

`terraform import` faithfully echoes a resource's live state, including pairs of attributes the provider marks mutually exclusive. We import S3/ALB/ENI constantly, so this bites in practice.

## Root cause

Two emit paths share `EmitImportedTF`, but only one normalized its output:

| Path | Normalized? |
|---|---|
| Reverse-import (`pkg/reverseimport/run.go`) | ✅ runs `NormalizeImportedHCL` |
| Composer (`composeStackImpl`) | ❌ wrote `EmitImportedTF` straight to `files["/imported.tf"]` |

So the composer path shipped conflicting args for **all ~24 AWS fixup types** (ENI, ALB, VPC, subnet, KMS, DynamoDB, Lambda, NAT, SG, DB instance, …), not just the three this account surfaced.

## Fix

Make the composer path run the same normalization the reverse path does.

1. **Relocate** the fixup engine (`NormalizeImportedHCL` + the `resourceTypeFixups` registry + helpers) out of `cmd/insideout-import/genconfig` into a new leaf package `pkg/composer/imported/normalize`. It imports only `pkg/composer/imported` (no cycle), so both consumers can share one registry without a `pkg → cmd` dependency inversion. Pure refactor — behavior identical; the full `fixups_test.go` (127 tests) moved with it and stays green.
2. **Wire the composer path** (`compose.go`): run `normalize.NormalizeImportedHCL` on the emitted `/imported.tf`, gated on AWS exactly like `run.go` (`strings.EqualFold(cloud, "aws")` — `composeStackImpl`'s `cloud` isn't pre-lowercased).

## Tests (fail on pre-fix, pass after — independently verified)

- `TestImportedConflicts_ComposePathNormalizes` — HCL-level regression via the real `ComposeStackWithIssues` entrypoint. **Vacuity-guarded**: asserts the raw `EmitImportedTF` still carries both conflicting pairs, then asserts the composed `/imported.tf` keeps exactly one side (`private_ips` kept, `private_ip_list` dropped; `subnets` kept, `subnet_mapping` dropped). Runs in normal CI (no terraform).
- `TestImportedConflicts_ComposePathTerraformValidate` (`-tags tfvalidate`) — before/after real `terraform validate` at the pinned provider (`= 6.46.0`): raw emit reproduces the errors; normalized composer output validates clean.
- Fixture `testdata/imported_conflicts.json` — a reduced, self-contained closure (2 ENI → 2 subnet → 2 vpc + ALB + S3) from a real whole-account manifest.

### Before → after (`terraform validate`, pinned aws 6.46.0)
```
Error: Conflicting configuration arguments (ENI private_ip_list vs private_ips)
Error: Invalid combination of arguments  (ALB subnets vs subnet_mapping)
        ↓
Success! The configuration is valid.   (only S3 inline-SSE deprecation warnings remain)
```

## Verification

- `go build ./...`, `go vet`, `gofmt -l` — clean
- Affected suites (`pkg/composer/...`, `pkg/reverseimport/...`, `cmd/insideout-import/...`) — 17 packages ok, 0 fail
- `-tags tfvalidate` conflict test — pass
- Reviewed by qa-professor: PASS (both tests confirmed to fail on the pre-fix code at the correct post-condition)

## Follow-ups (out of scope)

- `google_compute_firewall` fixup: `run.go` gates normalization on `cloud == "aws"`, so the one GCP fixup runs on neither path. Wiring GCP normalization is a separate change for both paths.
- `aws_s3_bucket` inline `server_side_encryption_configuration` / `grant` are provider *deprecation warnings*, not conflict errors — no fixup needed today.