### PR TITLE
fix(imported): generalize computed nested-object drop (odb class); add drift scanner + compose harness

### DIFF
--- a/cmd/composetest/main.go
+++ b/cmd/composetest/main.go
@@ -1,0 +1,86 @@
+// Command composetest composes a preset stack to a local directory so the
+// generated terraform can be exercised directly (init/plan/apply/destroy)
+// against a test account. Throwaway harness for interactive testing.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+func main() {
+	keys := flag.String("keys", "aws_s3", "comma-separated component keys")
+	out := flag.String("out", "", "output directory (required)")
+	project := flag.String("project", "clwtest", "project naming prefix")
+	region := flag.String("region", "us-west-2", "region")
+	importedJSON := flag.String("imported", "", "optional path to imported resources JSON ([]imported.ImportedResource)")
+	flag.Parse()
+	if *out == "" {
+		fmt.Fprintln(os.Stderr, "-out required")
+		os.Exit(2)
+	}
+
+	var selected []composer.ComponentKey
+	for _, k := range strings.Split(*keys, ",") {
+		if k = strings.TrimSpace(k); k != "" {
+			selected = append(selected, composer.ComponentKey(k))
+		}
+	}
+
+	var irs []imported.ImportedResource
+	if *importedJSON != "" {
+		raw, err := os.ReadFile(*importedJSON)
+		if err != nil {
+			fatal("read imported: %v", err)
+		}
+		if err := jsonUnmarshal(raw, &irs); err != nil {
+			fatal("decode imported: %v", err)
+		}
+	}
+
+	comps := &composer.Components{Cloud: "aws"}
+	cfg := &composer.Config{Region: *region}
+
+	c := composer.New()
+	res, err := c.ComposeStackWithIssues(composer.ComposeStackOpts{
+		Cloud:           "aws",
+		SelectedKeys:    selected,
+		Comps:           comps,
+		Cfg:             cfg,
+		Project:         *project,
+		Region:          *region,
+		Imported:        irs,
+		ImportProjectID: *project,
+		ImportSessionID: "sess_clwtest",
+	})
+	if err != nil {
+		fatal("compose: %v", err)
+	}
+	for _, is := range res.Issues {
+		fmt.Printf("ISSUE code=%s field=%s value=%s reason=%s\n", is.Code, is.Field, is.Value, is.Reason)
+	}
+	for path, content := range res.Files {
+		dst := filepath.Join(*out, strings.TrimPrefix(path, "/"))
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			fatal("mkdir: %v", err)
+		}
+		if err := os.WriteFile(dst, content, 0o644); err != nil {
+			fatal("write %s: %v", dst, err)
+		}
+	}
+	fmt.Printf("composed %d files -> %s\n", len(res.Files), *out)
+}
+
+func fatal(f string, a ...any) {
+	fmt.Fprintf(os.Stderr, f+"\n", a...)
+	os.Exit(1)
+}
+
+func jsonUnmarshal(b []byte, v any) error { return json.Unmarshal(b, v) }

--- a/cmd/driftscan/main.go
+++ b/cmd/driftscan/main.go
@@ -1,0 +1,207 @@
+// Command driftscan cross-checks every generated typed model against a real
+// `terraform providers schema -json` dump, hunting the odb_network_arn bug
+// class: nested-object attributes the emitter renders as object literals
+// (`attr = [{...}]`), which terraform type-checks against the provider's FULL
+// nested schema — so any Required sub-attribute missing from our generated
+// struct fails plan the moment the provider adds it.
+//
+// Usage: go run ./cmd/driftscan -schema aws-6.52.0-schema.json
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+type providerSchemaDoc struct {
+	ProviderSchemas map[string]struct {
+		ResourceSchemas map[string]resourceSchema `json:"resource_schemas"`
+	} `json:"provider_schemas"`
+}
+
+type resourceSchema struct {
+	Block blockSchema `json:"block"`
+}
+
+type blockSchema struct {
+	Attributes map[string]attrSchema `json:"attributes"`
+	BlockTypes map[string]struct {
+		Block blockSchema `json:"block"`
+	} `json:"block_types"`
+}
+
+type attrSchema struct {
+	Required   bool        `json:"required"`
+	Optional   bool        `json:"optional"`
+	Computed   bool        `json:"computed"`
+	NestedType *nestedType `json:"nested_type"`
+	// Type is the cty type; object-list attrs look like ["list",["object",{...}]]
+	Type json.RawMessage `json:"type"`
+}
+
+type nestedType struct {
+	Attributes map[string]attrSchema `json:"attributes"`
+}
+
+// objectAttrNames extracts sub-attribute names+requiredness for an SDKv2-style
+// object-typed attribute: type = ["list"|"set", ["object", {name: ctytype}]].
+// SDKv2 object attrs have no per-sub-attr required flags in the schema dump —
+// terraform derives requiredness from the object type itself: EVERY attribute
+// of a cty object type is required unless marked optional, and the schema JSON
+// cannot mark them, so ALL names are effectively required in a literal.
+func objectAttrNames(raw json.RawMessage) []string {
+	var outer []json.RawMessage
+	if json.Unmarshal(raw, &outer) != nil || len(outer) != 2 {
+		return nil
+	}
+	var kind string
+	if json.Unmarshal(outer[0], &kind) != nil || (kind != "list" && kind != "set" && kind != "map") {
+		return nil
+	}
+	var inner []json.RawMessage
+	if json.Unmarshal(outer[1], &inner) != nil || len(inner) != 2 {
+		return nil
+	}
+	var innerKind string
+	if json.Unmarshal(inner[0], &innerKind) != nil || innerKind != "object" {
+		return nil
+	}
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(inner[1], &fields) != nil {
+		return nil
+	}
+	names := make([]string, 0, len(fields))
+	for k := range fields {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func structTFTags(t reflect.Type) map[string]bool {
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		tag := strings.Split(t.Field(i).Tag.Get("tf"), ",")[0]
+		if tag != "" {
+			out[tag] = true
+		}
+	}
+	return out
+}
+
+func main() {
+	schemaPath := flag.String("schema", "", "path to terraform providers schema -json output")
+	flag.Parse()
+	raw, err := os.ReadFile(*schemaPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	var doc providerSchemaDoc
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	var resources map[string]resourceSchema
+	for name, ps := range doc.ProviderSchemas {
+		if strings.Contains(name, "hashicorp/aws") {
+			resources = ps.ResourceSchemas
+		}
+	}
+
+	bugs := 0
+	fragile := 0
+	for _, tfType := range generated.RegisteredTypes() {
+		if !strings.HasPrefix(tfType, "aws_") {
+			continue
+		}
+		goType, schema, ok := generated.Lookup(tfType)
+		if !ok {
+			continue
+		}
+		rs, ok := resources[tfType]
+		if !ok {
+			fmt.Printf("NOTE  %s: not in provider schema (removed/renamed?)\n", tfType)
+			continue
+		}
+		if goType.Kind() == reflect.Pointer {
+			goType = goType.Elem()
+		}
+		for i := 0; i < goType.NumField(); i++ {
+			fld := goType.Field(i)
+			parts := strings.Split(fld.Tag.Get("tf"), ",")
+			tag := parts[0]
+			if tag == "" || len(parts) > 1 { // skip block/blocks-tagged: emitted as blocks, validated per-attr
+				continue
+			}
+			// nested-object attr? element must be a struct that is NOT a Value carrier
+			ft := fld.Type
+			for ft.Kind() == reflect.Pointer || ft.Kind() == reflect.Slice {
+				ft = ft.Elem()
+			}
+			if ft.Kind() != reflect.Struct {
+				continue
+			}
+			if _, isVal := ft.FieldByName("Literal"); isVal {
+				continue // scalar Value[T]
+			}
+			// This field is emitted as an object literal. Find provider-side sub-attrs.
+			var provSubs map[string]attrSchema
+			var subNames []string
+			if pa, ok := rs.Block.Attributes[tag]; ok {
+				if pa.NestedType != nil {
+					provSubs = pa.NestedType.Attributes
+					for k := range provSubs {
+						subNames = append(subNames, k)
+					}
+					sort.Strings(subNames)
+				} else {
+					subNames = objectAttrNames(pa.Type)
+				}
+			} else if _, isBlock := rs.Block.BlockTypes[tag]; isBlock {
+				// provider models it as a BLOCK; emitting as attr literal is still
+				// legal (TF converts), but block emission would be safer. Not the
+				// odb class. Skip.
+				continue
+			} else {
+				fmt.Printf("NOTE  %s.%s: attr not in provider schema\n", tfType, tag)
+				continue
+			}
+			fs := schema[tag]
+			if !fs.Required && !fs.Optional {
+				continue // computed-only: MarshalHCLConfigurable already drops it — never emitted
+			}
+			ours := structTFTags(ft)
+			var missing []string
+			for _, n := range subNames {
+				if provSubs != nil {
+					// framework nested attr: only Required sub-attrs break literals
+					if !provSubs[n].Required {
+						continue
+					}
+				}
+				// SDKv2 object type: every sub-attr name is required in a literal
+				if !ours[n] {
+					missing = append(missing, n)
+				}
+			}
+			cls := "fragile-literal"
+			if len(missing) > 0 {
+				cls = "BUG(missing-required)"
+				bugs++
+			} else {
+				fragile++
+			}
+			fmt.Printf("%-22s %-45s attr=%-30s optional=%v computed=%v missing=%v\n",
+				cls, tfType, tag, fs.Optional, fs.Computed, missing)
+		}
+	}
+	fmt.Printf("\nSUMMARY: %d missing-required BUGS, %d fragile object-literal attrs\n", bugs, fragile)
+}

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -284,12 +285,11 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 		}
 		ensureLambdaPlaceholderSource(typed)
 		ensureKeyPairPlaceholder(typed)
-		ensureSecurityGroupRuleLists(typed)
-		dropRouteTableComputedRoutes(typed)
 		// Pass the registered schema so computed-only attributes are
 		// dropped. Lookup returns a nil schema for unregistered types,
 		// which makes MarshalHCLConfigurable byte-identical to MarshalHCL.
 		_, schema, _ := generated.Lookup(ir.Identity.Type)
+		dropUneditedComputedNestedObjectAttrs(typed, schema, ir.FieldEdits)
 		body, err := generated.MarshalHCLConfigurable(typed, schema)
 		if err != nil {
 			return nil, fmt.Errorf("marshal typed body for %q: %w", ir.Identity.Type, err)
@@ -299,67 +299,98 @@ func emitImportedResourceBody(ir imported.ImportedResource) ([]byte, error) {
 	return emitOpaqueAttrsBody(ir)
 }
 
-func ensureSecurityGroupRuleLists(typed any) {
-	sg, ok := typed.(*generated.AWSSecurityGroup)
-	if !ok {
+// dropUneditedComputedNestedObjectAttrs nils every Optional+Computed
+// nested-object ATTRIBUTE (a `tf:"name"`-tagged field whose element is a
+// nested struct, emitted as an object literal `name = [{...}]` / `name =
+// {...}`) on an imported resource's typed model before emission — unless the
+// resource carries a FieldEdit targeting that attribute.
+//
+// Why (the odb_network_arn class): terraform type-checks each object-literal
+// element against the provider's FULL nested schema, so the moment a provider
+// release widens the nested object with a new Required sub-attribute the
+// generated model doesn't know about, every emitted element fails plan with
+// `Inappropriate value for attribute "<attr>": element 0: attribute "<x>" is
+// required`. AWS provider v6.52.0 did exactly this to aws_route_table.route
+// (added the Required `odb_network_arn`), breaking every whole-account
+// reverse-import apply that discovered a route table with inline routes. A
+// live schema scan (cmd/driftscan) found 10 more attrs one provider bump away
+// from the same failure: aws_security_group / aws_network_acl ingress+egress,
+// aws_bedrockagent_agent memory/prompt_override configuration,
+// aws_bedrockagent_agent_alias routing_configuration,
+// aws_opensearchserverless_collection encryption_config, and aws_s3vectors_*
+// encryption_configuration.
+//
+// Because these attributes are Computed, terraform reads their real values
+// from the imported resource's refreshed state — omitting them from the
+// generated config is a plan no-op, and it immunizes the emitter against the
+// whole drift class instead of hand-patching one resource at a time (this
+// generalizes and retires the earlier ensureSecurityGroupRuleLists and
+// dropRouteTableComputedRoutes point fixes).
+//
+// Edits are preserved: if ir.FieldEdits contains a path rooted at the
+// attribute (exact, dotted, or indexed — "ingress", "ingress[0].from_port"),
+// the literal is kept so the operator's change still materializes in HCL.
+// Optional-only (non-Computed) nested attrs are never dropped — they are real
+// configuration with no state to fall back on.
+func dropUneditedComputedNestedObjectAttrs(typed any, schema map[string]generated.FieldSchema, edits map[string]imported.FieldEdit) {
+	if typed == nil || schema == nil {
 		return
 	}
-	for i := range sg.Egress {
-		ensureSecurityGroupEgressRuleLists(&sg.Egress[i])
+	v := reflect.ValueOf(typed)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
 	}
-	for i := range sg.Ingress {
-		ensureSecurityGroupIngressRuleLists(&sg.Ingress[i])
+	if v.Kind() != reflect.Struct {
+		return
 	}
-}
-
-func ensureSecurityGroupEgressRuleLists(rule *generated.AWSSecurityGroupEgress) {
-	if rule.IPV6CIDRBlocks == nil {
-		rule.IPV6CIDRBlocks = []*generated.Value[string]{}
-	}
-	if rule.PrefixListIDS == nil {
-		rule.PrefixListIDS = []*generated.Value[string]{}
-	}
-	if rule.SecurityGroups == nil {
-		rule.SecurityGroups = []*generated.Value[string]{}
-	}
-}
-
-func ensureSecurityGroupIngressRuleLists(rule *generated.AWSSecurityGroupIngress) {
-	if rule.IPV6CIDRBlocks == nil {
-		rule.IPV6CIDRBlocks = []*generated.Value[string]{}
-	}
-	if rule.PrefixListIDS == nil {
-		rule.PrefixListIDS = []*generated.Value[string]{}
-	}
-	if rule.SecurityGroups == nil {
-		rule.SecurityGroups = []*generated.Value[string]{}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		fld := t.Field(i)
+		parts := strings.Split(fld.Tag.Get("tf"), ",")
+		tag := parts[0]
+		if tag == "" || len(parts) > 1 {
+			continue // untagged, or a block/blocks field (validated per-attribute)
+		}
+		fs, ok := schema[tag]
+		if !ok || !fs.Optional || !fs.Computed {
+			continue // only Optional+Computed attrs are safe plan no-ops to omit
+		}
+		if !isNestedObjectAttrField(fld.Type) {
+			continue // scalar Value[T] / lists / maps of scalars are not the class
+		}
+		if fieldEditTargets(edits, tag) {
+			continue // operator edited it — the literal must materialize
+		}
+		v.Field(i).SetZero()
 	}
 }
 
-// dropRouteTableComputedRoutes clears the inline `route` list on an imported
-// aws_route_table before emission.
-//
-// aws_route_table.route is Optional+Computed and is emitted as a nested-object
-// list literal (`route = [{ ... }]`). Terraform type-checks each object
-// element against the provider's full nested schema, so the moment the AWS
-// provider widens that schema with a new Required sub-attribute the emitter
-// doesn't know about, every element fails plan with `Inappropriate value for
-// attribute "route": element 0: attribute "<x>" is required`. AWS provider
-// v6.52.0 did exactly this — it added the Required `odb_network_arn` (Oracle
-// Database@AWS routing) to the route object — which broke every whole-account
-// reverse-import apply that discovered a route table with inline routes.
-//
-// Because `route` is Computed, terraform reads the route table's real routes
-// from the imported resource's refreshed state, so simply not declaring them
-// is a plan no-op — and it makes the emitter immune to this class of provider
-// nested-schema drift (the same failure mode ensureSecurityGroupRuleLists
-// hand-patches for aws_security_group's ingress/egress objects). We drop the
-// inline routes rather than re-declaring them; adopting a route table does not
-// require re-stating routes terraform can already read.
-func dropRouteTableComputedRoutes(typed any) {
-	if rt, ok := typed.(*generated.AWSRouteTable); ok {
-		rt.Route = nil
+// isNestedObjectAttrField reports whether an attr-tagged field's element is a
+// nested-object struct (emitted as an object literal) rather than a scalar
+// Value[T] carrier. Pointer/slice layers are unwrapped to the element type.
+func isNestedObjectAttrField(t reflect.Type) bool {
+	for t.Kind() == reflect.Pointer || t.Kind() == reflect.Slice {
+		t = t.Elem()
 	}
+	if t.Kind() != reflect.Struct {
+		return false
+	}
+	_, isValueCarrier := t.FieldByName("Literal")
+	return !isValueCarrier
+}
+
+// fieldEditTargets reports whether any FieldEdit path is rooted at attr:
+// exact ("ingress"), dotted ("ingress.0.from_port"), or indexed
+// ("ingress[0].from_port").
+func fieldEditTargets(edits map[string]imported.FieldEdit, attr string) bool {
+	for path := range edits {
+		if path == attr ||
+			strings.HasPrefix(path, attr+".") ||
+			strings.HasPrefix(path, attr+"[") {
+			return true
+		}
+	}
+	return false
 }
 
 // stripResourceIDAttr removes the top-level `id` key from a typed-Attrs

--- a/pkg/composer/imported_emit_test.go
+++ b/pkg/composer/imported_emit_test.go
@@ -284,7 +284,7 @@ func TestEmitImportedTF_LambdaTypedAttrsInjectsPlaceholderFilename(t *testing.T)
 	assert.Contains(t, s, "ignore_changes", "placeholder filename must still be pinned under ignore_changes")
 }
 
-func TestEmitImportedTF_SecurityGroupTypedAttrsRestoresEmptyRuleLists(t *testing.T) {
+func TestEmitImportedTF_SecurityGroupDropsUneditedComputedRules(t *testing.T) {
 	t.Parallel()
 	attrs, err := json.Marshal(&generated.AWSSecurityGroup{
 		Name:  generated.LiteralOf("web"),
@@ -312,10 +312,61 @@ func TestEmitImportedTF_SecurityGroupTypedAttrsRestoresEmptyRuleLists(t *testing
 	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
 	require.NotNil(t, out)
 	s := string(out)
-	for _, want := range []string{"ipv6_cidr_blocks", "prefix_list_ids", "security_groups"} {
-		assert.Regexpf(t, regexp.MustCompile(`(?m)^\s*`+want+`\s*=\s*\[\]`), s,
-			"security group rule must restore required empty list %s:\n%s", want, s)
+	// ingress/egress are Optional+Computed nested-object attrs: unedited, they
+	// are dropped entirely (dropUneditedComputedNestedObjectAttrs) — terraform
+	// reads the real rules from the imported state, and omitting the literal
+	// immunizes against provider nested-schema drift (the odb_network_arn
+	// class). The old behavior padded required empty sub-lists instead; that
+	// point fix is superseded.
+	assert.NotRegexp(t, `(?m)^\s*ingress\s*=`, s,
+		"unedited computed ingress literal must be dropped:\n%s", s)
+	assert.NotContains(t, s, "cidr_blocks",
+		"dropping ingress must drop its nested sub-attributes too:\n%s", s)
+	assert.Regexp(t, `(?m)^\s*vpc_id\s*=\s*"vpc-123"`, s, "vpc_id must survive:\n%s", s)
+	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
+	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
+}
+
+// TestEmitImportedTF_EditedComputedNestedAttrSurvives pins the edit-preserving
+// carve-out of dropUneditedComputedNestedObjectAttrs: when the operator has a
+// FieldEdit rooted at a computed nested-object attribute, the literal must
+// still materialize in HCL so the edit reaches terraform.
+func TestEmitImportedTF_EditedComputedNestedAttrSurvives(t *testing.T) {
+	t.Parallel()
+	attrs, err := json.Marshal(&generated.AWSSecurityGroup{
+		Name:  generated.LiteralOf("web"),
+		VPCID: generated.LiteralOf("vpc-123"),
+		Ingress: []generated.AWSSecurityGroupIngress{{
+			CIDRBlocks:     []*generated.Value[string]{generated.LiteralOf("10.0.0.0/8")},
+			FromPort:       generated.LiteralOf[float64](443),
+			Protocol:       generated.LiteralOf("tcp"),
+			Self:           generated.LiteralOf(false),
+			ToPort:         generated.LiteralOf[float64](443),
+			IPV6CIDRBlocks: []*generated.Value[string]{},
+			PrefixListIDS:  []*generated.Value[string]{},
+			SecurityGroups: []*generated.Value[string]{},
+		}},
+	})
+	require.NoError(t, err)
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_security_group",
+			Address:  "aws_security_group.web",
+			ImportID: "sg-123",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: attrs,
+		FieldEdits: map[string]imported.FieldEdit{
+			"ingress[0].from_port": {NewValue: "443"},
+		},
 	}
+	out, _ := EmitImportedTF("aws", []imported.ImportedResource{ir}, EmitImportedOpts{})
+	require.NotNil(t, out)
+	s := string(out)
+	assert.Regexp(t, `(?m)^\s*ingress\s*=`, s,
+		"edited ingress literal must survive the computed-nested drop:\n%s", s)
+	assert.Contains(t, s, "10.0.0.0/8", "edited rule content must materialize:\n%s", s)
 	_, diags := hclsyntax.ParseConfig(out, "imported.tf", hcl.InitialPos)
 	require.Falsef(t, diags.HasErrors(), "imported.tf must parse: %s\n%s", diags.Error(), s)
 }


### PR DESCRIPTION
## The class, measured

A live schema scan against AWS provider **6.52.0** (via the included `cmd/driftscan`) shows the `odb_network_arn` failure class is not route-table-specific. Exactly **1 missing-required bug exists today** (route — behaviorally fixed by #839) and **10 more Optional+Computed nested-object attributes** are emitted as object literals, each one provider bump away from the same `attribute "<x>" is required` plan failure:

- `aws_security_group` / `aws_network_acl` — `ingress`, `egress`
- `aws_bedrockagent_agent` — `memory_configuration`, `prompt_override_configuration`
- `aws_bedrockagent_agent_alias` — `routing_configuration`
- `aws_opensearchserverless_collection` — `encryption_config`
- `aws_s3vectors_index` / `aws_s3vectors_vector_bucket` — `encryption_configuration`

## The fix (altitude: one mechanism, not 11 patches)

Replace both per-resource point fixes (`dropRouteTableComputedRoutes` from #839, `ensureSecurityGroupRuleLists` from the earlier SG whack-a-mole) with one reflection-based guard in the typed import emit path: **`dropUneditedComputedNestedObjectAttrs`** nils every Optional+Computed nested-object attribute before marshaling.

- Safe: these attrs are Computed — terraform reads their real values from the imported resource's refreshed state, so omission is a plan no-op.
- Edit-preserving: if the resource carries a `FieldEdit` rooted at the attribute (`ingress`, `ingress[0].from_port`, …), the literal is kept so operator edits still materialize.
- Optional-only (non-Computed) nested attrs are never dropped — they're real configuration (`aws_bedrockagent_agent.guardrail_configuration` stays, and being a framework nested attr it only breaks on a Required sub-attr addition, which the scanner watches).

## Verified live in cust3 before generalizing

Using the new `claude-web-tf-session` credential (ui-infrastructure #353), end-to-end from the sandbox against account `031780745048` on provider 6.52.0:

1. Composed s3 stack → `init`/`plan`/`apply` (6 created) ✅
2. Created a real route table with inline routes, composed an **import-only stack** for it (+ s3 bucket + child + one deliberate dangling orphan) → orphan dropped (#836 ✅), route literal dropped (#839 ✅), `plan: 3 to import, 0 to add, 3 to change (tag-only)` ✅
3. `apply: 3 imported` ✅ → **second plan: "No changes"** (steady-state contract) ✅
4. Destroyed everything through the imported stack + fixtures — account clean ✅

The generalized guard emits **byte-identical** imported.tf for that fixture.

## Also included (standing tools)

- **`cmd/driftscan`** — cross-checks every generated typed model against a real `terraform providers schema -json` dump; classifies `BUG(missing-required)` vs `fragile-literal`. Run at every provider bump. (Follow-up: wire as a CI job that inits the pinned provider and fails on any missing-required.)
- **`cmd/composetest`** — composes a preset stack (optionally with imported-resources JSON) to a local dir for direct terraform lifecycle testing against cust3. This is the tight iteration loop that replaced the merge→deploy→Mars round trip.

## Tests

- SG test updated to the new drop semantics (supersedes empty-sub-list padding, renamed accordingly)
- New `TestEmitImportedTF_EditedComputedNestedAttrSurvives`
- Route-table regression test unchanged, green
- Full `pkg/composer/...` suite passes

## Follow-ups (not in this PR)

- CI job for driftscan against the composer's pinned provider version
- Regenerate `pkg/composer/imported/generated` against provider 6.52.0 (`cmd/imported-codegen`) — structs predate it (e.g. `AWSRouteTableRoute` lacks `odb_network_arn`); non-breaking now that emission drops the class, but staleness accumulates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_