### PR TITLE
fix(composer): surface imported_resource_emit_failed instead of silently skipping the resource

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -735,7 +735,12 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// was dropped and why; emitting it anyway would turn a one-resource
 	// gap into a stack-wide planning failure.
 	composable := dropUncomposable(importedResources, emitReadiness)
-	importedTF, importedClouds := EmitImportedTF(cloud, composable, emitOpts)
+	importedTF, importedClouds, emitIssues := EmitImportedTFWithIssues(cloud, composable, emitOpts)
+	// Surface emit-time failures (marshal / provenance-injection errors) that
+	// would otherwise silently drop a resource from /imported.tf — the
+	// "apply silently lands nothing" fail-open family (reliable #1922). See
+	// CodeImportedResourceEmitFailed.
+	issues = append(issues, emitIssues...)
 	// Normalize the emitted HCL through the shared resource-type fixups. This
 	// is the SAME pass the reverse-import pipeline runs over the FINAL
 	// imported.tf it emits (pkg/reverseimport/run.go): terraform import

--- a/pkg/composer/imported_emit.go
+++ b/pkg/composer/imported_emit.go
@@ -90,9 +90,45 @@ const (
 // compatibility. EmitImportedTF mutates ir.WeakLocked in irs to record the
 // provenance decision per resource — callers that need the original slice
 // untouched should pass a copy.
+//
+// EmitImportedTF is a thin backwards-compatible wrapper over
+// EmitImportedTFWithIssues that discards the surfaced issues. Direct callers
+// (e.g. ui-core's proxy) that want the fail-open signal — a resource that
+// fails body emission or provenance injection and would otherwise vanish
+// silently from the archive — should call EmitImportedTFWithIssues instead.
 func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImportedOpts) (out []byte, providersUsed map[string]bool) {
+	out, providersUsed, _ = EmitImportedTFWithIssues(cloud, irs, opts)
+	return out, providersUsed
+}
+
+// CodeImportedResourceEmitFailed is raised by EmitImportedTFWithIssues when an
+// emit-eligible imported resource fails to render — either its typed Attrs fail
+// to marshal into an HCL body (emitImportedResourceBody) or provenance
+// injection fails (injectProvenance). Historically both failures hit a bare
+// `continue` in the per-resource loop, so the resource silently vanished from
+// /imported.tf with NO signal: the subsequent `terraform apply` landed nothing
+// for it and no validator caught the gap. This is the "apply silently lands
+// nothing" fail-open family (reliable #1922).
+//
+// The compose-time pre-validators only partially cover this: ValidateImportedResources
+// catches Attrs DECODE failures (imported_resource_decode_failed), but emit-time
+// marshal errors and provenance-injection errors fall through, and direct callers
+// of EmitImportedTF get no validation at all.
+//
+// Surfacing the failure as a structured issue makes the disposition the
+// downstream caller's severity policy, not a silent drop. reliable treats
+// unknown issue codes as fatal, so this code fails closed there (the desired
+// behaviour) — an emit failure aborts the compose instead of shipping an archive
+// that is missing a resource the operator asked to import.
+const CodeImportedResourceEmitFailed = "imported_resource_emit_failed"
+
+// EmitImportedTFWithIssues is EmitImportedTF plus a slice of ValidationIssues
+// describing resources that failed to emit. See EmitImportedTF for the base
+// contract and CodeImportedResourceEmitFailed for the fail-open history the
+// issues close.
+func EmitImportedTFWithIssues(cloud string, irs []imported.ImportedResource, opts EmitImportedOpts) (out []byte, providersUsed map[string]bool, issues []ValidationIssue) {
 	if len(irs) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	wantCloud := strings.ToLower(strings.TrimSpace(cloud))
 	providersUsed = map[string]bool{}
@@ -155,11 +191,23 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 		case emitModeResourceImport, emitModeResourceOnly:
 			body, err := emitImportedResourceBody(*ir)
 			if err != nil {
+				issues = append(issues, ValidationIssue{
+					Field:  "imported." + addr,
+					Value:  ir.Identity.Type,
+					Code:   CodeImportedResourceEmitFailed,
+					Reason: fmt.Sprintf("emit resource body: %v", err),
+				})
 				continue
 			}
 			if opts.shouldInject() {
 				body, err = injectProvenance(body, ir, opts.ImportProjectID, opts.ImportSessionID, opts.ImportedAt)
 				if err != nil {
+					issues = append(issues, ValidationIssue{
+						Field:  "imported." + addr,
+						Value:  ir.Identity.Type,
+						Code:   CodeImportedResourceEmitFailed,
+						Reason: fmt.Sprintf("inject provenance: %v", err),
+					})
 					continue
 				}
 			}
@@ -184,7 +232,7 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 	}
 
 	if len(entries) == 0 {
-		return nil, providersUsed
+		return nil, providersUsed, issues
 	}
 
 	sort.Slice(entries, func(i, j int) bool { return entries[i].address < entries[j].address })
@@ -220,9 +268,9 @@ func EmitImportedTF(cloud string, irs []imported.ImportedResource, opts EmitImpo
 	if diags.HasErrors() {
 		// Fall back to the raw concatenation if parse failed; ValidateComposedRoot
 		// will surface the parse error so the caller still sees the failure.
-		return doc.Bytes(), providersUsed
+		return doc.Bytes(), providersUsed, issues
 	}
-	return formatted.Bytes(), providersUsed
+	return formatted.Bytes(), providersUsed, issues
 }
 
 // classifyEmitMode decides what artifact(s) to emit for ir.

--- a/pkg/composer/imported_emit_failure_test.go
+++ b/pkg/composer/imported_emit_failure_test.go
@@ -1,0 +1,126 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// TestEmitImportedTFWithIssues_SurfacesEmitFailure pins the fail-open fix
+// (reliable #1922): a resource whose typed Attrs fail to decode at emit time
+// must surface an imported_resource_emit_failed issue instead of silently
+// vanishing from /imported.tf, and it must NOT take the rest of the batch down
+// with it — a valid sibling resource still emits.
+//
+// The bad fixture gives aws_s3_bucket a numeric `bucket` literal where the
+// generated model expects Value[string]; generated.UnmarshalAttrs rejects it
+// inside emitImportedResourceBody, hitting the first (body-emit) continue site.
+func TestEmitImportedTFWithIssues_SurfacesEmitFailure(t *testing.T) {
+	t.Parallel()
+
+	badAddr := "aws_s3_bucket.broken"
+	goodAddr := "aws_sqs_queue.orders_dlq"
+
+	bad := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  badAddr,
+			Region:   "us-east-1",
+			ImportID: "broken-bucket",
+		},
+		Tier: imported.TierImportedFlat,
+		// bucket is Value[string]; a numeric literal fails UnmarshalAttrs.
+		Attrs: []byte(`{"bucket": {"literal": 123}}`),
+	}
+	good := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_sqs_queue",
+			Address:  goodAddr,
+			Region:   "us-east-1",
+			ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders-DLQ",
+		},
+		Tier:  imported.TierImportedFlat,
+		Attrs: []byte(`{"name":{"literal":"orders-DLQ"}}`),
+	}
+
+	out, used, issues := EmitImportedTFWithIssues("aws", []imported.ImportedResource{bad, good}, EmitImportedOpts{})
+
+	// (a) exactly one emit-failure issue, naming the bad address.
+	var emitFail []ValidationIssue
+	for _, iss := range issues {
+		if iss.Code == CodeImportedResourceEmitFailed {
+			emitFail = append(emitFail, iss)
+		}
+	}
+	require.Len(t, emitFail, 1, "expected exactly one imported_resource_emit_failed issue, got: %+v", issues)
+	assert.Equal(t, "imported."+badAddr, emitFail[0].Field)
+	assert.Equal(t, "aws_s3_bucket", emitFail[0].Value)
+	assert.Contains(t, emitFail[0].Reason, "emit resource body:")
+
+	// (b) the valid resource still emits.
+	require.NotNil(t, out)
+	s := string(out)
+	assert.Contains(t, s, goodAddr, "valid resource must still emit:\n%s", s)
+	assert.True(t, used["aws"])
+
+	// (c) the bad address never appears in the output.
+	assert.NotContains(t, s, badAddr, "failed resource must not leak into imported.tf:\n%s", s)
+}
+
+// TestComposeStack_SurfacesEmitFailureIssue pushes the same bad IR through the
+// full compose path. See the in-body comment for the pre-validation-shadowing
+// analysis: the decode failure is flagged twice (once by ValidateImportedResources
+// pre-emit, once by the emit site), and dropUncomposable does NOT remove it
+// (its `bucket` key is present, so it is not missing-required). Both codes fire.
+func TestComposeStack_SurfacesEmitFailureIssue(t *testing.T) {
+	t.Parallel()
+
+	badAddr := "aws_s3_bucket.broken"
+	c := newTestClient()
+	res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC},
+		Comps:        &Components{Cloud: "AWS"},
+		Cfg:          &Config{},
+		Project:      "demo",
+		Region:       "us-east-1",
+		Imported: []imported.ImportedResource{
+			{
+				Identity: imported.ResourceIdentity{
+					Cloud:    "aws",
+					Type:     "aws_s3_bucket",
+					Address:  badAddr,
+					Region:   "us-east-1",
+					ImportID: "broken-bucket",
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"bucket": {"literal": 123}}`),
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	var sawDecode, sawEmit bool
+	for _, iss := range res.Issues {
+		switch iss.Code {
+		case "imported_resource_decode_failed":
+			sawDecode = true
+		case CodeImportedResourceEmitFailed:
+			sawEmit = true
+			assert.Equal(t, "imported."+badAddr, iss.Field)
+		}
+	}
+	// Pre-validation shadows the decode error, but does not suppress the emit
+	// site: the emit-failure issue still fires on the compose path.
+	assert.True(t, sawDecode, "expected pre-validation to flag imported_resource_decode_failed; issues: %+v", res.Issues)
+	assert.True(t, sawEmit, "expected the emit site to flag imported_resource_emit_failed; issues: %+v", res.Issues)
+
+	// The bad resource must not have leaked into the emitted archive.
+	assert.NotContains(t, string(res.Files["/imported.tf"]), badAddr)
+}


### PR DESCRIPTION
Stacked on #842 (auto-retargets to `main` when it merges).

## Problem

`EmitImportedTF`'s per-resource loop had two bare `continue` sites: body-emit failure and provenance-injection failure. A resource hitting either vanished from `/imported.tf` with no signal — the subsequent apply silently lands nothing for it (the reliable #1922 fail-open family). Compose pre-validators catch Attrs *decode* failures, but emit-time errors fell through, and direct callers of `EmitImportedTF` (ui-core's proxy) get no validation at all.

## Fix

- New `EmitImportedTFWithIssues` returns `[]ValidationIssue` alongside the emitted bytes; each former silent-skip site records `imported_resource_emit_failed` (Field `imported.<addr>`, Value `<tf type>`, Reason carrying the underlying error).
- `composeStackImpl` uses the WithIssues variant and accumulates the issues with the other validators. Disposition is the downstream caller's severity policy — reliable treats unknown codes as fatal, so this fails closed there.
- `EmitImportedTF` stays as a thin wrapper discarding issues (public API compatibility for ui-core).

## Notes

- Investigated whether pre-validation shadows the emit branch: it does not. `ValidateImportedResources` flags a decode-broken resource but `dropUncomposable` only removes missing-required-attr resources, so the malformed resource genuinely reaches the emitter — both codes fire and the new issue is not shadowed.
- Full existing Emit/Imported/Compose suite passes unchanged — no existing fixture triggers the new code, so escalating it to fatal downstream is safe.

## Testing

- `TestEmitImportedTFWithIssues_SurfacesEmitFailure` — bad + valid resource in one batch: one issue naming the bad address, valid sibling still emits, bad address absent from output.
- `TestComposeStack_SurfacesEmitFailureIssue` — end-to-end via `ComposeStackWithIssues`: both codes surface, resource excluded from the archive.
- gofmt / build / vet / full `-run 'Emit|Imported|Compose'` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_