### PR TITLE
Regenerate typed models against AWS 6.52.0; catalogue + gate depchase literal degradation

### DIFF
--- a/cmd/insideout-import/depchase/degradation_catalogue.go
+++ b/cmd/insideout-import/depchase/degradation_catalogue.go
@@ -1,0 +1,50 @@
+package depchase
+
+// Literal-reference degradation catalogue (presets#834).
+//
+// The dep-chase loop's happy path RESOLVES a cross-resource ARN literal in the
+// generated config to a real resource reference: it discovers the target, adds
+// it to the import set, re-runs genconfig, and crossref.go rewrites the literal
+// to `aws_<type>.<name>.<attr>`. A reference "degrades to a literal" when any
+// stage below prevents that rewrite, so the ARN string is left verbatim in the
+// generated config. All degradations are non-fatal — the stack still plans —
+// but a literal weakens the imported graph (edits to the target don't
+// propagate; later plans don't see the relationship).
+//
+// This catalogue enumerates every class that leaves a literal, keyed to the
+// code that produces it, with a per-class decision: EMIT (resolve to a real
+// reference — the happy path) or DOCUMENTED-LITERAL (the literal is the correct
+// terminal state, or resolving it is out of scope for this repo).
+//
+// Reference types the loop can RESOLVE (arnTFTypeMap, arnparse.go): aws_iam_role,
+// aws_iam_policy, aws_kms_key (from a kms key OR alias ARN), aws_s3_bucket,
+// aws_lambda_function, aws_secretsmanager_secret, aws_dynamodb_table,
+// aws_cloudwatch_log_group, aws_sqs_queue. Each is paired with a registered
+// awsdiscover discoverer + a generated Layer-1 typed model, so a reference to a
+// CUSTOMER-OWNED instance of one of these types is emitted and resolved.
+//
+//	# | Degradation class                     | Trigger (code)                                   | Warned?                              | Decision            | Rationale
+//	--|---------------------------------------|--------------------------------------------------|--------------------------------------|---------------------|----------
+//	A | Ref in a nested attr / block          | finder.collectFromBodyWithHits walks TOP-LEVEL   | no (silent)                          | documented-literal  | Conservative finder; nested ARN literals are rare. Widening is a follow-up (finder.go comment).
+//	  |                                       | attrs only                                       |                                      | (widen finder)      |
+//	B | Ref in a non-ARN identifier form      | finder.isARNLiteral requires `arn:` + >=5 colons | no (silent)                          | documented-literal  | Bare id/name/URL refs (KMS KeyId UUID, S3 name, GCP self-link) aren't ARN-shaped; out of the ARN-based chase's scope.
+//	C | Unsupported ARN service/resource-type | ParseRef -> ErrUnsupportedType (not in           | yes: "unsupported ARN type"          | documented-literal  | Type has no discoverer + typed model (SNS, ECR, ACM, SES, EFS, ...). Emitting needs a new discoverer+model — deliberate scope expansion, not a chase bug.
+//	  |                                       | arnTFTypeMap)                                    |                                      | (out of scope)      |
+//	D | Malformed ARN literal                 | ParseRef -> parse error                          | yes: "could not parse ARN"           | documented-literal  | Not a resolvable reference.
+//	E | Target not found                      | DiscoverByID -> Err{Not,}Found                    | yes: "ARN ... : not found"           | documented-literal  | Deleted / cross-account / cross-partition target; nothing to emit.
+//	F | Discoverer rejected the ID            | DiscoverByID -> ErrNotSupported, incl.           | yes: "discoverer rejected ID"        | documented-literal  | Intended exclusion (e.g. AWS-managed IAM policy, ARN account="aws", #652). Not customer-owned.
+//	  |                                       | SkipIdentifier exclusions                        |                                      | (intended)          |
+//	G | Target inherently un-importable       | NEW gate: imported.UnimportableReason(ir) != ""  | yes: precise "un-importable (<reason>)" | documented-literal  | AWS-managed KMS key (KeyManager=AWS), service-linked IAM role (role/aws-service-role/), service-managed ENI, ManagedBy service resource, already-InsideOut-imported. The target CANNOT be adopted into customer TF state, so the literal is the correct terminal state. THIS is the #834 aws_kms_key / aws_iam_role class — now gated pre-add with a precise reason instead of the opaque class H warning.
+//	H | Discovered, but genconfig dropped it  | partitionDiscoveries "dropped": address absent   | yes: "generated config omitted it;   | documented-literal  | Backstop for any un-adoptable target class G did not pre-classify (e.g. `terraform plan -generate-config-out` produced no body, or the genconfig unimportable-HCL prune removed it). Before #834 this was the ONLY signal for the KMS/IAM cases — opaque, read like a bug.
+//	  |                                       | from regenerated set                             | leaving the literal reference"       | (backstop)          |
+//	I | Reference cycle / stable unresolved   | unresolved set equal across iterations           | yes: "unresolved ... stable"         | documented-literal  | Target unreachable via DiscoverByID, or a reference cycle the loop can't close by adding resources.
+//
+// Decision summary: every SUPPORTED, CUSTOMER-OWNED target is EMITTED and its
+// reference resolved (happy path). The classes above are all DOCUMENTED-LITERAL
+// — either the target is genuinely un-adoptable (F, G), gone (E), or resolving
+// it is out of the ARN-based chase's scope (A, B, C, D, I). #834's contribution
+// is class G: move the two observed reference types (aws_kms_key, aws_iam_role)
+// out of the opaque class-H backstop and into a precise, pre-add gate that
+// names WHY the literal is correct, and add the missing service-linked-IAM-role
+// classifier to the shared imported.UnimportableReason so discovery, the
+// genconfig prune, and this loop all agree.

--- a/cmd/insideout-import/depchase/degradation_catalogue.go
+++ b/cmd/insideout-import/depchase/degradation_catalogue.go
@@ -25,9 +25,9 @@ package depchase
 //
 //	# | Degradation class                     | Trigger (code)                                   | Warned?                              | Decision            | Rationale
 //	--|---------------------------------------|--------------------------------------------------|--------------------------------------|---------------------|----------
-//	A | Ref in a nested attr / block          | finder.collectFromBodyWithHits walks TOP-LEVEL   | no (silent)                          | documented-literal  | Conservative finder; nested ARN literals are rare. Widening is a follow-up (finder.go comment).
-//	  |                                       | attrs only                                       |                                      | (widen finder)      |
-//	B | Ref in a non-ARN identifier form      | finder.isARNLiteral requires `arn:` + >=5 colons | no (silent)                          | documented-literal  | Bare id/name/URL refs (KMS KeyId UUID, S3 name, GCP self-link) aren't ARN-shaped; out of the ARN-based chase's scope.
+//	A | Ref in a nested attr / block          | scanNestedAndNonARN walks nested blocks +        | yes: "nested_ref_literal"            | EMIT (Tier 2)       | #834: nested/collection ARN literals are now surfaced by the recursive hclsyntax walk (finder_nested.go) and fed into the SAME discover→gate→add chase as top-level hits. Adoptable targets are emitted; the nested literal itself is retained (crossref rewrite is still top-level-only — Tier 3 skipped as it would contort the rewriter).
+//	  |                                       | tuple/object expression trees (finder_nested.go) |                                      |                     |
+//	B | Ref in a non-ARN identifier form      | scanNestedAndNonARN curated attr map             | yes: "non_arn_ref_literal"           | EMIT (curated attrs)| #834: a curated (attr-name → tfType) allowlist with per-type value gates surfaces bare-identifier refs. KMS KeyId UUIDs in kms_key_id / kms_master_key_id → aws_kms_key are CHASED (the KMS Cloud Control DiscoverByID accepts a bare KeyId). Other bare forms (S3 name, GCP self-link) remain out of scope: their value shapes are too permissive to gate without false positives — extend nonARNAttrRules to add one.
 //	C | Unsupported ARN service/resource-type | ParseRef -> ErrUnsupportedType (not in           | yes: "unsupported ARN type"          | documented-literal  | Type has no discoverer + typed model (SNS, ECR, ACM, SES, EFS, ...). Emitting needs a new discoverer+model — deliberate scope expansion, not a chase bug.
 //	  |                                       | arnTFTypeMap)                                    |                                      | (out of scope)      |
 //	D | Malformed ARN literal                 | ParseRef -> parse error                          | yes: "could not parse ARN"           | documented-literal  | Not a resolvable reference.
@@ -40,11 +40,26 @@ package depchase
 //	I | Reference cycle / stable unresolved   | unresolved set equal across iterations           | yes: "unresolved ... stable"         | documented-literal  | Target unreachable via DiscoverByID, or a reference cycle the loop can't close by adding resources.
 //
 // Decision summary: every SUPPORTED, CUSTOMER-OWNED target is EMITTED and its
-// reference resolved (happy path). The classes above are all DOCUMENTED-LITERAL
-// — either the target is genuinely un-adoptable (F, G), gone (E), or resolving
-// it is out of the ARN-based chase's scope (A, B, C, D, I). #834's contribution
-// is class G: move the two observed reference types (aws_kms_key, aws_iam_role)
-// out of the opaque class-H backstop and into a precise, pre-add gate that
-// names WHY the literal is correct, and add the missing service-linked-IAM-role
-// classifier to the shared imported.UnimportableReason so discovery, the
-// genconfig prune, and this loop all agree.
+// reference resolved (happy path). #834 eliminates the two SILENT classes:
+//
+//   - class A (nested/collection ARN literal) and class B (curated non-ARN
+//     identifier, KMS KeyId UUID) are now SURFACED — the finder walks nested
+//     blocks + tuple/object expression trees (finder_nested.go) and a curated
+//     attr-name allowlist — and CHASED through the same discover→gate→add path
+//     as top-level hits (Tier 2). Neither literal is rewritten in place (the
+//     genconfig crossref pass is still top-level-only; nested Tier-3 rewrite is
+//     deferred), but the adoptable target enters the import set and every hit
+//     emits a precise nested_ref_literal / non_arn_ref_literal warning. No hit
+//     is silent anymore.
+//   - class G: the two observed reference types (aws_kms_key, aws_iam_role) were
+//     moved out of the opaque class-H backstop into a precise, pre-add
+//     imported.UnimportableReason gate that names WHY the literal is correct
+//     (adding the service-linked-IAM-role classifier so discovery, the genconfig
+//     prune, and this loop all agree).
+//
+// The remaining classes stay DOCUMENTED-LITERAL — the target is genuinely
+// un-adoptable (F, G), gone (E), or resolving it is out of the chase's supported
+// scope (C, D, I). A nested/non-ARN hit whose target falls into one of those
+// (e.g. a nested ARN of an unsupported service, or a KMS KeyId that resolves to
+// an AWS-managed key) still emits its class-A/B detection warning AND the
+// downstream class-C/G/E outcome warning — surfaced twice, never silent.

--- a/cmd/insideout-import/depchase/degradation_catalogue.go
+++ b/cmd/insideout-import/depchase/degradation_catalogue.go
@@ -25,9 +25,9 @@ package depchase
 //
 //	# | Degradation class                     | Trigger (code)                                   | Warned?                              | Decision            | Rationale
 //	--|---------------------------------------|--------------------------------------------------|--------------------------------------|---------------------|----------
-//	A | Ref in a nested attr / block          | scanNestedAndNonARN walks nested blocks +        | yes: "nested_ref_literal"            | EMIT (Tier 2)       | #834: nested/collection ARN literals are now surfaced by the recursive hclsyntax walk (finder_nested.go) and fed into the SAME discover→gate→add chase as top-level hits. Adoptable targets are emitted; the nested literal itself is retained (crossref rewrite is still top-level-only — Tier 3 skipped as it would contort the rewriter).
+//	A | Ref in a nested attr / block          | scanNestedAndNonARN walks nested blocks +        | yes: "nested_ref_literal"            | EMIT (Tier 2)       | #834: nested/collection ARN literals are surfaced by the recursive hclsyntax walk (finder_nested.go) and fed into the SAME discover→gate→add chase as top-level hits. Adoptable targets are emitted; the nested literal itself is retained (crossref rewrite is still top-level-only — Tier 3 skipped as it would contort the rewriter). Post-review hardening: a nested literal is TERMINAL-BY-DESIGN (chased exactly once, then excluded from cycle detection so a never-byte-matching literal can't trip ErrCyclicDependency — F2); a hard (non-sentinel) discovery error on a nested ref degrades to a warning instead of aborting the whole import (F1); and EVERY nested consumer of a literal records its own graph edge — a literal referenced by two resources, or one that ALSO appears top-level, keeps every edge and every distinct nested warning (F4).
 //	  |                                       | tuple/object expression trees (finder_nested.go) |                                      |                     |
-//	B | Ref in a non-ARN identifier form      | scanNestedAndNonARN curated attr map             | yes: "non_arn_ref_literal"           | EMIT (curated attrs)| #834: a curated (attr-name → tfType) allowlist with per-type value gates surfaces bare-identifier refs. KMS KeyId UUIDs in kms_key_id / kms_master_key_id → aws_kms_key are CHASED (the KMS Cloud Control DiscoverByID accepts a bare KeyId). Other bare forms (S3 name, GCP self-link) remain out of scope: their value shapes are too permissive to gate without false positives — extend nonARNAttrRules to add one.
+//	B | Ref in a non-ARN identifier form      | scanNestedAndNonARN curated attr map             | yes: "non_arn_ref_literal"           | EMIT (curated attrs)| #834: a curated (attr-name → tfType) allowlist with per-type value gates surfaces bare-identifier refs. KMS KeyId UUIDs in kms_key_id / kms_master_key_id → aws_kms_key are CHASED (the KMS Cloud Control DiscoverByID accepts a bare KeyId), now including UUIDs nested inside OBJECT expressions (`rule = { x = { kms_master_key_id = "<uuid>" } }`, F6), not just body attributes. The bare UUID carries no region, so it is discovered in the CONSUMER resource's region — a CMK is same-region as its SSE consumer — falling back to the run's primary region only when the consumer has none (F3). Class B shares class A's terminal-by-design (F2) + fail-open-on-hard-error (F1) semantics, and a key referenced by BOTH a full ARN and a bare UUID is adopted once while recording both consumer edges (F8). Other bare forms (S3 name, GCP self-link) remain out of scope: their value shapes are too permissive to gate without false positives — extend nonARNAttrRules to add one.
 //	C | Unsupported ARN service/resource-type | ParseRef -> ErrUnsupportedType (not in           | yes: "unsupported ARN type"          | documented-literal  | Type has no discoverer + typed model (SNS, ECR, ACM, SES, EFS, ...). Emitting needs a new discoverer+model — deliberate scope expansion, not a chase bug.
 //	  |                                       | arnTFTypeMap)                                    |                                      | (out of scope)      |
 //	D | Malformed ARN literal                 | ParseRef -> parse error                          | yes: "could not parse ARN"           | documented-literal  | Not a resolvable reference.
@@ -50,7 +50,16 @@ package depchase
 //     genconfig crossref pass is still top-level-only; nested Tier-3 rewrite is
 //     deferred), but the adoptable target enters the import set and every hit
 //     emits a precise nested_ref_literal / non_arn_ref_literal warning. No hit
-//     is silent anymore.
+//     is silent anymore. Because these literals are never rewritten they are
+//     TERMINAL-BY-DESIGN: each is chased exactly once and then excluded from
+//     the unresolved-set stability comparison, so a nested literal whose target
+//     adopts a different canonical id can never masquerade as a reference cycle
+//     (F2). A hard discovery error on a class-A/B ref is a warning, never a
+//     fatal (F1) — these are fidelity enhancements and must not fail an import
+//     that previously (silently) succeeded. Consumer-edge accounting is
+//     per-consumer: multi-consumer and dual-occurrence (top-level + nested)
+//     literals keep every edge (F4), and a target reached by both a full ARN
+//     and a bare UUID is adopted once with both edges recorded (F8).
 //   - class G: the two observed reference types (aws_kms_key, aws_iam_role) were
 //     moved out of the opaque class-H backstop into a precise, pre-add
 //     imported.UnimportableReason gate that names WHY the literal is correct

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -305,6 +305,27 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				}
 				continue
 			}
+			// Un-importability gate (presets#834). A ref can point at a
+			// resource that DiscoverByID finds but that is inherently
+			// un-adoptable into customer Terraform state — an AWS-managed KMS
+			// key (KeyManager=AWS), a service-linked IAM role
+			// (role/aws-service-role/…), a service-managed ENI, an
+			// already-InsideOut-imported resource, etc. Adding it would only
+			// have RunGenconfig drop it again (no generated body / provider
+			// import failure), surfacing the opaque "discovered … but generated
+			// config omitted it" warning and burning a full regenerate cycle.
+			// Consult the SAME classifier discovery and the genconfig prune use
+			// (imported.UnimportableReason, #709) so all three agree, leave the
+			// literal knowingly, and emit a precise reason instead. The observed
+			// aws_kms_key / aws_iam_role literals from the account-141812438321
+			// import (#834) are exactly this class.
+			if reason := imported.UnimportableReason(ir); reason != "" {
+				addWarning(res, seenWarning,
+					fmt.Sprintf("ARN %q (%s) references an un-importable resource (%s: %s); leaving the literal reference — the target cannot be adopted into Terraform state, so the literal is the correct terminal state",
+						s.arn, s.ref.TFType, reason, imported.ReasonDescription(reason)))
+				ignoredARNs[s.arn] = struct{}{}
+				continue
+			}
 			added = append(added, ir)
 			discoveries = append(discoveries, discoveredResource{seed: s, resource: ir})
 		}

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -210,10 +210,12 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		if err != nil {
 			return nil, fmt.Errorf("depchase: read generated.tf: %w", err)
 		}
-		unresolved, consumersByARN, err := findUnresolvedWithConsumers(raw, res.Resources)
+		scan, err := scanGenerated(raw, res.Resources)
 		if err != nil {
 			return nil, err
 		}
+		unresolved := scan.unresolved
+		consumersByARN := scan.consumers
 		unresolved = filterIgnoredARNs(unresolved, ignoredARNs)
 		if len(unresolved) == 0 {
 			res.GeneratedPath = generatedPath
@@ -249,6 +251,33 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 
 		var newSeeds []seed
 		for _, arn := range unresolved {
+			// presets#834 class A — an ARN literal the historical top-level
+			// pass would have MISSED (nested inside a block or a
+			// list/object expression) is now surfaced. Emit the precise
+			// detection warning up front so class A is never silent,
+			// regardless of whether the chase below succeeds, fails, or hits
+			// an unsupported type. The literal itself is not rewritten (the
+			// genconfig crossref pass is also top-level-only), but the target
+			// is chased and — when adoptable — emitted, improving graph
+			// fidelity.
+			if nh, ok := scan.nested[arn]; ok {
+				addWarning(res, seenWarning,
+					fmt.Sprintf("nested_ref_literal: reference literal inside nested attribute %s of %s; target %s — surfaced by the nested-body walk (previously silent); chasing target, nested literal retained",
+						nh.path, nh.addr, arn))
+			}
+			// presets#834 class B — a curated, non-ARN identifier reference
+			// (a KMS KeyId UUID in kms_key_id / kms_master_key_id). isARNLiteral
+			// never considered it, so it was silent. The KMS Cloud Control
+			// DiscoverByID accepts a bare KeyId, so we chase it with a
+			// pre-resolved Ref (no ARN to ParseRef); a bare UUID carries no
+			// region, so the target is looked up in the run's primary region.
+			if nq, ok := scan.nonARN[arn]; ok {
+				addWarning(res, seenWarning,
+					fmt.Sprintf("non_arn_ref_literal: non-ARN identifier in curated attribute %s of %s; value %q resolves to %s — surfaced by the curated-attr walk (previously silent); chasing by bare identifier",
+						nq.attr, nq.addr, arn, nq.tfType))
+				newSeeds = append(newSeeds, seed{arn: arn, ref: Ref{TFType: nq.tfType, ImportID: nq.id, Region: opts.Region}})
+				continue
+			}
 			ref, err := ParseRef(arn)
 			if err != nil {
 				if errors.Is(err, ErrUnsupportedType) {

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -200,6 +200,24 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	ignoredARNs := make(map[string]struct{})
 	var prevUnresolved []string
 
+	// chased records every nested (class A) / nonARN (class B) literal that has
+	// been seeded once, regardless of discovery outcome (F2). Such literals are
+	// never rewritten by crossref, so after their single chase they may remain
+	// textually unresolved forever (e.g. a version-qualified lambda ARN whose
+	// adopted NativeIDs never byte-match). Excluding them from re-seeding and
+	// from the unresolved-set stability comparison prevents both a spurious
+	// ErrCyclicDependency on a previously-clean run and pointless re-discovery
+	// every iteration. Their warning already documents that the literal is
+	// retained, so dropping them from the unresolved accounting loses nothing.
+	chased := make(map[string]struct{})
+
+	// seenAddedAddr deduplicates res.Added across iterations by resource
+	// address: the same target can be referenced by two different literals in
+	// one iteration (e.g. a KMS key by full ARN nested AND by bare UUID in a
+	// kms_key_id attr, F8). We record every consumer edge but adopt the resource
+	// once.
+	seenAddedAddr := make(map[string]struct{})
+
 	// seenEdges deduplicates Edges across iterations: the same
 	// (consumer → discovered) pair can re-surface if the regenerate
 	// step rewrites the consumer's HCL without changing the reference.
@@ -217,6 +235,15 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		unresolved := scan.unresolved
 		consumersByARN := scan.consumers
 		unresolved = filterIgnoredARNs(unresolved, ignoredARNs)
+		// Drop terminal-by-design literals already chased once (F2): they are
+		// excluded from the len==0 convergence check, the stability comparison,
+		// and re-seeding below.
+		unresolved = filterIgnoredARNs(unresolved, chased)
+		// Build a consumer-address → region index for this iteration so a
+		// class-B bare-UUID seed (which carries no region of its own) can be
+		// discovered in the CONSUMER's region — a KMS CMK is same-region as its
+		// SSE consumer — rather than blindly in the run's primary region (F3).
+		regionByAddr := regionIndex(res.Resources)
 		if len(unresolved) == 0 {
 			res.GeneratedPath = generatedPath
 			sortEdges(res)
@@ -251,6 +278,11 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 
 		var newSeeds []seed
 		for _, arn := range unresolved {
+			// A literal that ALSO appears top-level keeps top-level chase
+			// semantics (fatal-on-error, non-terminal): its top-level occurrence
+			// is rewritten by crossref, so resolution is expected there even if
+			// it is additionally nested elsewhere.
+			_, isTopLevel := scan.topLevel[arn]
 			// presets#834 class A — an ARN literal the historical top-level
 			// pass would have MISSED (nested inside a block or a
 			// list/object expression) is now surfaced. Emit the precise
@@ -259,8 +291,14 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 			// an unsupported type. The literal itself is not rewritten (the
 			// genconfig crossref pass is also top-level-only), but the target
 			// is chased and — when adoptable — emitted, improving graph
-			// fidelity.
+			// fidelity. For a dual-occurrence literal (also top-level) the
+			// nested consumer is still warned about here, but the seed is tagged
+			// top-level so its failure policy matches the top-level occurrence.
+			class := classTopLevel
 			if nh, ok := scan.nested[arn]; ok {
+				if !isTopLevel {
+					class = classNested
+				}
 				addWarning(res, seenWarning,
 					fmt.Sprintf("nested_ref_literal: reference literal inside nested attribute %s of %s; target %s — surfaced by the nested-body walk (previously silent); chasing target, nested literal retained",
 						nh.path, nh.addr, arn))
@@ -269,14 +307,26 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 			// (a KMS KeyId UUID in kms_key_id / kms_master_key_id). isARNLiteral
 			// never considered it, so it was silent. The KMS Cloud Control
 			// DiscoverByID accepts a bare KeyId, so we chase it with a
-			// pre-resolved Ref (no ARN to ParseRef); a bare UUID carries no
-			// region, so the target is looked up in the run's primary region.
+			// pre-resolved Ref (no ARN to ParseRef). A bare UUID carries no
+			// region of its own, so the Region is left EMPTY here and filled
+			// from the consumer resource's region below (F3), falling back to
+			// the run's primary region only if the consumer has none.
 			if nq, ok := scan.nonARN[arn]; ok {
+				chased[arn] = struct{}{}
 				addWarning(res, seenWarning,
 					fmt.Sprintf("non_arn_ref_literal: non-ARN identifier in curated attribute %s of %s; value %q resolves to %s — surfaced by the curated-attr walk (previously silent); chasing by bare identifier",
 						nq.attr, nq.addr, arn, nq.tfType))
-				newSeeds = append(newSeeds, seed{arn: arn, ref: Ref{TFType: nq.tfType, ImportID: nq.id, Region: opts.Region}})
+				newSeeds = append(newSeeds, seed{
+					arn:   arn,
+					class: classNonARN,
+					ref:   Ref{TFType: nq.tfType, ImportID: arn, Region: regionByAddr[nq.addr]},
+				})
 				continue
+			}
+			// Mark a purely-nested literal terminal-by-design before ParseRef so
+			// it is chased exactly once regardless of the parse/discovery outcome.
+			if class == classNested {
+				chased[arn] = struct{}{}
 			}
 			ref, err := ParseRef(arn)
 			if err != nil {
@@ -291,7 +341,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				ignoredARNs[arn] = struct{}{}
 				continue
 			}
-			newSeeds = append(newSeeds, seed{arn: arn, ref: ref})
+			newSeeds = append(newSeeds, seed{arn: arn, class: class, ref: ref})
 		}
 		// Sort seeds for deterministic discovery order (the discoverer
 		// has no guaranteed ordering on lookups across types/calls).
@@ -299,7 +349,18 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 
 		var added []imported.ImportedResource
 		var discoveries []discoveredResource
+		// seenIterAddr dedups the resources ADDED this iteration by address so
+		// two seeds resolving to the same target (F8) adopt it once. Consumer
+		// edges are still recorded for both via `discoveries`.
+		seenIterAddr := make(map[string]struct{})
 		for _, s := range newSeeds {
+			// label distinguishes an ARN literal from a bare-identifier
+			// (class-B) literal in operator-facing warnings — "reference %q"
+			// reads correctly for a UUID, "ARN %q" does not (F3).
+			label := "ARN"
+			if s.class == classNonARN {
+				label = "reference"
+			}
 			// Discover each ref in ITS OWN region (the ARN's 4th segment),
 			// falling back to the run's primary region for global/region-less
 			// ARNs (IAM/CloudFront/Route53/S3, where Region is empty). This is
@@ -322,13 +383,25 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				switch {
 				case errors.Is(err, awsdiscover.ErrNotFound), errors.Is(err, gcpdiscover.ErrNotFound):
 					addWarning(res, seenWarning,
-						fmt.Sprintf("ARN %q (%s): %v", s.arn, s.ref.TFType, err))
+						fmt.Sprintf("%s %q (%s): %v", label, s.arn, s.ref.TFType, err))
 					ignoredARNs[s.arn] = struct{}{}
 				case errors.Is(err, awsdiscover.ErrNotSupported), errors.Is(err, gcpdiscover.ErrNotSupported):
 					addWarning(res, seenWarning,
-						fmt.Sprintf("ARN %q: %s discoverer rejected ID: %v", s.arn, s.ref.TFType, err))
+						fmt.Sprintf("%s %q: %s discoverer rejected ID: %v", label, s.arn, s.ref.TFType, err))
 					ignoredARNs[s.arn] = struct{}{}
 				default:
+					// A non-sentinel (hard) discovery error aborts the run only
+					// for a top-level seed, whose resolution is expected. For a
+					// nested/nonARN fidelity-enhancement seed it must NOT fail an
+					// import that previously (silently) succeeded — degrade to a
+					// warning and leave the literal (F1).
+					if s.class.terminal() {
+						addWarning(res, seenWarning,
+							fmt.Sprintf("%s %q (%s): discovery error on a %s reference treated as non-fatal (fidelity enhancement; import preserved, literal retained): %v",
+								label, s.arn, s.ref.TFType, s.class, err))
+						ignoredARNs[s.arn] = struct{}{}
+						break
+					}
 					sortEdges(res)
 					return res, fmt.Errorf("DiscoverByID(%s, %s): %w", s.ref.TFType, s.ref.ImportID, err)
 				}
@@ -350,13 +423,28 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 			// import (#834) are exactly this class.
 			if reason := imported.UnimportableReason(ir); reason != "" {
 				addWarning(res, seenWarning,
-					fmt.Sprintf("ARN %q (%s) references an un-importable resource (%s: %s); leaving the literal reference — the target cannot be adopted into Terraform state, so the literal is the correct terminal state",
-						s.arn, s.ref.TFType, reason, imported.ReasonDescription(reason)))
+					fmt.Sprintf("%s %q (%s) references an un-importable resource (%s: %s); leaving the literal reference — the target cannot be adopted into Terraform state, so the literal is the correct terminal state",
+						label, s.arn, s.ref.TFType, reason, imported.ReasonDescription(reason)))
 				ignoredARNs[s.arn] = struct{}{}
 				continue
 			}
-			added = append(added, ir)
+			// Record the discovery for edge accounting regardless, but adopt the
+			// resource into the import set at most once per address (F8): a
+			// second seed pointing at the same target (same key by ARN and by
+			// bare UUID) must not double-add it, though its consumer edge is
+			// still recorded via `discoveries` → `kept` below.
 			discoveries = append(discoveries, discoveredResource{seed: s, resource: ir})
+			addr := ir.Identity.Address
+			if addr != "" {
+				if _, dup := seenIterAddr[addr]; dup {
+					continue
+				}
+				if _, prior := seenAddedAddr[addr]; prior {
+					continue
+				}
+				seenIterAddr[addr] = struct{}{}
+			}
+			added = append(added, ir)
 		}
 
 		if len(added) == 0 {
@@ -403,6 +491,13 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				for _, fromAddr := range consumersByARN[d.seed.arn] {
 					recordEdge(res, seenEdges, fromAddr, toAddr)
 				}
+				// Adopt the resource into res.Added once per address (F8): both
+				// seeds' edges above are still recorded, but two literals
+				// resolving to the same target contribute a single Added entry.
+				if _, dup := seenAddedAddr[toAddr]; dup {
+					continue
+				}
+				seenAddedAddr[toAddr] = struct{}{}
 			}
 			res.Added = append(res.Added, d.resource)
 		}
@@ -425,6 +520,12 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	// residual could not actually be enumerated.
 	raw, _ := os.ReadFile(generatedPath)
 	residual, residualErr := FindUnresolved(raw, res.Resources)
+	// Exclude ignored + terminal-by-design (chased) literals from the residual
+	// accounting so the operator-facing "N unresolved ref(s) remain" message
+	// lists only genuinely-unconverged references, not nested/nonARN literals
+	// that are retained by design (F2) or already warned-and-ignored.
+	residual = filterIgnoredARNs(residual, ignoredARNs)
+	residual = filterIgnoredARNs(residual, chased)
 	res.GeneratedPath = generatedPath
 	residualStr := strings.Join(residual, ", ")
 	sortEdges(res)
@@ -436,16 +537,64 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		ErrMaxIterations, opts.MaxIterations, len(residual), residualStr)
 }
 
-// seed pairs an unresolved ARN string with the parsed Ref so the
-// loop can carry both through to discovery + warning paths.
+// seedClass records where a seed's literal was found so the loop can apply the
+// right failure policy. A topLevel literal is one the historical top-level pass
+// found and that the genconfig crossref rewrites — its discovery is EXPECTED to
+// resolve, so a hard discovery error is fatal. A nested (class A) or nonARN
+// (class B) literal is a fidelity ENHANCEMENT surfaced by presets#834: it is
+// never rewritten in place, so a hard discovery error must not abort an import
+// that previously (silently) succeeded — it degrades to a warning (F1). Both
+// nested/nonARN literals are also terminal-by-design: once chased, they may
+// legitimately remain textually unresolved forever, so the loop chases each
+// exactly once and excludes it from cycle detection (F2).
+type seedClass uint8
+
+const (
+	classTopLevel seedClass = iota
+	classNested
+	classNonARN
+)
+
+func (c seedClass) String() string {
+	switch c {
+	case classNested:
+		return "nested"
+	case classNonARN:
+		return "non-ARN"
+	default:
+		return "top-level"
+	}
+}
+
+// terminal reports whether the class is terminal-by-design (chased once, never
+// re-seeded, excluded from cycle detection) and fail-open on discovery error.
+func (c seedClass) terminal() bool { return c == classNested || c == classNonARN }
+
+// seed pairs an unresolved literal with the parsed Ref and its origin class so
+// the loop can carry all three through to discovery + warning paths.
 type seed struct {
-	arn string
-	ref Ref
+	arn   string
+	class seedClass
+	ref   Ref
 }
 
 type discoveredResource struct {
 	seed     seed
 	resource imported.ImportedResource
+}
+
+// regionIndex maps each resource address to its identity Region so a class-B
+// bare-UUID seed can inherit the region of the resource that consumes it (F3).
+// Addresses with an empty Region are still indexed (as "") so the caller's
+// primary-region fallback applies.
+func regionIndex(resources []imported.ImportedResource) map[string]string {
+	idx := make(map[string]string, len(resources))
+	for _, r := range resources {
+		if r.Identity.Address != "" {
+			idx[r.Identity.Address] = r.Identity.Region
+		}
+	}
+	return idx
 }
 
 func filterIgnoredARNs(unresolved []string, ignored map[string]struct{}) []string {

--- a/cmd/insideout-import/depchase/depchase_test.go
+++ b/cmd/insideout-import/depchase/depchase_test.go
@@ -21,6 +21,7 @@ type fakeDiscoverer struct {
 	byID         map[string]imported.ImportedResource
 	notFound     map[string]bool // key = tfType|id
 	notSupported map[string]bool
+	hardErr      map[string]bool // key = tfType|id → a NON-sentinel (fatal-class) error
 	calls        []string
 	regionByID   map[string]string // id → region passed to DiscoverByID
 }
@@ -37,6 +38,12 @@ func (f *fakeDiscoverer) DiscoverByID(_ context.Context, tfType, id, region, _ s
 	// exercised — a regression to `err == awsdiscover.ErrNotFound`
 	// would still pass against bare-sentinel returns and silently
 	// break under real wrapped errors.
+	if f.hardErr[key] {
+		// A non-sentinel error: neither ErrNotFound nor ErrNotSupported, so the
+		// loop's error switch hits its default branch (fatal for top-level
+		// seeds, warn-and-continue for nested/nonARN seeds — F1).
+		return imported.ImportedResource{}, fmt.Errorf("fake: %s %q transient discovery failure", tfType, id)
+	}
 	if f.notSupported[key] {
 		return imported.ImportedResource{}, fmt.Errorf("fake: %s %q rejected: %w", tfType, id, awsdiscover.ErrNotSupported)
 	}
@@ -816,9 +823,13 @@ resource "aws_lambda_function" "h` + suffix + `" {
 	dir := writeGen(t, gen("0"))
 
 	// Discoverer returns a synthetic role for every lookup, but the
-	// regenerated stack always has a fresh unresolved ARN.
+	// regenerated stack always has a fresh unresolved ARN. Each role gets a
+	// DISTINCT address (derived from its name): real resources never share an
+	// address, and the F8 same-address adoption dedup would otherwise collapse
+	// these synthetic roles into one and converge early.
 	role := func(arn string) imported.ImportedResource {
-		return newRes("aws_iam_role.r", "r", arn, "aws_iam_role")
+		name := arn[strings.LastIndex(arn, "/")+1:]
+		return newRes("aws_iam_role."+name, name, arn, "aws_iam_role")
 	}
 	byID := map[string]imported.ImportedResource{
 		"aws_iam_role|arn:aws:iam::123:role/role-0": role("arn:aws:iam::123:role/role-0"),
@@ -1024,6 +1035,299 @@ func TestRun_NoEdgesWhenNothingAdded(t *testing.T) {
 // (From, To) uniqueness invariant is already pinned by the happy-path
 // edges assertion in TestRun_RecordsEdges, which exercises the same
 // recordEdge code path.)
+
+// TestRun_NestedHardErrorIsNonFatal pins F1: a non-sentinel (hard) discovery
+// error on a NESTED (class-A) reference — a fidelity enhancement that a
+// previous run would have silently skipped — must NOT abort the whole import.
+// It degrades to a warning and the run completes; the SAME error on a top-level
+// reference still fails the run.
+func TestRun_NestedHardErrorIsNonFatal(t *testing.T) {
+	t.Parallel()
+	nestedARN := "arn:aws:kms:us-east-1:123:key/aaaa1111-bbbb-2222-cccc-333333333333"
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  function_name = "io-foo-h"
+  environment {
+    variables = {
+      SIGNING_KEY = "` + nestedARN + `"
+    }
+  }
+}`
+	dir := writeGen(t, gen0)
+	lambda := newRes("aws_lambda_function.h", "io-foo-h",
+		"arn:aws:lambda:us-east-1:123:function:io-foo-h", "aws_lambda_function")
+	disc := &fakeDiscoverer{hardErr: map[string]bool{"aws_kms_key|" + nestedARN: true}}
+	// No regenerate needed: the nested ref errors out (non-fatal) and is chased
+	// once, so the loop converges without a genconfig pass.
+	p := &scriptedPipeline{t: t, workdir: dir}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{lambda})
+	if err != nil {
+		t.Fatalf("nested hard error should be non-fatal; err=%v", err)
+	}
+	joined := strings.Join(got.Warnings, "\n")
+	if !strings.Contains(joined, "non-fatal") || !strings.Contains(joined, nestedARN) {
+		t.Errorf("want a non-fatal warning mentioning the nested ARN; got:\n%s", joined)
+	}
+	if len(disc.calls) != 1 {
+		t.Errorf("DiscoverByID calls=%v, want exactly 1 (nested ref chased once)", disc.calls)
+	}
+
+	// Same hard error on a TOP-LEVEL reference must still be fatal.
+	genTL := `
+resource "aws_lambda_function" "h" {
+  role = "arn:aws:iam::123:role/io-foo-role"
+}`
+	dirTL := writeGen(t, genTL)
+	discTL := &fakeDiscoverer{hardErr: map[string]bool{"aws_iam_role|arn:aws:iam::123:role/io-foo-role": true}}
+	pTL := &scriptedPipeline{t: t, workdir: dirTL}
+	_, errTL := Run(context.Background(), Options{
+		Workdir: dirTL, Discoverer: discTL, Pipeline: pTL.fns(),
+	}, nil)
+	if errTL == nil {
+		t.Fatal("top-level hard discovery error must remain fatal")
+	}
+	if !strings.Contains(errTL.Error(), "DiscoverByID") {
+		t.Errorf("top-level fatal err=%q, want a DiscoverByID abort", errTL)
+	}
+}
+
+// TestRun_NestedLiteralTerminalNoCycle pins F2: a nested ARN whose discovered
+// resource's NativeIDs do NOT byte-match the literal (so the literal is never
+// rewritten and stays textually present) converges cleanly — it is
+// terminal-by-design, excluded from cycle detection — instead of tripping
+// ErrCyclicDependency. DiscoverByID is called exactly once for it.
+func TestRun_NestedLiteralTerminalNoCycle(t *testing.T) {
+	t.Parallel()
+	// Version-qualified-style nested ARN; the discovered key's NativeIDs carry
+	// a DIFFERENT canonical arn, so the literal never enters the resolved set.
+	nestedARN := "arn:aws:kms:us-east-1:123:key/aaaa1111-bbbb-2222-cccc-333333333333"
+	canonicalARN := "arn:aws:kms:us-east-1:999:key/aaaa1111-bbbb-2222-cccc-333333333333"
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  environment {
+    variables = {
+      SIGNING_KEY = "` + nestedARN + `"
+    }
+  }
+}`
+	dir := writeGen(t, gen0)
+	lambda := newRes("aws_lambda_function.h", "io-foo-h",
+		"arn:aws:lambda:us-east-1:123:function:io-foo-h", "aws_lambda_function")
+	// Discovered key adopts a canonical arn that does not match the literal.
+	key := newRes("aws_kms_key.signing", canonicalARN, canonicalARN, "aws_kms_key")
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_kms_key|" + nestedARN: key,
+	}}
+	// One regenerate after the add; the literal still sits nested (crossref is
+	// top-level-only) but is terminal-by-design so the loop must converge.
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen0}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{lambda})
+	if err != nil {
+		t.Fatalf("terminal nested literal must converge, not cycle; err=%v", err)
+	}
+	if len(disc.calls) != 1 {
+		t.Errorf("DiscoverByID calls=%v, want exactly 1 (nested literal chased once)", disc.calls)
+	}
+	if len(got.Added) != 1 {
+		t.Errorf("Added=%+v, want the one adoptable key", got.Added)
+	}
+}
+
+// TestRun_ClassBUsesConsumerRegion pins F3: a class-B bare-UUID reference is
+// discovered in the CONSUMER resource's region (a KMS CMK is same-region as its
+// SSE consumer), not the run's primary region.
+func TestRun_ClassBUsesConsumerRegion(t *testing.T) {
+	t.Parallel()
+	keyUUID := "1234abcd-12ab-34cd-56ef-1234567890ab"
+	gen0 := `
+resource "aws_sqs_queue" "q" {
+  kms_master_key_id = "` + keyUUID + `"
+}`
+	dir := writeGen(t, gen0)
+	// Consumer lives in eu-west-1 while the run's primary region is us-east-1.
+	queue := imported.ImportedResource{Identity: imported.ResourceIdentity{
+		Address: "aws_sqs_queue.q", Type: "aws_sqs_queue", Region: "eu-west-1",
+	}}
+	key := newRes("aws_kms_key.by_id", keyUUID,
+		"arn:aws:kms:eu-west-1:123:key/"+keyUUID, "aws_kms_key")
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_kms_key|" + keyUUID: key,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen0}}
+
+	_, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{queue})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := disc.regionByID[keyUUID]; got != "eu-west-1" {
+		t.Errorf("class-B key discovered in region %q, want eu-west-1 (the consumer's region, not the primary us-east-1)", got)
+	}
+}
+
+// TestRun_MultipleNestedConsumersRecordAllEdges pins F4 (case 1): two resources
+// nesting the SAME ARN both contribute a dependency edge — the single-winner
+// nested-hit map must not collapse them to one consumer.
+func TestRun_MultipleNestedConsumersRecordAllEdges(t *testing.T) {
+	t.Parallel()
+	kmsARN := "arn:aws:kms:us-east-1:123:key/aaaa1111-bbbb-2222-cccc-333333333333"
+	gen0 := `
+resource "aws_lambda_function" "a" {
+  environment {
+    variables = { SIGNING_KEY = "` + kmsARN + `" }
+  }
+}
+resource "aws_lambda_function" "b" {
+  environment {
+    variables = { SIGNING_KEY = "` + kmsARN + `" }
+  }
+}`
+	dir := writeGen(t, gen0)
+	la := newRes("aws_lambda_function.a", "a", "arn:aws:lambda:us-east-1:123:function:a", "aws_lambda_function")
+	lb := newRes("aws_lambda_function.b", "b", "arn:aws:lambda:us-east-1:123:function:b", "aws_lambda_function")
+	key := newRes("aws_kms_key.signing", kmsARN, kmsARN, "aws_kms_key")
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{"aws_kms_key|" + kmsARN: key}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen0}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{la, lb})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	wantEdges := map[string]bool{
+		"aws_lambda_function.a→aws_kms_key.signing": false,
+		"aws_lambda_function.b→aws_kms_key.signing": false,
+	}
+	for _, e := range got.Edges {
+		wantEdges[e.From+"→"+e.To] = true
+	}
+	for k, seen := range wantEdges {
+		if !seen {
+			t.Errorf("missing edge %s; got edges %+v", k, got.Edges)
+		}
+	}
+}
+
+// TestRun_DualOccurrenceKeepsNestedEdgeAndWarning pins F4 (case 2): an ARN that
+// appears TOP-LEVEL in X and NESTED in Y must still record Y's edge AND emit
+// Y's nested_ref_literal warning — the top-level occurrence must not suppress
+// the nested consumer.
+func TestRun_DualOccurrenceKeepsNestedEdgeAndWarning(t *testing.T) {
+	t.Parallel()
+	roleARN := "arn:aws:iam::123:role/shared-role"
+	gen0 := `
+resource "aws_lambda_function" "x" {
+  role = "` + roleARN + `"
+}
+resource "aws_lambda_function" "y" {
+  environment {
+    variables = { EXEC_ROLE = "` + roleARN + `" }
+  }
+}`
+	dir := writeGen(t, gen0)
+	lx := newRes("aws_lambda_function.x", "x", "arn:aws:lambda:us-east-1:123:function:x", "aws_lambda_function")
+	ly := newRes("aws_lambda_function.y", "y", "arn:aws:lambda:us-east-1:123:function:y", "aws_lambda_function")
+	role := newRes("aws_iam_role.shared_role", "shared-role", roleARN, "aws_iam_role")
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{"aws_iam_role|" + roleARN: role}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen0}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{lx, ly})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Y's nested edge must exist.
+	haveY := false
+	for _, e := range got.Edges {
+		if e.From == "aws_lambda_function.y" && e.To == "aws_iam_role.shared_role" {
+			haveY = true
+		}
+	}
+	if !haveY {
+		t.Errorf("missing nested consumer edge aws_lambda_function.y → aws_iam_role.shared_role; got %+v", got.Edges)
+	}
+	// Y's nested warning must be emitted (not suppressed by X's top-level use).
+	joined := strings.Join(got.Warnings, "\n")
+	if !strings.Contains(joined, "nested_ref_literal") || !strings.Contains(joined, "aws_lambda_function.y") {
+		t.Errorf("want a nested_ref_literal warning for aws_lambda_function.y; got:\n%s", joined)
+	}
+}
+
+// TestRun_SameKeyByARNAndUUIDAdoptedOnce pins F8: a key referenced by full ARN
+// (nested) in one resource and by bare UUID (class-B attr) in another resolves
+// to one Added entry, but BOTH consumer edges are recorded.
+func TestRun_SameKeyByARNAndUUIDAdoptedOnce(t *testing.T) {
+	t.Parallel()
+	keyUUID := "1234abcd-12ab-34cd-56ef-1234567890ab"
+	keyARN := "arn:aws:kms:us-east-1:123:key/" + keyUUID
+	gen0 := `
+resource "aws_lambda_function" "fn" {
+  environment {
+    variables = { SIGNING_KEY = "` + keyARN + `" }
+  }
+}
+resource "aws_sqs_queue" "q" {
+  kms_master_key_id = "` + keyUUID + `"
+}`
+	dir := writeGen(t, gen0)
+	fn := newRes("aws_lambda_function.fn", "fn", "arn:aws:lambda:us-east-1:123:function:fn", "aws_lambda_function")
+	q := newRes("aws_sqs_queue.q", "q", "arn:aws:sqs:us-east-1:123:q", "aws_sqs_queue")
+	// Both the ARN lookup and the UUID lookup resolve to the SAME key address.
+	key := newRes("aws_kms_key.shared", keyARN, keyARN, "aws_kms_key")
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_kms_key|" + keyARN:  key,
+		"aws_kms_key|" + keyUUID: key,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen0}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{fn, q})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Exactly one adoption of the shared key.
+	kmsCount := 0
+	for _, r := range got.Added {
+		if r.Identity.Address == "aws_kms_key.shared" {
+			kmsCount++
+		}
+	}
+	if kmsCount != 1 {
+		t.Errorf("aws_kms_key.shared appears %d time(s) in Added, want exactly 1; Added=%+v", kmsCount, got.Added)
+	}
+	// Both consumer edges present.
+	haveFn, haveQ := false, false
+	for _, e := range got.Edges {
+		if e.To != "aws_kms_key.shared" {
+			continue
+		}
+		if e.From == "aws_lambda_function.fn" {
+			haveFn = true
+		}
+		if e.From == "aws_sqs_queue.q" {
+			haveQ = true
+		}
+	}
+	if !haveFn || !haveQ {
+		t.Errorf("want both consumer edges (fn + q) → aws_kms_key.shared; got %+v", got.Edges)
+	}
+}
 
 // TestRun_EdgesOmittedWhenDiscoveryFails pins that warnings (NotFound
 // or NotSupported) do not produce edges — the picker only shows

--- a/cmd/insideout-import/depchase/depchase_test.go
+++ b/cmd/insideout-import/depchase/depchase_test.go
@@ -316,6 +316,90 @@ resource "aws_lambda_function" "h" {
 	}
 }
 
+// TestRun_UnimportableRefLeavesLiteralWithPreciseReason pins the
+// presets#834 fix: a discovered dependency reference whose target is
+// inherently un-adoptable into customer Terraform state (an AWS-managed KMS
+// key, KeyManager=AWS; a service-linked IAM role, role/aws-service-role/…) is
+// gated by imported.UnimportableReason BEFORE the add, so the loop leaves the
+// literal knowingly, emits a precise reason-citing warning, and never burns a
+// RunGenconfig regenerate cycle to have genconfig drop it back out as an opaque
+// "generated config omitted it" orphan. This reproduces the two observed
+// reference types from the account-141812438321 whole-account import (#834).
+func TestRun_UnimportableRefLeavesLiteralWithPreciseReason(t *testing.T) {
+	t.Parallel()
+	kmsARN := "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+	slrARN := "arn:aws:iam::123456789012:role/aws-service-role/elasticbeanstalk.amazonaws.com/AWSServiceRoleForElasticBeanstalk"
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  function_name = "io-foo-handler"
+  kms_key_arn   = "` + kmsARN + `"
+  role          = "` + slrARN + `"
+}`
+	dir := writeGen(t, gen0)
+	lambda := newRes("aws_lambda_function.h", "io-foo-handler",
+		"arn:aws:lambda:us-east-1:123456789012:function:io-foo-handler", "aws_lambda_function")
+
+	// AWS-managed KMS key: DiscoverByID finds it and PostDiscover stamps
+	// key_manager=AWS, so imported.UnimportableReason → ReasonAWSManagedKMSKey.
+	awsManagedKey := imported.ImportedResource{Identity: imported.ResourceIdentity{
+		Address:   "aws_kms_key.managed",
+		Type:      "aws_kms_key",
+		ImportID:  kmsARN,
+		NativeIDs: map[string]string{"arn": kmsARN, "key_manager": "AWS"},
+	}}
+	// Service-linked IAM role: ARN carries role/aws-service-role/, so
+	// imported.UnimportableReason → ReasonServiceLinkedIAMRole.
+	slrRole := imported.ImportedResource{Identity: imported.ResourceIdentity{
+		Address:   "aws_iam_role.slr",
+		Type:      "aws_iam_role",
+		ImportID:  slrARN,
+		NativeIDs: map[string]string{"arn": slrARN},
+	}}
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_kms_key|" + kmsARN:  awsManagedKey,
+		"aws_iam_role|" + slrARN: slrRole,
+	}}
+	// No generatedTF bodies: both refs are gated pre-add, so RunGenconfig /
+	// RunDriftfix must never be called.
+	p := &scriptedPipeline{t: t, workdir: dir}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{lambda})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(got.Added) != 0 {
+		t.Errorf("Added=%+v, want none (both refs un-importable)", got.Added)
+	}
+	if len(got.Edges) != 0 {
+		t.Errorf("Edges=%+v, want none", got.Edges)
+	}
+	if p.gcCalls != 0 || p.dfCalls != 0 {
+		t.Errorf("pipeline calls gc=%d df=%d, want 0/0 (gated before regenerate)", p.gcCalls, p.dfCalls)
+	}
+	if len(got.Warnings) != 2 {
+		t.Fatalf("Warnings=%v, want exactly 2 (one per un-importable ref)", got.Warnings)
+	}
+	joined := strings.Join(got.Warnings, "\n")
+	for _, want := range []string{
+		imported.ReasonAWSManagedKMSKey,
+		imported.ReasonServiceLinkedIAMRole,
+		"un-importable",
+		"leaving the literal reference",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("warnings missing %q; got:\n%s", want, joined)
+		}
+	}
+	// The precise reason must REPLACE the misleading genconfig-omission message
+	// for these gated refs — that message reads like a bug, this is intended.
+	if strings.Contains(joined, "generated config omitted it") {
+		t.Errorf("gated refs should not surface the misleading omission warning; got:\n%s", joined)
+	}
+}
+
 // TestRun_DepOfDepConvergesAfterTwoIterations pins the chained-dep
 // case: Lambda → IAM role → IAM policy. Three resources end up in
 // the set; the loop converges in 2 iterations.

--- a/cmd/insideout-import/depchase/depchase_test.go
+++ b/cmd/insideout-import/depchase/depchase_test.go
@@ -400,6 +400,149 @@ resource "aws_lambda_function" "h" {
 	}
 }
 
+// TestRun_NestedARNsSurfacedAndChased pins presets#834 class A end-to-end
+// through the chase loop (Tier 2): ARN literals the historical top-level pass
+// would have SILENTLY skipped — one nested inside an object-in-a-block, one
+// inside a list — are now surfaced with a precise nested_ref_literal warning
+// AND fed into the same discover → un-importable-gate → add path as top-level
+// hits. The customer-managed KMS key is adoptable and emitted; the
+// service-linked IAM role is gated pre-add with its precise reason. Neither
+// nested literal is rewritten (the literal is retained), but the adoptable
+// target enters the import set, improving graph fidelity.
+func TestRun_NestedARNsSurfacedAndChased(t *testing.T) {
+	t.Parallel()
+	kmsARN := "arn:aws:kms:us-east-1:123456789012:key/aaaa1111-bbbb-2222-cccc-333333333333"
+	slrARN := "arn:aws:iam::123456789012:role/aws-service-role/x.amazonaws.com/AWSServiceRoleForX"
+	gen0 := `
+resource "aws_lambda_function" "h" {
+  function_name   = "io-foo-handler"
+  execution_roles = ["` + slrARN + `"]
+  environment {
+    variables = {
+      SIGNING_KEY = "` + kmsARN + `"
+    }
+  }
+}`
+	dir := writeGen(t, gen0)
+	lambda := newRes("aws_lambda_function.h", "io-foo-handler",
+		"arn:aws:lambda:us-east-1:123456789012:function:io-foo-handler", "aws_lambda_function")
+
+	// Customer-managed KMS key: no key_manager marker → UnimportableReason
+	// returns "" → adoptable and emitted.
+	adoptableKey := newRes("aws_kms_key.signing", kmsARN, kmsARN, "aws_kms_key")
+	// Service-linked IAM role: ARN carries role/aws-service-role/ →
+	// UnimportableReason → ReasonServiceLinkedIAMRole; gated pre-add.
+	slrRole := imported.ImportedResource{Identity: imported.ResourceIdentity{
+		Address:   "aws_iam_role.slr",
+		Type:      "aws_iam_role",
+		ImportID:  slrARN,
+		NativeIDs: map[string]string{"arn": slrARN},
+	}}
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_kms_key|" + kmsARN:  adoptableKey,
+		"aws_iam_role|" + slrARN: slrRole,
+	}}
+	// One regenerate after the single KMS add; the KMS ARN then enters the
+	// resolved set (via res.Resources), so the nested literal no longer
+	// surfaces and the loop converges.
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen0}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123456789012",
+		Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{lambda})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	// The adoptable nested KMS key must be pulled into the import set.
+	if len(got.Added) != 1 || got.Added[0].Identity.Type != "aws_kms_key" {
+		t.Fatalf("Added=%+v, want exactly one aws_kms_key (the adoptable nested ref)", got.Added)
+	}
+	// The nested KMS key must have been discovered in the ARN's OWN region.
+	if r := disc.regionByID[kmsARN]; r != "us-east-1" {
+		t.Errorf("nested KMS discovered in region %q, want us-east-1 (ARN region)", r)
+	}
+	joined := strings.Join(got.Warnings, "\n")
+	// Both nested literals must be non-silent: a precise class-A warning each.
+	if strings.Count(joined, "nested_ref_literal") != 2 {
+		t.Errorf("want 2 nested_ref_literal warnings (KMS + SLR), got:\n%s", joined)
+	}
+	for _, want := range []string{
+		"nested attribute environment.variables.SIGNING_KEY",
+		"execution_roles[0]",
+		kmsARN, slrARN,
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("warnings missing %q; got:\n%s", want, joined)
+		}
+	}
+	// The service-linked role must be gated with its precise un-importable
+	// reason — NOT emitted, NOT an opaque genconfig-omission.
+	if !strings.Contains(joined, imported.ReasonServiceLinkedIAMRole) {
+		t.Errorf("warnings missing service-linked-role reason; got:\n%s", joined)
+	}
+	if strings.Contains(joined, "generated config omitted it") {
+		t.Errorf("gated SLR should not surface the opaque omission warning; got:\n%s", joined)
+	}
+	// Graph edge: the lambda consumer → the adopted KMS key.
+	if len(got.Edges) != 1 || got.Edges[0].From != "aws_lambda_function.h" || got.Edges[0].To != "aws_kms_key.signing" {
+		t.Errorf("Edges=%+v, want one (aws_lambda_function.h → aws_kms_key.signing)", got.Edges)
+	}
+}
+
+// TestRun_NonARNKMSKeyIDSurfacedAndChased pins presets#834 class B end-to-end:
+// a bare KMS KeyId UUID in a curated attribute (kms_master_key_id) — which
+// isARNLiteral never considered, so it was silent — is surfaced with a
+// non_arn_ref_literal warning and chased by the bare identifier (the KMS Cloud
+// Control DiscoverByID accepts a KeyId). The discovered customer-managed key is
+// adopted into the import set.
+func TestRun_NonARNKMSKeyIDSurfacedAndChased(t *testing.T) {
+	t.Parallel()
+	keyUUID := "1234abcd-12ab-34cd-56ef-1234567890ab"
+	gen0 := `
+resource "aws_sqs_queue" "q" {
+  name              = "io-foo-q"
+  kms_master_key_id = "` + keyUUID + `"
+}`
+	dir := writeGen(t, gen0)
+	queue := newRes("aws_sqs_queue.q", "io-foo-q",
+		"arn:aws:sqs:us-east-1:123:io-foo-q", "aws_sqs_queue")
+	key := newRes("aws_kms_key.by_id", keyUUID,
+		"arn:aws:kms:us-east-1:123:key/"+keyUUID, "aws_kms_key")
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_kms_key|" + keyUUID: key,
+	}}
+	// After the key is added, its ARN + ImportID(uuid) enter the resolved set,
+	// so the bare-id literal no longer surfaces; converge after one regenerate.
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen0}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer: disc, Pipeline: p.fns(),
+	}, []imported.ImportedResource{queue})
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if len(got.Added) != 1 || got.Added[0].Identity.Type != "aws_kms_key" {
+		t.Fatalf("Added=%+v, want exactly one aws_kms_key chased by bare KeyId", got.Added)
+	}
+	// The discoverer must have been called with the bare UUID as the id.
+	if len(disc.calls) == 0 || disc.calls[0] != "aws_kms_key|"+keyUUID {
+		t.Errorf("DiscoverByID calls=%v, want first call aws_kms_key|%s", disc.calls, keyUUID)
+	}
+	joined := strings.Join(got.Warnings, "\n")
+	if !strings.Contains(joined, "non_arn_ref_literal") {
+		t.Errorf("want a non_arn_ref_literal warning; got:\n%s", joined)
+	}
+	for _, want := range []string{"kms_master_key_id", keyUUID, "aws_kms_key"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("warnings missing %q; got:\n%s", want, joined)
+		}
+	}
+}
+
 // TestRun_DepOfDepConvergesAfterTwoIterations pins the chained-dep
 // case: Lambda → IAM role → IAM policy. Three resources end up in
 // the set; the loop converges in 2 iterations.

--- a/cmd/insideout-import/depchase/finder.go
+++ b/cmd/insideout-import/depchase/finder.go
@@ -35,26 +35,53 @@ const generatedFile = "generated.tf"
 // ImportID. A literal that matches any of those is considered
 // in-batch and therefore not unresolved.
 func FindUnresolved(raw []byte, resources []imported.ImportedResource) ([]string, error) {
-	out, _, err := findUnresolvedWithConsumers(raw, resources)
-	return out, err
+	scan, err := scanGenerated(raw, resources)
+	if err != nil {
+		return nil, err
+	}
+	return scan.unresolved, nil
 }
 
-// findUnresolvedWithConsumers is the testable form of FindUnresolved
-// that additionally returns a map from each unresolved ARN literal to
-// the deterministic set of Terraform-address consumer blocks that
-// referenced it. The Run loop uses the consumer map to record
-// (consumer → discovered) graph edges (#297). Two distinct callers
-// (the public FindUnresolved and the Run loop) share the parser pass
-// rather than walking generated.tf twice per iteration.
-func findUnresolvedWithConsumers(raw []byte, resources []imported.ImportedResource) ([]string, map[string][]string, error) {
+// scanResult bundles everything one generated.tf pass surfaces for the
+// chase loop. unresolved is the deterministic-sorted, deduplicated set of
+// reference literals to chase — top-level ARN hits (historical), class-A
+// nested ARN hits, and class-B curated non-ARN identifier hits, unified into
+// one keyspace so the Run loop's cycle detection / ignore filtering treats
+// them identically. consumers maps each literal to its sorted consumer
+// addresses (for #297 graph edges). nested / nonARN carry the per-literal
+// location + classification metadata so Run can emit the precise
+// class-A / class-B warnings (presets#834).
+type scanResult struct {
+	unresolved []string
+	consumers  map[string][]string
+	nested     map[string]nestedHit
+	nonARN     map[string]nonARNHit
+}
+
+// scanGenerated is the shared parser pass behind the public FindUnresolved
+// and the Run loop. It runs the historical top-level ARN pass (hclwrite) plus
+// the presets#834 nested/non-ARN walk (hclsyntax), unifies their hits into one
+// unresolved set, and records the consumer addresses the Run loop turns into
+// (consumer → discovered) graph edges (#297).
+func scanGenerated(raw []byte, resources []imported.ImportedResource) (scanResult, error) {
 	resolved := buildResolvedSet(resources)
 	f, diags := hclwrite.ParseConfig(raw, generatedFile, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return nil, nil, fmt.Errorf("depchase: parse generated.tf: %s", diags.Error())
+		return scanResult{}, fmt.Errorf("depchase: parse generated.tf: %s", diags.Error())
 	}
 
 	seen := make(map[string]struct{})
-	consumers := make(map[string]map[string]struct{}) // arn → set of addresses
+	consumers := make(map[string]map[string]struct{}) // literal → set of addresses
+	addConsumer := func(lit, addr string) {
+		seen[lit] = struct{}{}
+		set, ok := consumers[lit]
+		if !ok {
+			set = make(map[string]struct{})
+			consumers[lit] = set
+		}
+		set[addr] = struct{}{}
+	}
+
 	for _, blk := range f.Body().Blocks() {
 		if blk.Type() != "resource" {
 			continue
@@ -65,14 +92,30 @@ func findUnresolvedWithConsumers(raw []byte, resources []imported.ImportedResour
 		addr := blk.Labels()[0] + "." + blk.Labels()[1]
 		hits := collectFromBodyWithHits(blk.Body(), resolved)
 		for _, lit := range hits {
-			seen[lit] = struct{}{}
-			set, ok := consumers[lit]
-			if !ok {
-				set = make(map[string]struct{})
-				consumers[lit] = set
-			}
-			set[addr] = struct{}{}
+			addConsumer(lit, addr)
 		}
+	}
+
+	// Snapshot the top-level ARN set so the nested walk can subtract it: a
+	// literal already surfaced at top level is chased once, without a
+	// redundant class-A warning.
+	topLevel := make(map[string]struct{}, len(seen))
+	for k := range seen {
+		topLevel[k] = struct{}{}
+	}
+
+	// presets#834 classes A + B: nested ARN literals and curated non-ARN
+	// identifier references. Merge their literals into the same unresolved
+	// keyspace + consumer map so the Run loop chases them like any other hit.
+	nested, nonARN, err := scanNestedAndNonARN(raw, resolved, topLevel)
+	if err != nil {
+		return scanResult{}, err
+	}
+	for arn, h := range nested {
+		addConsumer(arn, h.addr)
+	}
+	for id, h := range nonARN {
+		addConsumer(id, h.addr)
 	}
 
 	out := make([]string, 0, len(seen))
@@ -92,17 +135,18 @@ func findUnresolvedWithConsumers(raw []byte, resources []imported.ImportedResour
 		sort.Strings(addrs)
 		flat[arn] = addrs
 	}
-	return out, flat, nil
+	return scanResult{unresolved: out, consumers: flat, nested: nested, nonARN: nonARN}, nil
 }
 
 // collectFromBodyWithHits scans every top-level attribute on a body
 // for ARN literals not in the resolved set, returning the
-// deduplicated-within-this-body list of hits. Nested blocks (e.g.
-// `environment { variables = {...} }`) are NOT walked: HCL maps and
-// lists of objects rarely contain bare ARN literals at the leaf, and
-// walking them would explode the surface this conservative pass needs
-// to maintain. If a real-world stack lands ARN refs in nested
-// attributes the behavior can be widened in a follow-up.
+// deduplicated-within-this-body list of hits. This is the HISTORICAL
+// top-level-only pass; nested blocks and collection expressions
+// (`environment { variables = {...} }`, `layers = ["arn:…"]`) are
+// walked separately by scanNestedAndNonARN (finder_nested.go, class A of
+// presets#834), which surfaces them as nested hits with a precise
+// warning. The two passes share the same conservative "pure string
+// literal only" contract (stringLiteralValue ↔ pureStringLiteral).
 func collectFromBodyWithHits(body *hclwrite.Body, resolved map[string]struct{}) []string {
 	var hits []string
 	seen := make(map[string]struct{})

--- a/cmd/insideout-import/depchase/finder.go
+++ b/cmd/insideout-import/depchase/finder.go
@@ -48,14 +48,20 @@ func FindUnresolved(raw []byte, resources []imported.ImportedResource) ([]string
 // nested ARN hits, and class-B curated non-ARN identifier hits, unified into
 // one keyspace so the Run loop's cycle detection / ignore filtering treats
 // them identically. consumers maps each literal to its sorted consumer
-// addresses (for #297 graph edges). nested / nonARN carry the per-literal
-// location + classification metadata so Run can emit the precise
-// class-A / class-B warnings (presets#834).
+// addresses (for #297 graph edges) — every distinct (literal → consumer) pair
+// across BOTH passes, so no consumer edge is lost when a literal is referenced
+// by multiple resources or appears both top-level and nested (F4). nested /
+// nonARN carry the per-literal location + classification metadata so Run can
+// emit the precise class-A / class-B warnings (presets#834). topLevel is the
+// set of literals the historical top-level ARN pass found — Run consults it to
+// decide a hit's origin class (a literal that is ALSO top-level keeps top-level
+// chase semantics rather than the terminal-by-design nested/nonARN semantics).
 type scanResult struct {
 	unresolved []string
 	consumers  map[string][]string
 	nested     map[string]nestedHit
 	nonARN     map[string]nonARNHit
+	topLevel   map[string]struct{}
 }
 
 // scanGenerated is the shared parser pass behind the public FindUnresolved
@@ -82,6 +88,11 @@ func scanGenerated(raw []byte, resources []imported.ImportedResource) (scanResul
 		set[addr] = struct{}{}
 	}
 
+	// topLevel is the set of literals the historical top-level pass finds. Built
+	// independently (not a post-hoc copy of `seen`, which the nested merge below
+	// mutates) so it stays a pure top-level snapshot the Run loop can consult for
+	// origin-class tagging.
+	topLevel := make(map[string]struct{})
 	for _, blk := range f.Body().Blocks() {
 		if blk.Type() != "resource" {
 			continue
@@ -92,30 +103,25 @@ func scanGenerated(raw []byte, resources []imported.ImportedResource) (scanResul
 		addr := blk.Labels()[0] + "." + blk.Labels()[1]
 		hits := collectFromBodyWithHits(blk.Body(), resolved)
 		for _, lit := range hits {
+			topLevel[lit] = struct{}{}
 			addConsumer(lit, addr)
 		}
 	}
 
-	// Snapshot the top-level ARN set so the nested walk can subtract it: a
-	// literal already surfaced at top level is chased once, without a
-	// redundant class-A warning.
-	topLevel := make(map[string]struct{}, len(seen))
-	for k := range seen {
-		topLevel[k] = struct{}{}
-	}
-
 	// presets#834 classes A + B: nested ARN literals and curated non-ARN
 	// identifier references. Merge their literals into the same unresolved
-	// keyspace + consumer map so the Run loop chases them like any other hit.
-	nested, nonARN, err := scanNestedAndNonARN(raw, resolved, topLevel)
+	// keyspace and fold EVERY (literal → consumer) pair the nested walk found
+	// into the consumer map — not just each literal's representative winner —
+	// so multi-consumer and dual-occurrence (top-level + nested) edges survive
+	// (F4).
+	nested, nonARN, nestedConsumers, err := scanNestedAndNonARN(raw, resolved)
 	if err != nil {
 		return scanResult{}, err
 	}
-	for arn, h := range nested {
-		addConsumer(arn, h.addr)
-	}
-	for id, h := range nonARN {
-		addConsumer(id, h.addr)
+	for lit, addrs := range nestedConsumers {
+		for addr := range addrs {
+			addConsumer(lit, addr)
+		}
 	}
 
 	out := make([]string, 0, len(seen))
@@ -135,7 +141,7 @@ func scanGenerated(raw []byte, resources []imported.ImportedResource) (scanResul
 		sort.Strings(addrs)
 		flat[arn] = addrs
 	}
-	return scanResult{unresolved: out, consumers: flat, nested: nested, nonARN: nonARN}, nil
+	return scanResult{unresolved: out, consumers: flat, nested: nested, nonARN: nonARN, topLevel: topLevel}, nil
 }
 
 // collectFromBodyWithHits scans every top-level attribute on a body

--- a/cmd/insideout-import/depchase/finder_nested.go
+++ b/cmd/insideout-import/depchase/finder_nested.go
@@ -1,0 +1,268 @@
+package depchase
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Nested + non-ARN reference detection (presets#834, classes A/B).
+//
+// The historical finder (finder.go:collectFromBodyWithHits) scanned ONLY
+// top-level, pure-double-quoted attribute values that were ARN-shaped. Two
+// whole classes of cross-resource reference literal slipped through SILENTLY —
+// no warning, no chase, quiet fidelity loss:
+//
+//	class A — an ARN literal nested inside a block (`environment { … }`) or a
+//	          collection expression (`layers = ["arn:…"]`, `x = { k = "arn:…" }`).
+//	class B — a bare, non-ARN identifier reference (a KMS KeyId UUID in
+//	          `kms_key_id` / `kms_master_key_id`) that isARNLiteral never even
+//	          considers.
+//
+// scanNestedAndNonARN walks each resource body recursively (nested blocks +
+// tuple/object expression trees) with the hclsyntax typed AST and surfaces both
+// classes so the chase loop can WARN on them (Tier 1) and, where the discoverer
+// accepts the identifier, CHASE the target (Tier 2). It deliberately reuses the
+// same conservative "pure string literal only" contract as the top-level pass
+// (pureStringLiteral below mirrors stringLiteralValue) so interpolations,
+// traversals, and ARNs embedded inside larger template text stay ignored.
+
+// uuidRe matches a canonical lowercase UUID — the shape a bare AWS KMS KeyId
+// takes in `kms_key_id` / `kms_master_key_id` when the customer wrote the key
+// id rather than the full key ARN. Anchored so a UUID embedded in a longer
+// string does not match.
+var uuidRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
+// nonARNAttrRule maps a curated attribute name to the Terraform type its
+// bare-identifier value references, plus a value matcher that gates on the
+// value shape. The matcher is what keeps this a CURATED, warn-first mechanism
+// rather than generic bare-name guessing: only a value that structurally looks
+// like the target identifier (a UUID for a KMS key id) is surfaced, so an
+// unrelated string that happens to sit in a same-named attribute never
+// false-positives.
+type nonARNAttrRule struct {
+	tfType string
+	match  func(string) bool
+}
+
+// nonARNAttrRules is the curated, extensible allowlist for class B. Extend it
+// only with (attr-name → tfType) pairs whose value form is DISTINCTIVE enough
+// to gate on (add a matcher), and whose tfType has a registered discoverer +
+// typed model so the chased target can actually be emitted. Bare S3 bucket
+// names, GCP self-links, etc. are intentionally NOT here — their value shapes
+// are too permissive to match without false positives.
+//
+//	Attribute            → Terraform type   (value gate)
+//	kms_key_id           → aws_kms_key      (UUID)
+//	kms_master_key_id    → aws_kms_key      (UUID)   (SQS/SNS CMK reference)
+var nonARNAttrRules = map[string]nonARNAttrRule{
+	"kms_key_id":        {tfType: "aws_kms_key", match: isKMSKeyUUID},
+	"kms_master_key_id": {tfType: "aws_kms_key", match: isKMSKeyUUID},
+}
+
+func isKMSKeyUUID(s string) bool { return uuidRe.MatchString(strings.TrimSpace(s)) }
+
+// nestedHit records a class-A ARN literal found in a nested position, with the
+// consumer resource address and a human-readable attribute path for the
+// warning. The literal's ARN is ALSO merged into the unresolved set so the
+// chase loop treats it exactly like a top-level hit (Tier 2).
+type nestedHit struct {
+	addr string // consumer resource address (e.g. aws_lambda_function.fn)
+	path string // attribute path where the literal sits (e.g. environment.variables.KEY)
+	arn  string // the ARN literal value
+}
+
+// nonARNHit records a class-B curated non-ARN identifier reference.
+type nonARNHit struct {
+	addr   string // consumer resource address
+	path   string // attribute path
+	attr   string // the curated attribute name (e.g. kms_key_id)
+	tfType string // resolved Terraform type (e.g. aws_kms_key)
+	id     string // the bare identifier value (e.g. the KMS KeyId UUID)
+}
+
+// scanNestedAndNonARN walks every resource body's nested blocks and
+// collection-expression trees, returning the class-A nested ARN hits and
+// class-B curated non-ARN hits. topLevelARNs (the set the historical
+// top-level pass already found) is subtracted from the nested set so a literal
+// that appears BOTH at top level and nested is chased once, via the existing
+// path, without a redundant nested warning. resolved is the in-batch identity
+// set — a nested/non-ARN literal that points at an already-imported resource
+// is not unresolved.
+func scanNestedAndNonARN(raw []byte, resolved, topLevelARNs map[string]struct{}) (map[string]nestedHit, map[string]nonARNHit, error) {
+	file, diags := hclsyntax.ParseConfig(raw, generatedFile, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, nil, fmt.Errorf("depchase: parse generated.tf (syntax): %s", diags.Error())
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, nil, fmt.Errorf("depchase: unexpected body type %T", file.Body)
+	}
+	w := &bodyWalker{
+		resolved: resolved,
+		topLevel: topLevelARNs,
+		nested:   map[string]nestedHit{},
+		nonARN:   map[string]nonARNHit{},
+	}
+	for _, blk := range body.Blocks {
+		if blk.Type != "resource" || len(blk.Labels) != 2 {
+			continue
+		}
+		w.addr = blk.Labels[0] + "." + blk.Labels[1]
+		w.walkBody(blk.Body, "", false)
+	}
+	return w.nested, w.nonARN, nil
+}
+
+// bodyWalker carries the per-resource walk state. addr is reset per resource
+// block; the hit maps accumulate across all resources.
+type bodyWalker struct {
+	addr     string
+	resolved map[string]struct{}
+	topLevel map[string]struct{}
+	nested   map[string]nestedHit
+	nonARN   map[string]nonARNHit
+}
+
+// walkBody recurses one body. inNested is false for the resource's own
+// top-level attributes (whose pure-literal ARN values are the historical
+// pass's job) and true once we descend into a nested block or collection —
+// only then is a pure-literal ARN a class-A hit.
+func (w *bodyWalker) walkBody(body *hclsyntax.Body, prefix string, inNested bool) {
+	for name, attr := range body.Attributes {
+		path := joinPath(prefix, name)
+		if v, ok := pureStringLiteral(attr.Expr); ok {
+			// class B is attr-name gated and applies at any depth where an
+			// attribute name exists (top-level attrs + nested-block attrs).
+			w.checkNonARN(name, v, path)
+			if inNested && isARNLiteral(v) {
+				w.recordNestedARN(v, path)
+			}
+			continue
+		}
+		// A complex expression (list / object / …): descend into its element
+		// tree collecting pure-literal ARNs, which are nested by construction.
+		w.walkExprARNs(attr.Expr, path)
+	}
+	for _, sub := range body.Blocks {
+		w.walkBody(sub.Body, joinPath(prefix, sub.Type), true)
+	}
+}
+
+// walkExprARNs collects pure-literal ARN values from a tuple/object expression
+// tree. Function calls, traversals, and other node kinds are deliberately not
+// descended — the conservative contract only acts on concrete string literals.
+func (w *bodyWalker) walkExprARNs(expr hclsyntax.Expression, path string) {
+	switch e := expr.(type) {
+	case *hclsyntax.TupleConsExpr:
+		for i, el := range e.Exprs {
+			w.walkExprARNs(el, fmt.Sprintf("%s[%d]", path, i))
+		}
+	case *hclsyntax.ObjectConsExpr:
+		for _, item := range e.Items {
+			w.walkExprARNs(item.ValueExpr, joinPath(path, objectKey(item.KeyExpr)))
+		}
+	default:
+		if v, ok := pureStringLiteral(expr); ok && isARNLiteral(v) {
+			w.recordNestedARN(v, path)
+		}
+	}
+}
+
+// recordNestedARN stores a class-A hit, skipping literals that are in-batch
+// (resolved) or already surfaced by the top-level pass. When the same ARN
+// appears in multiple nested positions the lexicographically-smallest
+// (addr, path) wins so the emitted warning is byte-stable across runs despite
+// non-deterministic map iteration.
+func (w *bodyWalker) recordNestedARN(arn, path string) {
+	if _, ok := w.resolved[arn]; ok {
+		return
+	}
+	if _, ok := w.topLevel[arn]; ok {
+		return
+	}
+	cand := nestedHit{addr: w.addr, path: path, arn: arn}
+	if existing, ok := w.nested[arn]; !ok || lessLoc(cand.addr, cand.path, existing.addr, existing.path) {
+		w.nested[arn] = cand
+	}
+}
+
+// checkNonARN stores a class-B hit when the attribute name is curated and its
+// value passes the type's shape gate and is not already in-batch.
+func (w *bodyWalker) checkNonARN(name, value, path string) {
+	rule, ok := nonARNAttrRules[name]
+	if !ok {
+		return
+	}
+	v := strings.TrimSpace(value)
+	if !rule.match(v) {
+		return
+	}
+	if _, ok := w.resolved[v]; ok {
+		return
+	}
+	cand := nonARNHit{addr: w.addr, path: path, attr: name, tfType: rule.tfType, id: v}
+	if existing, ok := w.nonARN[v]; !ok || lessLoc(cand.addr, cand.path, existing.addr, existing.path) {
+		w.nonARN[v] = cand
+	}
+}
+
+// pureStringLiteral is the hclsyntax analogue of stringLiteralValue: it returns
+// the value of an expression IFF the expression is a pure string literal with
+// no interpolation. A template with any `${…}` part, a traversal, or a
+// non-string literal returns ok=false so the walk leaves it alone — matching
+// the top-level pass's conservative contract exactly.
+func pureStringLiteral(expr hclsyntax.Expression) (string, bool) {
+	switch e := expr.(type) {
+	case *hclsyntax.TemplateExpr:
+		if !e.IsStringLiteral() {
+			return "", false
+		}
+		v, diags := e.Value(nil)
+		if diags.HasErrors() || v.IsNull() || v.Type() != cty.String {
+			return "", false
+		}
+		return v.AsString(), true
+	case *hclsyntax.LiteralValueExpr:
+		if e.Val.IsNull() || e.Val.Type() != cty.String {
+			return "", false
+		}
+		return e.Val.AsString(), true
+	}
+	return "", false
+}
+
+// objectKey renders an object item's key for the attribute path. Handles both
+// quoted keys (`"foo" = …`) and bare-identifier keys (`foo = …`); anything
+// exotic collapses to "*".
+func objectKey(e hclsyntax.Expression) string {
+	if k, ok := e.(*hclsyntax.ObjectConsKeyExpr); ok {
+		e = k.Wrapped
+	}
+	if v, ok := pureStringLiteral(e); ok {
+		return v
+	}
+	if t, ok := e.(*hclsyntax.ScopeTraversalExpr); ok && len(t.Traversal) == 1 {
+		return t.Traversal.RootName()
+	}
+	return "*"
+}
+
+func joinPath(prefix, name string) string {
+	if prefix == "" {
+		return name
+	}
+	return prefix + "." + name
+}
+
+// lessLoc orders two (addr, path) locations for deterministic hit selection.
+func lessLoc(a1, p1, a2, p2 string) bool {
+	if a1 != a2 {
+		return a1 < a2
+	}
+	return p1 < p2
+}

--- a/cmd/insideout-import/depchase/finder_nested.go
+++ b/cmd/insideout-import/depchase/finder_nested.go
@@ -31,11 +31,12 @@ import (
 // (pureStringLiteral below mirrors stringLiteralValue) so interpolations,
 // traversals, and ARNs embedded inside larger template text stay ignored.
 
-// uuidRe matches a canonical lowercase UUID — the shape a bare AWS KMS KeyId
-// takes in `kms_key_id` / `kms_master_key_id` when the customer wrote the key
-// id rather than the full key ARN. Anchored so a UUID embedded in a longer
-// string does not match.
-var uuidRe = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+// uuidRe matches a canonical UUID — the shape a bare AWS KMS KeyId takes in
+// `kms_key_id` / `kms_master_key_id` when the customer wrote the key id rather
+// than the full key ARN. Case-insensitive: AWS accepts and the console
+// sometimes renders KeyId UUIDs with uppercase hex (F9). Anchored so a UUID
+// embedded in a longer string does not match.
+var uuidRe = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
 
 // nonARNAttrRule maps a curated attribute name to the Terraform type its
 // bare-identifier value references, plus a value matcher that gates on the
@@ -56,6 +57,10 @@ type nonARNAttrRule struct {
 // names, GCP self-links, etc. are intentionally NOT here — their value shapes
 // are too permissive to match without false positives.
 //
+// Each entry's tfType MUST agree with the canonical cross-reference registry
+// pkg/imported/dependencies (dependencies.Lookup / FieldRefs, presets#482/#667)
+// — the drift test TestNonARNAttrRulesAgreeWithDependencyRegistry pins it.
+//
 //	Attribute            → Terraform type   (value gate)
 //	kms_key_id           → aws_kms_key      (UUID)
 //	kms_master_key_id    → aws_kms_key      (UUID)   (SQS/SNS CMK reference)
@@ -64,49 +69,58 @@ var nonARNAttrRules = map[string]nonARNAttrRule{
 	"kms_master_key_id": {tfType: "aws_kms_key", match: isKMSKeyUUID},
 }
 
-func isKMSKeyUUID(s string) bool { return uuidRe.MatchString(strings.TrimSpace(s)) }
+// isKMSKeyUUID reports whether s is a canonical KMS KeyId UUID. Callers
+// (checkNonARN) trim before invoking, so this does NOT re-trim (single TrimSpace
+// at the call site — cleanup dedup).
+func isKMSKeyUUID(s string) bool { return uuidRe.MatchString(s) }
 
 // nestedHit records a class-A ARN literal found in a nested position, with the
 // consumer resource address and a human-readable attribute path for the
-// warning. The literal's ARN is ALSO merged into the unresolved set so the
-// chase loop treats it exactly like a top-level hit (Tier 2).
+// warning. The ARN literal itself is the map key in bodyWalker.nested, so it is
+// not duplicated here (cleanup). The literal is ALSO merged into the unresolved
+// set so the chase loop treats it exactly like a top-level hit (Tier 2).
 type nestedHit struct {
 	addr string // consumer resource address (e.g. aws_lambda_function.fn)
 	path string // attribute path where the literal sits (e.g. environment.variables.KEY)
-	arn  string // the ARN literal value
 }
 
-// nonARNHit records a class-B curated non-ARN identifier reference.
+// nonARNHit records a class-B curated non-ARN identifier reference. The bare
+// identifier value itself is the map key in bodyWalker.nonARN, so it is not
+// duplicated here (cleanup).
 type nonARNHit struct {
 	addr   string // consumer resource address
 	path   string // attribute path
 	attr   string // the curated attribute name (e.g. kms_key_id)
 	tfType string // resolved Terraform type (e.g. aws_kms_key)
-	id     string // the bare identifier value (e.g. the KMS KeyId UUID)
 }
 
 // scanNestedAndNonARN walks every resource body's nested blocks and
-// collection-expression trees, returning the class-A nested ARN hits and
-// class-B curated non-ARN hits. topLevelARNs (the set the historical
-// top-level pass already found) is subtracted from the nested set so a literal
-// that appears BOTH at top level and nested is chased once, via the existing
-// path, without a redundant nested warning. resolved is the in-batch identity
-// set — a nested/non-ARN literal that points at an already-imported resource
-// is not unresolved.
-func scanNestedAndNonARN(raw []byte, resolved, topLevelARNs map[string]struct{}) (map[string]nestedHit, map[string]nonARNHit, error) {
+// collection-expression trees, returning the class-A nested ARN hits, the
+// class-B curated non-ARN hits, and the full set of (literal → consumer
+// address) pairs for both classes. resolved is the in-batch identity set — a
+// nested/non-ARN literal that points at an already-imported resource is not
+// unresolved.
+//
+// Unlike an earlier revision, the walk no longer subtracts the top-level ARN
+// set: a literal that appears BOTH top-level (in X) and nested (in Y) must
+// STILL record Y's consumer edge and STILL surface Y's nested warning (F4). The
+// unified `seen` keyspace in scanGenerated dedups the CHASE to one call; the
+// top-level-vs-nested class distinction is made by the Run loop from
+// scanResult.topLevel, not here.
+func scanNestedAndNonARN(raw []byte, resolved map[string]struct{}) (nested map[string]nestedHit, nonARN map[string]nonARNHit, consumers map[string]map[string]struct{}, err error) {
 	file, diags := hclsyntax.ParseConfig(raw, generatedFile, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return nil, nil, fmt.Errorf("depchase: parse generated.tf (syntax): %s", diags.Error())
+		return nil, nil, nil, fmt.Errorf("depchase: parse generated.tf (syntax): %s", diags.Error())
 	}
 	body, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
-		return nil, nil, fmt.Errorf("depchase: unexpected body type %T", file.Body)
+		return nil, nil, nil, fmt.Errorf("depchase: unexpected body type %T", file.Body)
 	}
 	w := &bodyWalker{
-		resolved: resolved,
-		topLevel: topLevelARNs,
-		nested:   map[string]nestedHit{},
-		nonARN:   map[string]nonARNHit{},
+		resolved:  resolved,
+		nested:    map[string]nestedHit{},
+		nonARN:    map[string]nonARNHit{},
+		consumers: map[string]map[string]struct{}{},
 	}
 	for _, blk := range body.Blocks {
 		if blk.Type != "resource" || len(blk.Labels) != 2 {
@@ -115,17 +129,32 @@ func scanNestedAndNonARN(raw []byte, resolved, topLevelARNs map[string]struct{})
 		w.addr = blk.Labels[0] + "." + blk.Labels[1]
 		w.walkBody(blk.Body, "", false)
 	}
-	return w.nested, w.nonARN, nil
+	return w.nested, w.nonARN, w.consumers, nil
 }
 
 // bodyWalker carries the per-resource walk state. addr is reset per resource
-// block; the hit maps accumulate across all resources.
+// block; the hit maps and the consumer-edge map accumulate across all resources.
 type bodyWalker struct {
 	addr     string
 	resolved map[string]struct{}
-	topLevel map[string]struct{}
 	nested   map[string]nestedHit
 	nonARN   map[string]nonARNHit
+	// consumers records EVERY distinct (literal → consumer addr) pair the walk
+	// observes (F4). The nested / nonARN winner-hit maps keep only one
+	// representative (addr, path) per literal for the warning text; consumers
+	// keeps them all so no consumer's dependency edge is dropped when a literal
+	// is referenced by more than one resource (or also appears top-level).
+	consumers map[string]map[string]struct{}
+}
+
+// addConsumer records one (literal → consumer addr) edge candidate.
+func (w *bodyWalker) addConsumer(lit, addr string) {
+	set, ok := w.consumers[lit]
+	if !ok {
+		set = map[string]struct{}{}
+		w.consumers[lit] = set
+	}
+	set[addr] = struct{}{}
 }
 
 // walkBody recurses one body. inNested is false for the resource's own
@@ -149,13 +178,21 @@ func (w *bodyWalker) walkBody(body *hclsyntax.Body, prefix string, inNested bool
 		w.walkExprARNs(attr.Expr, path)
 	}
 	for _, sub := range body.Blocks {
-		w.walkBody(sub.Body, joinPath(prefix, sub.Type), true)
+		// Include block labels in the path segment so two same-type labeled
+		// blocks (e.g. `rule "a" {}` / `rule "b" {}`) produce distinct paths
+		// in the emitted warnings (F10). Rendered as `type[label][label…]`.
+		seg := sub.Type
+		for _, lbl := range sub.Labels {
+			seg += "[" + lbl + "]"
+		}
+		w.walkBody(sub.Body, joinPath(prefix, seg), true)
 	}
 }
 
-// walkExprARNs collects pure-literal ARN values from a tuple/object expression
-// tree. Function calls, traversals, and other node kinds are deliberately not
-// descended — the conservative contract only acts on concrete string literals.
+// walkExprARNs collects pure-literal ARN values (class A) and curated non-ARN
+// identifiers (class B) from a tuple/object expression tree. Function calls,
+// traversals, and other node kinds are deliberately not descended — the
+// conservative contract only acts on concrete string literals.
 func (w *bodyWalker) walkExprARNs(expr hclsyntax.Expression, path string) {
 	switch e := expr.(type) {
 	case *hclsyntax.TupleConsExpr:
@@ -164,7 +201,20 @@ func (w *bodyWalker) walkExprARNs(expr hclsyntax.Expression, path string) {
 		}
 	case *hclsyntax.ObjectConsExpr:
 		for _, item := range e.Items {
-			w.walkExprARNs(item.ValueExpr, joinPath(path, objectKey(item.KeyExpr)))
+			key := objectKey(item.KeyExpr)
+			itemPath := joinPath(path, key)
+			// A pure-literal object VALUE is a leaf: check it for both classes
+			// here (F6 — class B in object expressions was previously only
+			// checked on body attributes, never on object items). Non-literal
+			// values recurse.
+			if v, ok := pureStringLiteral(item.ValueExpr); ok {
+				w.checkNonARN(key, v, itemPath)
+				if isARNLiteral(v) {
+					w.recordNestedARN(v, itemPath)
+				}
+				continue
+			}
+			w.walkExprARNs(item.ValueExpr, itemPath)
 		}
 	default:
 		if v, ok := pureStringLiteral(expr); ok && isARNLiteral(v) {
@@ -174,7 +224,9 @@ func (w *bodyWalker) walkExprARNs(expr hclsyntax.Expression, path string) {
 }
 
 // recordNestedARN stores a class-A hit, skipping literals that are in-batch
-// (resolved) or already surfaced by the top-level pass. When the same ARN
+// (resolved). The consumer edge is recorded UNCONDITIONALLY (minus resolved):
+// even when the same ARN also appears top-level in another resource, this
+// nested consumer's dependency edge must survive (F4). When the same ARN
 // appears in multiple nested positions the lexicographically-smallest
 // (addr, path) wins so the emitted warning is byte-stable across runs despite
 // non-deterministic map iteration.
@@ -182,17 +234,16 @@ func (w *bodyWalker) recordNestedARN(arn, path string) {
 	if _, ok := w.resolved[arn]; ok {
 		return
 	}
-	if _, ok := w.topLevel[arn]; ok {
-		return
-	}
-	cand := nestedHit{addr: w.addr, path: path, arn: arn}
+	w.addConsumer(arn, w.addr)
+	cand := nestedHit{addr: w.addr, path: path}
 	if existing, ok := w.nested[arn]; !ok || lessLoc(cand.addr, cand.path, existing.addr, existing.path) {
 		w.nested[arn] = cand
 	}
 }
 
 // checkNonARN stores a class-B hit when the attribute name is curated and its
-// value passes the type's shape gate and is not already in-batch.
+// value passes the type's shape gate and is not already in-batch. The consumer
+// edge is recorded for every consumer of the identifier (F4).
 func (w *bodyWalker) checkNonARN(name, value, path string) {
 	rule, ok := nonARNAttrRules[name]
 	if !ok {
@@ -205,7 +256,8 @@ func (w *bodyWalker) checkNonARN(name, value, path string) {
 	if _, ok := w.resolved[v]; ok {
 		return
 	}
-	cand := nonARNHit{addr: w.addr, path: path, attr: name, tfType: rule.tfType, id: v}
+	w.addConsumer(v, w.addr)
+	cand := nonARNHit{addr: w.addr, path: path, attr: name, tfType: rule.tfType}
 	if existing, ok := w.nonARN[v]; !ok || lessLoc(cand.addr, cand.path, existing.addr, existing.path) {
 		w.nonARN[v] = cand
 	}
@@ -238,9 +290,21 @@ func pureStringLiteral(expr hclsyntax.Expression) (string, bool) {
 
 // objectKey renders an object item's key for the attribute path. Handles both
 // quoted keys (`"foo" = …`) and bare-identifier keys (`foo = …`); anything
-// exotic collapses to "*".
+// exotic — including a parenthesized dynamic key `(expr) = …` — collapses to
+// "*".
+//
+// This mirrors pkg/composer.objectConsKeyAsString (the canonical helper). In
+// particular it re-applies that helper's ForceNonLiteral guard: HCL sets
+// ForceNonLiteral on the ObjectConsKeyExpr when the source wrapped the key in
+// parens to force dynamic evaluation, and treating such a key as a static name
+// would fabricate a bogus path segment. (Kept as a local copy rather than
+// importing the unexported composer helper; keep the two in sync.)
 func objectKey(e hclsyntax.Expression) string {
 	if k, ok := e.(*hclsyntax.ObjectConsKeyExpr); ok {
+		// Parenthesized `(expr) = …` dynamic key: not a static name.
+		if k.ForceNonLiteral {
+			return "*"
+		}
 		e = k.Wrapped
 	}
 	if v, ok := pureStringLiteral(e); ok {

--- a/cmd/insideout-import/depchase/finder_test.go
+++ b/cmd/insideout-import/depchase/finder_test.go
@@ -105,14 +105,15 @@ resource "aws_lambda_function" "c" {
 
 func TestFindUnresolved_IgnoresNonLiteralExpressions(t *testing.T) {
 	t.Parallel()
-	// Interpolations, list values, and references to other resources
-	// should not be treated as unresolved literals — the conservative
-	// finder leaves them alone for genconfig's crossref pass.
+	// Interpolations, traversals, and ARNs embedded inside larger template
+	// text must NOT be treated as reference literals — the conservative
+	// finder leaves them alone for genconfig's crossref pass. (The class-A
+	// nested-list case — `layers = ["arn:…"]` — IS now surfaced by design;
+	// see TestFindUnresolved_SurfacesNestedListAndObjectARNs.)
 	raw := []byte(`
 resource "aws_lambda_function" "a" {
   role           = aws_iam_role.handler.arn
   source_account = "123"
-  layers         = ["arn:aws:lambda:us-east-1:123:layer:x:1"]
   description    = "see arn:aws:iam::123:role/embedded inside text"
 }
 `)
@@ -121,7 +122,90 @@ resource "aws_lambda_function" "a" {
 		t.Fatal(err)
 	}
 	if len(got) != 0 {
-		t.Errorf("got %v, want empty (no top-level pure-literal ARN attrs)", got)
+		t.Errorf("got %v, want empty (traversal / non-arn / embedded-in-text)", got)
+	}
+}
+
+// TestFindUnresolved_SurfacesNestedListAndObjectARNs pins presets#834 class A:
+// an ARN literal nested inside a list element or an object attribute value —
+// which the historical top-level-only pass silently skipped — is now surfaced
+// by the nested-body walk. The lambda-layer ARN sits in a list; the KMS ARN
+// sits in an object value inside a nested block.
+func TestFindUnresolved_SurfacesNestedListAndObjectARNs(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`
+resource "aws_lambda_function" "a" {
+  layers = ["arn:aws:lambda:us-east-1:123:layer:x:1"]
+  environment {
+    variables = {
+      SIGNING_KEY = "arn:aws:kms:us-east-1:123:key/uuid-1"
+    }
+  }
+}
+`)
+	got, err := FindUnresolved(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"arn:aws:kms:us-east-1:123:key/uuid-1",
+		"arn:aws:lambda:us-east-1:123:layer:x:1",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v (nested list + object-in-block ARNs)", got, want)
+	}
+}
+
+// TestFindUnresolved_NestedARNResolvedWhenTargetInBatch pins that a nested ARN
+// pointing at an in-batch resource is NOT surfaced — the resolved-set check
+// applies to nested hits exactly as it does to top-level ones.
+func TestFindUnresolved_NestedARNResolvedWhenTargetInBatch(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`
+resource "aws_lambda_function" "a" {
+  layers = ["arn:aws:lambda:us-east-1:123:layer:shared:1"]
+}
+`)
+	in := []imported.ImportedResource{
+		resource("aws_lambda_layer_version.shared", "arn:aws:lambda:us-east-1:123:layer:shared:1",
+			map[string]string{"arn": "arn:aws:lambda:us-east-1:123:layer:shared:1"}),
+	}
+	got, err := FindUnresolved(raw, in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty (nested ARN target is in the batch)", got)
+	}
+}
+
+// TestFindUnresolved_SurfacesCuratedNonARNIdentifier pins presets#834 class B:
+// a bare KMS KeyId UUID in a curated attribute (kms_key_id / kms_master_key_id)
+// is surfaced, while the SAME UUID shape in a non-curated attribute is not
+// (guards against generic bare-name matching / false positives).
+func TestFindUnresolved_SurfacesCuratedNonARNIdentifier(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`
+resource "aws_sqs_queue" "q" {
+  kms_master_key_id = "1234abcd-12ab-34cd-56ef-1234567890ab"
+}
+resource "aws_ebs_volume" "v" {
+  kms_key_id = "abcd0000-11ab-22cd-33ef-abcdef012345"
+}
+resource "aws_instance" "i" {
+  some_other_id = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+}
+`)
+	got, err := FindUnresolved(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"1234abcd-12ab-34cd-56ef-1234567890ab",
+		"abcd0000-11ab-22cd-33ef-abcdef012345",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v (only curated kms_* attrs; some_other_id UUID must NOT match)", got, want)
 	}
 }
 

--- a/cmd/insideout-import/depchase/finder_test.go
+++ b/cmd/insideout-import/depchase/finder_test.go
@@ -5,7 +5,37 @@ import (
 	"testing"
 
 	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/imported/dependencies"
 )
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNonARNAttrRulesAgreeWithDependencyRegistry is a drift guard: every
+// class-B curated attr rule's tfType MUST agree with the canonical
+// cross-reference registry pkg/imported/dependencies (Lookup / FieldRefs,
+// presets#482/#667). The class-B chase seeds a discoverer with rule.tfType; if
+// this map drifted from the registry the chase would look up the wrong resource
+// type. Triggering example: kms_master_key_id → aws_kms_key must match in both.
+func TestNonARNAttrRulesAgreeWithDependencyRegistry(t *testing.T) {
+	t.Parallel()
+	for attr, rule := range nonARNAttrRules {
+		want, ok := dependencies.Lookup(attr)
+		if !ok {
+			t.Errorf("nonARNAttrRules[%q] has no entry in pkg/imported/dependencies (Lookup); every class-B attr must be a known cross-ref field", attr)
+			continue
+		}
+		if rule.tfType != want {
+			t.Errorf("nonARNAttrRules[%q].tfType=%q disagrees with dependencies.Lookup=%q", attr, rule.tfType, want)
+		}
+	}
+}
 
 func resource(addr, importID string, native map[string]string) imported.ImportedResource {
 	return imported.ImportedResource{
@@ -206,6 +236,149 @@ resource "aws_instance" "i" {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v, want %v (only curated kms_* attrs; some_other_id UUID must NOT match)", got, want)
+	}
+}
+
+// TestFindUnresolved_SurfacesClassBInObjectExpression pins F6: a curated
+// non-ARN identifier (KMS KeyId UUID) nested inside an OBJECT expression value
+// — not just a top-level/nested-block attribute — is surfaced. Before F6,
+// checkNonARN ran only on body attributes, so an object-shaped SSE config was
+// silent.
+func TestFindUnresolved_SurfacesClassBInObjectExpression(t *testing.T) {
+	t.Parallel()
+	uuid := "1234abcd-12ab-34cd-56ef-1234567890ab"
+	raw := []byte(`
+resource "aws_s3_bucket" "b" {
+  rule = {
+    x = {
+      kms_master_key_id = "` + uuid + `"
+    }
+  }
+}
+`)
+	scan, err := scanGenerated(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit, ok := scan.nonARN[uuid]
+	if !ok {
+		t.Fatalf("object-nested kms_master_key_id UUID not surfaced; nonARN=%+v", scan.nonARN)
+	}
+	if hit.path != "rule.x.kms_master_key_id" {
+		t.Errorf("class-B object path=%q, want rule.x.kms_master_key_id", hit.path)
+	}
+	if !contains(scan.unresolved, uuid) {
+		t.Errorf("unresolved=%v, want it to include the object-nested UUID", scan.unresolved)
+	}
+}
+
+// TestObjectKey_DynamicKeyYieldsStar pins F7: a parenthesized dynamic object key
+// `(expr) = …` must collapse to the '*' path segment (matching the canonical
+// pkg/composer.objectConsKeyAsString ForceNonLiteral guard), not a fabricated
+// static name.
+func TestObjectKey_DynamicKeyYieldsStar(t *testing.T) {
+	t.Parallel()
+	arn := "arn:aws:iam::123:role/dynamic-keyed"
+	// A SINGLE-segment parenthesized key `(k) = …`: without the ForceNonLiteral
+	// guard the local objectKey would fall through to the single-segment
+	// ScopeTraversalExpr branch and fabricate the static name "k"; the guard
+	// forces the '*' fallback (matching pkg/composer.objectConsKeyAsString).
+	raw := []byte(`
+resource "aws_lambda_function" "fn" {
+  tags = {
+    (k) = "` + arn + `"
+  }
+}
+`)
+	scan, err := scanGenerated(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit, ok := scan.nested[arn]
+	if !ok {
+		t.Fatalf("dynamic-keyed nested ARN not surfaced; nested=%+v", scan.nested)
+	}
+	if hit.path != "tags.*" {
+		t.Errorf("dynamic-key path=%q, want tags.* (ForceNonLiteral guard); a fabricated static name like tags.k means the guard is missing", hit.path)
+	}
+}
+
+// TestFindUnresolved_UppercaseKMSKeyUUID pins F9: the KMS KeyId UUID matcher is
+// case-insensitive — an uppercase-hex UUID (as the AWS console sometimes renders
+// it) is surfaced, and a non-hex look-alike is not.
+func TestFindUnresolved_UppercaseKMSKeyUUID(t *testing.T) {
+	t.Parallel()
+	upper := "ABCD0000-11AB-22CD-33EF-ABCDEF012345"
+	raw := []byte(`
+resource "aws_sqs_queue" "q" {
+  kms_master_key_id = "` + upper + `"
+}
+resource "aws_sqs_queue" "bad" {
+  kms_master_key_id = "gggg0000-11ab-22cd-33ef-abcdef012345"
+}
+`)
+	got, err := FindUnresolved(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{upper}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v (uppercase UUID matches, non-hex does not)", got, want)
+	}
+}
+
+// TestFindUnresolved_LabeledNestedBlockPaths pins F10: two same-type LABELED
+// nested blocks yield distinct attribute paths (labels are folded into the path
+// segment as type[label]) so their warnings are individually traceable.
+func TestFindUnresolved_LabeledNestedBlockPaths(t *testing.T) {
+	t.Parallel()
+	arnA := "arn:aws:kms:us-east-1:123:key/aaaa1111-bbbb-2222-cccc-333333333333"
+	arnB := "arn:aws:kms:us-east-1:123:key/bbbb2222-cccc-3333-dddd-444444444444"
+	raw := []byte(`
+resource "aws_s3_bucket" "b" {
+  rule "a" {
+    signing_key = "` + arnA + `"
+  }
+  rule "b" {
+    signing_key = "` + arnB + `"
+  }
+}
+`)
+	scan, err := scanGenerated(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit := scan.nested[arnA]; hit.path != "rule[a].signing_key" {
+		t.Errorf("labeled block A path=%q, want rule[a].signing_key", hit.path)
+	}
+	if hit := scan.nested[arnB]; hit.path != "rule[b].signing_key" {
+		t.Errorf("labeled block B path=%q, want rule[b].signing_key", hit.path)
+	}
+}
+
+// TestFindUnresolved_IgnoresNestedNonLiterals pins the conservative contract at
+// depth: a nested interpolation, a nested traversal, and an ARN embedded inside
+// a larger nested string must ALL be ignored — only concrete, pure string
+// literals are surfaced.
+func TestFindUnresolved_IgnoresNestedNonLiterals(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`
+resource "aws_lambda_function" "a" {
+  layers = ["${aws_lambda_layer_version.y.arn}"]
+  environment {
+    variables = {
+      TRAVERSAL = aws_iam_role.handler.arn
+      EMBEDDED  = "prefix arn:aws:iam::123:role/embedded suffix"
+    }
+  }
+}
+`)
+	got, err := FindUnresolved(raw, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty (nested interpolation / traversal / embedded-in-text all ignored)", got)
 	}
 }
 

--- a/pkg/composer/imported/generated/aws_acm_certificate.gen.go
+++ b/pkg/composer/imported/generated/aws_acm_certificate.gen.go
@@ -20,6 +20,8 @@ type AWSAcmCertificate struct {
 	NotBefore               *Value[string]                             `tf:"not_before" json:"not_before,omitempty"`
 	PendingRenewal          *Value[bool]                               `tf:"pending_renewal" json:"pending_renewal,omitempty"`
 	PrivateKey              *Value[string]                             `tf:"private_key" json:"private_key,omitempty"`
+	PrivateKeyWo            *Value[string]                             `tf:"private_key_wo" json:"private_key_wo,omitempty"`
+	PrivateKeyWoVersion     *Value[float64]                            `tf:"private_key_wo_version" json:"private_key_wo_version,omitempty"`
 	Region                  *Value[string]                             `tf:"region" json:"region,omitempty"`
 	RenewalEligibility      *Value[string]                             `tf:"renewal_eligibility" json:"renewal_eligibility,omitempty"`
 	RenewalSummary          []AWSAcmCertificateRenewalSummary          `tf:"renewal_summary" json:"renewal_summary,omitempty"`
@@ -77,6 +79,8 @@ var AWSAcmCertificateSchema = map[string]FieldSchema{
 	"not_before":                {Computed: true, Replacement: ReplacementUnknown},
 	"pending_renewal":           {Computed: true, Replacement: ReplacementUnknown},
 	"private_key":               {Optional: true, Sensitive: true, Replacement: ReplacementUnknown},
+	"private_key_wo":            {Optional: true, Replacement: ReplacementUnknown},
+	"private_key_wo_version":    {Optional: true, Replacement: ReplacementUnknown},
 	"region":                    {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 	"renewal_eligibility":       {Computed: true, Replacement: ReplacementUnknown},
 	"renewal_summary":           {Computed: true, Replacement: ReplacementUnknown},

--- a/pkg/composer/imported/generated/aws_bedrockagentcore_gateway.gen.go
+++ b/pkg/composer/imported/generated/aws_bedrockagentcore_gateway.gen.go
@@ -7,24 +7,25 @@ import "reflect"
 // AWSBedrockagentcoreGateway is the generated Layer 1 typed model for the
 // `aws_bedrockagentcore_gateway` Terraform resource.
 type AWSBedrockagentcoreGateway struct {
-	AuthorizerType           *Value[string]                                       `tf:"authorizer_type" json:"authorizer_type,omitempty"`
-	Description              *Value[string]                                       `tf:"description" json:"description,omitempty"`
-	ExceptionLevel           *Value[string]                                       `tf:"exception_level" json:"exception_level,omitempty"`
-	GatewayARN               *Value[string]                                       `tf:"gateway_arn" json:"gateway_arn,omitempty"`
-	GatewayID                *Value[string]                                       `tf:"gateway_id" json:"gateway_id,omitempty"`
-	GatewayURL               *Value[string]                                       `tf:"gateway_url" json:"gateway_url,omitempty"`
-	KMSKeyARN                *Value[string]                                       `tf:"kms_key_arn" json:"kms_key_arn,omitempty"`
-	Name                     *Value[string]                                       `tf:"name" json:"name,omitempty"`
-	ProtocolType             *Value[string]                                       `tf:"protocol_type" json:"protocol_type,omitempty"`
-	Region                   *Value[string]                                       `tf:"region" json:"region,omitempty"`
-	RoleARN                  *Value[string]                                       `tf:"role_arn" json:"role_arn,omitempty"`
-	Tags                     map[string]*Value[string]                            `tf:"tags" json:"tags,omitempty"`
-	TagsAll                  map[string]*Value[string]                            `tf:"tags_all" json:"tags_all,omitempty"`
-	WorkloadIdentityDetails  []AWSBedrockagentcoreGatewayWorkloadIdentityDetails  `tf:"workload_identity_details" json:"workload_identity_details,omitempty"`
-	AuthorizerConfiguration  []AWSBedrockagentcoreGatewayAuthorizerConfiguration  `tf:"authorizer_configuration,blocks" json:"authorizer_configuration,omitempty"`
-	InterceptorConfiguration []AWSBedrockagentcoreGatewayInterceptorConfiguration `tf:"interceptor_configuration,blocks" json:"interceptor_configuration,omitempty"`
-	ProtocolConfiguration    []AWSBedrockagentcoreGatewayProtocolConfiguration    `tf:"protocol_configuration,blocks" json:"protocol_configuration,omitempty"`
-	Timeouts                 *AWSBedrockagentcoreGatewayTimeouts                  `tf:"timeouts,block" json:"timeouts,omitempty"`
+	AuthorizerType            *Value[string]                                        `tf:"authorizer_type" json:"authorizer_type,omitempty"`
+	Description               *Value[string]                                        `tf:"description" json:"description,omitempty"`
+	ExceptionLevel            *Value[string]                                        `tf:"exception_level" json:"exception_level,omitempty"`
+	GatewayARN                *Value[string]                                        `tf:"gateway_arn" json:"gateway_arn,omitempty"`
+	GatewayID                 *Value[string]                                        `tf:"gateway_id" json:"gateway_id,omitempty"`
+	GatewayURL                *Value[string]                                        `tf:"gateway_url" json:"gateway_url,omitempty"`
+	KMSKeyARN                 *Value[string]                                        `tf:"kms_key_arn" json:"kms_key_arn,omitempty"`
+	Name                      *Value[string]                                        `tf:"name" json:"name,omitempty"`
+	ProtocolType              *Value[string]                                        `tf:"protocol_type" json:"protocol_type,omitempty"`
+	Region                    *Value[string]                                        `tf:"region" json:"region,omitempty"`
+	RoleARN                   *Value[string]                                        `tf:"role_arn" json:"role_arn,omitempty"`
+	Tags                      map[string]*Value[string]                             `tf:"tags" json:"tags,omitempty"`
+	TagsAll                   map[string]*Value[string]                             `tf:"tags_all" json:"tags_all,omitempty"`
+	WorkloadIdentityDetails   []AWSBedrockagentcoreGatewayWorkloadIdentityDetails   `tf:"workload_identity_details" json:"workload_identity_details,omitempty"`
+	AuthorizerConfiguration   []AWSBedrockagentcoreGatewayAuthorizerConfiguration   `tf:"authorizer_configuration,blocks" json:"authorizer_configuration,omitempty"`
+	InterceptorConfiguration  []AWSBedrockagentcoreGatewayInterceptorConfiguration  `tf:"interceptor_configuration,blocks" json:"interceptor_configuration,omitempty"`
+	PolicyEngineConfiguration []AWSBedrockagentcoreGatewayPolicyEngineConfiguration `tf:"policy_engine_configuration,blocks" json:"policy_engine_configuration,omitempty"`
+	ProtocolConfiguration     []AWSBedrockagentcoreGatewayProtocolConfiguration     `tf:"protocol_configuration,blocks" json:"protocol_configuration,omitempty"`
+	Timeouts                  *AWSBedrockagentcoreGatewayTimeouts                   `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // AWSBedrockagentcoreGatewayAuthorizerConfiguration is a nested-block type used by the parent resource.
@@ -82,6 +83,12 @@ type AWSBedrockagentcoreGatewayInterceptorConfigurationInterceptorLambda struct 
 	ARN *Value[string] `tf:"arn" json:"arn,omitempty"`
 }
 
+// AWSBedrockagentcoreGatewayPolicyEngineConfiguration is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayPolicyEngineConfiguration struct {
+	ARN  *Value[string] `tf:"arn" json:"arn,omitempty"`
+	Mode *Value[string] `tf:"mode" json:"mode,omitempty"`
+}
+
 // AWSBedrockagentcoreGatewayProtocolConfiguration is a nested-block type used by the parent resource.
 type AWSBedrockagentcoreGatewayProtocolConfiguration struct {
 	Mcp []AWSBedrockagentcoreGatewayProtocolConfigurationMcp `tf:"mcp,blocks" json:"mcp,omitempty"`
@@ -89,9 +96,21 @@ type AWSBedrockagentcoreGatewayProtocolConfiguration struct {
 
 // AWSBedrockagentcoreGatewayProtocolConfigurationMcp is a nested-block type used by the parent resource.
 type AWSBedrockagentcoreGatewayProtocolConfigurationMcp struct {
-	Instructions      *Value[string]   `tf:"instructions" json:"instructions,omitempty"`
-	SearchType        *Value[string]   `tf:"search_type" json:"search_type,omitempty"`
-	SupportedVersions []*Value[string] `tf:"supported_versions" json:"supported_versions,omitempty"`
+	Instructions           *Value[string]                                                             `tf:"instructions" json:"instructions,omitempty"`
+	SearchType             *Value[string]                                                             `tf:"search_type" json:"search_type,omitempty"`
+	SupportedVersions      []*Value[string]                                                           `tf:"supported_versions" json:"supported_versions,omitempty"`
+	SessionConfiguration   []AWSBedrockagentcoreGatewayProtocolConfigurationMcpSessionConfiguration   `tf:"session_configuration,blocks" json:"session_configuration,omitempty"`
+	StreamingConfiguration []AWSBedrockagentcoreGatewayProtocolConfigurationMcpStreamingConfiguration `tf:"streaming_configuration,blocks" json:"streaming_configuration,omitempty"`
+}
+
+// AWSBedrockagentcoreGatewayProtocolConfigurationMcpSessionConfiguration is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayProtocolConfigurationMcpSessionConfiguration struct {
+	SessionTimeoutInSeconds *Value[int64] `tf:"session_timeout_in_seconds" json:"session_timeout_in_seconds,omitempty"`
+}
+
+// AWSBedrockagentcoreGatewayProtocolConfigurationMcpStreamingConfiguration is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayProtocolConfigurationMcpStreamingConfiguration struct {
+	EnableResponseStreaming *Value[bool] `tf:"enable_response_streaming" json:"enable_response_streaming,omitempty"`
 }
 
 // AWSBedrockagentcoreGatewayTimeouts is a nested-block type used by the parent resource.
@@ -109,24 +128,25 @@ type AWSBedrockagentcoreGatewayWorkloadIdentityDetails struct {
 // AWSBedrockagentcoreGatewaySchema describes provider metadata for each attribute / nested
 // block of aws_bedrockagentcore_gateway.
 var AWSBedrockagentcoreGatewaySchema = map[string]FieldSchema{
-	"authorizer_type":           {Required: true, Replacement: ReplacementUnknown},
-	"description":               {Optional: true, Replacement: ReplacementUnknown},
-	"exception_level":           {Optional: true, Replacement: ReplacementUnknown},
-	"gateway_arn":               {Computed: true, Replacement: ReplacementUnknown},
-	"gateway_id":                {Computed: true, Replacement: ReplacementUnknown},
-	"gateway_url":               {Computed: true, Replacement: ReplacementUnknown},
-	"kms_key_arn":               {Optional: true, Replacement: ReplacementUnknown},
-	"name":                      {Required: true, Replacement: ReplacementUnknown},
-	"protocol_type":             {Required: true, Replacement: ReplacementUnknown},
-	"region":                    {Optional: true, Computed: true, Replacement: ReplacementUnknown},
-	"role_arn":                  {Required: true, Replacement: ReplacementUnknown},
-	"tags":                      {Optional: true, Replacement: ReplacementUnknown},
-	"tags_all":                  {Computed: true, Replacement: ReplacementUnknown},
-	"workload_identity_details": {Computed: true, Replacement: ReplacementUnknown},
-	"authorizer_configuration":  {Optional: true, Replacement: ReplacementUnknown},
-	"interceptor_configuration": {Optional: true, Replacement: ReplacementUnknown},
-	"protocol_configuration":    {Optional: true, Replacement: ReplacementUnknown},
-	"timeouts":                  {Optional: true, Replacement: ReplacementUnknown},
+	"authorizer_type":             {Required: true, Replacement: ReplacementUnknown},
+	"description":                 {Optional: true, Replacement: ReplacementUnknown},
+	"exception_level":             {Optional: true, Replacement: ReplacementUnknown},
+	"gateway_arn":                 {Computed: true, Replacement: ReplacementUnknown},
+	"gateway_id":                  {Computed: true, Replacement: ReplacementUnknown},
+	"gateway_url":                 {Computed: true, Replacement: ReplacementUnknown},
+	"kms_key_arn":                 {Optional: true, Replacement: ReplacementUnknown},
+	"name":                        {Required: true, Replacement: ReplacementUnknown},
+	"protocol_type":               {Optional: true, Computed: true, Replacement: ReplacementUnknown},
+	"region":                      {Optional: true, Computed: true, Replacement: ReplacementUnknown},
+	"role_arn":                    {Required: true, Replacement: ReplacementUnknown},
+	"tags":                        {Optional: true, Replacement: ReplacementUnknown},
+	"tags_all":                    {Computed: true, Replacement: ReplacementUnknown},
+	"workload_identity_details":   {Computed: true, Replacement: ReplacementUnknown},
+	"authorizer_configuration":    {Optional: true, Replacement: ReplacementUnknown},
+	"interceptor_configuration":   {Optional: true, Replacement: ReplacementUnknown},
+	"policy_engine_configuration": {Optional: true, Replacement: ReplacementUnknown},
+	"protocol_configuration":      {Optional: true, Replacement: ReplacementUnknown},
+	"timeouts":                    {Optional: true, Replacement: ReplacementUnknown},
 }
 
 func init() {

--- a/pkg/composer/imported/generated/aws_bedrockagentcore_gateway_target.gen.go
+++ b/pkg/composer/imported/generated/aws_bedrockagentcore_gateway_target.gen.go
@@ -14,15 +14,18 @@ type AWSBedrockagentcoreGatewayTarget struct {
 	TargetID                        *Value[string]                                                    `tf:"target_id" json:"target_id,omitempty"`
 	CredentialProviderConfiguration []AWSBedrockagentcoreGatewayTargetCredentialProviderConfiguration `tf:"credential_provider_configuration,blocks" json:"credential_provider_configuration,omitempty"`
 	MetadataConfiguration           []AWSBedrockagentcoreGatewayTargetMetadataConfiguration           `tf:"metadata_configuration,blocks" json:"metadata_configuration,omitempty"`
+	PrivateEndpoint                 []AWSBedrockagentcoreGatewayTargetPrivateEndpoint                 `tf:"private_endpoint,blocks" json:"private_endpoint,omitempty"`
 	TargetConfiguration             []AWSBedrockagentcoreGatewayTargetTargetConfiguration             `tf:"target_configuration,blocks" json:"target_configuration,omitempty"`
 	Timeouts                        *AWSBedrockagentcoreGatewayTargetTimeouts                         `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // AWSBedrockagentcoreGatewayTargetCredentialProviderConfiguration is a nested-block type used by the parent resource.
 type AWSBedrockagentcoreGatewayTargetCredentialProviderConfiguration struct {
-	APIKey         []AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationAPIKey         `tf:"api_key,blocks" json:"api_key,omitempty"`
-	GatewayIAMRole []AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationGatewayIAMRole `tf:"gateway_iam_role,blocks" json:"gateway_iam_role,omitempty"`
-	Oauth          []AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationOauth          `tf:"oauth,blocks" json:"oauth,omitempty"`
+	APIKey               []AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationAPIKey               `tf:"api_key,blocks" json:"api_key,omitempty"`
+	CallerIAMCredentials []AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationCallerIAMCredentials `tf:"caller_iam_credentials,blocks" json:"caller_iam_credentials,omitempty"`
+	GatewayIAMRole       []AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationGatewayIAMRole       `tf:"gateway_iam_role,blocks" json:"gateway_iam_role,omitempty"`
+	JWTPassthrough       []AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationJWTPassthrough       `tf:"jwt_passthrough,blocks" json:"jwt_passthrough,omitempty"`
+	Oauth                []AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationOauth                `tf:"oauth,blocks" json:"oauth,omitempty"`
 }
 
 // AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationAPIKey is a nested-block type used by the parent resource.
@@ -33,8 +36,20 @@ type AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationAPIKey struc
 	ProviderARN             *Value[string] `tf:"provider_arn" json:"provider_arn,omitempty"`
 }
 
+// AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationCallerIAMCredentials is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationCallerIAMCredentials struct {
+	Region  *Value[string] `tf:"region" json:"region,omitempty"`
+	Service *Value[string] `tf:"service" json:"service,omitempty"`
+}
+
 // AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationGatewayIAMRole is a nested-block type used by the parent resource.
 type AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationGatewayIAMRole struct {
+	Region  *Value[string] `tf:"region" json:"region,omitempty"`
+	Service *Value[string] `tf:"service" json:"service,omitempty"`
+}
+
+// AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationJWTPassthrough is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationJWTPassthrough struct {
 }
 
 // AWSBedrockagentcoreGatewayTargetCredentialProviderConfigurationOauth is a nested-block type used by the parent resource.
@@ -53,9 +68,42 @@ type AWSBedrockagentcoreGatewayTargetMetadataConfiguration struct {
 	AllowedResponseHeaders []*Value[string] `tf:"allowed_response_headers" json:"allowed_response_headers,omitempty"`
 }
 
+// AWSBedrockagentcoreGatewayTargetPrivateEndpoint is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayTargetPrivateEndpoint struct {
+	ManagedVPCResource         []AWSBedrockagentcoreGatewayTargetPrivateEndpointManagedVPCResource         `tf:"managed_vpc_resource,blocks" json:"managed_vpc_resource,omitempty"`
+	SelfManagedLatticeResource []AWSBedrockagentcoreGatewayTargetPrivateEndpointSelfManagedLatticeResource `tf:"self_managed_lattice_resource,blocks" json:"self_managed_lattice_resource,omitempty"`
+}
+
+// AWSBedrockagentcoreGatewayTargetPrivateEndpointManagedVPCResource is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayTargetPrivateEndpointManagedVPCResource struct {
+	EndpointIpAddressType *Value[string]            `tf:"endpoint_ip_address_type" json:"endpoint_ip_address_type,omitempty"`
+	RoutingDomain         *Value[string]            `tf:"routing_domain" json:"routing_domain,omitempty"`
+	SecurityGroupIDS      []*Value[string]          `tf:"security_group_ids" json:"security_group_ids,omitempty"`
+	SubnetIDS             []*Value[string]          `tf:"subnet_ids" json:"subnet_ids,omitempty"`
+	Tags                  map[string]*Value[string] `tf:"tags" json:"tags,omitempty"`
+	VPCIdentifier         *Value[string]            `tf:"vpc_identifier" json:"vpc_identifier,omitempty"`
+}
+
+// AWSBedrockagentcoreGatewayTargetPrivateEndpointSelfManagedLatticeResource is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayTargetPrivateEndpointSelfManagedLatticeResource struct {
+	ResourceConfigurationIdentifier *Value[string] `tf:"resource_configuration_identifier" json:"resource_configuration_identifier,omitempty"`
+}
+
 // AWSBedrockagentcoreGatewayTargetTargetConfiguration is a nested-block type used by the parent resource.
 type AWSBedrockagentcoreGatewayTargetTargetConfiguration struct {
-	Mcp []AWSBedrockagentcoreGatewayTargetTargetConfigurationMcp `tf:"mcp,blocks" json:"mcp,omitempty"`
+	HTTP []AWSBedrockagentcoreGatewayTargetTargetConfigurationHTTP `tf:"http,blocks" json:"http,omitempty"`
+	Mcp  []AWSBedrockagentcoreGatewayTargetTargetConfigurationMcp  `tf:"mcp,blocks" json:"mcp,omitempty"`
+}
+
+// AWSBedrockagentcoreGatewayTargetTargetConfigurationHTTP is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayTargetTargetConfigurationHTTP struct {
+	AgentcoreRuntime []AWSBedrockagentcoreGatewayTargetTargetConfigurationHTTPAgentcoreRuntime `tf:"agentcore_runtime,blocks" json:"agentcore_runtime,omitempty"`
+}
+
+// AWSBedrockagentcoreGatewayTargetTargetConfigurationHTTPAgentcoreRuntime is a nested-block type used by the parent resource.
+type AWSBedrockagentcoreGatewayTargetTargetConfigurationHTTPAgentcoreRuntime struct {
+	ARN       *Value[string] `tf:"arn" json:"arn,omitempty"`
+	Qualifier *Value[string] `tf:"qualifier" json:"qualifier,omitempty"`
 }
 
 // AWSBedrockagentcoreGatewayTargetTargetConfigurationMcp is a nested-block type used by the parent resource.
@@ -282,7 +330,8 @@ type AWSBedrockagentcoreGatewayTargetTargetConfigurationMcpLambdaToolSchemaS3 st
 
 // AWSBedrockagentcoreGatewayTargetTargetConfigurationMcpMcpServer is a nested-block type used by the parent resource.
 type AWSBedrockagentcoreGatewayTargetTargetConfigurationMcpMcpServer struct {
-	Endpoint *Value[string] `tf:"endpoint" json:"endpoint,omitempty"`
+	Endpoint    *Value[string] `tf:"endpoint" json:"endpoint,omitempty"`
+	ListingMode *Value[string] `tf:"listing_mode" json:"listing_mode,omitempty"`
 }
 
 // AWSBedrockagentcoreGatewayTargetTargetConfigurationMcpOpenAPISchema is a nested-block type used by the parent resource.
@@ -336,6 +385,7 @@ var AWSBedrockagentcoreGatewayTargetSchema = map[string]FieldSchema{
 	"target_id":                         {Computed: true, Replacement: ReplacementUnknown},
 	"credential_provider_configuration": {Optional: true, Replacement: ReplacementUnknown},
 	"metadata_configuration":            {Optional: true, Replacement: ReplacementUnknown},
+	"private_endpoint":                  {Optional: true, Replacement: ReplacementUnknown},
 	"target_configuration":              {Optional: true, Replacement: ReplacementUnknown},
 	"timeouts":                          {Optional: true, Replacement: ReplacementUnknown},
 }

--- a/pkg/composer/imported/generated/aws_cloudfront_distribution.gen.go
+++ b/pkg/composer/imported/generated/aws_cloudfront_distribution.gen.go
@@ -34,6 +34,7 @@ type AWSCloudfrontDistribution struct {
 	TrustedSigners                []AWSCloudfrontDistributionTrustedSigners                `tf:"trusted_signers" json:"trusted_signers,omitempty"`
 	WaitForDeployment             *Value[bool]                                             `tf:"wait_for_deployment" json:"wait_for_deployment,omitempty"`
 	WebACLID                      *Value[string]                                           `tf:"web_acl_id" json:"web_acl_id,omitempty"`
+	CacheTagConfig                []AWSCloudfrontDistributionCacheTagConfig                `tf:"cache_tag_config,blocks" json:"cache_tag_config,omitempty"`
 	ConnectionFunctionAssociation []AWSCloudfrontDistributionConnectionFunctionAssociation `tf:"connection_function_association,blocks" json:"connection_function_association,omitempty"`
 	CustomErrorResponse           []AWSCloudfrontDistributionCustomErrorResponse           `tf:"custom_error_response,blocks" json:"custom_error_response,omitempty"`
 	DefaultCacheBehavior          []AWSCloudfrontDistributionDefaultCacheBehavior          `tf:"default_cache_behavior,blocks" json:"default_cache_behavior,omitempty"`
@@ -44,6 +45,11 @@ type AWSCloudfrontDistribution struct {
 	Restrictions                  []AWSCloudfrontDistributionRestrictions                  `tf:"restrictions,blocks" json:"restrictions,omitempty"`
 	ViewerCertificate             []AWSCloudfrontDistributionViewerCertificate             `tf:"viewer_certificate,blocks" json:"viewer_certificate,omitempty"`
 	ViewerMtlsConfig              []AWSCloudfrontDistributionViewerMtlsConfig              `tf:"viewer_mtls_config,blocks" json:"viewer_mtls_config,omitempty"`
+}
+
+// AWSCloudfrontDistributionCacheTagConfig is a nested-block type used by the parent resource.
+type AWSCloudfrontDistributionCacheTagConfig struct {
+	HeaderName *Value[string] `tf:"header_name" json:"header_name,omitempty"`
 }
 
 // AWSCloudfrontDistributionConnectionFunctionAssociation is a nested-block type used by the parent resource.
@@ -203,13 +209,19 @@ type AWSCloudfrontDistributionOriginCustomHeader struct {
 
 // AWSCloudfrontDistributionOriginCustomOriginConfig is a nested-block type used by the parent resource.
 type AWSCloudfrontDistributionOriginCustomOriginConfig struct {
-	HTTPPort               *Value[float64]  `tf:"http_port" json:"http_port,omitempty"`
-	HTTPSPort              *Value[float64]  `tf:"https_port" json:"https_port,omitempty"`
-	IpAddressType          *Value[string]   `tf:"ip_address_type" json:"ip_address_type,omitempty"`
-	OriginKeepaliveTimeout *Value[int64]    `tf:"origin_keepalive_timeout" json:"origin_keepalive_timeout,omitempty"`
-	OriginProtocolPolicy   *Value[string]   `tf:"origin_protocol_policy" json:"origin_protocol_policy,omitempty"`
-	OriginReadTimeout      *Value[int64]    `tf:"origin_read_timeout" json:"origin_read_timeout,omitempty"`
-	OriginSSLProtocols     []*Value[string] `tf:"origin_ssl_protocols" json:"origin_ssl_protocols,omitempty"`
+	HTTPPort               *Value[float64]                                                     `tf:"http_port" json:"http_port,omitempty"`
+	HTTPSPort              *Value[float64]                                                     `tf:"https_port" json:"https_port,omitempty"`
+	IpAddressType          *Value[string]                                                      `tf:"ip_address_type" json:"ip_address_type,omitempty"`
+	OriginKeepaliveTimeout *Value[int64]                                                       `tf:"origin_keepalive_timeout" json:"origin_keepalive_timeout,omitempty"`
+	OriginProtocolPolicy   *Value[string]                                                      `tf:"origin_protocol_policy" json:"origin_protocol_policy,omitempty"`
+	OriginReadTimeout      *Value[int64]                                                       `tf:"origin_read_timeout" json:"origin_read_timeout,omitempty"`
+	OriginSSLProtocols     []*Value[string]                                                    `tf:"origin_ssl_protocols" json:"origin_ssl_protocols,omitempty"`
+	OriginMtlsConfig       []AWSCloudfrontDistributionOriginCustomOriginConfigOriginMtlsConfig `tf:"origin_mtls_config,blocks" json:"origin_mtls_config,omitempty"`
+}
+
+// AWSCloudfrontDistributionOriginCustomOriginConfigOriginMtlsConfig is a nested-block type used by the parent resource.
+type AWSCloudfrontDistributionOriginCustomOriginConfigOriginMtlsConfig struct {
+	ClientCertificateARN *Value[string] `tf:"client_certificate_arn" json:"client_certificate_arn,omitempty"`
 }
 
 // AWSCloudfrontDistributionOriginGroup is a nested-block type used by the parent resource.
@@ -335,6 +347,7 @@ var AWSCloudfrontDistributionSchema = map[string]FieldSchema{
 	"trusted_signers":                 {Computed: true, Replacement: ReplacementUnknown},
 	"wait_for_deployment":             {Optional: true, Replacement: ReplacementUnknown},
 	"web_acl_id":                      {Optional: true, Replacement: ReplacementUnknown},
+	"cache_tag_config":                {Optional: true, Replacement: ReplacementUnknown},
 	"connection_function_association": {Optional: true, Replacement: ReplacementUnknown},
 	"custom_error_response":           {Optional: true, Replacement: ReplacementUnknown},
 	"default_cache_behavior":          {Required: true, Replacement: ReplacementUnknown},

--- a/pkg/composer/imported/generated/aws_cloudfront_function.gen.go
+++ b/pkg/composer/imported/generated/aws_cloudfront_function.gen.go
@@ -7,17 +7,19 @@ import "reflect"
 // AWSCloudfrontFunction is the generated Layer 1 typed model for the
 // `aws_cloudfront_function` Terraform resource.
 type AWSCloudfrontFunction struct {
-	ARN                       *Value[string]   `tf:"arn" json:"arn,omitempty"`
-	Code                      *Value[string]   `tf:"code" json:"code,omitempty"`
-	Comment                   *Value[string]   `tf:"comment" json:"comment,omitempty"`
-	Etag                      *Value[string]   `tf:"etag" json:"etag,omitempty"`
-	ID                        *Value[string]   `tf:"id" json:"id,omitempty"`
-	KeyValueStoreAssociations []*Value[string] `tf:"key_value_store_associations" json:"key_value_store_associations,omitempty"`
-	LiveStageEtag             *Value[string]   `tf:"live_stage_etag" json:"live_stage_etag,omitempty"`
-	Name                      *Value[string]   `tf:"name" json:"name,omitempty"`
-	Publish                   *Value[bool]     `tf:"publish" json:"publish,omitempty"`
-	Runtime                   *Value[string]   `tf:"runtime" json:"runtime,omitempty"`
-	Status                    *Value[string]   `tf:"status" json:"status,omitempty"`
+	ARN                       *Value[string]            `tf:"arn" json:"arn,omitempty"`
+	Code                      *Value[string]            `tf:"code" json:"code,omitempty"`
+	Comment                   *Value[string]            `tf:"comment" json:"comment,omitempty"`
+	Etag                      *Value[string]            `tf:"etag" json:"etag,omitempty"`
+	ID                        *Value[string]            `tf:"id" json:"id,omitempty"`
+	KeyValueStoreAssociations []*Value[string]          `tf:"key_value_store_associations" json:"key_value_store_associations,omitempty"`
+	LiveStageEtag             *Value[string]            `tf:"live_stage_etag" json:"live_stage_etag,omitempty"`
+	Name                      *Value[string]            `tf:"name" json:"name,omitempty"`
+	Publish                   *Value[bool]              `tf:"publish" json:"publish,omitempty"`
+	Runtime                   *Value[string]            `tf:"runtime" json:"runtime,omitempty"`
+	Status                    *Value[string]            `tf:"status" json:"status,omitempty"`
+	Tags                      map[string]*Value[string] `tf:"tags" json:"tags,omitempty"`
+	TagsAll                   map[string]*Value[string] `tf:"tags_all" json:"tags_all,omitempty"`
 }
 
 // AWSCloudfrontFunctionSchema describes provider metadata for each attribute / nested
@@ -34,6 +36,8 @@ var AWSCloudfrontFunctionSchema = map[string]FieldSchema{
 	"publish":                      {Optional: true, Replacement: ReplacementUnknown},
 	"runtime":                      {Required: true, Replacement: ReplacementUnknown},
 	"status":                       {Computed: true, Replacement: ReplacementUnknown},
+	"tags":                         {Optional: true, Replacement: ReplacementUnknown},
+	"tags_all":                     {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 }
 
 func init() {

--- a/pkg/composer/imported/generated/aws_eks_cluster.gen.go
+++ b/pkg/composer/imported/generated/aws_eks_cluster.gen.go
@@ -100,13 +100,21 @@ type AWSEKSClusterKubernetesNetworkConfigElasticLoadBalancing struct {
 // AWSEKSClusterOutpostConfig is a nested-block type used by the parent resource.
 type AWSEKSClusterOutpostConfig struct {
 	ControlPlaneInstanceType *Value[string]                                    `tf:"control_plane_instance_type" json:"control_plane_instance_type,omitempty"`
+	EtcdInstanceType         *Value[string]                                    `tf:"etcd_instance_type" json:"etcd_instance_type,omitempty"`
 	OutpostArns              []*Value[string]                                  `tf:"outpost_arns" json:"outpost_arns,omitempty"`
 	ControlPlanePlacement    []AWSEKSClusterOutpostConfigControlPlanePlacement `tf:"control_plane_placement,blocks" json:"control_plane_placement,omitempty"`
+	EtcdPlacement            []AWSEKSClusterOutpostConfigEtcdPlacement         `tf:"etcd_placement,blocks" json:"etcd_placement,omitempty"`
 }
 
 // AWSEKSClusterOutpostConfigControlPlanePlacement is a nested-block type used by the parent resource.
 type AWSEKSClusterOutpostConfigControlPlanePlacement struct {
-	GroupName *Value[string] `tf:"group_name" json:"group_name,omitempty"`
+	GroupName   *Value[string] `tf:"group_name" json:"group_name,omitempty"`
+	SpreadLevel *Value[string] `tf:"spread_level" json:"spread_level,omitempty"`
+}
+
+// AWSEKSClusterOutpostConfigEtcdPlacement is a nested-block type used by the parent resource.
+type AWSEKSClusterOutpostConfigEtcdPlacement struct {
+	SpreadLevel *Value[string] `tf:"spread_level" json:"spread_level,omitempty"`
 }
 
 // AWSEKSClusterRemoteNetworkConfig is a nested-block type used by the parent resource.
@@ -150,6 +158,7 @@ type AWSEKSClusterUpgradePolicy struct {
 // AWSEKSClusterVPCConfig is a nested-block type used by the parent resource.
 type AWSEKSClusterVPCConfig struct {
 	ClusterSecurityGroupID *Value[string]   `tf:"cluster_security_group_id" json:"cluster_security_group_id,omitempty"`
+	ControlPlaneEgressMode *Value[string]   `tf:"control_plane_egress_mode" json:"control_plane_egress_mode,omitempty"`
 	EndpointPrivateAccess  *Value[bool]     `tf:"endpoint_private_access" json:"endpoint_private_access,omitempty"`
 	EndpointPublicAccess   *Value[bool]     `tf:"endpoint_public_access" json:"endpoint_public_access,omitempty"`
 	PublicAccessCidrs      []*Value[string] `tf:"public_access_cidrs" json:"public_access_cidrs,omitempty"`

--- a/pkg/composer/imported/generated/aws_elasticache_replication_group.gen.go
+++ b/pkg/composer/imported/generated/aws_elasticache_replication_group.gen.go
@@ -19,6 +19,7 @@ type AWSElasticacheReplicationGroup struct {
 	ConfigurationEndpointAddress *Value[string]                                           `tf:"configuration_endpoint_address" json:"configuration_endpoint_address,omitempty"`
 	DataTieringEnabled           *Value[bool]                                             `tf:"data_tiering_enabled" json:"data_tiering_enabled,omitempty"`
 	Description                  *Value[string]                                           `tf:"description" json:"description,omitempty"`
+	Durability                   *Value[string]                                           `tf:"durability" json:"durability,omitempty"`
 	Engine                       *Value[string]                                           `tf:"engine" json:"engine,omitempty"`
 	EngineVersion                *Value[string]                                           `tf:"engine_version" json:"engine_version,omitempty"`
 	EngineVersionActual          *Value[string]                                           `tf:"engine_version_actual" json:"engine_version_actual,omitempty"`
@@ -101,6 +102,7 @@ var AWSElasticacheReplicationGroupSchema = map[string]FieldSchema{
 	"configuration_endpoint_address": {Computed: true, Replacement: ReplacementUnknown},
 	"data_tiering_enabled":           {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 	"description":                    {Required: true, Replacement: ReplacementUnknown},
+	"durability":                     {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 	"engine":                         {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 	"engine_version":                 {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 	"engine_version_actual":          {Computed: true, Replacement: ReplacementUnknown},

--- a/pkg/composer/imported/generated/aws_kinesis_stream.gen.go
+++ b/pkg/composer/imported/generated/aws_kinesis_stream.gen.go
@@ -20,6 +20,7 @@ type AWSKinesisStream struct {
 	ShardLevelMetrics       []*Value[string]                    `tf:"shard_level_metrics" json:"shard_level_metrics,omitempty"`
 	Tags                    map[string]*Value[string]           `tf:"tags" json:"tags,omitempty"`
 	TagsAll                 map[string]*Value[string]           `tf:"tags_all" json:"tags_all,omitempty"`
+	WarmThroughputMibPs     *Value[float64]                     `tf:"warm_throughput_mib_ps" json:"warm_throughput_mib_ps,omitempty"`
 	StreamModeDetails       []AWSKinesisStreamStreamModeDetails `tf:"stream_mode_details,blocks" json:"stream_mode_details,omitempty"`
 	Timeouts                *AWSKinesisStreamTimeouts           `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
@@ -52,6 +53,7 @@ var AWSKinesisStreamSchema = map[string]FieldSchema{
 	"shard_level_metrics":       {Optional: true, Replacement: ReplacementUnknown},
 	"tags":                      {Optional: true, Replacement: ReplacementUnknown},
 	"tags_all":                  {Optional: true, Computed: true, Replacement: ReplacementUnknown},
+	"warm_throughput_mib_ps":    {Optional: true, Replacement: ReplacementUnknown},
 	"stream_mode_details":       {Optional: true, Replacement: ReplacementUnknown},
 	"timeouts":                  {Optional: true, Replacement: ReplacementUnknown},
 }

--- a/pkg/composer/imported/generated/aws_lambda_alias.gen.go
+++ b/pkg/composer/imported/generated/aws_lambda_alias.gen.go
@@ -16,11 +16,17 @@ type AWSLambdaAlias struct {
 	Name            *Value[string]                `tf:"name" json:"name,omitempty"`
 	Region          *Value[string]                `tf:"region" json:"region,omitempty"`
 	RoutingConfig   []AWSLambdaAliasRoutingConfig `tf:"routing_config,blocks" json:"routing_config,omitempty"`
+	Timeouts        *AWSLambdaAliasTimeouts       `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
 // AWSLambdaAliasRoutingConfig is a nested-block type used by the parent resource.
 type AWSLambdaAliasRoutingConfig struct {
 	AdditionalVersionWeights map[string]*Value[float64] `tf:"additional_version_weights" json:"additional_version_weights,omitempty"`
+}
+
+// AWSLambdaAliasTimeouts is a nested-block type used by the parent resource.
+type AWSLambdaAliasTimeouts struct {
+	Update *Value[string] `tf:"update" json:"update,omitempty"`
 }
 
 // AWSLambdaAliasSchema describes provider metadata for each attribute / nested
@@ -35,6 +41,7 @@ var AWSLambdaAliasSchema = map[string]FieldSchema{
 	"name":             {Required: true, Replacement: ReplacementUnknown},
 	"region":           {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 	"routing_config":   {Optional: true, Replacement: ReplacementUnknown},
+	"timeouts":         {Optional: true, Replacement: ReplacementUnknown},
 }
 
 func init() {

--- a/pkg/composer/imported/generated/aws_lb.gen.go
+++ b/pkg/composer/imported/generated/aws_lb.gen.go
@@ -18,6 +18,7 @@ type AWSLb struct {
 	EnableCrossZoneLoadBalancing                         *Value[bool]                       `tf:"enable_cross_zone_load_balancing" json:"enable_cross_zone_load_balancing,omitempty"`
 	EnableDeletionProtection                             *Value[bool]                       `tf:"enable_deletion_protection" json:"enable_deletion_protection,omitempty"`
 	EnableHttp2                                          *Value[bool]                       `tf:"enable_http2" json:"enable_http2,omitempty"`
+	EnablePrefixForIPV6SourceNat                         *Value[string]                     `tf:"enable_prefix_for_ipv6_source_nat" json:"enable_prefix_for_ipv6_source_nat,omitempty"`
 	EnableTLSVersionAndCipherSuiteHeaders                *Value[bool]                       `tf:"enable_tls_version_and_cipher_suite_headers" json:"enable_tls_version_and_cipher_suite_headers,omitempty"`
 	EnableWAFFailOpen                                    *Value[bool]                       `tf:"enable_waf_fail_open" json:"enable_waf_fail_open,omitempty"`
 	EnableXffClientPort                                  *Value[bool]                       `tf:"enable_xff_client_port" json:"enable_xff_client_port,omitempty"`
@@ -110,6 +111,7 @@ var AWSLbSchema = map[string]FieldSchema{
 	"enable_cross_zone_load_balancing":            {Optional: true, Replacement: ReplacementUnknown},
 	"enable_deletion_protection":                  {Optional: true, Replacement: ReplacementUnknown},
 	"enable_http2":                                {Optional: true, Replacement: ReplacementUnknown},
+	"enable_prefix_for_ipv6_source_nat":           {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 	"enable_tls_version_and_cipher_suite_headers": {Optional: true, Replacement: ReplacementUnknown},
 	"enable_waf_fail_open":                        {Optional: true, Replacement: ReplacementUnknown},
 	"enable_xff_client_port":                      {Optional: true, Replacement: ReplacementUnknown},

--- a/pkg/composer/imported/generated/aws_opensearch_domain.gen.go
+++ b/pkg/composer/imported/generated/aws_opensearch_domain.gen.go
@@ -54,6 +54,7 @@ type AWSOpensearchDomainAdvancedSecurityOptions struct {
 // AWSOpensearchDomainAdvancedSecurityOptionsJWTOptions is a nested-block type used by the parent resource.
 type AWSOpensearchDomainAdvancedSecurityOptionsJWTOptions struct {
 	Enabled    *Value[bool]   `tf:"enabled" json:"enabled,omitempty"`
+	JwksURL    *Value[string] `tf:"jwks_url" json:"jwks_url,omitempty"`
 	PublicKey  *Value[string] `tf:"public_key" json:"public_key,omitempty"`
 	RolesKey   *Value[string] `tf:"roles_key" json:"roles_key,omitempty"`
 	SubjectKey *Value[string] `tf:"subject_key" json:"subject_key,omitempty"`

--- a/pkg/composer/imported/generated/aws_opensearchserverless_collection.gen.go
+++ b/pkg/composer/imported/generated/aws_opensearchserverless_collection.gen.go
@@ -21,6 +21,7 @@ type AWSOpensearchserverlessCollection struct {
 	Tags                map[string]*Value[string]                           `tf:"tags" json:"tags,omitempty"`
 	TagsAll             map[string]*Value[string]                           `tf:"tags_all" json:"tags_all,omitempty"`
 	Type_               *Value[string]                                      `tf:"type" json:"type,omitempty"`
+	VectorOptions       []AWSOpensearchserverlessCollectionVectorOptions    `tf:"vector_options" json:"vector_options,omitempty"`
 	Timeouts            *AWSOpensearchserverlessCollectionTimeouts          `tf:"timeouts,block" json:"timeouts,omitempty"`
 }
 
@@ -34,6 +35,11 @@ type AWSOpensearchserverlessCollectionEncryptionConfig struct {
 type AWSOpensearchserverlessCollectionTimeouts struct {
 	Create *Value[string] `tf:"create" json:"create,omitempty"`
 	Delete *Value[string] `tf:"delete" json:"delete,omitempty"`
+}
+
+// AWSOpensearchserverlessCollectionVectorOptions is a nested-block type used by the parent resource.
+type AWSOpensearchserverlessCollectionVectorOptions struct {
+	ServerlessVectorAcceleration *Value[string] `tf:"serverless_vector_acceleration" json:"serverless_vector_acceleration,omitempty"`
 }
 
 // AWSOpensearchserverlessCollectionSchema describes provider metadata for each attribute / nested
@@ -53,6 +59,7 @@ var AWSOpensearchserverlessCollectionSchema = map[string]FieldSchema{
 	"tags":                  {Optional: true, Replacement: ReplacementUnknown},
 	"tags_all":              {Computed: true, Replacement: ReplacementUnknown},
 	"type":                  {Optional: true, Computed: true, Replacement: ReplacementUnknown},
+	"vector_options":        {Optional: true, Computed: true, Replacement: ReplacementUnknown},
 	"timeouts":              {Optional: true, Replacement: ReplacementUnknown},
 }
 

--- a/pkg/composer/imported/generated/aws_route_table.gen.go
+++ b/pkg/composer/imported/generated/aws_route_table.gen.go
@@ -31,6 +31,7 @@ type AWSRouteTableRoute struct {
 	LocalGatewayID          *Value[string] `tf:"local_gateway_id" json:"local_gateway_id,omitempty"`
 	NatGatewayID            *Value[string] `tf:"nat_gateway_id" json:"nat_gateway_id,omitempty"`
 	NetworkInterfaceID      *Value[string] `tf:"network_interface_id" json:"network_interface_id,omitempty"`
+	OdbNetworkARN           *Value[string] `tf:"odb_network_arn" json:"odb_network_arn,omitempty"`
 	TransitGatewayID        *Value[string] `tf:"transit_gateway_id" json:"transit_gateway_id,omitempty"`
 	VPCEndpointID           *Value[string] `tf:"vpc_endpoint_id" json:"vpc_endpoint_id,omitempty"`
 	VPCPeeringConnectionID  *Value[string] `tf:"vpc_peering_connection_id" json:"vpc_peering_connection_id,omitempty"`

--- a/pkg/composer/imported/generated/version.gen.go
+++ b/pkg/composer/imported/generated/version.gen.go
@@ -8,7 +8,7 @@ package generated
 // schema drift.
 const (
 	AWSProviderSource         = "registry.terraform.io/hashicorp/aws"
-	AWSProviderVersion        = "6.45.0"
+	AWSProviderVersion        = "6.52.0"
 	GoogleProviderSource      = "registry.terraform.io/hashicorp/google"
 	GoogleProviderVersion     = "6.10.0"
 	GoogleBetaProviderSource  = "registry.terraform.io/hashicorp/google-beta"

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -88,6 +88,19 @@ const (
 	// managed by InsideOut. The marker key is the signal; a project/account tag
 	// alone is not enough.
 	ReasonInsideOutImported = "insideout_imported"
+
+	// ReasonServiceLinkedIAMRole marks an aws_iam_role whose ARN carries the
+	// reserved `role/aws-service-role/` path segment — an AWS service-linked
+	// role (AWSServiceRoleFor…). Service-linked roles are created and deleted
+	// by the owning AWS service, not the customer; the IAM API rejects an
+	// out-of-band create/delete, so they cannot be adopted into customer
+	// Terraform state. The bulk list discoverer already excludes them
+	// (listIAMRoleNamesNonSLR), but the dep-chase DiscoverByID path can still
+	// reach one via a cross-resource ARN reference (e.g. a role= literal
+	// pointing at a service-linked role); this reason lets that path leave the
+	// literal knowingly instead of dropping it as an opaque no_generated_config
+	// orphan (presets#834).
+	ReasonServiceLinkedIAMRole = "service_linked_iam_role"
 )
 
 // awsManagedKMSAliasPrefix is the reserved alias prefix the AWS provider
@@ -105,6 +118,13 @@ const (
 // manages on the customer's behalf (vs "CUSTOMER" for customer-managed
 // keys). An AWS-managed key cannot be imported into Terraform state.
 const awsManagedKMSKeyManager = "AWS"
+
+// serviceLinkedIAMRoleARNSegment is the reserved ARN path segment AWS stamps
+// on every service-linked role (the role's Path is "/aws-service-role/…",
+// which renders as "role/aws-service-role/…" in the role ARN). A role whose
+// ARN carries it is created and owned by an AWS service and cannot be adopted
+// into customer Terraform state.
+const serviceLinkedIAMRoleARNSegment = ":role/aws-service-role/"
 
 // importableENIInterfaceTypes is the set of interface_type values an
 // aws_network_interface can legitimately carry for a customer-managed,
@@ -138,6 +158,16 @@ func IsAWSManagedKMSAliasName(name string) bool {
 // backstop.
 func IsAWSManagedKMSKeyManager(keyManager string) bool {
 	return keyManager == awsManagedKMSKeyManager
+}
+
+// IsServiceLinkedIAMRoleARN reports whether an aws_iam_role ARN denotes an AWS
+// service-linked role (reserved `role/aws-service-role/` path segment), which
+// the customer cannot import or manage. The empty string (ARN not surfaced by
+// the discoverer) is treated as importable so an absent discriminator never
+// drops a customer-managed role — the genconfig prune (#708) remains the
+// backstop, matching the KMS-key / ENI posture.
+func IsServiceLinkedIAMRoleARN(arn string) bool {
+	return strings.Contains(arn, serviceLinkedIAMRoleARNSegment)
 }
 
 // IsServiceManaged reports whether an identity carries a service-managed
@@ -205,6 +235,10 @@ func UnimportableReason(ir ImportedResource) string {
 	}
 
 	switch ir.Identity.Type {
+	case "aws_iam_role":
+		if IsServiceLinkedIAMRoleARN(iamRoleARN(ir.Identity)) {
+			return ReasonServiceLinkedIAMRole
+		}
 	case "aws_kms_alias":
 		if IsAWSManagedKMSAliasName(kmsAliasName(ir.Identity)) {
 			return ReasonAWSManagedKMSAlias
@@ -243,9 +277,18 @@ func ReasonDescription(reason string) string {
 		return "Ephemeral CloudWatch log stream (auto-created and rotated by its log group) — not declarative infrastructure; manage the log group instead."
 	case ReasonInsideOutImported:
 		return "Already managed by InsideOut — cannot be selected for a new import."
+	case ReasonServiceLinkedIAMRole:
+		return "AWS service-linked IAM role (role/aws-service-role/* path) — created and deleted by the owning AWS service; cannot be imported into Terraform."
 	default:
 		return ""
 	}
+}
+
+// iamRoleARN resolves an IAM role's ARN from NativeIDs["arn"] (populated by the
+// iam_role discoverer's arnUnderKey("Arn") extractor). Empty when the
+// discoverer did not surface it — treated as importable upstream.
+func iamRoleARN(id ResourceIdentity) string {
+	return id.NativeIDs["arn"]
 }
 
 // kmsAliasName resolves the alias name from the identity surface the KMS-alias

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -21,6 +21,7 @@ func TestReasonCodes_WireStable(t *testing.T) {
 	assert.Equal(t, "service_managed", ReasonServiceManaged)
 	assert.Equal(t, "ephemeral_log_stream", ReasonEphemeralLogStream)
 	assert.Equal(t, "insideout_imported", ReasonInsideOutImported)
+	assert.Equal(t, "service_linked_iam_role", ReasonServiceLinkedIAMRole)
 }
 
 func TestIsAWSManagedKMSAliasName(t *testing.T) {
@@ -73,6 +74,41 @@ func TestUnimportableReason_KMSKey(t *testing.T) {
 			Type:      "aws_kms_key",
 			NativeIDs: map[string]string{"arn": "arn:aws:kms:us-east-1:111111111111:key/1234abcd"},
 		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
+}
+
+func TestUnimportableReason_ServiceLinkedIAMRole(t *testing.T) {
+	t.Parallel()
+	t.Run("service-linked role (role/aws-service-role/ ARN) is un-importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type: "aws_iam_role",
+			NativeIDs: map[string]string{
+				"arn": "arn:aws:iam::123456789012:role/aws-service-role/elasticbeanstalk.amazonaws.com/AWSServiceRoleForElasticBeanstalk",
+			},
+		}}
+		assert.Equal(t, ReasonServiceLinkedIAMRole, UnimportableReason(ir))
+	})
+	t.Run("customer role is importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type: "aws_iam_role",
+			NativeIDs: map[string]string{
+				"arn": "arn:aws:iam::123456789012:role/io-foo-handler-role",
+			},
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
+	t.Run("customer role under a /service-role/ path (not aws-service-role) is importable", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{
+			Type: "aws_iam_role",
+			NativeIDs: map[string]string{
+				"arn": "arn:aws:iam::123456789012:role/service-role/my-app-role",
+			},
+		}}
+		assert.Equal(t, "", UnimportableReason(ir))
+	})
+	t.Run("absent arn is importable (discriminator not surfaced; genconfig backstop covers it)", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{Type: "aws_iam_role"}}
 		assert.Equal(t, "", UnimportableReason(ir))
 	})
 }
@@ -297,6 +333,9 @@ func TestReasonDescription(t *testing.T) {
 	assert.Truef(t, strings.Contains(insideOut, "InsideOut"), "InsideOut-imported description must mention InsideOut, got %q", insideOut)
 	svcManaged := ReasonDescription(ReasonServiceManaged)
 	assert.Truef(t, strings.Contains(svcManaged, "Service-managed"), "service-managed description must mention Service-managed, got %q", svcManaged)
+	slrRole := ReasonDescription(ReasonServiceLinkedIAMRole)
+	assert.Truef(t, strings.Contains(slrRole, "service-linked"), "service-linked-role description must mention service-linked, got %q", slrRole)
+	assert.NotEqual(t, slrRole, svcManaged, "the service-linked-role and generic service-managed descriptions must be distinct")
 	assert.NotEqual(t, eni, svcManaged, "the ENI and generic service-managed descriptions must be distinct")
 	assert.NotEqual(t, kms, eni, "the two descriptions must be distinct (guards against swapped case bodies)")
 	assert.NotEqual(t, kms, kmsKey, "the KMS-alias and KMS-key descriptions must be distinct")

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -166,8 +166,15 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			}, resources)
 			return chaseErr
 		}); err != nil {
+			// Surface depchase warnings even on a chase error (e.g.
+			// ErrCyclicDependency): the loop records precise per-literal
+			// warnings BEFORE returning the error, and they are the operator's
+			// only breadcrumb to the unconverged references. Mirror how
+			// discover.go surfaces its warnings before a fatal exit (F5).
+			foldDepChaseWarnings(&result, dcRes)
 			return result, fmt.Errorf("depchase: %w", err)
 		}
+		foldDepChaseWarnings(&result, dcRes)
 		if dcRes != nil {
 			resources = dedupeByAddress(dcRes.Resources)
 			appendDepChaseDependencies(dependenciesByAddress, resources, dcRes.Edges)
@@ -286,15 +293,9 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 			return result, err
 		}
 	}
-	if dcRes != nil {
-		for _, warning := range dcRes.Warnings {
-			result.Diagnostics = append(result.Diagnostics, job.Diagnostic{
-				Severity: "warning",
-				Code:     "depchase_warning",
-				Message:  warning,
-			})
-		}
-	}
+	// depchase warnings are folded into result.Diagnostics right after the
+	// chase phase (success AND error paths, F5) — not here — so they survive a
+	// chase abort. See foldDepChaseWarnings.
 
 	if fpErr != nil {
 		// Un-attributable / non-convergent failure: abort as before. Persist
@@ -636,6 +637,24 @@ func appendDepChaseDependencies(dependenciesByAddress map[string][]imported.Reso
 			continue
 		}
 		dependenciesByAddress[edge.From] = append(dependenciesByAddress[edge.From], to)
+	}
+}
+
+// foldDepChaseWarnings appends every depchase warning to result.Diagnostics as
+// a "depchase_warning". It is called exactly once per run — on the chase
+// success path and on the chase error path (which are mutually exclusive), so
+// warnings survive an ErrCyclicDependency / ErrMaxIterations abort instead of
+// being dropped before the fold (F5). Nil-safe: a nil dcRes is a no-op.
+func foldDepChaseWarnings(result *job.Result, dcRes *depchase.Result) {
+	if dcRes == nil {
+		return
+	}
+	for _, warning := range dcRes.Warnings {
+		result.Diagnostics = append(result.Diagnostics, job.Diagnostic{
+			Severity: "warning",
+			Code:     "depchase_warning",
+			Message:  warning,
+		})
 	}
 }
 

--- a/pkg/reverseimport/run_test.go
+++ b/pkg/reverseimport/run_test.go
@@ -723,6 +723,68 @@ func fakeDepChase(_ context.Context, _ depchase.Options, resources []imported.Im
 	return &depchase.Result{Resources: resources}, nil
 }
 
+// stubByIDDiscoverer satisfies the Discoverer surface so the depchase phase is
+// entered (opts.Discoverer != nil). The fake runDepChase never calls it.
+type stubByIDDiscoverer struct{}
+
+func (stubByIDDiscoverer) DiscoverByID(context.Context, string, string, string, string) (imported.ImportedResource, error) {
+	return imported.ImportedResource{}, nil
+}
+
+// TestRunFoldsDepChaseWarningsOnChaseError pins F5: when the chase phase returns
+// an error (e.g. ErrCyclicDependency), the depchase warnings recorded on the
+// (still-populated) Result must be folded into result.Diagnostics BEFORE the
+// error return — they are the operator's only breadcrumb to the unconverged
+// references and were previously dropped on the error path.
+func TestRunFoldsDepChaseWarningsOnChaseError(t *testing.T) {
+	dir := t.TempDir()
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	const warning = "nested_ref_literal: reference literal inside nested attribute environment.variables.KEY of aws_lambda_function.h; target arn:aws:iam::123:role/x — nested literal retained"
+	chaseErrDepChase := func(_ context.Context, _ depchase.Options, resources []imported.ImportedResource) (*depchase.Result, error) {
+		return &depchase.Result{Resources: resources, Warnings: []string{warning}}, depchase.ErrCyclicDependency
+	}
+
+	result, err := Run(context.Background(), req, Options{
+		OutputDir:  dir,
+		Discoverer: stubByIDDiscoverer{},
+		deps: deps{
+			runGenconfig: fakeGenconfig,
+			runDriftfix:  fakeDriftfix,
+			runDepChase:  chaseErrDepChase,
+			tf:           fakeTerraformRunner{},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected a depchase error to propagate")
+	}
+	if !errors.Is(err, depchase.ErrCyclicDependency) {
+		t.Fatalf("err=%v, want ErrCyclicDependency", err)
+	}
+	found := false
+	for _, d := range result.Diagnostics {
+		if d.Code == "depchase_warning" && d.Message == warning {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("depchase warning not folded into diagnostics on the error path; got %#v", result.Diagnostics)
+	}
+}
+
 type fakeTerraformRunner struct {
 	importCount int
 }

--- a/schemas/providers.tf
+++ b/schemas/providers.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 6.45.0"
+      version = "= 6.52.0"
     }
     google = {
       source  = "hashicorp/google"


### PR DESCRIPTION
Closes #845. Closes #834. Stacked on #842 (auto-retargets to `main` when it merges).

Two commits, done in order so the depchase evaluation ran against fresh models.

## Commit 1 — #845 regen (6.45.0 → 6.52.0)

- Regenerated `pkg/composer/imported/generated/*.gen.go` + `schemas/aws.filtered.json` + pin bump via `cmd/imported-codegen filter`/`gen` against a real `terraform providers schema -json` dump for aws 6.52.0. GCP inputs unchanged (round-tripped byte-identical).
- Field churn is **additive-only** across 13 AWS types (semantic tf-tag diff: zero removed fields). Highlights: `aws_route_table.route.odb_network_arn`, ACM write-only private key, EKS etcd/egress attrs, bedrockagentcore expansions, CloudFront mTLS, `aws_cloudfront_function` tags.
- driftscan: `aws_route_table.route` flips `BUG(missing-required)` → `fragile-literal missing=[]`; **1 BUG → 0 BUGs**. (The #844 gate's allowlist row for this entry can be deleted once both merge.)
- Newly generated Optional+Computed nested-object attr, auto-covered by the #842 emit guard (for the record per #845): `aws_opensearchserverless_collection.vector_options`.
- No golden reseeds required; `pkg/composer/...` + `cmd/imported-codegen` suites green.

## Commit 2 — #834 depchase catalogue + fix

Root cause of the 11 observed `depchase_warning`s (fully contained in this repo): references to **inherently un-adoptable** targets — AWS-managed KMS keys (KeyManager=AWS) and service-linked IAM roles. `DiscoverByID` found them, genconfig then dropped them, and depchase surfaced the opaque "generated config omitted it" warning after burning a regenerate cycle. Two gaps:
1. `imported.UnimportableReason` had no `aws_iam_role` service-linked case (bulk discovery excludes SLRs, but the by-ID chase path never classified them).
2. depchase never consulted the classifier, even though the by-ID path already stamps the discriminators.

Fixed: new `ReasonServiceLinkedIAMRole` classifier case + a pre-add gate in `depchase.Run` that consults `imported.UnimportableReason` right after `DiscoverByID` — leaves the literal **knowingly, with a precise reason**, and skips the wasted pipeline cycle. Tests cover both the `aws_kms_key` and `aws_iam_role` cases per the issue's acceptance criteria (0 pipeline calls, precise warnings).

Full degradation catalogue (also in `cmd/insideout-import/depchase/degradation_catalogue.go`):

| # | Degradation class | Warned? | Decision |
|---|---|---|---|
| A | Ref in nested attr / block (finder walks top-level only) | no (silent) | documented-literal; widen finder as follow-up |
| B | Non-ARN identifier form (bare id/name/URL) | no (silent) | documented-literal |
| C | Unsupported ARN service/rtype (not in `arnTFTypeMap`) | yes | documented-literal (scope expansion to emit) |
| D | Malformed ARN literal | yes | documented-literal |
| E | Target not found (deleted / cross-account) | yes | documented-literal |
| F | Discoverer rejected (e.g. AWS-managed policies, #652) | yes | documented-literal (intended) |
| G | **Target inherently un-importable — NEW gate** | **yes, precise reason** | **documented-literal (the #834 kms/iam class)** |
| H | Discovered but genconfig dropped (backstop) | yes (opaque) | documented-literal backstop |
| I | Cycle / stable unresolved set | yes | documented-literal |

Note on Closes vs Refs #834: acceptance (1) — the catalogue with per-type decisions — is delivered; acceptance (2) — resolution + tests for types "we choose to emit" — the analysis shows the observed cases are correctly documented-literal (targets cannot be adopted), and the tests cover exactly those two types. If reviewers want any class-C type promoted to emit instead, that's a scope expansion (new discoverer + typed model) — happy to split it out.

Follow-up candidates: classes A and B degrade silently today — worth issues if fidelity there matters.

Verification: gofmt/vet clean; full `pkg/composer` (297s), `pkg/composer/imported/...`, `pkg/reverseimport/...`, all `cmd/insideout-import/...`, `cmd/imported-codegen` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9mZGiqtkryFohgBP5SUFR)_