### PR TITLE
feat(imported): existence probe + per-resource Found sink for reverse-import

### DIFF
--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -259,6 +259,12 @@ func (p *Provider) EnrichByID(ctx context.Context, identity *imported.ResourceId
 		return nil, fmt.Errorf("%w: %s", imp.ErrEnrichByIDNotImplemented, identity.Type)
 	case errors.Is(err, awsdiscover.ErrEnrichClientUnavailable):
 		return nil, fmt.Errorf("%w: %s", imp.ErrEnrichClientUnavailable, identity.Type)
+	case errors.Is(err, awsdiscover.ErrNotFound):
+		// A definitive not-found means the resource is gone. Wrap the
+		// cross-cloud sentinel so a cloud-agnostic caller (imp.FilterExisting)
+		// can classify existence, while keeping awsdiscover.ErrNotFound in the
+		// chain for existing drift-refresh callers that match on it.
+		return nil, fmt.Errorf("%w: %w", imp.ErrResourceNotFound, err)
 	default:
 		return nil, err
 	}

--- a/pkg/imported/aws/provider.go
+++ b/pkg/imported/aws/provider.go
@@ -175,9 +175,10 @@ func (p *Provider) CanonicalAddress(identity *imported.ResourceIdentity) string 
 //   - TagSelectors → TagSelectors (translated to awsdiscover.TagSelector)
 //   - AccountID  → AccountID
 //   - Progress   → a per-type progress bridge on Emitter (#699)
+//   - Found      → a per-resource trickle bridge on the same Emitter
 //
-// Per-type progress: when opts.Progress is non-nil, the Emitter handed
-// to DiscoverTypes is a bridge (imp.NewProgressEmitter) that forwards
+// Per-type progress: when opts.Progress and/or opts.Found is non-nil, the
+// Emitter handed to DiscoverTypes is a bridge (imp.NewDiscoverEmitter) that forwards
 // one per-Terraform-type completion event to opts.Progress as the
 // parallel walk lands each type, serialized and with a monotonic
 // N-of-total count. A nil sink resolves to progress.NopEmitter{}, which
@@ -192,7 +193,7 @@ func (p *Provider) Discover(ctx context.Context, types []string, clients imp.Cli
 		Regions:      opts.Regions,
 		TagSelectors: toAWSTagSelectors(opts.TagSelectors),
 		AccountID:    opts.AccountID,
-		Emitter:      imp.NewProgressEmitter(opts.Progress),
+		Emitter:      imp.NewDiscoverEmitter(opts.Progress, opts.Found),
 	}
 	return p.d.DiscoverTypes(ctx, types, args)
 }

--- a/pkg/imported/errors.go
+++ b/pkg/imported/errors.go
@@ -29,3 +29,17 @@ var ErrEnrichClientUnavailable = errors.New("imported: required SDK client unava
 // Clients correctly at construction time; this sentinel exists so
 // runtime guards in the per-cloud impls have a typed return path.
 var ErrClientsWrongCloud = errors.New("imported: Clients union carries the wrong cloud")
+
+// ErrResourceNotFound signals that a per-resource EnrichByID probe
+// determined the resource no longer exists in the cloud (a definitive
+// not-found from the underlying describe/get, NOT a transient / auth /
+// throttle error). The per-cloud providers wrap the underlying
+// awsdiscover.ErrNotFound / gcpdiscover.ErrNotFound with this
+// cross-cloud sentinel (preserving the original in the chain), so a
+// cloud-agnostic caller — the existence-prune in FilterExisting, and
+// reliable's reverse-import carry-forward prune (which drops import{}
+// blocks for resources deleted since they were adopted, #reliable) —
+// can classify "gone" without importing the per-cloud discover
+// packages. Distinct from ErrEnrichByIDNotImplemented (the type has no
+// by-id probe, so existence is UNKNOWN, not "gone").
+var ErrResourceNotFound = errors.New("imported: resource no longer exists")

--- a/pkg/imported/exists.go
+++ b/pkg/imported/exists.go
@@ -1,0 +1,77 @@
+package imported
+
+import (
+	"context"
+	"errors"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// ExistenceVerdict classifies one resource's continued existence as
+// determined by a per-type EnrichByID probe.
+type ExistenceVerdict int
+
+const (
+	// ExistenceUnknown means the probe could not decide: the type has no
+	// by-id enricher (ErrEnrichByIDNotImplemented), the SDK client was
+	// unavailable, or the call errored transiently (throttle / auth /
+	// network). Callers MUST treat this as "keep" — never a prune signal.
+	ExistenceUnknown ExistenceVerdict = iota
+	// ExistenceExists means the probe fetched the resource: it is live.
+	ExistenceExists
+	// ExistenceGone means the probe returned a definitive not-found: the
+	// resource has been deleted from the cloud.
+	ExistenceGone
+)
+
+// ClassifyExistence probes a single resource's existence via the provider's
+// per-type EnrichByID and returns a verdict. It NEVER returns ExistenceGone
+// for anything but a definitive ErrResourceNotFound — a type without a by-id
+// enricher, an unavailable client, and any transient/auth error all return
+// ExistenceUnknown, because dropping a live resource (false-drop) is far worse
+// than keeping a dead one (which surfaces loudly at terraform apply). p and
+// identity must be non-nil.
+func ClassifyExistence(ctx context.Context, p Provider, clients Clients, identity *composerimported.ResourceIdentity) ExistenceVerdict {
+	if p == nil || identity == nil {
+		return ExistenceUnknown
+	}
+	if _, err := p.EnrichByID(ctx, identity, clients); err != nil {
+		if errors.Is(err, ErrResourceNotFound) {
+			return ExistenceGone
+		}
+		return ExistenceUnknown
+	}
+	return ExistenceExists
+}
+
+// FilterExisting probes each identity and returns the subset that is
+// DEFINITELY gone (ClassifyExistence == ExistenceGone), preserving input
+// order. Resources that still exist, whose type has no by-id enricher, or that
+// error transiently are treated as inconclusive and are NOT returned — the
+// caller keeps them. This is the cloud-agnostic existence-prune primitive the
+// InsideOut backend uses to drop `import{}` blocks for reverse-import
+// carry-forward resources that have been deleted from the cloud since they
+// were adopted (which would otherwise abort the whole terraform apply with
+// "Cannot import non-existent remote object").
+//
+// The probe is one EnrichByID per identity (a per-type describe/get); a
+// not-found short-circuits cheaply, while a live resource pays the enrich
+// cost. Callers that need throughput can shard the slice and call
+// FilterExisting concurrently — each call is independent and holds no shared
+// state. A nil identity in the slice is skipped. err is returned only for a
+// caller-fatal condition (nil provider); per-resource probe errors are folded
+// into "keep", never a batch failure.
+func FilterExisting(ctx context.Context, p Provider, clients Clients, identities []*composerimported.ResourceIdentity) (gone []*composerimported.ResourceIdentity, err error) {
+	if p == nil {
+		return nil, errors.New("imported: FilterExisting called with nil provider")
+	}
+	for _, id := range identities {
+		if id == nil {
+			continue
+		}
+		if ClassifyExistence(ctx, p, clients, id) == ExistenceGone {
+			gone = append(gone, id)
+		}
+	}
+	return gone, nil
+}

--- a/pkg/imported/exists_test.go
+++ b/pkg/imported/exists_test.go
@@ -1,0 +1,114 @@
+package imported_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	composerimported "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	imp "github.com/luthersystems/insideout-terraform-presets/pkg/imported"
+)
+
+// existProvider embeds the shared stubProvider and makes EnrichByID
+// configurable per identity, so a test can drive ClassifyExistence /
+// FilterExisting without a live cloud.
+type existProvider struct {
+	*stubProvider
+	byID func(id *composerimported.ResourceIdentity) (imp.Attrs, error)
+}
+
+func (e *existProvider) EnrichByID(_ context.Context, id *composerimported.ResourceIdentity, _ imp.Clients) (imp.Attrs, error) {
+	return e.byID(id)
+}
+
+var _ imp.Provider = (*existProvider)(nil)
+
+func identFor(addr string) *composerimported.ResourceIdentity {
+	return &composerimported.ResourceIdentity{Address: addr, Type: "aws_iam_role"}
+}
+
+func mkExistProvider(fn func(id *composerimported.ResourceIdentity) (imp.Attrs, error)) *existProvider {
+	return &existProvider{stubProvider: &stubProvider{}, byID: fn}
+}
+
+// TestFilterExisting_OnlyDefinitiveNotFoundIsGone is the load-bearing
+// contract: a resource is pruned ONLY on a definitive ErrResourceNotFound.
+// A live resource, a type with no by-id probe, and a transient/throttle
+// error are all KEPT — never a false-drop.
+func TestFilterExisting_OnlyDefinitiveNotFoundIsGone(t *testing.T) {
+	p := mkExistProvider(func(id *composerimported.ResourceIdentity) (imp.Attrs, error) {
+		switch id.Address {
+		case "aws_iam_role.live":
+			return imp.Attrs("{}"), nil
+		case "aws_iam_role.gone":
+			// Mirror the provider's not-found wrap (sentinel + underlying).
+			return nil, fmt.Errorf("%w: %w", imp.ErrResourceNotFound, errors.New("NoSuchEntity: role not found"))
+		case "aws_iam_role.noprobe":
+			return nil, fmt.Errorf("%w: aws_iam_role", imp.ErrEnrichByIDNotImplemented)
+		default: // "aws_iam_role.throttled"
+			return nil, errors.New("ThrottlingException: rate exceeded")
+		}
+	})
+
+	ids := []*composerimported.ResourceIdentity{
+		identFor("aws_iam_role.live"),
+		identFor("aws_iam_role.gone"),
+		identFor("aws_iam_role.noprobe"),
+		identFor("aws_iam_role.throttled"),
+		nil, // skipped, must not panic
+	}
+	gone, err := imp.FilterExisting(context.Background(), p, imp.Clients{}, ids)
+	if err != nil {
+		t.Fatalf("FilterExisting err: %v", err)
+	}
+	if len(gone) != 1 {
+		addrs := make([]string, len(gone))
+		for i, g := range gone {
+			addrs[i] = g.Address
+		}
+		t.Fatalf("expected exactly 1 gone (the definitive not-found); got %d: %v", len(gone), addrs)
+	}
+	if gone[0].Address != "aws_iam_role.gone" {
+		t.Fatalf("wrong resource classified gone: %s", gone[0].Address)
+	}
+}
+
+func TestClassifyExistence_Verdicts(t *testing.T) {
+	cases := []struct {
+		name string
+		fn   func() (imp.Attrs, error)
+		want imp.ExistenceVerdict
+	}{
+		{"exists", func() (imp.Attrs, error) { return imp.Attrs("{}"), nil }, imp.ExistenceExists},
+		{"gone", func() (imp.Attrs, error) { return nil, fmt.Errorf("%w: 404", imp.ErrResourceNotFound) }, imp.ExistenceGone},
+		{"no-probe-is-unknown", func() (imp.Attrs, error) { return nil, imp.ErrEnrichByIDNotImplemented }, imp.ExistenceUnknown},
+		{"client-unavailable-is-unknown", func() (imp.Attrs, error) { return nil, imp.ErrEnrichClientUnavailable }, imp.ExistenceUnknown},
+		{"transient-is-unknown", func() (imp.Attrs, error) { return nil, errors.New("timeout") }, imp.ExistenceUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := mkExistProvider(func(*composerimported.ResourceIdentity) (imp.Attrs, error) { return tc.fn() })
+			got := imp.ClassifyExistence(context.Background(), p, imp.Clients{}, identFor("aws_iam_role.x"))
+			if got != tc.want {
+				t.Fatalf("ClassifyExistence = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyExistence_NilInputsAreUnknown(t *testing.T) {
+	p := mkExistProvider(func(*composerimported.ResourceIdentity) (imp.Attrs, error) { return imp.Attrs{}, nil })
+	if v := imp.ClassifyExistence(context.Background(), nil, imp.Clients{}, identFor("a")); v != imp.ExistenceUnknown {
+		t.Fatalf("nil provider must be Unknown, got %v", v)
+	}
+	if v := imp.ClassifyExistence(context.Background(), p, imp.Clients{}, nil); v != imp.ExistenceUnknown {
+		t.Fatalf("nil identity must be Unknown, got %v", v)
+	}
+}
+
+func TestFilterExisting_NilProviderErrors(t *testing.T) {
+	if _, err := imp.FilterExisting(context.Background(), nil, imp.Clients{}, nil); err == nil {
+		t.Fatal("nil provider must return an error")
+	}
+}

--- a/pkg/imported/gcp/provider.go
+++ b/pkg/imported/gcp/provider.go
@@ -133,8 +133,8 @@ func (p *Provider) CanonicalAddress(identity *imported.ResourceIdentity) string 
 // construction time). opts.ProjectID is ignored when the underlying
 // discoverer was constructed with one — see NewGCPDiscoverer.
 //
-// Per-type progress: when opts.Progress is non-nil, the Emitter handed
-// to DiscoverTypes is a bridge (imp.NewProgressEmitter) that forwards
+// Per-type progress: when opts.Progress and/or opts.Found is non-nil, the
+// Emitter handed to DiscoverTypes is a bridge (imp.NewDiscoverEmitter) that forwards
 // one per-Terraform-type completion event to opts.Progress with a
 // monotonic N-of-total count (#699). A nil sink resolves to
 // progress.NopEmitter{}, byte-for-byte the pre-#699 behavior.
@@ -146,7 +146,7 @@ func (p *Provider) Discover(ctx context.Context, types []string, clients imp.Cli
 		Project:      opts.Project,
 		Regions:      opts.Regions,
 		TagSelectors: toGCPTagSelectors(opts.TagSelectors),
-		Emitter:      imp.NewProgressEmitter(opts.Progress),
+		Emitter:      imp.NewDiscoverEmitter(opts.Progress, opts.Found),
 	}
 	return p.d.DiscoverTypes(ctx, types, args)
 }

--- a/pkg/imported/gcp/provider.go
+++ b/pkg/imported/gcp/provider.go
@@ -209,6 +209,12 @@ func (p *Provider) EnrichByID(ctx context.Context, identity *imported.ResourceId
 		return nil, fmt.Errorf("%w: %s", imp.ErrEnrichByIDNotImplemented, identity.Type)
 	case errors.Is(err, gcpdiscover.ErrEnrichClientUnavailable):
 		return nil, fmt.Errorf("%w: %s", imp.ErrEnrichClientUnavailable, identity.Type)
+	case errors.Is(err, gcpdiscover.ErrNotFound):
+		// A definitive not-found means the resource is gone. Wrap the
+		// cross-cloud sentinel so a cloud-agnostic caller (imp.FilterExisting)
+		// can classify existence, while keeping gcpdiscover.ErrNotFound in the
+		// chain for existing drift-refresh callers that match on it.
+		return nil, fmt.Errorf("%w: %w", imp.ErrResourceNotFound, err)
 	default:
 		return nil, err
 	}

--- a/pkg/imported/progress.go
+++ b/pkg/imported/progress.go
@@ -32,10 +32,22 @@ import (
 // DiscoverOpts.Progress / EnrichOpts.Progress and let the Provider wire
 // it up.
 func NewProgressEmitter(sink func(DiscoverProgress)) progress.Emitter {
-	if sink == nil {
+	return NewDiscoverEmitter(sink, nil)
+}
+
+// NewDiscoverEmitter is NewProgressEmitter plus an optional per-resource
+// Found sink: when found is non-nil the bridge ALSO forwards each
+// ItemFound tick (fired by the discoverers the moment each resource is
+// found, mid-scan) as a DiscoverFound. This powers the live
+// "resources as we find them" trickle on the reverse-import Scan panel.
+// Both sinks nil → NopEmitter, byte-for-byte the no-progress path.
+// Found invocations are serialized under the same mutex as TypeDone, so
+// the sink is safe to call from the parallel per-type scan goroutines.
+func NewDiscoverEmitter(sink func(DiscoverProgress), found func(DiscoverFound)) progress.Emitter {
+	if sink == nil && found == nil {
 		return progress.NopEmitter{}
 	}
-	return &progressBridge{sink: sink}
+	return &progressBridge{sink: sink, found: found}
 }
 
 // progressBridge adapts a per-type DiscoverProgress sink onto the
@@ -45,7 +57,8 @@ func NewProgressEmitter(sink func(DiscoverProgress)) progress.Emitter {
 // progress.TypeProgressEmitter to receive and forward the per-type
 // completion events.
 type progressBridge struct {
-	sink func(DiscoverProgress)
+	sink  func(DiscoverProgress)
+	found func(DiscoverFound)
 
 	mu        sync.Mutex
 	completed int // running count of types done; guarded by mu
@@ -58,13 +71,35 @@ var (
 	_ progress.TypeProgressEmitter = (*progressBridge)(nil)
 )
 
-// The per-(service,region) Emitter events are not part of the facade's
-// per-type progress contract, so the bridge swallows them.
+// The per-(service,region) Emitter events other than ItemFound are not
+// part of the facade's contract, so the bridge swallows them.
 func (b *progressBridge) ServiceStart(string, string)                      {}
 func (b *progressBridge) ServiceFinish(string, string, int, time.Duration) {}
-func (b *progressBridge) ItemFound(string, string, string, string)         {}
 func (b *progressBridge) StageFinish(string, int, time.Duration)           {}
 func (b *progressBridge) ServiceWarn(string, string, string)               {}
+
+// ItemFound forwards each per-resource discovery tick to the optional
+// Found sink (NewDiscoverEmitter), serialized under the same mutex as
+// TypeDone so a single consumer-side sink needs no locking. Phase is
+// fixed to "discover": providers wire the Found sink only on the
+// Discover leg (EnrichAttributes keeps the progress-only emitter), and
+// the enrich pass's own ItemFound ticks identify themselves via the
+// "enrich" service slug anyway. Nil sink (NewProgressEmitter callers)
+// keeps the historical swallow.
+func (b *progressBridge) ItemFound(service, region, tfType, importID string) {
+	if b.found == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.found(DiscoverFound{
+		Phase:    "discover",
+		Service:  service,
+		Region:   region,
+		Type:     tfType,
+		ImportID: importID,
+	})
+}
 
 // TypeDone increments the running completed-type counter and forwards a
 // DiscoverProgress to the sink. The lock both serializes concurrent
@@ -72,6 +107,11 @@ func (b *progressBridge) ServiceWarn(string, string, string)               {}
 // the increment-then-deliver atomic, so the sink observes CompletedTypes
 // as a strictly monotonic 1..Total sequence.
 func (b *progressBridge) TypeDone(p progress.TypeProgress) {
+	if b.sink == nil {
+		// Found-only bridge (NewDiscoverEmitter(nil, found)): no per-type
+		// progress consumer, so swallow — matching the pre-bridge NopEmitter.
+		return
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.completed++

--- a/pkg/imported/progress_test.go
+++ b/pkg/imported/progress_test.go
@@ -115,3 +115,66 @@ func TestProgressBridge_ConcurrentTypeDoneIsSafe(t *testing.T) {
 		}
 	}
 }
+
+// TestNewDiscoverEmitter_FoundSink pins the per-resource trickle bridge:
+// ItemFound ticks forward to the Found sink as DiscoverFound events with
+// Phase="discover" and verbatim service/region/type/import-id; a found-
+// only bridge (nil progress sink) must swallow TypeDone without
+// panicking; and both-nil resolves to NopEmitter.
+func TestNewDiscoverEmitter_FoundSink(t *testing.T) {
+	t.Parallel()
+
+	var found []imp.DiscoverFound
+	e := imp.NewDiscoverEmitter(nil, func(f imp.DiscoverFound) { found = append(found, f) })
+
+	e.ItemFound("sqs", "us-east-1", "aws_sqs_queue", "https://sqs.us-east-1.amazonaws.com/1/q")
+	e.ItemFound("s3", "us-west-2", "aws_s3_bucket", "my-bucket")
+
+	if len(found) != 2 {
+		t.Fatalf("expected 2 found events, got %d", len(found))
+	}
+	want := imp.DiscoverFound{Phase: "discover", Service: "sqs", Region: "us-east-1", Type: "aws_sqs_queue", ImportID: "https://sqs.us-east-1.amazonaws.com/1/q"}
+	if found[0] != want {
+		t.Errorf("found[0] = %+v, want %+v", found[0], want)
+	}
+
+	// Found-only bridge must not panic on TypeDone (nil progress sink).
+	if tp, ok := e.(progress.TypeProgressEmitter); ok {
+		tp.TypeDone(progress.TypeProgress{Phase: "discover", TFType: "aws_s3_bucket", Found: 1, Total: 2})
+	} else {
+		t.Fatal("found-sink emitter must still implement TypeProgressEmitter")
+	}
+
+	// Both sinks nil → NopEmitter (the zero-overhead default path).
+	if imp.NewDiscoverEmitter(nil, nil) != (progress.NopEmitter{}) {
+		t.Error("NewDiscoverEmitter(nil, nil) must be NopEmitter")
+	}
+}
+
+// TestNewDiscoverEmitter_ConcurrentItemFound pins the serialization
+// contract: concurrent ItemFound callers (the per-type scan goroutines)
+// are safe with a lock-free consumer sink.
+func TestNewDiscoverEmitter_ConcurrentItemFound(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex // consumer-side count only; the bridge serializes delivery
+	count := 0
+	e := imp.NewDiscoverEmitter(nil, func(imp.DiscoverFound) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+	})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				e.ItemFound("svc", "r", "t", "id")
+			}
+		}()
+	}
+	wg.Wait()
+	if count != 400 {
+		t.Fatalf("expected 400 found events, got %d", count)
+	}
+}

--- a/pkg/imported/types.go
+++ b/pkg/imported/types.go
@@ -141,6 +141,40 @@ type DiscoverOpts struct {
 	AccountID    string
 	ProjectID    string
 	Progress     func(DiscoverProgress)
+	// Found is an optional per-resource sink fired the moment each
+	// resource is discovered, DURING the scan — before the full
+	// ImportedResource set is assembled and returned. It carries the
+	// identity fragment the underlying discoverers report on their
+	// ItemFound tick (service slug, region, Terraform type, import id) —
+	// enough for a live "resources as we find them" panel to render a
+	// provisional row, not enough to import. Consumers must treat rows
+	// delivered here as provisional and replace them with the
+	// authoritative ImportedResource set when Discover returns. A nil
+	// sink is byte-for-byte the pre-existing behavior. Like Progress,
+	// invocations are serialized by the provider's bridge, so the sink
+	// may be called from concurrent per-type scan goroutines without
+	// caller-side locking.
+	Found func(DiscoverFound)
+}
+
+// DiscoverFound is one per-resource discovery event delivered to
+// DiscoverOpts.Found as the underlying scan finds each resource. It is
+// the wire-through of the discoverers' ItemFound tick: identity
+// fragments for a provisional UI row, not a full ImportedResource (no
+// address, tags, or attrs — those arrive with Discover's return value).
+type DiscoverFound struct {
+	// Phase is "discover" or "enrich", mirroring DiscoverProgress.Phase.
+	Phase string
+	// Service is the cloud service slug the discoverer reported, e.g.
+	// "sqs" (AWS) or a GCP service slug. Display-informational only.
+	Service string
+	// Region is the region/location the resource was found in.
+	Region string
+	// Type is the Terraform resource type, e.g. "aws_sqs_queue".
+	Type string
+	// ImportID is the provider import identifier the discoverer
+	// reported (an ARN, URL, name, or composite id depending on type).
+	ImportID string
 }
 
 // DiscoverProgress is one per-Terraform-type completion event delivered


### PR DESCRIPTION
Two small, back-compat facade additions in `pkg/imported`, both consumed by ui-core + reliable for the reverse-import surface. Foundation legs of two cross-repo efforts landing tonight.

## 1. Existence probe (reliable Finding B — carry-forward prune)

Reliable's reverse-import apply composes `import {}` blocks for the union of resources a session has adopted across rounds. A resource deleted from the cloud after adoption still rides that union, and terraform aborts the entire apply with `Cannot import non-existent remote object` — one dead resource poisons every future apply (observed live: 234 dead imports failing a staging session's apply).

- `ErrResourceNotFound`: cross-cloud sentinel for a definitive not-found. The aws/gcp providers' `EnrichByID` now wrap `awsdiscover.ErrNotFound` / `gcpdiscover.ErrNotFound` with it (multi-`%w`, so existing drift-refresh callers matching the per-cloud sentinels still work).
- `ClassifyExistence` / `FilterExisting`: probe identities via the existing per-type `EnrichByID` and report only the DEFINITELY-gone subset. A live resource, a type with no by-id enricher, an unavailable client, or any transient/auth/throttle error are all inconclusive and kept — never a false-drop (pruning a live resource is strictly worse than keeping a dead one, which fails loudly at apply).

## 2. Per-resource Found sink (live discover trickle)

The discoverers already emit a per-resource `ItemFound` tick the moment each resource is found (both awsdiscover and gcpdiscover); the facade bridge swallowed it. This exposes it:

- `DiscoverOpts.Found` + `DiscoverFound`: optional per-resource sink carrying identity fragments (service, region, type, import id) for a provisional UI row. Documented contract: consumers replace provisional rows with the authoritative `Discover` return set (unsupported-type ticks and cross-discoverer duplicates are possible mid-scan by design).
- `NewDiscoverEmitter(progress, found)`: bridge constructor; `ItemFound` forwards under the same mutex as `TypeDone`. `NewProgressEmitter` delegates with `found=nil` — byte-for-byte back-compat; both-nil still resolves to `NopEmitter`.
- aws/gcp `Provider.Discover` wire `opts.Found` through; the enrich leg keeps the progress-only emitter.

## Verification

- `go build ./...` clean; `gofmt`/`go vet` clean.
- Full `pkg/imported/...` + `pkg/composer/...` test suites pass; full-repo test sweep ran clean.
- New tests: `exists_test.go` (only definitive not-found prunes; no-probe/throttle/nil are kept; nil-provider errors) and `progress_test.go` additions (Found forwarding + field mapping, found-only bridge swallows TypeDone, both-nil = NopEmitter, concurrent ItemFound safety).
- Downstream consumers (ui-core exists endpoint + `{"found":...}` stream line; reliable prune + panel forwarding) are staged on matching branches pinned to this SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK)_