### PR TITLE
fix(imported): AWS default parameter groups un-importable + compose-side DropUnimportable

### DIFF
--- a/pkg/composer/compose.go
+++ b/pkg/composer/compose.go
@@ -712,6 +712,17 @@ func (c *Client) composeStackImpl(opts ComposeStackOpts) (*ComposeStackResult, e
 	// dropped addresses).
 	importedResources, _ := imported.DropOrphanedChildren(opts.Imported)
 
+	// Drop inherently un-importable resources (same philosophy: one
+	// un-manageable resource must not fail the entire stack). A session's
+	// persisted imported baseline can carry instances discovery now
+	// excludes — the canonical case is an AWS-managed default parameter
+	// group (default.<family>): it imports into state, but the Project-tag
+	// stamp then fails the WHOLE apply with "InvalidParameterValue: Tagging
+	// on default resources is not supported" (20 of them on a whole-account
+	// staging import). UnimportableReason is the same classifier the
+	// discover/run path uses to route these to unsupported.json.
+	importedResources, _ = imported.DropUnimportable(importedResources)
+
 	issues = append(issues, ValidateImportedResources(cloud, importedResources)...)
 	// Emit-readiness checks (required-argument completeness) run here —
 	// at compose time, on the final ready-to-emit resource set — not in

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -101,7 +101,38 @@ const (
 	// literal knowingly instead of dropping it as an opaque no_generated_config
 	// orphan (presets#834).
 	ReasonServiceLinkedIAMRole = "service_linked_iam_role"
+
+	// ReasonAWSDefaultParameterGroup marks an AWS-managed default parameter
+	// group (ElastiCache `default.<family>` / RDS `default.<family>` names —
+	// the reserved `default.` prefix customers cannot create under). AWS
+	// creates one per engine family; they import into state, but every
+	// mutating operation is rejected — the triggering case was the imported
+	// Project tag stamp failing the WHOLE apply with "InvalidParameterValue:
+	// Tagging on default resources is not supported" (20 default ElastiCache
+	// parameter groups on a whole-account staging import). Not customer
+	// infrastructure; manage a custom parameter group instead.
+	ReasonAWSDefaultParameterGroup = "aws_default_parameter_group"
 )
+
+// awsDefaultParameterGroupPrefix is the reserved name prefix of AWS-managed
+// default parameter groups (ElastiCache and RDS both use `default.<family>`;
+// the API rejects customer-created groups under it).
+const awsDefaultParameterGroupPrefix = "default."
+
+// awsDefaultParameterGroupTypes is the set of Terraform types whose
+// AWS-managed `default.*` instances are un-importable (tagging and every
+// other mutation is rejected by the service).
+var awsDefaultParameterGroupTypes = map[string]struct{}{
+	"aws_elasticache_parameter_group": {},
+	"aws_db_parameter_group":          {},
+	"aws_rds_cluster_parameter_group": {},
+}
+
+// IsAWSDefaultParameterGroupName reports whether a parameter-group name is an
+// AWS-managed default (reserved `default.` prefix).
+func IsAWSDefaultParameterGroupName(name string) bool {
+	return strings.HasPrefix(strings.TrimSpace(name), awsDefaultParameterGroupPrefix)
+}
 
 // awsManagedKMSAliasPrefix is the reserved alias prefix the AWS provider
 // refuses to create or import an aws_kms_alias under.
@@ -256,7 +287,42 @@ func UnimportableReason(ir ImportedResource) string {
 		// ReasonEphemeralLogStream).
 		return ReasonEphemeralLogStream
 	}
+	if _, pg := awsDefaultParameterGroupTypes[ir.Identity.Type]; pg {
+		if IsAWSDefaultParameterGroupName(parameterGroupName(ir.Identity)) {
+			return ReasonAWSDefaultParameterGroup
+		}
+	}
 	return ""
+}
+
+// DropUnimportable returns irs with every resource whose UnimportableReason
+// is non-empty removed, plus the dropped (address, reason) pairs for the
+// caller's audit trail. Compose consumes this right after
+// DropOrphanedChildren and with the same philosophy: one un-manageable
+// resource must not fail the entire stack. The canonical case is an
+// AWS-managed default parameter group persisted into a session's imported
+// baseline before discovery learned to exclude it — it imports, but the
+// Project-tag stamp then fails the WHOLE apply ("Tagging on default
+// resources is not supported").
+func DropUnimportable(irs []ImportedResource) (kept []ImportedResource, dropped [][2]string) {
+	kept = make([]ImportedResource, 0, len(irs))
+	for _, ir := range irs {
+		if reason := UnimportableReason(ir); reason != "" {
+			dropped = append(dropped, [2]string{ir.Identity.Address, reason})
+			continue
+		}
+		kept = append(kept, ir)
+	}
+	return kept, dropped
+}
+
+// parameterGroupName resolves a parameter group's name: the import ID is the
+// group name for all three parameter-group types; NameHint is the fallback.
+func parameterGroupName(id ResourceIdentity) string {
+	if n := strings.TrimSpace(id.ImportID); n != "" {
+		return n
+	}
+	return strings.TrimSpace(id.NameHint)
 }
 
 // ReasonDescription returns a short, operator-facing explanation for an
@@ -279,6 +345,8 @@ func ReasonDescription(reason string) string {
 		return "Already managed by InsideOut — cannot be selected for a new import."
 	case ReasonServiceLinkedIAMRole:
 		return "AWS service-linked IAM role (role/aws-service-role/* path) — created and deleted by the owning AWS service; cannot be imported into Terraform."
+	case ReasonAWSDefaultParameterGroup:
+		return "AWS-managed default parameter group (reserved default.* name) — AWS rejects tagging and every other modification; manage a custom parameter group instead."
 	default:
 		return ""
 	}

--- a/pkg/composer/imported/importability_default_pg_test.go
+++ b/pkg/composer/imported/importability_default_pg_test.go
@@ -1,0 +1,47 @@
+package imported
+
+import "testing"
+
+// Pins the AWS-managed default parameter group classification (the
+// "Tagging on default resources is not supported" apply failure) and the
+// compose-side DropUnimportable pass.
+func TestUnimportableReason_AWSDefaultParameterGroups(t *testing.T) {
+	mk := func(tfType, importID string) ImportedResource {
+		return ImportedResource{Identity: ResourceIdentity{Type: tfType, Address: tfType + ".x", ImportID: importID}}
+	}
+	cases := []struct {
+		name string
+		ir   ImportedResource
+		want string
+	}{
+		{"elasticache default", mk("aws_elasticache_parameter_group", "default.memcached1.5"), ReasonAWSDefaultParameterGroup},
+		{"elasticache valkey default", mk("aws_elasticache_parameter_group", "default.valkey9.cluster.on"), ReasonAWSDefaultParameterGroup},
+		{"rds default", mk("aws_db_parameter_group", "default.postgres16"), ReasonAWSDefaultParameterGroup},
+		{"rds cluster default", mk("aws_rds_cluster_parameter_group", "default.aurora-postgresql15"), ReasonAWSDefaultParameterGroup},
+		{"custom elasticache group importable", mk("aws_elasticache_parameter_group", "io-abc-redis7"), ""},
+		{"default prefix on unrelated type importable", mk("aws_sqs_queue", "default.something"), ""},
+		{"name from NameHint fallback", ImportedResource{Identity: ResourceIdentity{Type: "aws_elasticache_parameter_group", Address: "a.b", NameHint: "default.redis7"}}, ReasonAWSDefaultParameterGroup},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UnimportableReason(tc.ir); got != tc.want {
+				t.Fatalf("UnimportableReason = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDropUnimportable(t *testing.T) {
+	def := ImportedResource{Identity: ResourceIdentity{Type: "aws_elasticache_parameter_group", Address: "aws_elasticache_parameter_group.d", ImportID: "default.memcached1.5"}}
+	custom := ImportedResource{Identity: ResourceIdentity{Type: "aws_elasticache_parameter_group", Address: "aws_elasticache_parameter_group.c", ImportID: "io-x-redis"}}
+	kept, dropped := DropUnimportable([]ImportedResource{def, custom})
+	if len(kept) != 1 || kept[0].Identity.Address != "aws_elasticache_parameter_group.c" {
+		t.Fatalf("kept = %+v", kept)
+	}
+	if len(dropped) != 1 || dropped[0][0] != "aws_elasticache_parameter_group.d" || dropped[0][1] != ReasonAWSDefaultParameterGroup {
+		t.Fatalf("dropped = %+v", dropped)
+	}
+	if desc := ReasonDescription(ReasonAWSDefaultParameterGroup); desc == "" {
+		t.Fatal("ReasonDescription must cover the new reason")
+	}
+}


### PR DESCRIPTION
Fifth iteration of the reverse-import hardening loop on staging. With dead imports, dangling refs, and unprobeable-type residue all fixed (presets#859 + ui-core#446/#447 + reliable#2218/#2219), **34/34 imports succeeded** and the apply failed one layer deeper: 20 AWS-managed default ElastiCache parameter groups (`default.memcached1.5` … `default.valkey9.cluster.on`) imported cleanly and then the imported Project-tag stamp failed the WHOLE apply with `InvalidParameterValue: Tagging on default resources is not supported`.

## Changes

- `ReasonAWSDefaultParameterGroup` + `IsAWSDefaultParameterGroupName`: the reserved `default.` name prefix on `aws_elasticache_parameter_group` / `aws_db_parameter_group` / `aws_rds_cluster_parameter_group` marks an AWS-managed default the service refuses to tag or otherwise modify — same taxonomy as `alias/aws/` KMS aliases and service-linked IAM roles. Covered by `UnimportableReason` (the discover/run path routes new selections to unsupported.json) and `ReasonDescription`.
- `DropUnimportable` + compose wiring: `ComposeStackWithIssues` now drops un-importable resources right after `DropOrphanedChildren`, same philosophy (one un-manageable resource must not fail the entire stack) — covering imported baselines persisted before discovery learned to exclude an instance.

## Verification

- New tests: all three parameter-group types classified on the `default.` prefix (ImportID + NameHint fallback), custom groups + unrelated types unaffected, `DropUnimportable` keeps/drops correctly, `ReasonDescription` covers the new code.
- `go build ./pkg/...` clean; targeted `pkg/composer/imported` tests green.
- Downstream: reliable pin bump follows (compose runs in reliable's binary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK)_