### PR TITLE
fix(genconfig): remove stale generated.tf before depchase regenerate (silent dependency drop)

### DIFF
--- a/cmd/insideout-import/genconfig/genconfig.go
+++ b/cmd/insideout-import/genconfig/genconfig.go
@@ -481,6 +481,26 @@ func runSingleRegion(ctx context.Context, opts Options, resources []imported.Imp
 	}
 
 	generatedPath := filepath.Join(opts.Workdir, generatedFile)
+	// `terraform plan -generate-config-out=<path>` refuses to write when
+	// <path> already exists and is non-empty: it fails PRE-write with
+	// "Target generated file already exists" and writes nothing. The first
+	// pass runs in a fresh workdir so this never bites, but depchase
+	// (Stage 2c3) re-invokes genconfig on the SAME workdir — after the first
+	// pass already wrote generated.tf and driftfix mutated it in place — to
+	// render the dependencies it just discovered. Without clearing the stale
+	// file the re-run's plan errors out, the recovery branch below mis-reads
+	// the leftover pass-1 file as a freshly-written "partial config", and
+	// every depchase-discovered dependency is then pruned as an orphan
+	// against the stale HCL and silently dropped. Observed live: 19
+	// customer aws_kms_key refs (nested kms_master_key_id in S3 SSE configs)
+	// discovered by depchase, 0 imported — reverse-import job
+	// ri-be57064b-bqqvq / session sess_v2_ENiPyXEdf6Ja. Remove any stale
+	// generated.tf so the regenerate always writes into a new file, honoring
+	// the depchase RunGenconfig contract that it regenerates generated.tf
+	// from the CURRENT resource set.
+	if err := os.Remove(generatedPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("remove stale generated.tf before regenerate: %w", err)
+	}
 	progressf(opts.Stdout, "genconfig: %s: terraform plan -generate-config-out (parallelism=%d)…\n", scope, opts.parallelismOrDefault())
 	if _, err := runner.PlanGenerate(ctx, generatedPath, opts.parallelismOrDefault()); err != nil {
 		// `terraform plan -generate-config-out` writes generated.tf and

--- a/cmd/insideout-import/genconfig/genconfig_test.go
+++ b/cmd/insideout-import/genconfig/genconfig_test.go
@@ -413,6 +413,91 @@ func TestRun_RecoversFromPlanErrorWhenFileWritten(t *testing.T) {
 	}
 }
 
+// refuseIfExistsRunner models the REAL `terraform plan -generate-config-out`
+// pre-write refusal: when the target file already exists and is non-empty,
+// terraform fails BEFORE generating ("Target generated file already exists")
+// and writes nothing, leaving the stale file intact. This is distinct from
+// recoveringFakeRunner, which models the post-write validation failure
+// (aws_lambda_function) where the file IS written before the error.
+type refuseIfExistsRunner struct {
+	fakeRunner
+}
+
+func (r *refuseIfExistsRunner) PlanGenerate(_ context.Context, generatedPath string, parallelism int) (bool, error) {
+	r.calls = append(r.calls, "plan")
+	r.planCalled++
+	r.generatedPath = generatedPath
+	r.lastParallelism = parallelism
+	if b, err := os.ReadFile(generatedPath); err == nil && len(b) > 0 {
+		// Pre-write refusal: write NOTHING, leave the stale file, error out.
+		return false, errors.New("Target generated file already exists")
+	}
+	if err := os.WriteFile(generatedPath, []byte(r.planBody), 0o644); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// TestRun_RegeneratesIntoFreshFileOnSameWorkdir is the regression guard for the
+// depchase silent-drop bug: genconfig is re-invoked on the SAME workdir after
+// the first pass already wrote generated.tf (depchase's RunGenconfig contract),
+// but `terraform plan -generate-config-out` refuses to overwrite an existing
+// file. runSingleRegion must clear the stale generated.tf before the readback
+// so the regenerate renders the CURRENT (expanded) resource set. Without the
+// os.Remove, the second pass errors out, the recovery branch mis-reads the
+// leftover pass-1 file as a "partial config", the newly-added resource has no
+// body and is orphan-pruned — reproducing the live loss of 19 depchase-
+// discovered aws_kms_key deps (job ri-be57064b-bqqvq, 0 imported).
+func TestRun_RegeneratesIntoFreshFileOnSameWorkdir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	schema := minimalAWSSchema()
+
+	// Pass 1: fresh workdir, one resource. Writes generated.tf with body A.
+	pass1 := &refuseIfExistsRunner{fakeRunner: fakeRunner{
+		planBody: `resource "aws_sqs_queue" "x" { name = "alpha" }`,
+		schemas:  schema,
+	}}
+	if _, err := Run(context.Background(), Options{Workdir: dir, Region: "us-east-1", Runner: pass1},
+		[]imported.ImportedResource{{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.x", ImportID: "x"}}}); err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+
+	// Pass 2: SAME workdir, expanded set (x + newly-discovered y), mimicking a
+	// depchase regenerate. Body B renders BOTH resources. The pre-existing
+	// generated.tf must be cleared so PlanGenerate writes body B fresh; then y
+	// survives instead of being orphan-pruned against the stale body A.
+	pass2 := &refuseIfExistsRunner{fakeRunner: fakeRunner{
+		planBody: "resource \"aws_sqs_queue\" \"x\" { name = \"alpha\" }\n" +
+			"resource \"aws_sqs_queue\" \"y\" { name = \"beta\" }\n",
+		schemas: schema,
+	}}
+	res, err := Run(context.Background(), Options{Workdir: dir, Region: "us-east-1", Runner: pass2},
+		[]imported.ImportedResource{
+			{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.x", ImportID: "x"}},
+			{Identity: imported.ResourceIdentity{Address: "aws_sqs_queue.y", ImportID: "y"}},
+		})
+	if err != nil {
+		t.Fatalf("pass 2 (regenerate on existing workdir): %v", err)
+	}
+	if len(res.Resources) != 2 {
+		t.Fatalf("regenerate dropped a resource: got %d, want 2 (%+v) — stale generated.tf was not cleared before the readback",
+			len(res.Resources), res.Resources)
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("regenerate orphan-pruned %d resource(s); want 0: %+v", len(res.Skipped), res.Skipped)
+	}
+	// The retained body must be the FRESH pass-2 render (contains y), not the
+	// leftover pass-1 body.
+	got := map[string]bool{}
+	for _, r := range res.Resources {
+		got[r.Identity.Address] = true
+	}
+	if !got["aws_sqs_queue.x"] || !got["aws_sqs_queue.y"] {
+		t.Errorf("regenerated set = %v, want both x and y", got)
+	}
+}
+
 func TestRun_DarioBroadAWSStackFixupsReachValidate(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem

`terraform plan -generate-config-out` refuses pre-write when the target file already exists ("Target generated file already exists") and writes nothing. Depchase (Stage 2c3) re-invokes `RunGenconfig` on the same workdir after pass 1 already wrote `generated.tf` (and driftfix mutated it in place), so the regenerate errors, the lambda-oriented partial-config recovery branch mis-reads the stale pass-1 file as fresh output, and every depchase-discovered dependency is pruned as an orphan and silently dropped (`depchase_config_omitted`).

Observed live on staging (job `ri-be57064b-bqqvq`, 2026-07-11): depchase discovered 19 importable customer KMS keys (nested `kms_master_key_id` refs in S3 SSE configs); 0 were imported. Run "succeeded" at 79/98 resources.

## Fix

Remove any stale `generated.tf` immediately before `PlanGenerate` in `runSingleRegion`, so a regenerate always writes into a fresh file — honoring depchase's contract that `RunGenconfig` regenerates from the current resource set. Depchase reads `generated.tf` before re-invoking, and re-runs driftfix after each regenerate, so nothing is lost.

The alarming raw `Error: Target generated file already exists` in otherwise-green logs can no longer occur; the "wrote partial config after an error" recovery line keeps its one legitimate trigger (post-write validation failures, e.g. `aws_lambda_function`).

## Test plan

- New `TestRun_RegeneratesIntoFreshFileOnSameWorkdir` with a runner modeling terraform's real pre-write refusal — fails without the fix (reproduces the orphan-prune drop), passes with it.
- `go test ./cmd/insideout-import/genconfig/ ./cmd/insideout-import/depchase/ ./pkg/reverseimport/` all ok; gofmt/vet clean.

Ship chain after merge: presets release → mars go.mod pin bump + image release → bump `ReverseImportMarsVersion` in reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK)_