### PR TITLE
fix(imported): classify AWS-managed EventBridge rules un-importable + discover-time ManagedBy backfill

### DIFF
--- a/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_extractors_test.go
@@ -236,23 +236,46 @@ func TestCloudWatchEventRuleConfig(t *testing.T) {
 	}
 
 	// Service-managed marker (#785): AWS-managed rules (AutoScalingManagedRule,
-	// etc.) carry a ManagedBy property. The discoverer must surface it so the
-	// importability classifier greys them out — tag/PutRule/DeleteRule all fail
-	// with ManagedRuleException on a managed rule.
+	// etc.) carry a ManagedBy principal, and the importability classifier greys
+	// them out — tag/PutRule/DeleteRule all fail with ManagedRuleException on a
+	// managed rule.
 	if cfg.ServiceManagedByFromProperties == nil {
-		t.Fatal("aws_cloudwatch_event_rule: ServiceManagedByFromProperties must be set to capture managed rules")
+		t.Fatal("aws_cloudwatch_event_rule: ServiceManagedByFromProperties must be set (props fast-path)")
 	}
+	// REALITY CHECK (staging apply ccs-101d5181-5czmw): Cloud Control's
+	// AWS::Events::Rule schema does NOT surface ManagedBy among its read-only
+	// properties, so for a REAL managed rule the props payload omits it and the
+	// fast-path returns "". Asserting only the with-ManagedBy case was false
+	// confidence — it let AutoScalingManagedRule through, get tag-stamped in
+	// imported.tf, and fail the whole 264-import apply with ManagedRuleException.
+	// The authoritative marker is backfilled at DISCOVER time by PostDiscover
+	// (events:DescribeRule); the props fast-path is best-effort only.
+	realWorldManagedProps := map[string]any{
+		"Name": "AutoScalingManagedRule",
+		"Arn":  "arn:aws:events:us-east-1:111111111111:rule/AutoScalingManagedRule",
+		// NOTE: no "ManagedBy" — this mirrors what CC actually returns.
+	}
+	if got := cfg.ServiceManagedByFromProperties(realWorldManagedProps); got != "" {
+		t.Errorf("ServiceManagedBy (CC omits ManagedBy for a real managed rule): got %q, want empty (backfilled by PostDiscover instead)", got)
+	}
+	// Fast-path: IF CC ever does carry ManagedBy, the extractor surfaces it.
 	managedProps := map[string]any{
 		"Name":      "AutoScalingManagedRule",
 		"Arn":       "arn:aws:events:us-east-1:111111111111:rule/AutoScalingManagedRule",
 		"ManagedBy": "autoscaling.amazonaws.com",
 	}
 	if got := cfg.ServiceManagedByFromProperties(managedProps); got != "autoscaling.amazonaws.com" {
-		t.Errorf("ServiceManagedBy (managed rule): got %q, want autoscaling.amazonaws.com", got)
+		t.Errorf("ServiceManagedBy (props fast-path, ManagedBy present): got %q, want autoscaling.amazonaws.com", got)
 	}
 	// A customer rule has no ManagedBy → empty marker → importable.
 	if got := cfg.ServiceManagedByFromProperties(props); got != "" {
 		t.Errorf("ServiceManagedBy (customer rule): got %q, want empty", got)
+	}
+	// The authoritative mechanism: PostDiscover MUST be wired so ManagedBy is
+	// backfilled via events:DescribeRule even though CC omits it (the fix for
+	// staging apply ccs-101d5181-5czmw).
+	if cfg.PostDiscover == nil {
+		t.Fatal("aws_cloudwatch_event_rule: PostDiscover must be wired to backfill ManagedBy via events:DescribeRule (CC omits it)")
 	}
 }
 

--- a/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
+++ b/cmd/insideout-import/awsdiscover/cloudcontrol_types.go
@@ -339,9 +339,26 @@ var cloudControlTypeConfigs = []cloudControlConfig{
 		// rule with ManagedBy set (ManagedRuleException), so the rule cannot
 		// be managed by Terraform at all. Absent-safe: a customer rule has no
 		// ManagedBy → empty marker → importable.
+		//
+		// LIMITATION: Cloud Control's AWS::Events::Rule schema does NOT list
+		// ManagedBy among its read-only properties, so this props fast-path
+		// returns "" for a real managed rule (surfacing it via props alone
+		// was false confidence — it let AutoScalingManagedRule through, get
+		// tag-stamped in imported.tf, and fail the whole 264-import apply
+		// with ManagedRuleException on staging job ccs-101d5181-5czmw). The
+		// authoritative marker is backfilled at DISCOVER time by PostDiscover
+		// (events:DescribeRule); the props fast-path is kept only for the
+		// rare case CC does carry ManagedBy.
 		ServiceManagedByFromProperties: func(props map[string]any) string {
 			return extractString(props, "ManagedBy")
 		},
+		// Resolve ManagedBy at DISCOVER time via events:DescribeRule. The CC
+		// schema omits ManagedBy (see the LIMITATION note above), so the
+		// props extractor above can't set it. PostDiscover stamps
+		// Identity.ServiceManagedBy so imported.UnimportableReason classifies
+		// AWS-managed rules (AutoScalingManagedRule, …) into unsupported.json
+		// instead of letting them sink the apply (job ccs-101d5181-5czmw).
+		PostDiscover: eventRulePostDiscover,
 	},
 
 	// =====================================================================

--- a/cmd/insideout-import/awsdiscover/event_rule_post_discover.go
+++ b/cmd/insideout-import/awsdiscover/event_rule_post_discover.go
@@ -1,0 +1,123 @@
+package awsdiscover
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// EventBridge rule PostDiscover follow-up — service-managed marker backfill.
+//
+// AWS-managed EventBridge rules (e.g. AutoScalingManagedRule, managed by
+// autoscaling.amazonaws.com) cannot be adopted into customer Terraform
+// state: AWS rejects tag / PutRule / DeleteRule on any rule with ManagedBy
+// set with a ManagedRuleException. Stamping the imported Project tag onto
+// such a rule in imported.tf fails the WHOLE apply — proven on staging apply
+// ccs-101d5181-5czmw, where AutoScalingManagedRule (arn
+// …:rule/AutoScalingManagedRule) sank a 264-import run with
+// "ManagedRuleException: Tag related operations on the managed rule … not
+// allowed".
+//
+// imported.UnimportableReason already classifies a rule as un-importable
+// when Identity.ServiceManagedBy is non-empty (ReasonServiceManaged, #785).
+// The gap: the Cloud Control AWS::Events::Rule schema does NOT expose
+// ManagedBy among its read-only properties, so the discoverer's
+// ServiceManagedByFromProperties extractor always returns "" and the
+// classifier never fires. The hand-rolled props fast-path is kept only for
+// the (rare) case CC does surface ManagedBy — the authoritative marker must
+// be resolved at DISCOVER time.
+//
+// eventRulePostDiscover issues one events:DescribeRule per discovered rule
+// and stamps Identity.ServiceManagedBy from the API's ManagedBy field so the
+// shared classifier excludes AWS-managed rules into unsupported.json rather
+// than letting them fall through and fail the apply. Soft-fails (returns an
+// error the discoverer logs) when the rule name is unresolvable or
+// DescribeRule fails — a customer rule with no ManagedBy is still treated as
+// importable, the same posture as the genconfig prune backstop (#708) and
+// the kms_key / network_acl PostDiscover hooks.
+
+// defaultEventBusName is EventBridge's implicit default event bus. A rule on
+// the default bus can be described without an explicit EventBusName, so the
+// hook only passes EventBusName for a custom bus.
+const defaultEventBusName = "default"
+
+// eventRuleDescriber is the narrow subset of the EventBridge API the
+// PostDiscover hook issues. Real *eventbridge.Client and in-test fakes
+// satisfy it; the production hook constructs the real client per region.
+type eventRuleDescriber interface {
+	DescribeRule(ctx context.Context, in *eventbridge.DescribeRuleInput, opts ...func(*eventbridge.Options)) (*eventbridge.DescribeRuleOutput, error)
+}
+
+// newEventRuleDescriber is the production factory; tests swap it (or call
+// eventRulePostDiscoverWithClient directly) to inject a fake.
+var newEventRuleDescriber = func(awsCfg aws.Config, region string) eventRuleDescriber {
+	return eventbridge.NewFromConfig(awsCfg, func(o *eventbridge.Options) {
+		if region != "" {
+			o.Region = region
+		}
+	})
+}
+
+// eventRulePostDiscover is the cloudControlConfig.PostDiscover hook for
+// aws_cloudwatch_event_rule. It resolves ManagedBy via events:DescribeRule
+// and stamps it onto Identity.ServiceManagedBy so imported.UnimportableReason
+// can classify AWS-managed rules. Soft-fails on an SDK error (the resource is
+// still emitted; a follow-up SDK miss must not drop an otherwise-importable
+// rule).
+func eventRulePostDiscover(ctx context.Context, awsCfg aws.Config, region string, ir *imported.ImportedResource) error {
+	return eventRulePostDiscoverWithClient(ctx, newEventRuleDescriber(awsCfg, region), ir)
+}
+
+func eventRulePostDiscoverWithClient(ctx context.Context, client eventRuleDescriber, ir *imported.ImportedResource) error {
+	if ir == nil {
+		return nil
+	}
+	name, busName := eventRuleNameForDescribe(&ir.Identity)
+	if name == "" {
+		return fmt.Errorf("event_rule: cannot derive rule name from Identity (Address=%q ImportID=%q NameHint=%q)",
+			ir.Identity.Address, ir.Identity.ImportID, ir.Identity.NameHint)
+	}
+	in := &eventbridge.DescribeRuleInput{Name: aws.String(name)}
+	if busName != "" && busName != defaultEventBusName {
+		in.EventBusName = aws.String(busName)
+	}
+	out, err := client.DescribeRule(ctx, in)
+	if err != nil {
+		return fmt.Errorf("event_rule %q: DescribeRule: %w", name, err)
+	}
+	if out == nil {
+		return fmt.Errorf("event_rule %q: DescribeRule returned no rule", name)
+	}
+	if mb := aws.ToString(out.ManagedBy); mb != "" {
+		ir.Identity.ServiceManagedBy = mb
+	}
+	return nil
+}
+
+// eventRuleNameForDescribe resolves the bare rule name and event-bus name the
+// DescribeRule call needs from the identity the aws_cloudwatch_event_rule
+// discoverer populates. NameHint carries the bare rule Name (the CFN `Name`
+// property); ImportID is the `<bus>/<name>` form, so the bus name — and a
+// fallback rule name — parse out of it.
+func eventRuleNameForDescribe(id *imported.ResourceIdentity) (name, busName string) {
+	if id == nil {
+		return "", ""
+	}
+	if imp := strings.TrimSpace(id.ImportID); imp != "" {
+		if idx := strings.LastIndex(imp, "/"); idx != -1 {
+			busName = imp[:idx]
+			name = imp[idx+1:]
+		} else {
+			name = imp
+		}
+	}
+	if nh := strings.TrimSpace(id.NameHint); nh != "" {
+		name = nh
+	}
+	return name, busName
+}

--- a/cmd/insideout-import/awsdiscover/event_rule_post_discover_test.go
+++ b/cmd/insideout-import/awsdiscover/event_rule_post_discover_test.go
@@ -1,0 +1,156 @@
+package awsdiscover
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eventbridge"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// fakeEventRuleDescriber is a minimal eventRuleDescriber stub for the
+// PostDiscover hook tests. It records the DescribeRule input so the tests can
+// assert the derived Name / EventBusName.
+type fakeEventRuleDescriber struct {
+	out            *eventbridge.DescribeRuleOutput
+	err            error
+	gotName        string
+	gotEventBusPtr *string
+}
+
+func (f *fakeEventRuleDescriber) DescribeRule(_ context.Context, in *eventbridge.DescribeRuleInput, _ ...func(*eventbridge.Options)) (*eventbridge.DescribeRuleOutput, error) {
+	f.gotName = aws.ToString(in.Name)
+	f.gotEventBusPtr = in.EventBusName
+	return f.out, f.err
+}
+
+// TestEventRulePostDiscover_ManagedRuleClassified is the ccs-101d5181-5czmw
+// regression: AutoScalingManagedRule on the default bus has its ManagedBy
+// resolved at DISCOVER time via events:DescribeRule and stamped onto
+// Identity.ServiceManagedBy, so the shared importability classifier excludes
+// it into unsupported.json instead of letting the imported Project-tag stamp
+// fail the whole apply with ManagedRuleException. CC omits ManagedBy from its
+// schema, which is why the props fast-path alone was insufficient.
+func TestEventRulePostDiscover_ManagedRuleClassified(t *testing.T) {
+	t.Parallel()
+	fake := &fakeEventRuleDescriber{
+		out: &eventbridge.DescribeRuleOutput{
+			Name:      aws.String("AutoScalingManagedRule"),
+			ManagedBy: aws.String("autoscaling.amazonaws.com"),
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_event_rule",
+			Region:   "us-east-1",
+			NameHint: "AutoScalingManagedRule",
+			ImportID: "default/AutoScalingManagedRule",
+			NativeIDs: map[string]string{
+				"arn": "arn:aws:events:us-east-1:111111111111:rule/AutoScalingManagedRule",
+			},
+		},
+	}
+	require.NoError(t, eventRulePostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "autoscaling.amazonaws.com", ir.Identity.ServiceManagedBy,
+		"ManagedBy must be backfilled for the classifier")
+	// Bare rule name is used for DescribeRule; the default bus is omitted.
+	assert.Equal(t, "AutoScalingManagedRule", fake.gotName)
+	assert.Nil(t, fake.gotEventBusPtr, "default bus must not pass EventBusName")
+	// The shared classifier now routes it to unsupported.json.
+	assert.Equal(t, imported.ReasonServiceManaged, imported.UnimportableReason(*ir),
+		"managed rule must classify as un-importable once ManagedBy is stamped")
+}
+
+// TestEventRulePostDiscover_CustomBusPassesBusName proves a rule on a custom
+// event bus passes EventBusName to DescribeRule (the default bus is omitted).
+func TestEventRulePostDiscover_CustomBusPassesBusName(t *testing.T) {
+	t.Parallel()
+	fake := &fakeEventRuleDescriber{
+		out: &eventbridge.DescribeRuleOutput{
+			Name:      aws.String("my-rule"),
+			ManagedBy: aws.String("some.service.amazonaws.com"),
+		},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_event_rule",
+			NameHint: "my-rule",
+			ImportID: "my-bus/my-rule",
+		},
+	}
+	require.NoError(t, eventRulePostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "my-rule", fake.gotName)
+	require.NotNil(t, fake.gotEventBusPtr, "custom bus must pass EventBusName")
+	assert.Equal(t, "my-bus", aws.ToString(fake.gotEventBusPtr))
+	assert.Equal(t, "some.service.amazonaws.com", ir.Identity.ServiceManagedBy)
+}
+
+// TestEventRulePostDiscover_CustomerRuleImportable proves a customer rule (no
+// ManagedBy) stays importable: ServiceManagedBy is left empty and
+// UnimportableReason returns "".
+func TestEventRulePostDiscover_CustomerRuleImportable(t *testing.T) {
+	t.Parallel()
+	fake := &fakeEventRuleDescriber{
+		out: &eventbridge.DescribeRuleOutput{Name: aws.String("my-app-rule")},
+	}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_event_rule",
+			NameHint: "my-app-rule",
+			ImportID: "default/my-app-rule",
+		},
+	}
+	require.NoError(t, eventRulePostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "", ir.Identity.ServiceManagedBy, "customer rule carries no ManagedBy")
+	assert.Equal(t, "", imported.UnimportableReason(*ir), "customer rule must remain importable")
+}
+
+// TestEventRulePostDiscover_SoftFailsOnError proves a DescribeRule failure is
+// surfaced as an error (the discoverer logs it via ServiceWarn) without
+// clobbering the IR — the rule is still emitted as importable, matching the
+// genconfig prune backstop posture.
+func TestEventRulePostDiscover_SoftFailsOnError(t *testing.T) {
+	t.Parallel()
+	fake := &fakeEventRuleDescriber{err: errors.New("AccessDenied")}
+	ir := &imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Type:     "aws_cloudwatch_event_rule",
+			NameHint: "my-app-rule",
+			ImportID: "default/my-app-rule",
+		},
+	}
+	require.Error(t, eventRulePostDiscoverWithClient(context.Background(), fake, ir))
+	assert.Equal(t, "", ir.Identity.ServiceManagedBy, "no marker stamped when DescribeRule fails")
+	assert.Equal(t, "", imported.UnimportableReason(*ir), "un-resolvable rule stays importable (backstop posture)")
+}
+
+// TestEventRulePostDiscover_EmptyIdentity proves a rule whose name cannot be
+// derived returns an error rather than panicking or issuing a garbage call.
+func TestEventRulePostDiscover_EmptyIdentity(t *testing.T) {
+	t.Parallel()
+	fake := &fakeEventRuleDescriber{}
+	ir := &imported.ImportedResource{Identity: imported.ResourceIdentity{Type: "aws_cloudwatch_event_rule"}}
+	require.Error(t, eventRulePostDiscoverWithClient(context.Background(), fake, ir))
+}
+
+// TestEventRuleConfig_WiresPostDiscover guards the registration: the
+// aws_cloudwatch_event_rule cloudControlConfig must carry the PostDiscover
+// hook, or the discover-time ManagedBy backfill silently regresses (CC omits
+// ManagedBy, so the props fast-path alone never fires — the ccs-101d5181-5czmw
+// class of failure).
+func TestEventRuleConfig_WiresPostDiscover(t *testing.T) {
+	t.Parallel()
+	var found bool
+	for _, cfg := range cloudControlTypeConfigs {
+		if cfg.TFType == "aws_cloudwatch_event_rule" {
+			found = true
+			require.NotNil(t, cfg.PostDiscover, "aws_cloudwatch_event_rule must wire PostDiscover for discover-time ManagedBy backfill")
+		}
+	}
+	require.True(t, found, "aws_cloudwatch_event_rule config not found")
+}

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/eks v1.83.0
 	github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2
 	github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12
+	github.com/aws/aws-sdk-go-v2/service/eventbridge v1.44.2
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.10
 	github.com/aws/aws-sdk-go-v2/service/kafka v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/kendra v1.60.27

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2 h1:5wbCUfyxXcjIqesyVfJB
 github.com/aws/aws-sdk-go-v2/service/elasticache v1.52.2/go.mod h1:o4vQxDt6oteknUjkXIEskp0ccy+93NRTPKXw3HlVMFE=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12 h1:TJXv7kZjdXA2maPDaJFFEQPBrPmvPtMybN3qYDOpJ4Y=
 github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2 v1.54.12/go.mod h1:lwjtb9DHOAmNt7EUW68Zd1Qd+cPyFxacXHN5c9JZ2VY=
+github.com/aws/aws-sdk-go-v2/service/eventbridge v1.44.2 h1:bJel1AiZqZ3od/nUjasWddTUXCePWRDflVJ0aCqTEo0=
+github.com/aws/aws-sdk-go-v2/service/eventbridge v1.44.2/go.mod h1:dyqzEdapinPXsOjvp8cHgGejFd7aUBqUGaPgvg2pprk=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10 h1:kcN3I3llO7VwIY5w3Pc5FmEonpsr23Ou7Cwk4qf7dik=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.10/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.9 h1:FLudkZLt5ci0ozzgkVo8BJGwvqNaZbTWb3UcucAateA=

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -112,6 +112,21 @@ const (
 	// parameter groups on a whole-account staging import). Not customer
 	// infrastructure; manage a custom parameter group instead.
 	ReasonAWSDefaultParameterGroup = "aws_default_parameter_group"
+
+	// ReasonAWSManagedEventRule marks an aws_cloudwatch_event_rule whose name
+	// is a well-known AWS-managed rule (AutoScalingManagedRule, …). AWS sets
+	// ManagedBy on these rules and rejects tag / PutRule / DeleteRule with a
+	// ManagedRuleException, so the rule cannot be managed by Terraform. The
+	// generic ReasonServiceManaged path already catches these WHEN discovery
+	// surfaced the ManagedBy marker (Identity.ServiceManagedBy) — but a stale
+	// imported baseline persisted before discovery learned to backfill
+	// ManagedBy carries no marker, so this NAME-based classifier is the
+	// compose-time backstop that still drops the rule (DropUnimportable in
+	// ComposeStackWithIssues, #860). Triggering incident: staging apply
+	// ccs-101d5181-5czmw, where the imported Project-tag stamp on
+	// AutoScalingManagedRule (arn …:rule/AutoScalingManagedRule) failed the
+	// whole 264-import apply with ManagedRuleException.
+	ReasonAWSManagedEventRule = "aws_managed_event_rule"
 )
 
 // awsDefaultParameterGroupPrefix is the reserved name prefix of AWS-managed
@@ -132,6 +147,31 @@ var awsDefaultParameterGroupTypes = map[string]struct{}{
 // AWS-managed default (reserved `default.` prefix).
 func IsAWSDefaultParameterGroupName(name string) bool {
 	return strings.HasPrefix(strings.TrimSpace(name), awsDefaultParameterGroupPrefix)
+}
+
+// awsManagedEventRuleNames is the allowlist of well-known AWS-managed
+// EventBridge rule names. AWS creates these on the customer's behalf and
+// stamps ManagedBy on them, so tag / PutRule / DeleteRule are all rejected
+// with ManagedRuleException — they cannot be managed by Terraform. This is a
+// name-based backstop for the case where discovery did NOT surface the live
+// ManagedBy marker (a stale imported baseline); a fresh discovery backfills
+// Identity.ServiceManagedBy and the generic IsServiceManaged path catches it
+// first. Extend by adding the exact rule name AWS uses.
+//
+//   - AutoScalingManagedRule — the EC2 Auto Scaling capacity-rebalance /
+//     lifecycle rule (ManagedBy = autoscaling.amazonaws.com). Triggering
+//     incident: staging apply ccs-101d5181-5czmw.
+var awsManagedEventRuleNames = map[string]struct{}{
+	"AutoScalingManagedRule": {},
+}
+
+// IsAWSManagedEventRuleName reports whether an EventBridge rule name is a
+// well-known AWS-managed rule (see awsManagedEventRuleNames). The empty string
+// (name not surfaced by the discoverer) is treated as importable so an absent
+// name never drops a customer rule — matching the KMS-key / ENI posture.
+func IsAWSManagedEventRuleName(name string) bool {
+	_, ok := awsManagedEventRuleNames[strings.TrimSpace(name)]
+	return ok
 }
 
 // awsManagedKMSAliasPrefix is the reserved alias prefix the AWS provider
@@ -286,6 +326,16 @@ func UnimportableReason(ir ImportedResource) string {
 		// Type-level: every log stream is ephemeral and un-importable (see
 		// ReasonEphemeralLogStream).
 		return ReasonEphemeralLogStream
+	case "aws_cloudwatch_event_rule":
+		// Name-based backstop for AWS-managed rules (AutoScalingManagedRule,
+		// …) when discovery did not surface the live ManagedBy marker — a
+		// stale imported baseline. A fresh discovery stamps
+		// Identity.ServiceManagedBy and the IsServiceManaged check above wins
+		// first (ReasonServiceManaged); this fires only when that marker is
+		// absent (incident: staging apply ccs-101d5181-5czmw).
+		if IsAWSManagedEventRuleName(eventRuleName(ir.Identity)) {
+			return ReasonAWSManagedEventRule
+		}
 	}
 	if _, pg := awsDefaultParameterGroupTypes[ir.Identity.Type]; pg {
 		if IsAWSDefaultParameterGroupName(parameterGroupName(ir.Identity)) {
@@ -325,6 +375,21 @@ func parameterGroupName(id ResourceIdentity) string {
 	return strings.TrimSpace(id.NameHint)
 }
 
+// eventRuleName resolves an EventBridge rule's bare name from the identity the
+// aws_cloudwatch_event_rule discoverer populates. NameHint carries the CFN
+// `Name` property (the bare rule name); ImportID is the `<bus>/<name>` form, so
+// the segment after the last `/` is the fallback rule name.
+func eventRuleName(id ResourceIdentity) string {
+	if n := strings.TrimSpace(id.NameHint); n != "" {
+		return n
+	}
+	imp := strings.TrimSpace(id.ImportID)
+	if idx := strings.LastIndex(imp, "/"); idx != -1 {
+		return imp[idx+1:]
+	}
+	return imp
+}
+
 // ReasonDescription returns a short, operator-facing explanation for an
 // un-importability reason code, suitable for a wizard tooltip or a CLI / 422
 // message. Returns "" for an unknown code so callers can fall back to a generic
@@ -347,6 +412,8 @@ func ReasonDescription(reason string) string {
 		return "AWS service-linked IAM role (role/aws-service-role/* path) — created and deleted by the owning AWS service; cannot be imported into Terraform."
 	case ReasonAWSDefaultParameterGroup:
 		return "AWS-managed default parameter group (reserved default.* name) — AWS rejects tagging and every other modification; manage a custom parameter group instead."
+	case ReasonAWSManagedEventRule:
+		return "AWS-managed EventBridge rule (well-known managed rule such as AutoScalingManagedRule, ManagedBy set) — AWS rejects tag / PutRule / DeleteRule with ManagedRuleException; manage a custom rule instead."
 	default:
 		return ""
 	}

--- a/pkg/composer/imported/importability_event_rule_test.go
+++ b/pkg/composer/imported/importability_event_rule_test.go
@@ -1,0 +1,110 @@
+package imported
+
+import "testing"
+
+// Pins the name-based AWS-managed EventBridge rule classification and the
+// compose-side DropUnimportable pass. This is the compose-time backstop that
+// fixes the reliable apply leg without waiting on the discovery/mars chain:
+// even when a stale imported baseline carries no live ManagedBy marker,
+// AutoScalingManagedRule is dropped by name so the imported Project-tag stamp
+// can't fail the whole apply with ManagedRuleException (staging apply
+// ccs-101d5181-5czmw, arn …:rule/AutoScalingManagedRule).
+func TestUnimportableReason_AWSManagedEventRule(t *testing.T) {
+	mkName := func(nameHint string) ImportedResource {
+		return ImportedResource{Identity: ResourceIdentity{
+			Type:     "aws_cloudwatch_event_rule",
+			Address:  "aws_cloudwatch_event_rule.x",
+			NameHint: nameHint,
+		}}
+	}
+	mkImport := func(importID string) ImportedResource {
+		return ImportedResource{Identity: ResourceIdentity{
+			Type:     "aws_cloudwatch_event_rule",
+			Address:  "aws_cloudwatch_event_rule.x",
+			ImportID: importID,
+		}}
+	}
+	cases := []struct {
+		name string
+		ir   ImportedResource
+		want string
+	}{
+		{"AutoScalingManagedRule by NameHint", mkName("AutoScalingManagedRule"), ReasonAWSManagedEventRule},
+		{"AutoScalingManagedRule via ImportID default bus", mkImport("default/AutoScalingManagedRule"), ReasonAWSManagedEventRule},
+		{"AutoScalingManagedRule via ImportID custom bus", mkImport("my-bus/AutoScalingManagedRule"), ReasonAWSManagedEventRule},
+		{"customer rule importable", mkName("my-app-rule"), ""},
+		{"managed name on unrelated type importable", ImportedResource{Identity: ResourceIdentity{Type: "aws_sqs_queue", NameHint: "AutoScalingManagedRule"}}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := UnimportableReason(tc.ir); got != tc.want {
+				t.Fatalf("UnimportableReason = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestUnimportableReason_EventRule_ServiceManagedWinsFirst proves the generic
+// ServiceManagedBy path (a fresh discovery that backfilled ManagedBy) wins
+// over the name-based backstop: a managed rule WITH the live marker classifies
+// as ReasonServiceManaged, not ReasonAWSManagedEventRule.
+func TestUnimportableReason_EventRule_ServiceManagedWinsFirst(t *testing.T) {
+	ir := ImportedResource{Identity: ResourceIdentity{
+		Type:             "aws_cloudwatch_event_rule",
+		NameHint:         "AutoScalingManagedRule",
+		ServiceManagedBy: "autoscaling.amazonaws.com",
+	}}
+	if got := UnimportableReason(ir); got != ReasonServiceManaged {
+		t.Fatalf("UnimportableReason = %q, want %q (live marker wins over name backstop)", got, ReasonServiceManaged)
+	}
+}
+
+func TestIsAWSManagedEventRuleName(t *testing.T) {
+	cases := map[string]bool{
+		"AutoScalingManagedRule":    true,
+		"  AutoScalingManagedRule ": true, // trimmed
+		"my-app-rule":               false,
+		"":                          false,
+		"autoscalingmanagedrule":    false, // case-sensitive: AWS uses the exact name
+	}
+	for name, want := range cases {
+		if got := IsAWSManagedEventRuleName(name); got != want {
+			t.Errorf("IsAWSManagedEventRuleName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+// TestDropUnimportable_AWSManagedEventRule is the compose-time drop citing the
+// incident: an AutoScalingManagedRule persisted into a session's imported
+// baseline (no live ManagedBy marker) is dropped by DropUnimportable so the
+// apply leg never tag-stamps it and never trips ManagedRuleException. Job
+// ccs-101d5181-5czmw, rule arn …:rule/AutoScalingManagedRule.
+func TestDropUnimportable_AWSManagedEventRule(t *testing.T) {
+	managed := ImportedResource{Identity: ResourceIdentity{
+		Type:     "aws_cloudwatch_event_rule",
+		Address:  "aws_cloudwatch_event_rule.autoscaling_managed_rule",
+		NameHint: "AutoScalingManagedRule",
+		ImportID: "default/AutoScalingManagedRule",
+		NativeIDs: map[string]string{
+			"arn": "arn:aws:events:us-west-2:031780745048:rule/AutoScalingManagedRule",
+		},
+	}}
+	custom := ImportedResource{Identity: ResourceIdentity{
+		Type:     "aws_cloudwatch_event_rule",
+		Address:  "aws_cloudwatch_event_rule.my_app_rule",
+		NameHint: "my-app-rule",
+		ImportID: "default/my-app-rule",
+	}}
+	kept, dropped := DropUnimportable([]ImportedResource{managed, custom})
+	if len(kept) != 1 || kept[0].Identity.Address != "aws_cloudwatch_event_rule.my_app_rule" {
+		t.Fatalf("kept = %+v", kept)
+	}
+	if len(dropped) != 1 ||
+		dropped[0][0] != "aws_cloudwatch_event_rule.autoscaling_managed_rule" ||
+		dropped[0][1] != ReasonAWSManagedEventRule {
+		t.Fatalf("dropped = %+v", dropped)
+	}
+	if desc := ReasonDescription(ReasonAWSManagedEventRule); desc == "" {
+		t.Fatal("ReasonDescription must cover the new reason")
+	}
+}

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -22,6 +22,8 @@ func TestReasonCodes_WireStable(t *testing.T) {
 	assert.Equal(t, "ephemeral_log_stream", ReasonEphemeralLogStream)
 	assert.Equal(t, "insideout_imported", ReasonInsideOutImported)
 	assert.Equal(t, "service_linked_iam_role", ReasonServiceLinkedIAMRole)
+	assert.Equal(t, "aws_default_parameter_group", ReasonAWSDefaultParameterGroup)
+	assert.Equal(t, "aws_managed_event_rule", ReasonAWSManagedEventRule)
 }
 
 func TestIsAWSManagedKMSAliasName(t *testing.T) {


### PR DESCRIPTION
## Show-stopper

An AWS-managed EventBridge rule (`AutoScalingManagedRule`) was tag-stamped in `imported.tf` and failed the **whole 264-import apply**:

```
ManagedRuleException: Tag related operations on the managed rule ... not allowed
```

Proven on staging apply `ccs-101d5181-5czmw` (rule arn `.../rule/AutoScalingManagedRule`).

## Root cause

Cloud Control's `AWS::Events::Rule` schema omits `ManagedBy`, so `ServiceManagedByFromProperties` (`cmd/insideout-import/awsdiscover/cloudcontrol_types.go`) always returns `""` and the existing `ReasonServiceManaged` classifier (#785) never fires — the managed rule sails through discovery and sinks the apply.

## Fix (two layers, one PR)

**1. Discover-time backfill.** New `eventRulePostDiscover` hook (mirrors `kms_key_post_discover.go`) issues one `events:DescribeRule` per discovered `aws_cloudwatch_event_rule` and stamps `Identity.ServiceManagedBy` from the API's `ManagedBy` field. Soft-fails on SDK error (rule stays importable; genconfig prune remains the backstop). Wired into the `aws_cloudwatch_event_rule` config; the props fast-path line is kept.

**2. Compose-time poka-yoke.** Name-based `IsAWSManagedEventRuleName` classifier (mirrors `IsAWSDefaultParameterGroupName`) with a well-known-name allowlist (`AutoScalingManagedRule`) plus a `ReasonAWSManagedEventRule` reason code + `ReasonDescription` row, so `DropUnimportable` (wired in `ComposeStackWithIssues` since #860) drops the rule **at compose time even against a stale imported baseline** that carries no live `ManagedBy` marker. This is the layer that fixes the reliable apply leg immediately, without waiting on the discovery/mars chain.

The generic `IsServiceManaged` check still wins first for a fresh discovery (returns `ReasonServiceManaged`); the name allowlist is the backstop for the marker-absent baseline.

## Tests

- Fixed the false-confidence extractor unit test — it only exercised the never-populated props path; it now asserts CC omits `ManagedBy` (returns `""`) and that `PostDiscover` is wired.
- Added `event_rule_post_discover_test.go` (fake `eventbridge` client: managed-rule classified, custom-bus `EventBusName` passthrough, customer rule importable, soft-fail on error, empty identity, config-wires-PostDiscover).
- Added `importability_event_rule_test.go` (name classifier, service-managed-wins-first, and a `DropUnimportable` case citing job `ccs-101d5181-5czmw`, rule arn `.../rule/AutoScalingManagedRule`).

## Gates

- `gofmt -l` clean
- `go vet ./pkg/composer/... ./cmd/insideout-import/...`
- `go test ./pkg/composer/... ./cmd/insideout-import/...` — all `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK)_