### PR TITLE
feat(composer): exported pick-time provenance ownership readers (reliable#2230)

### DIFF
--- a/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration.go
+++ b/cmd/insideout-import/awsdiscover/bedrock_model_invocation_logging_configuration.go
@@ -80,7 +80,7 @@ func (d *bedrockModelInvocationLoggingConfigurationDiscoverer) ResourceType() st
 //     multi-region scan should not abort the whole run).
 //
 // The resource carries no tags (untaggable in AWS provider 6.x — pinned
-// in pkg/composer/imported_provenance.go::untaggableAWS), so this
+// in pkg/composer/imported/provenance_owner.go::untaggableAWS), so this
 // discoverer does not run the post-fetch tag filter and emits an empty
 // (non-nil) Tags map per the #255 contract.
 //

--- a/pkg/composer/imported/importability.go
+++ b/pkg/composer/imported/importability.go
@@ -178,12 +178,9 @@ func IsAWSManagedEventRuleName(name string) bool {
 // refuses to create or import an aws_kms_alias under.
 const awsManagedKMSAliasPrefix = "alias/aws/"
 
-const (
-	awsTagKeyImported        = "InsideOutImported"
-	gcpLabelKeyImported      = "insideout-imported"
-	awsTagKeyImportProject   = "InsideOutImportProject"
-	gcpLabelKeyImportProject = "insideout-import-project"
-)
+// The provenance marker key literals live in marker_tags.go (canonical home
+// for both this package and the pkg/composer re-exports — reliable#2230
+// consolidation; this file previously carried a private duplicate set).
 
 // awsManagedKMSKeyManager is the KeyManager value KMS reports for keys it
 // manages on the customer's behalf (vs "CUSTOMER" for customer-managed
@@ -265,18 +262,12 @@ func IsServiceManagedENIInterfaceType(interfaceType string) bool {
 // adopted-resource marker tag/label stamped by InsideOut. The marker key's
 // presence is enough; callers must not infer ownership from the project tag
 // because some historical resources carry a bare account/project marker
-// without having been imported.
+// without having been imported. Key matching (TrimSpace + case-insensitive)
+// is shared with the provenance-owner reader via normalizedTagValue so the
+// "is it marked" and "who marked it" questions can never disagree.
 func HasInsideOutImportedMarker(tags map[string]string) bool {
-	if tags == nil {
-		return false
-	}
-	for key := range tags {
-		switch strings.ToLower(strings.TrimSpace(key)) {
-		case strings.ToLower(awsTagKeyImported), gcpLabelKeyImported:
-			return true
-		}
-	}
-	return false
+	_, ok := normalizedTagValue(tags, AWSTagKeyImported, GCPLabelKeyImported)
+	return ok
 }
 
 // UnimportableReason classifies a discovered resource as inherently

--- a/pkg/composer/imported/importability_test.go
+++ b/pkg/composer/imported/importability_test.go
@@ -172,11 +172,11 @@ func TestHasInsideOutImportedMarker(t *testing.T) {
 		want bool
 	}{
 		"aws imported marker present": {
-			tags: map[string]string{awsTagKeyImported: "true"},
+			tags: map[string]string{AWSTagKeyImported: "true"},
 			want: true,
 		},
 		"aws imported marker presence is enough": {
-			tags: map[string]string{awsTagKeyImported: ""},
+			tags: map[string]string{AWSTagKeyImported: ""},
 			want: true,
 		},
 		"aws imported marker match is case-insensitive": {
@@ -184,15 +184,15 @@ func TestHasInsideOutImportedMarker(t *testing.T) {
 			want: true,
 		},
 		"gcp imported marker present": {
-			tags: map[string]string{gcpLabelKeyImported: "true"},
+			tags: map[string]string{GCPLabelKeyImported: "true"},
 			want: true,
 		},
 		"bare aws import project account id is not ownership": {
-			tags: map[string]string{awsTagKeyImportProject: "123456789012"},
+			tags: map[string]string{AWSTagKeyImportProject: "123456789012"},
 			want: false,
 		},
 		"bare gcp import project label is not ownership": {
-			tags: map[string]string{gcpLabelKeyImportProject: "customer-project"},
+			tags: map[string]string{GCPLabelKeyImportProject: "customer-project"},
 			want: false,
 		},
 		"no tags": {
@@ -219,21 +219,21 @@ func TestUnimportableReason_InsideOutImportedMarker(t *testing.T) {
 	t.Run("aws marker makes otherwise importable resource un-importable", func(t *testing.T) {
 		ir := ImportedResource{Identity: ResourceIdentity{
 			Type: "aws_vpc",
-			Tags: map[string]string{awsTagKeyImported: "true"},
+			Tags: map[string]string{AWSTagKeyImported: "true"},
 		}}
 		assert.Equal(t, ReasonInsideOutImported, UnimportableReason(ir))
 	})
 	t.Run("gcp marker makes otherwise importable resource un-importable", func(t *testing.T) {
 		ir := ImportedResource{Identity: ResourceIdentity{
 			Type: "google_storage_bucket",
-			Tags: map[string]string{gcpLabelKeyImported: "true"},
+			Tags: map[string]string{GCPLabelKeyImported: "true"},
 		}}
 		assert.Equal(t, ReasonInsideOutImported, UnimportableReason(ir))
 	})
 	t.Run("bare import project account id stays importable", func(t *testing.T) {
 		ir := ImportedResource{Identity: ResourceIdentity{
 			Type: "aws_vpc",
-			Tags: map[string]string{awsTagKeyImportProject: "123456789012"},
+			Tags: map[string]string{AWSTagKeyImportProject: "123456789012"},
 		}}
 		assert.Equal(t, "", UnimportableReason(ir))
 	})

--- a/pkg/composer/imported/marker_tags.go
+++ b/pkg/composer/imported/marker_tags.go
@@ -1,58 +1,54 @@
-package composer
+package imported
 
-import "github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
-
-// Exported InsideOut import-provenance marker tag/label keys.
+// Canonical InsideOut import-provenance marker tag/label keys.
 //
 // Every taggable resource adopted by `insideout-import` is stamped with these
 // keys on first apply. Downstream consumers (the reliable backend, the
 // imported-resource drift classifier, the UI) need the same literals to
-// classify plan diffs as "expected provenance write" vs. real drift. The
-// canonical definitions live in pkg/composer/imported (marker_tags.go) so
-// that package's un-importability classifier and provenance-owner reader
-// share the exact literals without an import cycle (reliable#2230); this
-// re-export preserves the established pkg/composer surface — see issue #679
-// for the duplication that prompted the original export.
+// classify plan diffs as "expected provenance write" vs. real drift — see
+// issue #679 for the duplication that prompted the original export from
+// pkg/composer.
+//
+// This package is the single definition site (reliable#2230 consolidation):
+// pkg/composer re-exports these constants for its established public surface,
+// and importability.go's un-importability classifier reads the same literals —
+// previously it carried a private duplicate set. pkg/composer/imported cannot
+// import pkg/composer (cycle), so the canonical home is here, at the bottom of
+// the dependency graph.
 //
 // AWS uses CamelCase tag keys; GCP labels are restricted to lowercase letters,
 // digits, `-`, and `_`, so the GCP mirror uses kebab-case.
 const (
 	// AWSTagKeyImportProject identifies the InsideOut stack/import-project
 	// that owns this resource. Required on every adopted AWS resource.
-	AWSTagKeyImportProject = imported.AWSTagKeyImportProject
+	AWSTagKeyImportProject = "InsideOutImportProject"
 
 	// AWSTagKeyImportSession identifies the specific import session that
 	// adopted this resource. Optional — omitted when the caller did not
 	// supply a session ID.
-	AWSTagKeyImportSession = imported.AWSTagKeyImportSession
+	AWSTagKeyImportSession = "InsideOutImportSession"
 
 	// AWSTagKeyImported is the canonical boolean marker stamped on every
 	// adopted AWS resource. Its value is always "true".
-	AWSTagKeyImported = imported.AWSTagKeyImported
+	AWSTagKeyImported = "InsideOutImported"
 
 	// AWSTagKeyImportedAt is the RFC3339 UTC timestamp recorded when the
 	// resource was first adopted.
-	AWSTagKeyImportedAt = imported.AWSTagKeyImportedAt
+	AWSTagKeyImportedAt = "InsideOutImportedAt"
 
 	// GCPLabelKeyImportProject is the GCP-label mirror of
 	// AWSTagKeyImportProject.
-	GCPLabelKeyImportProject = imported.GCPLabelKeyImportProject
+	GCPLabelKeyImportProject = "insideout-import-project"
 
 	// GCPLabelKeyImportSession is the GCP-label mirror of
 	// AWSTagKeyImportSession.
-	GCPLabelKeyImportSession = imported.GCPLabelKeyImportSession
+	GCPLabelKeyImportSession = "insideout-import-session"
 
 	// GCPLabelKeyImported is the GCP-label mirror of AWSTagKeyImported.
-	GCPLabelKeyImported = imported.GCPLabelKeyImported
+	GCPLabelKeyImported = "insideout-imported"
 
 	// GCPLabelKeyImportedAt is the GCP-label mirror of AWSTagKeyImportedAt.
 	// The value is RFC3339 UTC, downcased with `:` and `.` replaced by `-`
 	// to satisfy the GCP label charset.
-	GCPLabelKeyImportedAt = imported.GCPLabelKeyImportedAt
+	GCPLabelKeyImportedAt = "insideout-imported-at"
 )
-
-// markerValueTrue is the canonical value of AWSTagKeyImported /
-// GCPLabelKeyImported. Kept unexported because it is the same literal in
-// both clouds and downstream classifiers only need to compare against the
-// constant `"true"`.
-const markerValueTrue = "true"

--- a/pkg/composer/imported/policy/aws_apprunner_custom_domain_association.policy.go
+++ b/pkg/composer/imported/policy/aws_apprunner_custom_domain_association.policy.go
@@ -13,8 +13,9 @@ package policy
 //
 // NOTE: this resource type does NOT accept tags. Confirmed in the
 // repo's NON_TAGGABLE_AWS allowlist (tests/lint-project-tag.sh) and
-// the untaggableAWS map in pkg/composer/imported_provenance.go. The
-// `tags` / `tags_all` entries are intentionally omitted.
+// the untaggableAWS map in pkg/composer/imported/provenance_owner.go
+// (alongside TaggableAttr). The `tags` / `tags_all` entries are
+// intentionally omitted.
 var awsApprunnerCustomDomainAssociationPolicy = Map{
 	// Identity ----------------------------------------------------------
 	"id": {

--- a/pkg/composer/imported/provenance_owner.go
+++ b/pkg/composer/imported/provenance_owner.go
@@ -1,0 +1,507 @@
+package imported
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported/generated"
+)
+
+// Provenance ownership reading (reliable#2230).
+//
+// A resource's InsideOut provenance claim can land in three placements, and
+// each import leg populates a different one:
+//
+//   - ir.Attrs — the typed tag/label literal. PLAN-AUTHORITATIVE: the composer
+//     emits the resource body from Attrs, so a value here is exactly what the
+//     next `terraform plan` will write. Populated by the Mars reverse-import
+//     backfill (pkg/reverseimport.BackfillImportedAttrsFromPlan) and by Cloud
+//     Control enrichment.
+//   - ir.Attributes — the opaque Phase-1 attribute bag (pre-typed
+//     intermediate).
+//   - ir.Identity.Tags — the LIVE cloud-side tag (AWS) / label (GCP) snapshot
+//     captured at discover time. The discover path populates ONLY this field
+//     (Attrs empty).
+//
+// Historically two divergent readers existed over disjoint subsets of these
+// fields — the composer's compose-time conflict guard read Attrs/Attributes
+// only, while reliable's picker/reverse-run guards read Identity.Tags only —
+// so a cross-project claim was invisible at pick/plan time and surfaced only
+// at apply-compose (reliable session sess_v2_tunCkPopdiKK, import
+// irun_jFcsE0sgd8NH). ProvenanceOwner / ProvenanceOwnedByOther below are the
+// single exported readers downstream consumers delegate to. This is the ONE
+// canonical copy of the precedence rationale; the pkg/composer wrappers
+// cross-reference it.
+//
+// Precedence: Attrs → Attributes → Identity.Tags, with two deliberate
+// restrictions on the live leg:
+//
+//  1. Identity.Tags is consulted ONLY for the literal discover-only shape
+//     (len(Attrs) == 0 AND len(Attributes) == 0). Once ANY desired state
+//     exists, the pipeline has already computed what the next plan writes,
+//     and a stale live tag must never shadow it — including the case where
+//     desired state deliberately REMOVES a marker (claim release).
+//  2. The live leg uses FULL-STAMP semantics: a claim counts only when the
+//     InsideOutImported co-marker accompanies a non-empty project value.
+//     Bare project/account markers are explicitly NOT ownership — see the
+//     HasInsideOutImportedMarker contract in importability.go ("some
+//     historical resources carry a bare account/project marker without
+//     having been imported"). Treating a bare live marker as a claim would
+//     manufacture unresolvable conflicts against an owner that never owned.
+//
+// The pair (project, session) is always read LAYER-COHERENTLY: both values
+// come from the single first layer that carries the project marker. Stitching
+// a project from one layer with a session from another lets a stale live
+// session marker satisfy the same-session self-claim escape (reliable#2068)
+// against a foreign desired-state project — silently suppressing a real
+// conflict.
+//
+// Relationship to compose-time enforcement: these readers are a SUPERSET
+// guard for pick/plan time, not a byte-parity mirror of
+// composer.ValidateProvenanceConflicts. Compose never *conflicts* on
+// live-only claims — DropUnimportable (compose.go, via UnimportableReason's
+// ReasonInsideOutImported) silently DROPS any resource whose live tags carry
+// the InsideOutImported co-marker before the validator runs, and the Mars-leg
+// gates (pkg/reverseimport run.go / closure.go, depchase) reject the same
+// class up front. The invariant, pinned by the pipeline matrix test in
+// pkg/composer: anything compose would reject as a provenance conflict OR
+// silently drop as foreign-claimed is flagged by ProvenanceOwnedByOther at
+// pick time. Callers should consult UnimportableReason alongside this reader:
+// UnimportableReason answers "is it already InsideOut-managed at all" (any
+// shape, no owner attribution); ProvenanceOwnedByOther answers "which OTHER
+// project claims it".
+
+// untaggableAWS mirrors the canonical NON_TAGGABLE_AWS array in
+// tests/lint-project-tag.sh. Resource types in this set do NOT accept a tags
+// attribute in AWS provider 6.x; the provenance injector skips them and marks
+// the resource WeakLocked. The composer's
+// TestUntaggableAllowlistsMatchLintScripts ensures this list stays in sync
+// with the bash array.
+var untaggableAWS = map[string]struct{}{
+	"aws_acm_certificate_validation":                     {},
+	"aws_api_gateway_deployment":                         {},
+	"aws_api_gateway_resource":                           {},
+	"aws_apigatewayv2_api_mapping":                       {},
+	"aws_apigatewayv2_authorizer":                        {},
+	"aws_apigatewayv2_integration":                       {},
+	"aws_apigatewayv2_route":                             {},
+	"aws_apprunner_custom_domain_association":            {},
+	"aws_autoscaling_group_tag":                          {},
+	"aws_backup_selection":                               {},
+	"aws_bedrock_model_invocation_logging_configuration": {},
+	"aws_bedrockagent_agent_action_group":                {},
+	"aws_bedrockagent_agent_knowledge_base_association":  {},
+	"aws_bedrockagent_data_source":                       {},
+	"aws_bedrockagentcore_gateway_target":                {},
+	"aws_cloudfront_monitoring_subscription":             {},
+	"aws_cloudfront_origin_access_identity":              {},
+	"aws_cloudwatch_dashboard":                           {},
+	"aws_cloudwatch_log_resource_policy":                 {},
+	"aws_cloudwatch_log_stream":                          {},
+	"aws_cognito_identity_provider":                      {},
+	"aws_cognito_resource_server":                        {},
+	"aws_cognito_user_pool_client":                       {},
+	"aws_cognito_user_pool_domain":                       {},
+	"aws_dynamodb_contributor_insights":                  {},
+	"aws_ecs_cluster_capacity_providers":                 {},
+	"aws_iam_group":                                      {},
+	"aws_iam_instance_profile":                           {},
+	"aws_iam_role_policy":                                {},
+	"aws_iam_role_policy_attachment":                     {},
+	"aws_iam_service_linked_role":                        {},
+	"aws_kms_alias":                                      {},
+	"aws_lambda_alias":                                   {},
+	"aws_lambda_function_url":                            {},
+	"aws_lambda_permission":                              {},
+	"aws_msk_configuration":                              {},
+	"aws_opensearchserverless_access_policy":             {},
+	"aws_opensearchserverless_security_policy":           {},
+	"aws_route53_record":                                 {},
+	"aws_s3_bucket_lifecycle_configuration":              {},
+	"aws_s3_bucket_ownership_controls":                   {},
+	"aws_s3_bucket_policy":                               {},
+	"aws_s3_bucket_public_access_block":                  {},
+	"aws_s3_bucket_server_side_encryption_configuration": {},
+	"aws_s3_bucket_versioning":                           {},
+	"aws_secretsmanager_secret_rotation":                 {},
+	"aws_security_group_rule":                            {},
+	"aws_sns_topic_subscription":                         {},
+	"aws_wafv2_web_acl_association":                      {},
+}
+
+// UntaggableAWSTypes returns the sorted untaggable AWS resource type list for
+// cross-checking against the lint script (tests/lint-project-tag.sh). The
+// slice is a stable copy.
+func UntaggableAWSTypes() []string {
+	out := make([]string, 0, len(untaggableAWS))
+	for k := range untaggableAWS {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TaggableAttr returns the HCL attribute name ("tags" for AWS, "labels" for
+// GCP) provenance markers live under for ir, or ("", false) if the resource
+// type does not support tag/label-based mutual exclusion (weak lock).
+//
+// Decision order:
+//  1. Layer 1 generated schema (authoritative when registered): the schema
+//     map indicates whether the type carries a "tags" or "labels" key.
+//  2. AWS unregistered types: default to taggable unless explicitly listed
+//     in untaggableAWS (most AWS resources accept tags).
+//  3. GCP unregistered types: weak-lock (the long tail of GCP types lives
+//     in the typed registry now after Bundle 9–12; anything still
+//     unregistered is too unknown to label safely). The historical
+//     `labelableGCP` static allowlist was deleted in #396 once every
+//     entry it carried also lived in the typed registry — the schema
+//     branch above subsumes it.
+func TaggableAttr(ir ImportedResource) (attr string, ok bool) {
+	cloud := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
+	tfType := strings.TrimSpace(ir.Identity.Type)
+	if cloud == "" || tfType == "" {
+		return "", false
+	}
+
+	// Instance-level untaggability (#785): a resource whose type is normally
+	// taggable is still NOT taggable when the cloud marks it service-managed.
+	// AWS rejects every tag operation on a service-managed instance (an
+	// EventBridge ManagedBy rule fails with ManagedRuleException), so the
+	// injector must skip provenance and weak-lock it. This sits alongside the
+	// type-level untaggableAWS map but keys off the per-instance marker the
+	// discoverer captured, so it works for any type and any selection path —
+	// the composer's last line of defense even if classification let the
+	// instance through.
+	if IsServiceManaged(ir.Identity) {
+		return "", false
+	}
+
+	if _, schema, registered := generated.Lookup(tfType); registered {
+		switch cloud {
+		case "aws":
+			if _, has := schema["tags"]; has {
+				return "tags", true
+			}
+			return "", false
+		case "gcp":
+			if _, has := schema["labels"]; has {
+				return "labels", true
+			}
+			return "", false
+		}
+	}
+
+	switch cloud {
+	case "aws":
+		if _, blocked := untaggableAWS[tfType]; blocked {
+			return "", false
+		}
+		return "tags", true
+	case "gcp":
+		// Unregistered GCP types weak-lock by design — see header
+		// comment for the rationale.
+		return "", false
+	}
+	return "", false
+}
+
+// TagLiteralValues decodes typed Attrs ONCE and returns the string-literal
+// values present at <attrName>[key] for each requested key. The result map
+// contains only the keys found with a plain string literal; entries whose
+// state is anything else (Expr / Null / Absent) are omitted. Returns nil when
+// the typed model does not decode, the struct has no field whose `tf:` tag
+// matches attrName, or the map is nil.
+//
+// The single-decode contract matters to callers reading marker PAIRS
+// (project + session): one decode guarantees both values come from the same
+// snapshot, and avoids the double-UnmarshalAttrs cost of key-at-a-time reads.
+func TagLiteralValues(tfType string, raw []byte, attrName string, keys ...string) map[string]string {
+	decoded, err := generated.UnmarshalAttrs(tfType, raw)
+	if err != nil {
+		return nil
+	}
+	v := reflect.ValueOf(decoded)
+	if v.Kind() == reflect.Pointer {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		fld := t.Field(i)
+		tag := strings.Split(fld.Tag.Get("tf"), ",")[0]
+		if tag != attrName {
+			continue
+		}
+		fv := v.Field(i)
+		if fv.Kind() != reflect.Map || fv.IsNil() {
+			return nil
+		}
+		out := make(map[string]string, len(keys))
+		for _, key := range keys {
+			entry := fv.MapIndex(reflect.ValueOf(key))
+			if !entry.IsValid() {
+				continue
+			}
+			if entry.Kind() == reflect.Pointer {
+				if entry.IsNil() {
+					continue
+				}
+				entry = entry.Elem()
+			}
+			if entry.Kind() != reflect.Struct {
+				continue
+			}
+			lit := entry.FieldByName("Literal")
+			if !lit.IsValid() || lit.IsNil() {
+				continue
+			}
+			s, ok := lit.Elem().Interface().(string)
+			if !ok {
+				continue
+			}
+			out[key] = s
+		}
+		return out
+	}
+	return nil
+}
+
+// OpaqueTagValues reads attrs[attrName][key] for each requested key from the
+// Phase 1 opaque attribute bag. The result map contains only the keys found
+// with a string value; returns nil when attrs has no attrName map.
+func OpaqueTagValues(attrs map[string]any, attrName string, keys ...string) map[string]string {
+	raw, ok := attrs[attrName]
+	if !ok {
+		return nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(map[string]string, len(keys))
+	for _, key := range keys {
+		v, has := m[key]
+		if !has {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			continue
+		}
+		out[key] = s
+	}
+	return out
+}
+
+// normalizedTagValue returns the value stored under any of the canonical
+// marker keys in a live cloud-side tag/label map, matching keys with
+// TrimSpace + case-insensitive comparison. This is the SAME key
+// normalization HasInsideOutImportedMarker applies — both readers share it
+// so the "is it marked" and "who marked it" questions can never disagree on
+// key matching. When several map keys normalize to the same canonical key,
+// the lexicographically smallest raw key wins (deterministic).
+func normalizedTagValue(tags map[string]string, canonical ...string) (string, bool) {
+	if len(tags) == 0 {
+		return "", false
+	}
+	want := make(map[string]struct{}, len(canonical))
+	for _, c := range canonical {
+		want[strings.ToLower(c)] = struct{}{}
+	}
+	var matched []string
+	for key := range tags {
+		if _, ok := want[strings.ToLower(strings.TrimSpace(key))]; ok {
+			matched = append(matched, key)
+		}
+	}
+	if len(matched) == 0 {
+		return "", false
+	}
+	sort.Strings(matched)
+	return tags[matched[0]], true
+}
+
+// ProvenanceOwner reads an imported resource's InsideOut provenance claim:
+// the import-project that owns it and the import-session that stamped it.
+// This is the single stable reader downstream consumers — reliable's resource
+// picker and its reverse-run / plan-preview ownership guards (reliable#2230)
+// — delegate to instead of re-reading provenance markers over their own
+// (previously divergent) field subset. See the package-level comment above
+// for the full layer/precedence contract; in short:
+//
+//   - Attrs, then Attributes, are read layer-coherently (project + session
+//     from the single first layer carrying the project marker), mirroring
+//     the desired-state semantics of the compose-time conflict guard —
+//     including degenerate empty-string claim values, which the guard also
+//     surfaces. These legs are TaggableAttr-gated exactly like that guard:
+//     an untaggable (weak-locked) or service-managed type has no
+//     emitter-writable tags/labels attribute (and no attribute NAME to read
+//     a desired-state claim under), and the validator skips those types
+//     too, so the gate cannot change results relative to it.
+//   - Identity.Tags is consulted only for the discover-only shape
+//     (len(Attrs) == 0 and len(Attributes) == 0) and only for a FULL stamp:
+//     InsideOutImported co-marker present (normalized key matching shared
+//     with HasInsideOutImportedMarker) and a non-empty project value, both
+//     clouds' key forms accepted. Live values are returned TrimSpace'd.
+//     This leg is deliberately NOT TaggableAttr-gated: untaggability is
+//     about what OUR emitter may write, but live cloud tags can exist on
+//     an instance regardless (stamped before the type joined the
+//     untaggable set, or before the service marked it managed), and
+//     DropUnimportable/UnimportableReason drop on the co-marker with no
+//     taggability gate either — gating here would let compose silently
+//     drop a claim that pick time reported as unclaimed, breaking the
+//     superset invariant (pinned by the pipeline matrix test).
+//
+// ok is true iff a project OWNER was read; session may be empty even when
+// ok is true (the stamper omits the session entry when the compose had no
+// session ID).
+func ProvenanceOwner(ir ImportedResource) (project, session string, ok bool) {
+	if attrName, tOK := TaggableAttr(ir); tOK {
+		projectKey, sessionKey := AWSTagKeyImportProject, AWSTagKeyImportSession
+		if attrName == "labels" {
+			projectKey, sessionKey = GCPLabelKeyImportProject, GCPLabelKeyImportSession
+		}
+		if len(ir.Attrs) > 0 {
+			if vals := TagLiteralValues(ir.Identity.Type, ir.Attrs, attrName, projectKey, sessionKey); vals != nil {
+				if p, found := vals[projectKey]; found {
+					return p, vals[sessionKey], true
+				}
+			}
+		}
+		if len(ir.Attributes) > 0 {
+			if vals := OpaqueTagValues(ir.Attributes, attrName, projectKey, sessionKey); vals != nil {
+				if p, found := vals[projectKey]; found {
+					return p, vals[sessionKey], true
+				}
+			}
+		}
+	}
+	if len(ir.Attrs) == 0 && len(ir.Attributes) == 0 {
+		return liveProvenanceOwner(ir.Identity.Tags)
+	}
+	return "", "", false
+}
+
+// liveProvenanceOwner reads a FULL-STAMP claim from the live cloud-side
+// tag/label snapshot: the InsideOutImported co-marker must be present and the
+// project value non-empty after trimming (a bare or empty project marker is
+// not ownership — see the package comment and importability.go). Both
+// clouds' key forms are accepted, mirroring HasInsideOutImportedMarker's
+// posture. Values are returned TrimSpace'd.
+func liveProvenanceOwner(tags map[string]string) (project, session string, ok bool) {
+	if !HasInsideOutImportedMarker(tags) {
+		return "", "", false
+	}
+	p, found := normalizedTagValue(tags, AWSTagKeyImportProject, GCPLabelKeyImportProject)
+	if !found {
+		return "", "", false
+	}
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return "", "", false
+	}
+	s, _ := normalizedTagValue(tags, AWSTagKeyImportSession, GCPLabelKeyImportSession)
+	return p, strings.TrimSpace(s), true
+}
+
+// ProvenanceOwnedByOther is the exported ownership DECISION for pick/plan
+// time (reliable#2230): it reports whether ir is claimed by an import
+// project OUTSIDE the caller's own set, returning that owner for display
+// ("claimed by project X"). It encapsulates the same-import-session
+// self-claim allowance (reliable#2068) and the backwards-compat mode, so
+// downstream guards get the decision — not just the raw read — and cannot
+// re-derive it divergently.
+//
+// ownProjectIDs is a SET because a session's own claim is legitimately
+// stamped under more than one project string (reliable#2068): the
+// import_apply leg uses the session-derived "io-<suffix>" name while the
+// mars reconcile leg stamps the Oracle deployment-project UUID — and a
+// reconcile-leg stamp can carry the UUID with NO session marker, so the
+// session escape alone cannot recognize it. Callers must pass every
+// identifier their session may have stamped under; passing only one
+// recreates the "Claimed by another import project (<own deployment UUID>)"
+// mislabel class.
+//
+// Rules, in order:
+//
+//   - ownProjectIDs empty (no entries, or all blank after TrimSpace) →
+//     ("", false): compose runs in pre-#153 backwards-compat mode with
+//     provenance disabled, so no per-resource ownership is enforced
+//     anywhere — flagging at pick time would be wider than every other
+//     stage combined.
+//   - no owner readable via ProvenanceOwner → ("", false).
+//   - observed project equals ANY entry of ownProjectIDs → self, ("", false).
+//   - observed session non-empty AND equals TrimSpace(importSessionID) →
+//     self (the session tag is the namespace-stable identity across import
+//     legs — reliable#2068). Empty importSessionID disables this arm,
+//     matching ValidateProvenanceConflicts.
+//   - otherwise → (owner, true).
+//
+// Comparison rule (V3 evidence — the stamper writes project/session values
+// verbatim; only the timestamp is GCP-charset-normalized): both sides are
+// TrimSpace'd, then compared byte-exactly — except live-leg claims on GCP,
+// which compare case-insensitively: GCP label VALUES are lowercase-only, so
+// a mixed-case canonical identifier (sess_v2_AbC…) can only ever exist on a
+// live GCP label in a lowercased form — byte-exact matching would make the
+// same-session escape silently unreachable on GCP. AWS live tags preserve
+// case and compare byte-exactly. (The compose-time validator compares raw,
+// untrimmed values; a whitespace-padded desired-state marker would conflict
+// there but read as self here. No pipeline leg produces padded markers —
+// the stamper writes trimmed caller identifiers — so the divergence is
+// theoretical; noted for completeness.)
+//
+// This is a SUPERSET of compose-time fatal conflicts, not a mirror:
+//
+//   - compose silently DROPS full-stamp live claims via DropUnimportable
+//     rather than conflicting on them — including on untaggable and
+//     service-managed types (see ProvenanceOwner's ungated live leg);
+//   - the validator reads project and session through two INDEPENDENT
+//     Attrs→Attributes fall-throughs while this decision is layer-coherent,
+//     so a split-layer placement (project in Attrs, session only in
+//     Attributes) is accepted as self by compose but flagged claimed here.
+//     No pipeline leg produces that shape (each leg writes its markers into
+//     one placement); the superset contract permits the extra flag.
+//
+// The invariant — anything compose would reject as a provenance conflict OR
+// silently drop as foreign-claimed is flagged here at pick time — is pinned
+// by the pipeline matrix test in pkg/composer.
+func ProvenanceOwnedByOther(ir ImportedResource, importSessionID string, ownProjectIDs ...string) (owner string, claimed bool) {
+	own := make([]string, 0, len(ownProjectIDs))
+	for _, id := range ownProjectIDs {
+		if trimmed := strings.TrimSpace(id); trimmed != "" {
+			own = append(own, trimmed)
+		}
+	}
+	if len(own) == 0 {
+		return "", false
+	}
+	project, session, ok := ProvenanceOwner(ir)
+	if !ok {
+		return "", false
+	}
+	live := len(ir.Attrs) == 0 && len(ir.Attributes) == 0
+	gcpLive := live && strings.EqualFold(strings.TrimSpace(ir.Identity.Cloud), "gcp")
+	equal := func(observed, ours string) bool {
+		if gcpLive {
+			return strings.EqualFold(observed, ours)
+		}
+		return observed == ours
+	}
+	observedProject := strings.TrimSpace(project)
+	for _, id := range own {
+		if equal(observedProject, id) {
+			return "", false
+		}
+	}
+	// Same-import-session self-claim (reliable#2068). The validator trims
+	// the caller's session before comparing; mirror that.
+	if mySession := strings.TrimSpace(importSessionID); mySession != "" {
+		if observedSession := strings.TrimSpace(session); observedSession != "" && equal(observedSession, mySession) {
+			return "", false
+		}
+	}
+	return observedProject, true
+}

--- a/pkg/composer/imported/provenance_owner_test.go
+++ b/pkg/composer/imported/provenance_owner_test.go
@@ -1,0 +1,539 @@
+package imported
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Unit tests for the pick-time provenance ownership readers (reliable#2230).
+// The layer/precedence contract under test is documented once, on
+// ProvenanceOwner / the package comment in provenance_owner.go. Motivating
+// incident: reliable session sess_v2_tunCkPopdiKK, import irun_jFcsE0sgd8NH
+// (staging, 2026-07-12) — a shared-account import selected resources already
+// claimed by other import projects and the conflict surfaced only at
+// apply-compose; these readers give the picker/reverse-run guards the same
+// ownership signal at selection time.
+
+// provCloudFixture parameterizes the per-cloud marker vocabulary once so
+// every test below iterates the same table instead of switching on cloud
+// inline. GCP label VALUES must be label-legal (lowercase) in fixtures —
+// uppercase values cannot exist on a live GCP label, so planting one would
+// vacuously pass comparisons production can never see.
+type provCloudFixture struct {
+	cloud       string
+	tfType      string
+	projectKey  string
+	sessionKey  string
+	importedKey string
+	// session is a legal live session value for this cloud: AWS tags
+	// preserve case; GCP labels are lowercase-only.
+	session string
+}
+
+var provClouds = []provCloudFixture{
+	{
+		cloud:       "aws",
+		tfType:      "aws_sqs_queue",
+		projectKey:  AWSTagKeyImportProject,
+		sessionKey:  AWSTagKeyImportSession,
+		importedKey: AWSTagKeyImported,
+		session:     "sess_v2_tunCkPopdiKK",
+	},
+	{
+		cloud:       "gcp",
+		tfType:      "google_storage_bucket",
+		projectKey:  GCPLabelKeyImportProject,
+		sessionKey:  GCPLabelKeyImportSession,
+		importedKey: GCPLabelKeyImported,
+		session:     "sess_v2_tunckpopdikk",
+	},
+}
+
+// ir returns the shared emit-eligible base resource for the fixture's cloud.
+func (fx provCloudFixture) ir() ImportedResource {
+	return ImportedResource{
+		Identity: ResourceIdentity{
+			Cloud:    fx.cloud,
+			Type:     fx.tfType,
+			Address:  fx.tfType + ".r",
+			ImportID: "id",
+		},
+		Tier: TierImportedFlat,
+	}
+}
+
+// attrName derives the tags/labels attribute via TaggableAttr — the same
+// gate production applies — rather than a parallel cloud→name mapping.
+func (fx provCloudFixture) attrName(t *testing.T) string {
+	t.Helper()
+	attr, ok := TaggableAttr(fx.ir())
+	require.Truef(t, ok, "fixture type %s must be taggable", fx.tfType)
+	return attr
+}
+
+// attrsJSON builds a typed-Attrs JSON literal carrying markers under the
+// fixture's tags/labels attribute (plus a name so the body stays realistic).
+func (fx provCloudFixture) attrsJSON(t *testing.T, markers map[string]string) []byte {
+	t.Helper()
+	inner := map[string]any{}
+	for k, v := range markers {
+		inner[k] = map[string]any{"literal": v}
+	}
+	raw, err := json.Marshal(map[string]any{
+		"name":         map[string]any{"literal": "n"},
+		fx.attrName(t): inner,
+	})
+	require.NoError(t, err)
+	return raw
+}
+
+// attributesBag builds an opaque Attributes bag carrying markers under the
+// fixture's tags/labels attribute.
+func (fx provCloudFixture) attributesBag(t *testing.T, markers map[string]string) map[string]any {
+	t.Helper()
+	inner := map[string]any{}
+	for k, v := range markers {
+		inner[k] = v
+	}
+	return map[string]any{"name": "n", fx.attrName(t): inner}
+}
+
+// fullLiveStamp is a well-formed live claim: project + session + the
+// InsideOutImported co-marker, as the stamper's apply leaves them on the
+// cloud resource.
+func (fx provCloudFixture) fullLiveStamp(project, session string) map[string]string {
+	m := map[string]string{
+		fx.projectKey:  project,
+		fx.importedKey: "true",
+	}
+	if session != "" {
+		m[fx.sessionKey] = session
+	}
+	return m
+}
+
+func TestProvenanceOwner_ClaimPlacements(t *testing.T) {
+	t.Parallel()
+	const wantProject = "io-owner-42"
+	for _, fx := range provClouds {
+		fx := fx
+		markers := map[string]string{fx.projectKey: wantProject, fx.sessionKey: fx.session}
+
+		t.Run(fx.cloud+"/attrs", func(t *testing.T) {
+			t.Parallel()
+			ir := fx.ir()
+			ir.Attrs = fx.attrsJSON(t, markers)
+			project, session, ok := ProvenanceOwner(ir)
+			require.True(t, ok)
+			assert.Equal(t, wantProject, project)
+			assert.Equal(t, fx.session, session)
+		})
+		t.Run(fx.cloud+"/attributes", func(t *testing.T) {
+			t.Parallel()
+			ir := fx.ir()
+			ir.Attributes = fx.attributesBag(t, markers)
+			project, session, ok := ProvenanceOwner(ir)
+			require.True(t, ok)
+			assert.Equal(t, wantProject, project)
+			assert.Equal(t, fx.session, session)
+		})
+		t.Run(fx.cloud+"/live-full-stamp", func(t *testing.T) {
+			t.Parallel()
+			ir := fx.ir() // discover-only shape: Attrs and Attributes empty
+			ir.Identity.Tags = fx.fullLiveStamp(wantProject, fx.session)
+			project, session, ok := ProvenanceOwner(ir)
+			require.True(t, ok, "full-stamp discover-only claim must be readable (reliable#2230)")
+			assert.Equal(t, wantProject, project)
+			assert.Equal(t, fx.session, session)
+		})
+	}
+}
+
+func TestProvenanceOwner_LayerRules(t *testing.T) {
+	t.Parallel()
+	for _, fx := range provClouds {
+		fx := fx
+		t.Run(fx.cloud, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("attrs beats attributes", func(t *testing.T) {
+				t.Parallel()
+				ir := fx.ir()
+				ir.Attrs = fx.attrsJSON(t, map[string]string{fx.projectKey: "io-from-attrs", fx.sessionKey: "sess-attrs"})
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.projectKey: "io-from-attributes", fx.sessionKey: "sess-attributes"})
+				project, session, ok := ProvenanceOwner(ir)
+				require.True(t, ok)
+				assert.Equal(t, "io-from-attrs", project, "typed Attrs is plan-authoritative")
+				assert.Equal(t, "sess-attrs", session)
+			})
+
+			t.Run("attributes read when attrs has no marker", func(t *testing.T) {
+				t.Parallel()
+				ir := fx.ir()
+				ir.Attrs = fx.attrsJSON(t, nil) // tags/labels map present, no project marker
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.projectKey: "io-from-attributes"})
+				project, _, ok := ProvenanceOwner(ir)
+				require.True(t, ok)
+				assert.Equal(t, "io-from-attributes", project)
+			})
+
+			t.Run("desired state present gates live leg off", func(t *testing.T) {
+				t.Parallel()
+				// The resource has been enriched/backfilled (Attrs non-empty)
+				// and its desired state carries NO claim — including the case
+				// where a prior claim was deliberately removed (claim
+				// release). The stale live stamp must NOT shadow that.
+				ir := fx.ir()
+				ir.Attrs = fx.attrsJSON(t, nil)
+				ir.Identity.Tags = fx.fullLiveStamp("io-foreign", fx.session)
+				_, _, ok := ProvenanceOwner(ir)
+				assert.False(t, ok, "live leg must be consulted only for the literal discover-only shape")
+			})
+
+			t.Run("pair is layer-coherent, never stitched", func(t *testing.T) {
+				t.Parallel()
+				// Attrs carries the project only; Attributes carries a
+				// session. The session must NOT be stitched in from the
+				// other layer — a stitched pair let a stale same-session
+				// marker suppress a real foreign-project conflict (F3).
+				ir := fx.ir()
+				ir.Attrs = fx.attrsJSON(t, map[string]string{fx.projectKey: "io-from-attrs"})
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.sessionKey: "sess-stitched"})
+				project, session, ok := ProvenanceOwner(ir)
+				require.True(t, ok)
+				assert.Equal(t, "io-from-attrs", project)
+				assert.Empty(t, session, "session must come from the same layer as the project marker")
+			})
+		})
+	}
+}
+
+func TestProvenanceOwner_LiveFullStampSemantics(t *testing.T) {
+	t.Parallel()
+	for _, fx := range provClouds {
+		fx := fx
+		t.Run(fx.cloud, func(t *testing.T) {
+			t.Parallel()
+
+			t.Run("bare project marker is not ownership", func(t *testing.T) {
+				t.Parallel()
+				// No InsideOutImported co-marker: per the
+				// HasInsideOutImportedMarker contract in importability.go,
+				// historical resources carry a bare account/project marker
+				// without having been imported. Treating it as a claim
+				// would demand a force-takeover from an owner that never
+				// owned.
+				ir := fx.ir()
+				ir.Identity.Tags = map[string]string{fx.projectKey: "io-foreign"}
+				_, _, ok := ProvenanceOwner(ir)
+				assert.False(t, ok, "bare live project marker must not read as a claim")
+			})
+
+			t.Run("empty project value is not ownership", func(t *testing.T) {
+				t.Parallel()
+				// An empty owner is unactionable (ForceTakeover requires a
+				// non-empty PreviousOwner) — require substance (F4).
+				for _, empty := range []string{"", "   "} {
+					ir := fx.ir()
+					ir.Identity.Tags = fx.fullLiveStamp(empty, fx.session)
+					_, _, ok := ProvenanceOwner(ir)
+					assert.False(t, ok, "empty/whitespace live project value must not read as a claim")
+				}
+			})
+
+			t.Run("normalized key matching and trimmed values", func(t *testing.T) {
+				t.Parallel()
+				// Key matching shares HasInsideOutImportedMarker's
+				// TrimSpace + case-insensitive normalization; values come
+				// back trimmed.
+				ir := fx.ir()
+				ir.Identity.Tags = map[string]string{
+					" " + fx.projectKey + " ": "  io-owner-42  ",
+					fx.importedKey:            "true",
+				}
+				project, _, ok := ProvenanceOwner(ir)
+				require.True(t, ok)
+				assert.Equal(t, "io-owner-42", project)
+			})
+		})
+	}
+}
+
+func TestProvenanceOwner_GatesAndNoClaim(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no markers anywhere", func(t *testing.T) {
+		t.Parallel()
+		fx := provClouds[0]
+		ir := fx.ir()
+		ir.Attrs = fx.attrsJSON(t, nil)
+		project, session, ok := ProvenanceOwner(ir)
+		assert.False(t, ok)
+		assert.Empty(t, project)
+		assert.Empty(t, session)
+	})
+
+	t.Run("untaggable type: live full stamp still reads (ungated live leg)", func(t *testing.T) {
+		t.Parallel()
+		// google_compute_network has no labels field (weak-lock), but a
+		// LIVE full stamp on it must still read as a claim: untaggability
+		// is about what OUR emitter may write, live labels exist on the
+		// instance regardless, and DropUnimportable drops this shape on
+		// the co-marker with no taggability gate — pick time must not
+		// report it unclaimed while compose silently drops it (superset
+		// invariant).
+		ir := ImportedResource{
+			Identity: ResourceIdentity{
+				Cloud: "gcp", Type: "google_compute_network",
+				Address: "google_compute_network.vpc", ImportID: "vpc",
+				Tags: map[string]string{
+					GCPLabelKeyImportProject: "io-foreign",
+					GCPLabelKeyImported:      "true",
+				},
+			},
+			Tier: TierImportedFlat,
+		}
+		project, _, ok := ProvenanceOwner(ir)
+		assert.True(t, ok, "live full stamp on an untaggable type must read as a claim")
+		assert.Equal(t, "io-foreign", project)
+		assert.Equal(t, ReasonInsideOutImported, UnimportableReason(ir),
+			"same shape compose drops through the already-imported channel")
+	})
+
+	t.Run("untaggable type: desired-state legs stay gated", func(t *testing.T) {
+		t.Parallel()
+		// The compose-time validator skips untaggable types, so the
+		// desired-state legs mirror it — there is no emitter-writable
+		// attribute NAME to read a tags/labels claim under.
+		ir := ImportedResource{
+			Identity: ResourceIdentity{
+				Cloud: "gcp", Type: "google_compute_network",
+				Address: "google_compute_network.vpc", ImportID: "vpc",
+			},
+			Tier: TierImportedFlat,
+			Attributes: map[string]any{
+				"name":   "vpc",
+				"labels": map[string]any{GCPLabelKeyImportProject: "io-foreign"},
+			},
+		}
+		_, _, ok := ProvenanceOwner(ir)
+		assert.False(t, ok, "untaggable desired-state claim must not read (validator parity)")
+	})
+
+	t.Run("service-managed instance: live full stamp still reads", func(t *testing.T) {
+		t.Parallel()
+		// Same rationale as the untaggable case: TaggableAttr weak-locks
+		// service-managed instances for EMISSION (#785), but a live claim
+		// on one is still a claim — UnimportableReason drops the shape
+		// (ReasonInsideOutImported wins over ReasonServiceManaged at
+		// classification) and pick time must agree it is foreign-claimed.
+		fx := provClouds[0]
+		ir := fx.ir()
+		ir.Identity.ServiceManagedBy = "autoscaling.amazonaws.com"
+		ir.Identity.Tags = fx.fullLiveStamp("io-foreign", fx.session)
+		project, _, ok := ProvenanceOwner(ir)
+		assert.True(t, ok, "live full stamp on a service-managed instance must read as a claim")
+		assert.Equal(t, "io-foreign", project)
+	})
+}
+
+func TestProvenanceOwnedByOther(t *testing.T) {
+	t.Parallel()
+	const (
+		myProject = "io-mine"
+		mySession = "sess_v2_tunCkPopdiKK"
+	)
+	fx := provClouds[0] // AWS; GCP-specific comparison rules are pinned below.
+
+	// deployUUID stands in for the Oracle deployment-project UUID — the
+	// second member of a session's own-claim set (reliable#2068's double
+	// namespace: the import_apply leg stamps the session-derived
+	// "io-<suffix>" name, the mars reconcile leg stamps the UUID).
+	const deployUUID = "1c3c8501-45fd-5f46-9a60-5a5d753a3e2b"
+
+	type tc struct {
+		name        string
+		ir          func(t *testing.T) ImportedResource
+		sessionID   string
+		ownProjects []string
+		wantOwner   string
+		wantClaimed bool
+	}
+	cases := []tc{
+		{
+			name: "foreign desired-state claim → claimed",
+			ir: func(t *testing.T) ImportedResource {
+				ir := fx.ir()
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.projectKey: "io-other", fx.sessionKey: "sess_v2_other"})
+				return ir
+			},
+			sessionID: mySession, ownProjects: []string{myProject, deployUUID},
+			wantOwner: "io-other", wantClaimed: true,
+		},
+		{
+			name: "foreign live full stamp → claimed",
+			ir: func(t *testing.T) ImportedResource {
+				ir := fx.ir()
+				ir.Identity.Tags = fx.fullLiveStamp("io-other", "sess_v2_other")
+				return ir
+			},
+			sessionID: mySession, ownProjects: []string{myProject, deployUUID},
+			wantOwner: "io-other", wantClaimed: true,
+		},
+		{
+			name: "own project → self",
+			ir: func(t *testing.T) ImportedResource {
+				ir := fx.ir()
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.projectKey: myProject})
+				return ir
+			},
+			sessionID: mySession, ownProjects: []string{myProject, deployUUID},
+		},
+		{
+			name: "own deployment UUID, NO session marker → self via the own-project SET",
+			ir: func(t *testing.T) ImportedResource {
+				// The reconcile-leg shape that motivated the set-valued
+				// API: the stamp carries the deployment UUID and NO
+				// session marker, so the session escape cannot recognize
+				// it — only membership in ownProjectIDs can. Passing a
+				// single "io-<suffix>" id here would mislabel the
+				// session's own resource as "claimed by another import
+				// project (<own deployment UUID>)".
+				ir := fx.ir()
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.projectKey: deployUUID})
+				return ir
+			},
+			sessionID: mySession, ownProjects: []string{myProject, deployUUID},
+		},
+		{
+			name: "own deployment UUID but caller passed only the io-name → claimed (caller must pass the full set)",
+			ir: func(t *testing.T) ImportedResource {
+				ir := fx.ir()
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.projectKey: deployUUID})
+				return ir
+			},
+			sessionID: mySession, ownProjects: []string{myProject},
+			wantOwner: deployUUID, wantClaimed: true,
+		},
+		{
+			name: "foreign project, same session → self (reliable#2068)",
+			ir: func(t *testing.T) ImportedResource {
+				// A project string outside the caller's set entirely, but
+				// the session tag — the namespace-stable identity — matches.
+				ir := fx.ir()
+				ir.Attributes = fx.attributesBag(t, map[string]string{
+					fx.projectKey: "some-legacy-namespace-id",
+					fx.sessionKey: mySession,
+				})
+				return ir
+			},
+			sessionID: mySession, ownProjects: []string{myProject, deployUUID},
+		},
+		{
+			name: "empty ownProjectIDs → backwards-compat, nothing claimed",
+			ir: func(t *testing.T) ImportedResource {
+				// Provenance is disabled everywhere in this mode (the
+				// validator emits only the skipped-no-project-id advisory
+				// and the injector stamps nothing), so pick time must not
+				// enforce either (F7).
+				ir := fx.ir()
+				ir.Identity.Tags = fx.fullLiveStamp("io-other", "sess_v2_other")
+				return ir
+			},
+			sessionID: mySession, ownProjects: nil,
+		},
+		{
+			name: "all-blank ownProjectIDs → backwards-compat too",
+			ir: func(t *testing.T) ImportedResource {
+				ir := fx.ir()
+				ir.Identity.Tags = fx.fullLiveStamp("io-other", "sess_v2_other")
+				return ir
+			},
+			sessionID: mySession, ownProjects: []string{"", "   "},
+		},
+		{
+			name: "empty importSessionID disables the session escape",
+			ir: func(t *testing.T) ImportedResource {
+				ir := fx.ir()
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.projectKey: "io-other", fx.sessionKey: mySession})
+				return ir
+			},
+			sessionID: "", ownProjects: []string{myProject, deployUUID},
+			wantOwner: "io-other", wantClaimed: true,
+		},
+		{
+			name: "resource has no session marker and foreign project → claimed",
+			ir: func(t *testing.T) ImportedResource {
+				ir := fx.ir()
+				ir.Attributes = fx.attributesBag(t, map[string]string{fx.projectKey: "io-other"})
+				return ir
+			},
+			sessionID: mySession, ownProjects: []string{myProject, deployUUID},
+			wantOwner: "io-other", wantClaimed: true,
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			owner, claimed := ProvenanceOwnedByOther(c.ir(t), c.sessionID, c.ownProjects...)
+			assert.Equal(t, c.wantClaimed, claimed)
+			assert.Equal(t, c.wantOwner, owner)
+		})
+	}
+}
+
+// TestProvenanceOwnedByOther_LiveValueComparison pins the per-cloud live-leg
+// comparison rule derived from how the stamper writes values
+// (provenanceKeysFor emits project/session VERBATIM; only the timestamp is
+// GCP-charset-normalized):
+//
+//   - GCP label values are lowercase-only, so the canonical mixed-case
+//     session id can only ever exist on a live label lowercased — the
+//     comparison folds case, otherwise the reliable#2068 self-claim escape
+//     would be silently unreachable on GCP live claims.
+//   - AWS tag values preserve case and compare byte-exactly: a live value
+//     that differs by case really is a different identifier.
+func TestProvenanceOwnedByOther_LiveValueComparison(t *testing.T) {
+	t.Parallel()
+	const mixedSession = "sess_v2_tunCkPopdiKK"
+
+	t.Run("gcp live folds case", func(t *testing.T) {
+		t.Parallel()
+		fx := provClouds[1]
+		ir := fx.ir()
+		ir.Identity.Tags = fx.fullLiveStamp("deploy-uuid-reconcile", "sess_v2_tunckpopdikk")
+		owner, claimed := ProvenanceOwnedByOther(ir, mixedSession, "io-mine")
+		assert.False(t, claimed, "lowercased live GCP session must match the mixed-case canonical id")
+		assert.Empty(t, owner)
+
+		// Project arm folds too: case-variant GCP projects cannot be
+		// distinct on a live label.
+		ir2 := fx.ir()
+		ir2.Identity.Tags = fx.fullLiveStamp("io-mine", "")
+		_, claimed = ProvenanceOwnedByOther(ir2, "", "IO-Mine")
+		assert.False(t, claimed)
+	})
+
+	t.Run("aws live is byte-exact", func(t *testing.T) {
+		t.Parallel()
+		fx := provClouds[0]
+		ir := fx.ir()
+		ir.Identity.Tags = fx.fullLiveStamp("io-other", "sess_v2_tunckpopdikk")
+		owner, claimed := ProvenanceOwnedByOther(ir, mixedSession, "io-mine")
+		assert.True(t, claimed, "AWS live tags preserve case; a case-variant session is a different session")
+		assert.Equal(t, "io-other", owner)
+	})
+
+	t.Run("comparisons trim caller identifiers", func(t *testing.T) {
+		t.Parallel()
+		fx := provClouds[0]
+		ir := fx.ir()
+		ir.Identity.Tags = fx.fullLiveStamp("io-mine", "")
+		_, claimed := ProvenanceOwnedByOther(ir, "", "  io-mine  ")
+		assert.False(t, claimed)
+	})
+}

--- a/pkg/composer/imported_provenance.go
+++ b/pkg/composer/imported_provenance.go
@@ -2,7 +2,6 @@ package composer
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 	"time"
@@ -20,125 +19,16 @@ import (
 // docs/managed-resource-tiers.md: the same logical <import-project-id> is
 // used across AWS+GCP for one InsideOut stack/session.
 
-// untaggableAWS mirrors the canonical NON_TAGGABLE_AWS array in
-// tests/lint-project-tag.sh. Resource types in this set do NOT accept a tags
-// attribute in AWS provider 6.x; the provenance injector skips them and marks
-// the resource WeakLocked. TestUntaggableAllowlistsMatchLintScripts ensures
-// this list stays in sync with the bash array.
-var untaggableAWS = map[string]struct{}{
-	"aws_acm_certificate_validation":                     {},
-	"aws_api_gateway_deployment":                         {},
-	"aws_api_gateway_resource":                           {},
-	"aws_apigatewayv2_api_mapping":                       {},
-	"aws_apigatewayv2_authorizer":                        {},
-	"aws_apigatewayv2_integration":                       {},
-	"aws_apigatewayv2_route":                             {},
-	"aws_apprunner_custom_domain_association":            {},
-	"aws_autoscaling_group_tag":                          {},
-	"aws_backup_selection":                               {},
-	"aws_bedrock_model_invocation_logging_configuration": {},
-	"aws_bedrockagent_agent_action_group":                {},
-	"aws_bedrockagent_agent_knowledge_base_association":  {},
-	"aws_bedrockagent_data_source":                       {},
-	"aws_bedrockagentcore_gateway_target":                {},
-	"aws_cloudfront_monitoring_subscription":             {},
-	"aws_cloudfront_origin_access_identity":              {},
-	"aws_cloudwatch_dashboard":                           {},
-	"aws_cloudwatch_log_resource_policy":                 {},
-	"aws_cloudwatch_log_stream":                          {},
-	"aws_cognito_identity_provider":                      {},
-	"aws_cognito_resource_server":                        {},
-	"aws_cognito_user_pool_client":                       {},
-	"aws_cognito_user_pool_domain":                       {},
-	"aws_dynamodb_contributor_insights":                  {},
-	"aws_ecs_cluster_capacity_providers":                 {},
-	"aws_iam_group":                                      {},
-	"aws_iam_instance_profile":                           {},
-	"aws_iam_role_policy":                                {},
-	"aws_iam_role_policy_attachment":                     {},
-	"aws_iam_service_linked_role":                        {},
-	"aws_kms_alias":                                      {},
-	"aws_lambda_alias":                                   {},
-	"aws_lambda_function_url":                            {},
-	"aws_lambda_permission":                              {},
-	"aws_msk_configuration":                              {},
-	"aws_opensearchserverless_access_policy":             {},
-	"aws_opensearchserverless_security_policy":           {},
-	"aws_route53_record":                                 {},
-	"aws_s3_bucket_lifecycle_configuration":              {},
-	"aws_s3_bucket_ownership_controls":                   {},
-	"aws_s3_bucket_policy":                               {},
-	"aws_s3_bucket_public_access_block":                  {},
-	"aws_s3_bucket_server_side_encryption_configuration": {},
-	"aws_s3_bucket_versioning":                           {},
-	"aws_secretsmanager_secret_rotation":                 {},
-	"aws_security_group_rule":                            {},
-	"aws_sns_topic_subscription":                         {},
-	"aws_wafv2_web_acl_association":                      {},
-}
-
 // taggable returns the HCL attribute name ("tags" for AWS, "labels" for GCP)
 // to inject provenance into for ir, or ("", false) if the resource type does
-// not support tag/label-based mutual exclusion (weak lock).
-//
-// Decision order:
-//  1. Layer 1 generated schema (authoritative when registered): the schema
-//     map indicates whether the type carries a "tags" or "labels" key.
-//  2. AWS unregistered types: default to taggable unless explicitly listed
-//     in untaggableAWS (most AWS resources accept tags).
-//  3. GCP unregistered types: weak-lock (the long tail of GCP types lives
-//     in the typed registry now after Bundle 9–12; anything still
-//     unregistered is too unknown to label safely). The historical
-//     `labelableGCP` static allowlist was deleted in #396 once every
-//     entry it carried also lived in the typed registry — the schema
-//     branch above subsumes it.
+// not support tag/label-based mutual exclusion (weak lock). Thin wrapper over
+// imported.TaggableAttr — the canonical home since reliable#2230, so the
+// pick-time ownership readers (imported.ProvenanceOwner /
+// imported.ProvenanceOwnedByOther) share the exact gate the compose-time
+// validator and injector apply; see there for the decision order and the
+// #785 service-managed instance override.
 func taggable(ir imported.ImportedResource) (attr string, ok bool) {
-	cloud := strings.ToLower(strings.TrimSpace(ir.Identity.Cloud))
-	tfType := strings.TrimSpace(ir.Identity.Type)
-	if cloud == "" || tfType == "" {
-		return "", false
-	}
-
-	// Instance-level untaggability (#785): a resource whose type is normally
-	// taggable is still NOT taggable when the cloud marks it service-managed.
-	// AWS rejects every tag operation on a service-managed instance (an
-	// EventBridge ManagedBy rule fails with ManagedRuleException), so the
-	// injector must skip provenance and weak-lock it. This sits alongside the
-	// type-level untaggableAWS map but keys off the per-instance marker the
-	// discoverer captured, so it works for any type and any selection path —
-	// the composer's last line of defense even if classification let the
-	// instance through.
-	if imported.IsServiceManaged(ir.Identity) {
-		return "", false
-	}
-
-	if _, schema, registered := generated.Lookup(tfType); registered {
-		switch cloud {
-		case "aws":
-			if _, has := schema["tags"]; has {
-				return "tags", true
-			}
-			return "", false
-		case "gcp":
-			if _, has := schema["labels"]; has {
-				return "labels", true
-			}
-			return "", false
-		}
-	}
-
-	switch cloud {
-	case "aws":
-		if _, blocked := untaggableAWS[tfType]; blocked {
-			return "", false
-		}
-		return "tags", true
-	case "gcp":
-		// Unregistered GCP types weak-lock by design — see header
-		// comment for the rationale.
-		return "", false
-	}
-	return "", false
+	return imported.TaggableAttr(ir)
 }
 
 // provenanceEntry is a single key/value pair to emit into the provenance
@@ -195,123 +85,99 @@ func gcpLabelTimestamp(t time.Time) string {
 	return s
 }
 
-// existingProvenanceProject reads the InsideOutImportProject (AWS) or
-// insideout-import-project (GCP) value from ir's desired state, preferring
-// the typed Attrs over the opaque Attributes bag. Returns ("", false) when
-// the resource does not advertise a prior owner. Used by the validator to
-// detect cross-session ownership conflicts.
-func existingProvenanceProject(ir imported.ImportedResource) (string, bool) {
+// readProvenanceMarker reads the InsideOut provenance marker identified by
+// awsKey (AWS tag key) / gcpKey (GCP label key — GCP claims live in labels)
+// from ir's DESIRED STATE, preferring the typed Attrs over the opaque
+// Attributes bag.
+//
+// Deliberately NOT consulted here: ir.Identity.Tags, the live cloud-side
+// snapshot (reliable#2230 follow-up). The validator and injector this feeds
+// run at compose time, where live-tag claims are already handled upstream —
+// composeStackImpl runs imported.DropUnimportable BEFORE
+// ValidateProvenanceConflicts, silently dropping every resource whose live
+// tags carry the InsideOutImported co-marker (ReasonInsideOutImported), and
+// the Mars-leg gates (pkg/reverseimport run.go, closure.go; depchase) reject
+// the same class before it ever reaches a compose. The live-tag population
+// that WOULD reach this reader is therefore the bare/partial-marker class
+// that imported.HasInsideOutImportedMarker's contract explicitly documents
+// as NOT ownership ("some historical resources carry a bare account/project
+// marker without having been imported") — conflicting on those would demand
+// a ForceTakeover from an owner that never owned, and refusing to stamp them
+// would break the #690 discovered-tags backfill. Pick-time surfacing of live
+// full-stamp claims is imported.ProvenanceOwnedByOther's job.
+func readProvenanceMarker(ir imported.ImportedResource, awsKey, gcpKey string) (string, bool) {
 	attrName, ok := taggable(ir)
 	if !ok {
 		return "", false
 	}
-	key := AWSTagKeyImportProject
+	key := awsKey
 	if attrName == "labels" {
-		key = GCPLabelKeyImportProject
+		key = gcpKey
 	}
 
 	if len(ir.Attrs) > 0 {
-		if v, found := readTypedTagLiteral(ir.Identity.Type, ir.Attrs, attrName, key); found {
-			return v, true
+		if vals := imported.TagLiteralValues(ir.Identity.Type, ir.Attrs, attrName, key); vals != nil {
+			if v, found := vals[key]; found {
+				return v, true
+			}
 		}
 	}
 	if len(ir.Attributes) > 0 {
-		if v, found := readOpaqueTagLiteral(ir.Attributes, attrName, key); found {
-			return v, true
+		if vals := imported.OpaqueTagValues(ir.Attributes, attrName, key); vals != nil {
+			if v, found := vals[key]; found {
+				return v, true
+			}
 		}
 	}
 	return "", false
 }
 
+// existingProvenanceProject reads the InsideOutImportProject (AWS) or
+// insideout-import-project (GCP) value from ir's desired state (Attrs →
+// Attributes; see readProvenanceMarker for why Identity.Tags is out of
+// scope). Returns ("", false) when the resource does not advertise a prior
+// owner. Used by the validator (ValidateProvenanceConflicts) and the
+// injector (injectProvenance) to detect cross-session ownership conflicts.
+func existingProvenanceProject(ir imported.ImportedResource) (string, bool) {
+	return readProvenanceMarker(ir, AWSTagKeyImportProject, GCPLabelKeyImportProject)
+}
+
 // existingProvenanceSession reads the InsideOutImportSession (AWS) or
-// insideout-import-session (GCP) value from ir's desired state, preferring the
-// typed Attrs over the opaque Attributes bag. Returns ("", false) when the
-// resource does not advertise a prior import session. Mirrors
-// existingProvenanceProject exactly, only over the session key.
+// insideout-import-session (GCP) value from ir's desired state. Returns
+// ("", false) when the resource does not advertise a prior import session.
+// Mirrors existingProvenanceProject exactly, only over the session key.
 //
 // The validator uses this for the same-import-session self-claim allowance
 // (reliable#2068): the session tag is the namespace-stable self identity
 // because it is stamped identically on every import leg, unlike the project
 // id whose namespace differs between the reconcile and apply legs.
 func existingProvenanceSession(ir imported.ImportedResource) (string, bool) {
-	attrName, ok := taggable(ir)
-	if !ok {
-		return "", false
-	}
-	key := AWSTagKeyImportSession
-	if attrName == "labels" {
-		key = GCPLabelKeyImportSession
-	}
-
-	if len(ir.Attrs) > 0 {
-		if v, found := readTypedTagLiteral(ir.Identity.Type, ir.Attrs, attrName, key); found {
-			return v, true
-		}
-	}
-	if len(ir.Attributes) > 0 {
-		if v, found := readOpaqueTagLiteral(ir.Attributes, attrName, key); found {
-			return v, true
-		}
-	}
-	return "", false
+	return readProvenanceMarker(ir, AWSTagKeyImportSession, GCPLabelKeyImportSession)
 }
 
-// readTypedTagLiteral decodes typed Attrs and reads the literal string value
-// at <Tags|Labels>[key]. Returns ok=false when the typed model has no
-// matching field, the entry is missing, or the entry's state is anything
-// other than a string literal (Expr / Null / Absent).
-//
-// Implementation: reflect into the decoded struct and find the field whose
-// `tf:"tags"` / `tf:"labels"` tag matches attrName. The map element type is
-// always *generated.Value[string] for tag/label maps, so the Literal pointer
-// gives us the string directly.
-func readTypedTagLiteral(tfType string, raw []byte, attrName, key string) (string, bool) {
-	decoded, err := generated.UnmarshalAttrs(tfType, raw)
-	if err != nil {
-		return "", false
-	}
-	v := reflect.ValueOf(decoded)
-	if v.Kind() == reflect.Pointer {
-		v = v.Elem()
-	}
-	if v.Kind() != reflect.Struct {
-		return "", false
-	}
-	t := v.Type()
-	for i := 0; i < t.NumField(); i++ {
-		fld := t.Field(i)
-		tag := strings.Split(fld.Tag.Get("tf"), ",")[0]
-		if tag != attrName {
-			continue
-		}
-		fv := v.Field(i)
-		if fv.Kind() != reflect.Map || fv.IsNil() {
-			return "", false
-		}
-		entry := fv.MapIndex(reflect.ValueOf(key))
-		if !entry.IsValid() {
-			return "", false
-		}
-		if entry.Kind() == reflect.Pointer {
-			if entry.IsNil() {
-				return "", false
-			}
-			entry = entry.Elem()
-		}
-		if entry.Kind() != reflect.Struct {
-			return "", false
-		}
-		lit := entry.FieldByName("Literal")
-		if !lit.IsValid() || lit.IsNil() {
-			return "", false
-		}
-		s, ok := lit.Elem().Interface().(string)
-		if !ok {
-			return "", false
-		}
-		return s, true
-	}
-	return "", false
+// ProvenanceOwner re-exports imported.ProvenanceOwner on the established
+// pkg/composer surface — the single stable reader of an imported resource's
+// InsideOut provenance claim for downstream consumers (reliable's resource
+// picker and reverse-run / plan-preview guards, reliable#2230). The canonical
+// layer/precedence contract is documented on imported.ProvenanceOwner.
+func ProvenanceOwner(ir imported.ImportedResource) (project, session string, ok bool) {
+	return imported.ProvenanceOwner(ir)
+}
+
+// ProvenanceOwnedByOther re-exports imported.ProvenanceOwnedByOther — the
+// pick/plan-time ownership DECISION ("claimed by project X"), encapsulating
+// the same-session self-claim allowance (reliable#2068) and the
+// backwards-compat mode. ownProjectIDs is the caller's full own-claim SET —
+// a session's own stamp may carry the session-derived "io-<suffix>" name OR
+// the Oracle deployment-project UUID (reliable#2068's double namespace), so
+// pass every identifier the session may have stamped under. It is a strict
+// SUPERSET of this package's compose-time
+// imported_resource_provenance_conflict set (compose silently DROPS
+// full-stamp live claims via imported.DropUnimportable rather than
+// conflicting); the invariant is pinned by the pipeline matrix test. See
+// imported.ProvenanceOwnedByOther for the full contract.
+func ProvenanceOwnedByOther(ir imported.ImportedResource, importSessionID string, ownProjectIDs ...string) (owner string, claimed bool) {
+	return imported.ProvenanceOwnedByOther(ir, importSessionID, ownProjectIDs...)
 }
 
 // validForceTakeover reports whether ft is non-nil, fully-populated, and
@@ -327,28 +193,6 @@ func validForceTakeover(ft *imported.ForceTakeover, observed string) bool {
 		return false
 	}
 	return ft.PreviousOwner == observed
-}
-
-// readOpaqueTagLiteral reads attrs[attrName][key] from the Phase 1 opaque
-// attribute bag. Returns ok=false on any type mismatch.
-func readOpaqueTagLiteral(attrs map[string]any, attrName, key string) (string, bool) {
-	raw, ok := attrs[attrName]
-	if !ok {
-		return "", false
-	}
-	m, ok := raw.(map[string]any)
-	if !ok {
-		return "", false
-	}
-	v, has := m[key]
-	if !has {
-		return "", false
-	}
-	s, ok := v.(string)
-	if !ok {
-		return "", false
-	}
-	return s, true
 }
 
 // injectProvenance rewrites the tags/labels attribute in body so it carries
@@ -576,21 +420,119 @@ func buildDiscoveredTagsExpression(cloud string, tags map[string]string, exclude
 	return b.String()
 }
 
-// preserveExistingImportedAt rewrites the InsideOutImportedAt entry's
-// value to the literal already present on the cloud-side resource
-// (ir.Identity.Tags) when the resource was previously imported under the
-// same project+session. Returns the entries slice unchanged when:
+// priorStampLayers collects each placement's marker values (presence
+// semantics: a key appears in a layer map iff that placement carries it),
+// in precedence order Attrs → Attributes → Identity.Tags. Unlike the
+// compose-time conflict reader, the live Identity.Tags leg here is
+// unconditional and needs no full-stamp co-marker: the preservation
+// predicate only ever fires when project AND session both match the CURRENT
+// pass (a self-stamp check), so a stale or bare foreign live marker can
+// never trigger it.
+//
+// Why all three placements (reliable#2230 review, F8b): the prior stamp
+// lands in different placements per leg — a Mars reverse-import leg
+// backfills it into typed Attrs (BackfillImportedAttrsFromPlan), while
+// post-apply re-discovery echoes it through Identity.Tags. Reading only
+// Identity.Tags (the historical behavior) meant an Attrs-shaped prior stamp
+// was re-stamped with a fresh nowFn() timestamp on every recompose,
+// breaking the byte-identical-HCL idempotency contract for exactly the
+// Mars-leg carry-forward this function exists to keep quiet.
+func priorStampLayers(ir *imported.ImportedResource, attrName, projectKey, sessionKey, importedAtKey string) []map[string]string {
+	var layers []map[string]string
+	if len(ir.Attrs) > 0 {
+		if vals := imported.TagLiteralValues(ir.Identity.Type, ir.Attrs, attrName, projectKey, sessionKey, importedAtKey); len(vals) > 0 {
+			layers = append(layers, vals)
+		}
+	}
+	if len(ir.Attributes) > 0 {
+		if vals := imported.OpaqueTagValues(ir.Attributes, attrName, projectKey, sessionKey, importedAtKey); len(vals) > 0 {
+			layers = append(layers, vals)
+		}
+	}
+	if len(ir.Identity.Tags) > 0 {
+		vals := map[string]string{}
+		for _, key := range []string{projectKey, sessionKey, importedAtKey} {
+			if v, ok := ir.Identity.Tags[key]; ok {
+				vals[key] = v
+			}
+		}
+		if len(vals) > 0 {
+			layers = append(layers, vals)
+		}
+	}
+	return layers
+}
+
+// qualifiedPriorImportedAt scans the placement layers for a preservable
+// prior ImportedAt stamp. Each layer must INDEPENDENTLY qualify — its OWN
+// project and session markers must match the current pass — before its
+// timestamp is accepted; project/session/ImportedAt are never stitched
+// across layers.
+//
+// Scan rules per layer, in placement order:
+//
+//   - no project marker in the layer → keep scanning (the layer says
+//     nothing about ownership);
+//   - project marker present but the layer does NOT qualify (project or
+//     session mismatch) → STOP with no preservation: the most
+//     authoritative placement that expresses ownership says it changed
+//     (force-takeover / cross-project / cross-session re-import), and a
+//     fresh stamp asserts the new ownership — falling past it could
+//     resurrect a stale stamp;
+//   - layer qualifies and carries a usable (non-blank) ImportedAt →
+//     preserve that literal;
+//   - layer qualifies but has NO usable ImportedAt → CONTINUE to later
+//     layers (reliable#2230 review, R4): a partial desired-state stamp
+//     (project+session backfilled, timestamp not captured) must not block
+//     preservation when the live cloud-side layer carries the full stamp —
+//     otherwise the timestamp churns on every recompose, permanent
+//     tag-only drift.
+func qualifiedPriorImportedAt(layers []map[string]string, projectKey, sessionKey, importedAtKey, projectID, sessionID string) (string, bool) {
+	for _, vals := range layers {
+		p, found := vals[projectKey]
+		if !found {
+			continue
+		}
+		if p != projectID {
+			return "", false
+		}
+		// Session marker comparison: if the current pass has a session, it
+		// must match the layer's. If the current pass has no session, the
+		// layer must also have no session — otherwise the prior belongs to
+		// a different temporal scope and a fresh stamp is the right signal.
+		s, hasS := vals[sessionKey]
+		if sessionID != "" {
+			if !hasS || s != sessionID {
+				return "", false
+			}
+		} else if hasS {
+			return "", false
+		}
+		if at, ok := vals[importedAtKey]; ok && strings.TrimSpace(at) != "" {
+			return at, true
+		}
+	}
+	return "", false
+}
+
+// preserveExistingImportedAt rewrites the InsideOutImportedAt entry's value
+// to the literal the resource already carries (via priorStampLayers /
+// qualifiedPriorImportedAt over typed Attrs, opaque Attributes, and the
+// cloud-side Identity.Tags snapshot) when the resource was previously
+// imported under the same project+session. Returns the entries slice
+// unchanged when:
 //
 //   - the cloud is neither aws nor gcp (the entries slice is empty in
 //     that case anyway — defensive),
-//   - ir.Identity.Tags has no ImportProject marker (first import — fresh
+//   - no placement carries an ImportProject marker (first import — fresh
 //     stamp is correct),
-//   - the existing ImportProject marker doesn't match projectID (a
+//   - the first ownership-expressing placement doesn't match projectID (a
 //     force-takeover or cross-project re-import — fresh stamp asserts
 //     the new ownership),
 //   - the session changed since the prior stamp (the session boundary is
 //     the natural place to refresh the timestamp),
-//   - or no existing ImportedAt literal is present (nothing to preserve).
+//   - or no qualifying placement carries a usable ImportedAt literal
+//     (nothing to preserve).
 //
 // Why this lives at the entries layer rather than overriding importedAt
 // for the whole call: provenanceKeysFor's signature is small and
@@ -605,16 +547,18 @@ func buildDiscoveredTagsExpression(cloud string, tags map[string]string, exclude
 // a tag-only diff in `terraform plan` on every flow even when nothing
 // material changed.
 func preserveExistingImportedAt(entries []provenanceEntry, ir *imported.ImportedResource, cloud, projectID, sessionID string) []provenanceEntry {
-	if ir == nil || len(ir.Identity.Tags) == 0 {
+	if ir == nil {
 		return entries
 	}
-	var projectKey, sessionKey, importedAtKey string
+	var attrName, projectKey, sessionKey, importedAtKey string
 	switch strings.ToLower(strings.TrimSpace(cloud)) {
 	case "aws":
+		attrName = "tags"
 		projectKey = AWSTagKeyImportProject
 		sessionKey = AWSTagKeyImportSession
 		importedAtKey = AWSTagKeyImportedAt
 	case "gcp":
+		attrName = "labels"
 		projectKey = GCPLabelKeyImportProject
 		sessionKey = GCPLabelKeyImportSession
 		importedAtKey = GCPLabelKeyImportedAt
@@ -622,24 +566,9 @@ func preserveExistingImportedAt(entries []provenanceEntry, ir *imported.Imported
 		return entries
 	}
 
-	if got, ok := ir.Identity.Tags[projectKey]; !ok || got != projectID {
-		return entries
-	}
-	// Session marker comparison: if the current pass has a session, it
-	// must match the prior stamp. If the current pass has no session,
-	// the prior stamp must also have no session — otherwise the prior
-	// belongs to a different temporal scope and a fresh stamp is the
-	// right signal.
-	if sessionID != "" {
-		if got, ok := ir.Identity.Tags[sessionKey]; !ok || got != sessionID {
-			return entries
-		}
-	} else if _, ok := ir.Identity.Tags[sessionKey]; ok {
-		return entries
-	}
-
-	existing, ok := ir.Identity.Tags[importedAtKey]
-	if !ok || strings.TrimSpace(existing) == "" {
+	layers := priorStampLayers(ir, attrName, projectKey, sessionKey, importedAtKey)
+	prior, ok := qualifiedPriorImportedAt(layers, projectKey, sessionKey, importedAtKey, projectID, sessionID)
+	if !ok {
 		return entries
 	}
 
@@ -650,7 +579,7 @@ func preserveExistingImportedAt(entries []provenanceEntry, ir *imported.Imported
 	copy(out, entries)
 	for i := range out {
 		if out[i].Key == importedAtKey {
-			out[i].Value = existing
+			out[i].Value = prior
 			break
 		}
 	}
@@ -801,14 +730,10 @@ func withFixedNow(t time.Time) (restore func()) {
 }
 
 // untaggableAWSSlice returns the sorted untaggable AWS resource type list
-// for cross-checking against the lint script. The slice is a stable copy.
+// for cross-checking against the lint script. The canonical map lives in
+// pkg/composer/imported alongside TaggableAttr (reliable#2230).
 func untaggableAWSSlice() []string {
-	out := make([]string, 0, len(untaggableAWS))
-	for k := range untaggableAWS {
-		out = append(out, k)
-	}
-	sort.Strings(out)
-	return out
+	return imported.UntaggableAWSTypes()
 }
 
 // labelableGCPFromRegistry returns the sorted list of GCP types whose

--- a/pkg/composer/imported_provenance_owner_test.go
+++ b/pkg/composer/imported_provenance_owner_test.go
@@ -1,0 +1,279 @@
+package composer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// TestProvenancePipelineMatrix is the poka-yoke for reliable#2230: it pins,
+// shape by shape, how a provenance claim travels the WHOLE compose pipeline
+// (DropUnimportable → ValidateProvenanceConflicts → injectProvenance, all
+// inside ComposeStackWithIssues) versus what the pick-time decision
+// (ProvenanceOwnedByOther) reports for the same resource.
+//
+// The invariant: anything compose would reject as a provenance conflict OR
+// silently drop as foreign-claimed is flagged by ProvenanceOwnedByOther at
+// pick time. It is a SUPERSET relation, not a mirror — compose never
+// *conflicts* on live-only claims; DropUnimportable (keying on the
+// InsideOutImported co-marker via UnimportableReason) silently removes them
+// before the validator runs.
+//
+// Motivating incident: reliable session sess_v2_tunCkPopdiKK, import
+// irun_jFcsE0sgd8NH (staging, 2026-07-12) — a shared-account selection
+// containing resources claimed by other import projects sailed through
+// picker and plan-preview and died at apply-compose with fatal=5
+// imported_resource_provenance_conflict.
+func TestProvenancePipelineMatrix(t *testing.T) {
+	t.Parallel()
+	const (
+		myProject = "io-mine"
+		mySession = "sess_v2_tunCkPopdiKK"
+		addr      = "aws_sqs_queue.q"
+	)
+	foreignStamp := map[string]string{
+		"InsideOutImportProject": "io-foreign",
+		"InsideOutImportSession": "sess_v2_other",
+		"InsideOutImported":      "true",
+		"InsideOutImportedAt":    "2026-05-26T21:10:48Z",
+	}
+
+	// compose runs one resource through the full stack compose and returns
+	// the result plus the issues referencing the resource's address.
+	compose := func(t *testing.T, ir imported.ImportedResource) (*ComposeStackResult, []ValidationIssue) {
+		t.Helper()
+		c := newTestClient()
+		res, err := c.ComposeStackWithIssues(ComposeStackOpts{
+			Cloud:           "aws",
+			SelectedKeys:    []ComponentKey{KeyAWSVPC},
+			Comps:           &Components{Cloud: "AWS"},
+			Cfg:             &Config{},
+			Project:         "demo",
+			Region:          "us-east-1",
+			ImportProjectID: myProject,
+			ImportSessionID: mySession,
+			Imported:        []imported.ImportedResource{ir},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		var addrIssues []ValidationIssue
+		for _, iss := range res.Issues {
+			if strings.Contains(iss.Field, ir.Identity.Address) {
+				addrIssues = append(addrIssues, iss)
+			}
+		}
+		return res, addrIssues
+	}
+
+	mkIR := func(tfType, addr string) imported.ImportedResource {
+		return imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Cloud: "aws", Type: tfType,
+				Address: addr, ImportID: "import-id",
+			},
+			Tier: imported.TierImportedFlat,
+		}
+	}
+	baseIR := func() imported.ImportedResource { return mkIR("aws_sqs_queue", addr) }
+	attrsWithMarkers := func(markers string) []byte {
+		return []byte(`{"name":{"literal":"q"},"tags":{` + markers + `}}`)
+	}
+
+	t.Run("a: full foreign live stamp — compose drops silently, pick time flags", func(t *testing.T) {
+		t.Parallel()
+		// Type choice is LOAD-BEARING — do not "simplify" it: the drop must
+		// be provably attributable to DropUnimportable running BEFORE the
+		// validators (compose.go: DropUnimportable precedes
+		// ValidateImportedResources / ValidateImportedEmitReadiness /
+		// ValidateProvenanceConflicts). aws_api_gateway_stage has three
+		// provider-Required attrs (rest_api_id, stage_name, deployment_id)
+		// and this resource ships EMPTY Attrs, so if anyone reorders
+		// compose to validate first, ValidateImportedEmitReadiness emits a
+		// spurious imported_resource_missing_required_attr for this address
+		// and the zero-issues assertion below goes red. A zero-Required
+		// type (aws_sqs_queue) would keep every assertion green across such
+		// a reorder and pin nothing.
+		ir := mkIR("aws_api_gateway_stage", "aws_api_gateway_stage.s")
+		// Discover-only shape: Attrs and Attributes empty.
+		ir.Identity.Tags = foreignStamp
+
+		res, addrIssues := compose(t, ir)
+		// Dropped BEFORE any validator runs: no conflict issue, no
+		// missing-required-attr issue — no trace at all beyond its absence.
+		assert.Empty(t, addrIssues, "dropped-before-validation resource must produce no issues")
+		assert.NotContains(t, string(res.Files["/imported.tf"]), ir.Identity.Address,
+			"full-stamp foreign-claimed resource must not be emitted")
+
+		owner, claimed := ProvenanceOwnedByOther(ir, mySession, myProject)
+		assert.True(t, claimed, "pick time must flag what compose silently drops as foreign-claimed")
+		assert.Equal(t, "io-foreign", owner)
+	})
+
+	t.Run("a2: full foreign live stamp on an UNTAGGABLE type — same verdicts", func(t *testing.T) {
+		t.Parallel()
+		// aws_iam_role_policy is untaggable (TaggableAttr=false: registered
+		// schema without a tags key). DropUnimportable still drops the
+		// full-stamp shape — UnimportableReason keys on the co-marker with
+		// no taggability gate — so ProvenanceOwnedByOther's ungated live
+		// leg must flag it too; gating the live read on TaggableAttr would
+		// break the superset invariant exactly here. The type also carries
+		// provider-Required attrs (policy, role), so like row (a) a compose
+		// reorder would surface spurious missing-required-attr issues and
+		// redden the zero-issues assertion.
+		ir := mkIR("aws_iam_role_policy", "aws_iam_role_policy.p")
+		ir.Identity.Tags = foreignStamp
+
+		res, addrIssues := compose(t, ir)
+		assert.Empty(t, addrIssues, "dropped-before-validation resource must produce no issues")
+		assert.NotContains(t, string(res.Files["/imported.tf"]), ir.Identity.Address,
+			"full-stamp foreign-claimed untaggable resource must not be emitted")
+		assert.Equal(t, imported.ReasonInsideOutImported, imported.UnimportableReason(ir))
+
+		owner, claimed := ProvenanceOwnedByOther(ir, mySession, myProject)
+		assert.True(t, claimed, "untaggable types must still surface live full-stamp claims at pick time")
+		assert.Equal(t, "io-foreign", owner)
+	})
+
+	t.Run("b: bare live project marker — not ownership anywhere", func(t *testing.T) {
+		t.Parallel()
+		// The historical bare account/project marker WITHOUT the
+		// InsideOutImported co-marker (see HasInsideOutImportedMarker's
+		// contract): compose keeps the resource, raises no conflict, and
+		// the injector stamps our fresh markers over it; pick time must
+		// not flag it either — conflicting would demand a ForceTakeover
+		// from an owner that never owned.
+		ir := baseIR()
+		ir.Attrs = []byte(`{"name":{"literal":"q"}}`)
+		ir.Identity.Tags = map[string]string{"InsideOutImportProject": "io-foreign"}
+
+		res, addrIssues := compose(t, ir)
+		assert.Empty(t, issuesWithCode(addrIssues, "imported_resource_provenance_conflict"),
+			"bare live marker must not conflict")
+		importedTF := string(res.Files["/imported.tf"])
+		assert.Contains(t, importedTF, addr, "resource must be emitted")
+		assert.True(t, hasAttr(t, importedTF, "InsideOutImportProject", `"`+myProject+`"`),
+			"injector must stamp our project over a bare marker:\n%s", importedTF)
+		assert.NotContains(t, importedTF, "io-foreign",
+			"the bare foreign marker is filtered from <discovered> and replaced by our stamp")
+
+		_, claimed := ProvenanceOwnedByOther(ir, mySession, myProject)
+		assert.False(t, claimed, "bare marker is not ownership at pick time either")
+	})
+
+	t.Run("c: foreign desired-state claim — compose conflicts, pick time flags", func(t *testing.T) {
+		t.Parallel()
+		ir := baseIR()
+		ir.Attrs = attrsWithMarkers(`"InsideOutImportProject":{"literal":"io-other"},"InsideOutImportSession":{"literal":"sess_v2_other"}`)
+
+		res, addrIssues := compose(t, ir)
+		conflicts := issuesWithCode(addrIssues, "imported_resource_provenance_conflict")
+		require.Len(t, conflicts, 1, "typed-Attrs foreign claim must conflict at compose time")
+		assert.Equal(t, "io-other", conflicts[0].Value)
+		// Injector refusal: our project must not overwrite the claim.
+		importedTF := string(res.Files["/imported.tf"])
+		assert.NotContains(t, importedTF, myProject,
+			"injector must not overwrite a conflicting claim without ForceTakeover")
+
+		owner, claimed := ProvenanceOwnedByOther(ir, mySession, myProject)
+		assert.True(t, claimed, "pick time must flag every compose-time conflict (superset invariant)")
+		assert.Equal(t, "io-other", owner)
+	})
+
+	t.Run("d: self shapes — neither conflict nor claim", func(t *testing.T) {
+		t.Parallel()
+		selfShapes := map[string]imported.ImportedResource{
+			"own project in Attrs": func() imported.ImportedResource {
+				ir := baseIR()
+				ir.Attrs = attrsWithMarkers(`"InsideOutImportProject":{"literal":"` + myProject + `"}`)
+				return ir
+			}(),
+			// The reconcile leg stamps the Oracle deployment UUID as the
+			// project string; the session tag is the namespace-stable self
+			// identity (reliable#2068).
+			"same session, different project string in Attrs": func() imported.ImportedResource {
+				ir := baseIR()
+				ir.Attrs = attrsWithMarkers(`"InsideOutImportProject":{"literal":"deploy-uuid-reconcile"},"InsideOutImportSession":{"literal":"` + mySession + `"}`)
+				return ir
+			}(),
+		}
+		for name, ir := range selfShapes {
+			ir := ir
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				_, addrIssues := compose(t, ir)
+				assert.Empty(t, issuesWithCode(addrIssues, "imported_resource_provenance_conflict"),
+					"self claim must not conflict at compose time")
+				_, claimed := ProvenanceOwnedByOther(ir, mySession, myProject)
+				assert.False(t, claimed, "self claim must not be flagged at pick time")
+			})
+		}
+
+		t.Run("own full live stamp", func(t *testing.T) {
+			t.Parallel()
+			// Discover-only shape carrying OUR full stamp. Pick time
+			// correctly reports "not claimed by other"; compose still drops
+			// it — through the already-imported channel
+			// (ReasonInsideOutImported keys on the co-marker regardless of
+			// owner), NOT as a provenance conflict. Pinning that keeps the
+			// superset invariant honest: the drop is not a foreign-claim
+			// signal, and the picker learns "already managed by InsideOut"
+			// from UnimportableReason, not from ProvenanceOwnedByOther.
+			ir := baseIR()
+			ir.Identity.Tags = map[string]string{
+				"InsideOutImportProject": myProject,
+				"InsideOutImportSession": mySession,
+				"InsideOutImported":      "true",
+			}
+			res, addrIssues := compose(t, ir)
+			assert.Empty(t, addrIssues, "own live stamp drops through the already-imported channel, no issues")
+			assert.NotContains(t, string(res.Files["/imported.tf"]), addr)
+			assert.Equal(t, imported.ReasonInsideOutImported, imported.UnimportableReason(ir))
+
+			_, claimed := ProvenanceOwnedByOther(ir, mySession, myProject)
+			assert.False(t, claimed, "our own stamp is not a foreign claim")
+		})
+	})
+}
+
+// issuesWithCode filters issues to those with the given code.
+func issuesWithCode(issues []ValidationIssue, code string) []ValidationIssue {
+	var out []ValidationIssue
+	for _, iss := range issues {
+		if iss.Code == code {
+			out = append(out, iss)
+		}
+	}
+	return out
+}
+
+// TestProvenanceOwnerReExports pins that the pkg/composer surface delegates
+// to the canonical pkg/composer/imported implementations — downstream
+// consumers import composer, and a drifted re-export would resurrect the
+// two-reader divergence this API exists to end.
+func TestProvenanceOwnerReExports(t *testing.T) {
+	t.Parallel()
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "q",
+			Tags: map[string]string{
+				"InsideOutImportProject": "io-other",
+				"InsideOutImported":      "true",
+			},
+		},
+		Tier: imported.TierImportedFlat,
+	}
+	p1, s1, ok1 := ProvenanceOwner(ir)
+	p2, s2, ok2 := imported.ProvenanceOwner(ir)
+	assert.Equal(t, p2, p1)
+	assert.Equal(t, s2, s1)
+	assert.Equal(t, ok2, ok1)
+
+	o1, c1 := ProvenanceOwnedByOther(ir, "sess", "io-mine", "deploy-uuid")
+	o2, c2 := imported.ProvenanceOwnedByOther(ir, "sess", "io-mine", "deploy-uuid")
+	assert.Equal(t, o2, o1)
+	assert.Equal(t, c2, c1)
+}

--- a/pkg/composer/imported_provenance_test.go
+++ b/pkg/composer/imported_provenance_test.go
@@ -515,6 +515,108 @@ func TestInjectProvenance_Idempotent_OnReEmissionWithPriorStamp(t *testing.T) {
 	}
 }
 
+// TestInjectProvenance_PreservesImportedAt_AttrsShapedPriorStamp pins the
+// Mars-leg variant of the idempotency contract (reliable#2230 review, F8b):
+// on the reverse-import leg the prior stamp lives in TYPED ATTRS — the plan
+// backfill (pkg/reverseimport.BackfillImportedAttrsFromPlan) writes the
+// merged tags, InsideOut markers included, back into Attrs and never touches
+// Identity.Tags. The historical preservation predicate read Identity.Tags
+// ONLY, so every recompose of such a resource re-stamped InsideOutImportedAt
+// with a fresh nowFn() value — a tag-only diff on every no-op pass, exactly
+// the churn preserveExistingImportedAt exists to prevent. The unified
+// layer-coherent read (priorProvenanceStamp: Attrs → Attributes →
+// Identity.Tags) must preserve the Attrs-shaped stamp and keep two composes
+// at different wall-clock times byte-identical.
+func TestInjectProvenance_PreservesImportedAt_AttrsShapedPriorStamp(t *testing.T) {
+	t.Parallel()
+	priorStampLit := "2026-05-26T21:10:48Z"
+	mkIR := func() imported.ImportedResource {
+		return imported.ImportedResource{
+			Identity: imported.ResourceIdentity{
+				Cloud:   "aws",
+				Type:    "aws_sqs_queue",
+				Address: "aws_sqs_queue.q",
+				// Identity.Tags deliberately EMPTY — the Mars-leg shape.
+			},
+			Tier: imported.TierImportedFlat,
+			Attrs: []byte(`{"name":{"literal":"q"},"tags":{` +
+				`"InsideOutImportProject":{"literal":"io-stack-1"},` +
+				`"InsideOutImportSession":{"literal":"sess-9"},` +
+				`"InsideOutImported":{"literal":"true"},` +
+				`"InsideOutImportedAt":{"literal":"` + priorStampLit + `"}` +
+				`}}`),
+		}
+	}
+
+	ir1 := mkIR()
+	body1, _, err := emitTestBody(t, ir1)
+	require.NoError(t, err)
+	out1, err := injectProvenance(body1, &ir1, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+
+	// Second pass a week later: identical inputs, different clock.
+	ir2 := mkIR()
+	body2, _, err := emitTestBody(t, ir2)
+	require.NoError(t, err)
+	out2, err := injectProvenance(body2, &ir2, "io-stack-1", "sess-9", fixedTime().Add(24*7*time.Hour))
+	require.NoError(t, err)
+
+	assert.True(t, hasAttr(t, string(out1), "InsideOutImportedAt", `"`+priorStampLit+`"`),
+		"Attrs-shaped prior stamp must be preserved:\n%s", out1)
+	assert.NotContains(t, string(out1), "2026-04-29T14:30:00Z",
+		"fresh nowFn stamp must not appear when the Attrs-shaped prior stamp matches:\n%s", out1)
+	assert.Equal(t, string(out1), string(out2),
+		"recompose of a Mars-leg (Attrs-shaped) stamp must be byte-identical regardless of the clock")
+}
+
+// TestInjectProvenance_PreservesImportedAt_PartialAttrsStampFallsToLive pins
+// the R4 refinement of the layer scan (reliable#2230 review): a desired-state
+// layer whose project+session markers match the current pass but which
+// carries NO usable InsideOutImportedAt (a partial backfill — the plan
+// captured the ownership markers but not the timestamp) must not TERMINATE
+// preservation. The scan continues to the live Identity.Tags layer and, when
+// that layer's OWN project+session also match (each layer must independently
+// qualify — no cross-layer stitching), preserves the live timestamp. Without
+// the fall-through, this shape re-stamps a fresh nowFn() on every recompose:
+// permanent tag-only drift churn on an unchanged resource.
+func TestInjectProvenance_PreservesImportedAt_PartialAttrsStampFallsToLive(t *testing.T) {
+	t.Parallel()
+	priorStampLit := "2026-05-26T21:10:48Z"
+	ir := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:   "aws",
+			Type:    "aws_sqs_queue",
+			Address: "aws_sqs_queue.q",
+			// Live cloud-side snapshot: the FULL prior stamp, timestamp
+			// included, matching the current pass's project+session.
+			Tags: map[string]string{
+				"InsideOutImportProject": "io-stack-1",
+				"InsideOutImportSession": "sess-9",
+				"InsideOutImported":      "true",
+				"InsideOutImportedAt":    priorStampLit,
+			},
+		},
+		Tier: imported.TierImportedFlat,
+		// Typed Attrs: project+session literals present, InsideOutImportedAt
+		// ABSENT — the partial-backfill shape.
+		Attrs: []byte(`{"name":{"literal":"q"},"tags":{` +
+			`"InsideOutImportProject":{"literal":"io-stack-1"},` +
+			`"InsideOutImportSession":{"literal":"sess-9"}` +
+			`}}`),
+	}
+	body, _, err := emitTestBody(t, ir)
+	require.NoError(t, err)
+	got, err := injectProvenance(body, &ir, "io-stack-1", "sess-9", fixedTime())
+	require.NoError(t, err)
+	s := string(got)
+
+	assert.True(t, hasAttr(t, s, "InsideOutImportedAt", `"`+priorStampLit+`"`),
+		"live-layer timestamp must be preserved when the partial Attrs layer qualifies but has no stamp:\n%s", s)
+	// fixedTime()'s RFC3339 form must not appear as the emitted stamp.
+	assert.False(t, hasAttr(t, s, "InsideOutImportedAt", `"2026-04-29T14:30:00Z"`),
+		"fresh nowFn stamp must not be emitted for the partial-Attrs + full-live shape:\n%s", s)
+}
+
 // TestPreserveExistingImportedAt covers the negative arms of the
 // preservation predicate: each non-match case must fall back to the
 // fresh stamp from `entries` so the caller's intent (re-stamp on a

--- a/pkg/composer/imported_validate_test.go
+++ b/pkg/composer/imported_validate_test.go
@@ -576,6 +576,100 @@ func TestValidateProvenanceConflicts_DifferentSessionDifferentProjectFails(t *te
 	assert.Equal(t, "io-other", issues[0].Value)
 }
 
+// TestValidateProvenanceConflicts_ClaimPlacementScope parameterizes WHERE the
+// foreign claim marker sits and pins the validator's read scope
+// (reliable#2230): desired-state placements (typed Attrs, opaque Attributes)
+// conflict; a claim visible ONLY on the live Identity.Tags snapshot does NOT
+// — that class is owned upstream. composeStackImpl runs
+// imported.DropUnimportable (keying on the InsideOutImported co-marker)
+// before this validator, silently dropping full-stamp live claims, and a
+// bare live project marker is explicitly not ownership (see
+// HasInsideOutImportedMarker's contract: historical resources carry a bare
+// account/project marker without having been imported). Conflicting on live
+// tags here would turn those bare markers into fatal conflicts demanding a
+// ForceTakeover from an owner that never owned. Pick-time surfacing of live
+// full-stamp claims is imported.ProvenanceOwnedByOther's job (pinned by
+// TestProvenancePipelineMatrix).
+func TestValidateProvenanceConflicts_ClaimPlacementScope(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		ir           imported.ImportedResource
+		cloud        string
+		wantConflict bool
+	}{
+		{
+			// Attributes-shaped claims are covered by
+			// TestValidateProvenanceConflicts_DifferentTagFails; typed-Attrs
+			// GCP by ..._GCPTagFromTypedAttrs. This row adds typed-Attrs AWS.
+			name:  "aws typed-Attrs claim conflicts",
+			cloud: "aws",
+			ir: imported.ImportedResource{
+				Identity: imported.ResourceIdentity{Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "q"},
+				Tier:     imported.TierImportedFlat,
+				Attrs:    []byte(`{"name":{"literal":"q"},"tags":{"InsideOutImportProject":{"literal":"io-other"}}}`),
+			},
+			wantConflict: true,
+		},
+		{
+			name:  "aws live-only full stamp does not conflict (DropUnimportable owns it)",
+			cloud: "aws",
+			ir: imported.ImportedResource{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "q",
+					Tags: map[string]string{
+						"InsideOutImportProject": "io-other",
+						"InsideOutImported":      "true",
+					},
+				},
+				Tier: imported.TierImportedFlat,
+			},
+			wantConflict: false,
+		},
+		{
+			name:  "gcp live-only full stamp does not conflict",
+			cloud: "gcp",
+			ir: imported.ImportedResource{
+				Identity: imported.ResourceIdentity{
+					Cloud: "gcp", Type: "google_storage_bucket", Address: "google_storage_bucket.b", ImportID: "b",
+					Tags: map[string]string{
+						"insideout-import-project": "io-other",
+						"insideout-imported":       "true",
+					},
+				},
+				Tier: imported.TierImportedFlat,
+			},
+			wantConflict: false,
+		},
+		{
+			name:  "aws bare live project marker does not conflict (not ownership)",
+			cloud: "aws",
+			ir: imported.ImportedResource{
+				Identity: imported.ResourceIdentity{
+					Cloud: "aws", Type: "aws_sqs_queue", Address: "aws_sqs_queue.q", ImportID: "q",
+					Tags: map[string]string{"InsideOutImportProject": "io-other"},
+				},
+				Tier:  imported.TierImportedFlat,
+				Attrs: []byte(`{"name":{"literal":"q"}}`),
+			},
+			wantConflict: false,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			issues := ValidateProvenanceConflicts(tc.cloud, []imported.ImportedResource{tc.ir}, ProvenanceOpts{ImportProjectID: "io-1"})
+			got := countCode(issues, "imported_resource_provenance_conflict")
+			if tc.wantConflict {
+				assert.Equal(t, 1, got, "expected a conflict; issues=%v", issueCodes(issues))
+			} else {
+				assert.Zero(t, got, "expected no conflict; issues=%v", issueCodes(issues))
+			}
+		})
+	}
+}
+
 // TestValidateProvenanceConflicts_SameProjectNoSessionOK proves the existing
 // project-id match path is intact: a resource claimed under the same project
 // with NO session tag is still allowed (the session allowance is additive).


### PR DESCRIPTION
## Summary

Upstream half of reliable#2230 (provenance conflict surfaces only at apply, not at plan/picker). Exports a single pick-time ownership reader so reliable's picker and reverse-run guards can never diverge from the compose-time verdicts again.

- New `pkg/composer/imported/provenance_owner.go`:
  - `ProvenanceOwner(ir)` — layer-coherent provenance read (Attrs → Attributes → Identity.Tags). The live (Identity.Tags) leg fires only for the discover-only shape (empty Attrs+Attributes), requires the full stamp (`InsideOutImported` co-marker, normalized keys, non-empty value), and is not TaggableAttr-gated (matching the `UnimportableReason` classifier).
  - `ProvenanceOwnedByOther(ir, importSessionID, ownProjectIDs...)` — the decision helper: trimming, the #2068 same-session escape, GCP live-leg case folding, and the own-project **set** (io-name + deployment UUID).
- `taggable`/`untaggableAWS`/marker-key constants consolidated into `pkg/composer/imported` (thin composer re-exports; zero call-site churn).
- Validator/injector (`existingProvenanceProject`/`Session`, `injectProvenance`) are byte-identical to main — deliberately NOT given the live-tag read (bare live markers must not conflict; full live stamps are dropped by `DropUnimportable` before the validator runs).
- `preserveExistingImportedAt` unified onto the layer-coherent read with per-layer qualification + timestamp fall-through (fixes fresh-stamp churn on Attrs-shaped prior stamps).
- Poka-yoke: `TestProvenancePipelineMatrix` runs `ComposeStackWithIssues` end-to-end and pins the superset contract (full foreign live stamp → dropped AND flagged; bare marker → neither; Attrs-shaped foreign claim → fatal conflict AND flagged; own/same-session → neither), with reorder tripwires (required-attr types) so a compose-pipeline reordering goes red.

## Review

Built by an agent workflow with 11 independent review passes; the first design (live-tag fallback inside the validator/injector) was rejected in review — it would have raised false fatal conflicts on the historical bare-marker class and silently broken the injector's #690 tag backfill on write-only-tag types — and replaced with the exported-reader design above.

## Test plan

- [x] `go test ./pkg/composer/... ./pkg/reverseimport/...` green
- [x] `go vet` / `gofmt` clean; golangci-lint zero findings on touched files
- [x] New: pipeline matrix (rows a/a2/b/c/d), OwnedByOther 10-row table (double-namespace rows), placement/precedence/gates suites, partial-stamp preserve test
- [x] Downstream: reliable pinned to this branch SHA passes its parity + guard suites (reliable PR follows)

Refs luthersystems/reliable#2230, reliable#2068.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK)_