### PR TITLE
feat(imported): discover-summary/label + state-bucket-type projections (reliable#2239)

### DIFF
--- a/pkg/composer/imported/discover_projection.go
+++ b/pkg/composer/imported/discover_projection.go
@@ -1,0 +1,457 @@
+package imported
+
+// discover_projection.go — per-type "discover summary" and label projection
+// for the reverse-Terraform import wizard.
+//
+// DiscoverSummary / DiscoverLabels are the presets-owned home for the curated
+// one-line attribute summary and the enriched-label overlay the importer
+// wizard renders beneath each discovered resource. They moved here from
+// reliable's internal/agentapi/import_dtos.go (reliable#2239, umbrella #1479)
+// so the per-type vocabulary lives upstream — reliable holds zero per-type
+// dispatch for the DTO summary/label surface.
+//
+// Contract (mirrors the reliable mappers they replace, byte-for-byte):
+//
+//   - DiscoverSummary returns the curated one-line summary for the five GCP
+//     types that carry one, or "" for every other type (an unmapped type
+//     rendered a blank summary before, and still does). Summaries never fail:
+//     Attrs that fail to decode collapse to a shorter summary (or "") rather
+//     than panicking, so the wizard renders a partial row instead of dropping
+//     it.
+//   - DiscoverLabels returns the enriched user-label overlay (a flat
+//     string→string map) for the types whose summary mapper surfaced labels,
+//     or an empty (non-nil) map otherwise. The consumer overlays these onto
+//     the base identity tags.
+//
+// The typed attr views mirror the relevant subset of the generated per-type
+// models (generated.GoogleStorageBucket, …) and Value[T]'s JSON wire shape
+// ({"literal": …}); the payload is decoded from the raw ImportedResource.Attrs
+// JSON so this file stays free of any dependency on the generated package
+// (same rationale as resource.go's Attrs=json.RawMessage note).
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+)
+
+// DiscoverSummary returns the importer wizard's one-line attribute summary for
+// a discovered resource, dispatching on Identity.Type. Returns "" for types
+// without a curated summary (matching the pre-move identity-only DTO).
+func DiscoverSummary(ir ImportedResource) string {
+	switch ir.Identity.Type {
+	case "google_storage_bucket":
+		return buildBucketSummary(ir)
+	case "google_pubsub_topic":
+		return buildPubsubTopicSummary(ir)
+	case "google_pubsub_subscription":
+		return buildPubsubSubscriptionSummary(ir)
+	case "google_secret_manager_secret":
+		return buildSecretManagerSecretSummary(ir)
+	case "google_compute_network":
+		return buildComputeNetworkSummary(ir)
+	default:
+		return ""
+	}
+}
+
+// DiscoverLabels returns the enriched user-label overlay for a discovered
+// resource, dispatching on Identity.Type. Returns an empty (non-nil) map for
+// types with no label surface (including google_compute_network, whose
+// generated schema exposes none). The map is the type-specific overlay only —
+// the consumer merges it onto the base identity tags.
+func DiscoverLabels(ir ImportedResource) map[string]string {
+	switch ir.Identity.Type {
+	case "google_storage_bucket":
+		return readBucketLabels(ir)
+	case "google_pubsub_topic":
+		return readPubsubTopicLabels(ir)
+	case "google_pubsub_subscription":
+		return readPubsubSubscriptionLabels(ir)
+	case "google_secret_manager_secret":
+		return readSecretManagerSecretLabels(ir)
+	default:
+		return map[string]string{}
+	}
+}
+
+// discoverLastPathSegment returns the substring after the last "/" of s, or
+// the empty string when s has no slash or is empty. Used to render the short
+// name of a fully-qualified Pub/Sub topic path (e.g. "projects/p/topics/t" →
+// "t").
+func discoverLastPathSegment(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if idx := strings.LastIndex(s, "/"); idx >= 0 {
+		return s[idx+1:]
+	}
+	return s
+}
+
+/* ------------------------------------------------------------------ */
+/* google_storage_bucket                                              */
+/* ------------------------------------------------------------------ */
+
+// bucketAttrsView is the minimal typed projection of ir.Attrs needed to build
+// the wizard's DTO summary + tags. Mirrors the relevant subset of
+// generated.GoogleStorageBucket (storage_class, labels) and Value[T]'s JSON
+// wire shape ({"literal": …}).
+type bucketAttrsView struct {
+	StorageClass *struct {
+		Literal string `json:"literal"`
+	} `json:"StorageClass,omitempty"`
+	Labels map[string]struct {
+		Literal string `json:"literal"`
+	} `json:"Labels,omitempty"`
+}
+
+// buildBucketSummary returns "<storage_class> · <location>". Falls back to just
+// location when Attrs are absent / unparseable.
+func buildBucketSummary(ir ImportedResource) string {
+	parts := []string{}
+	if v, ok := readBucketAttrsView(ir); ok && v.StorageClass != nil && v.StorageClass.Literal != "" {
+		parts = append(parts, v.StorageClass.Literal)
+	}
+	if ir.Identity.Location != "" {
+		parts = append(parts, ir.Identity.Location)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// readBucketLabels surfaces labels from the enriched Attrs as a flat
+// string→string map. Empty map (not nil) when no labels are populated.
+func readBucketLabels(ir ImportedResource) map[string]string {
+	out := map[string]string{}
+	v, ok := readBucketAttrsView(ir)
+	if !ok || v.Labels == nil {
+		return out
+	}
+	for k, lit := range v.Labels {
+		out[k] = lit.Literal
+	}
+	return out
+}
+
+// readBucketAttrsView parses ir.Attrs into the minimal bucketAttrsView.
+// Returns (zero, false) on absent / unparseable Attrs.
+func readBucketAttrsView(ir ImportedResource) (bucketAttrsView, bool) {
+	if len(ir.Attrs) == 0 {
+		return bucketAttrsView{}, false
+	}
+	var v bucketAttrsView
+	if err := json.Unmarshal(ir.Attrs, &v); err != nil {
+		return bucketAttrsView{}, false
+	}
+	return v, true
+}
+
+/* ------------------------------------------------------------------ */
+/* google_pubsub_topic                                                */
+/* ------------------------------------------------------------------ */
+
+// pubsubTopicAttrsView is the minimal typed projection of ir.Attrs needed to
+// build the wizard's DTO summary + tags. Field names mirror
+// generated.GooglePubsubTopic; the nested MessageStoragePolicy is decoded as a
+// list since the generated type declares it as a TF repeated-block.
+type pubsubTopicAttrsView struct {
+	MessageRetentionDuration *struct {
+		Literal string `json:"literal"`
+	} `json:"MessageRetentionDuration,omitempty"`
+	Labels map[string]struct {
+		Literal string `json:"literal"`
+	} `json:"Labels,omitempty"`
+	MessageStoragePolicy []struct {
+		AllowedPersistenceRegions []*struct {
+			Literal string `json:"literal"`
+		} `json:"AllowedPersistenceRegions,omitempty"`
+	} `json:"MessageStoragePolicy,omitempty"`
+}
+
+// buildPubsubTopicSummary returns "<regions> · <retention>". Empty parts are
+// skipped; both absent collapses to "".
+func buildPubsubTopicSummary(ir ImportedResource) string {
+	v, ok := readPubsubTopicAttrsView(ir)
+	if !ok {
+		return ""
+	}
+	parts := []string{}
+	regions := pubsubAllowedRegions(v)
+	if len(regions) > 0 {
+		parts = append(parts, strings.Join(regions, ","))
+	}
+	if v.MessageRetentionDuration != nil && v.MessageRetentionDuration.Literal != "" {
+		parts = append(parts, v.MessageRetentionDuration.Literal)
+	}
+	return strings.Join(parts, " · ")
+}
+
+// pubsubAllowedRegions flattens the typed repeated-block representation of
+// message_storage_policy.allowed_persistence_regions into a flat string slice.
+// Non-literal entries are dropped. Returns an empty slice (not nil).
+func pubsubAllowedRegions(v pubsubTopicAttrsView) []string {
+	if len(v.MessageStoragePolicy) == 0 {
+		return []string{}
+	}
+	regions := make([]string, 0)
+	for _, block := range v.MessageStoragePolicy {
+		for _, r := range block.AllowedPersistenceRegions {
+			if r == nil || r.Literal == "" {
+				continue
+			}
+			regions = append(regions, r.Literal)
+		}
+	}
+	return regions
+}
+
+// readPubsubTopicLabels surfaces labels from the enriched Attrs as a flat
+// string→string map. Empty map (not nil) when no labels are populated.
+func readPubsubTopicLabels(ir ImportedResource) map[string]string {
+	out := map[string]string{}
+	v, ok := readPubsubTopicAttrsView(ir)
+	if !ok || v.Labels == nil {
+		return out
+	}
+	for k, lit := range v.Labels {
+		out[k] = lit.Literal
+	}
+	return out
+}
+
+// readPubsubTopicAttrsView parses ir.Attrs into the minimal
+// pubsubTopicAttrsView. Returns (zero, false) on absent / unparseable Attrs.
+func readPubsubTopicAttrsView(ir ImportedResource) (pubsubTopicAttrsView, bool) {
+	if len(ir.Attrs) == 0 {
+		return pubsubTopicAttrsView{}, false
+	}
+	var v pubsubTopicAttrsView
+	if err := json.Unmarshal(ir.Attrs, &v); err != nil {
+		return pubsubTopicAttrsView{}, false
+	}
+	return v, true
+}
+
+/* ------------------------------------------------------------------ */
+/* google_pubsub_subscription                                         */
+/* ------------------------------------------------------------------ */
+
+// pubsubSubscriptionAttrsView is the minimal typed projection of ir.Attrs
+// needed to build the wizard's DTO summary + tags. Mirrors
+// generated.GooglePubsubSubscription.
+type pubsubSubscriptionAttrsView struct {
+	Topic *struct {
+		Literal string `json:"literal"`
+	} `json:"Topic,omitempty"`
+	AckDeadlineSeconds *struct {
+		Literal int64 `json:"literal"`
+	} `json:"AckDeadlineSeconds,omitempty"`
+	Labels map[string]struct {
+		Literal string `json:"literal"`
+	} `json:"Labels,omitempty"`
+}
+
+// buildPubsubSubscriptionSummary renders "topic=<short-topic> · <ack>s". Topic
+// is rendered as its short last-path-segment so the summary stays scannable.
+func buildPubsubSubscriptionSummary(ir ImportedResource) string {
+	v, ok := readPubsubSubscriptionAttrsView(ir)
+	if !ok {
+		return ""
+	}
+	parts := []string{}
+	if v.Topic != nil && v.Topic.Literal != "" {
+		topicShort := discoverLastPathSegment(v.Topic.Literal)
+		if topicShort == "" {
+			topicShort = v.Topic.Literal
+		}
+		parts = append(parts, "topic="+topicShort)
+	}
+	if v.AckDeadlineSeconds != nil && v.AckDeadlineSeconds.Literal > 0 {
+		parts = append(parts, strconv.FormatInt(v.AckDeadlineSeconds.Literal, 10)+"s")
+	}
+	return strings.Join(parts, " · ")
+}
+
+// readPubsubSubscriptionLabels surfaces user labels from ir.Attrs as a flat
+// string→string map. Empty map (not nil) when no labels populated.
+func readPubsubSubscriptionLabels(ir ImportedResource) map[string]string {
+	out := map[string]string{}
+	v, ok := readPubsubSubscriptionAttrsView(ir)
+	if !ok || v.Labels == nil {
+		return out
+	}
+	for k, lit := range v.Labels {
+		out[k] = lit.Literal
+	}
+	return out
+}
+
+// readPubsubSubscriptionAttrsView parses ir.Attrs into the minimal
+// pubsubSubscriptionAttrsView. Returns (zero, false) on absent / unparseable
+// Attrs.
+func readPubsubSubscriptionAttrsView(ir ImportedResource) (pubsubSubscriptionAttrsView, bool) {
+	if len(ir.Attrs) == 0 {
+		return pubsubSubscriptionAttrsView{}, false
+	}
+	var v pubsubSubscriptionAttrsView
+	if err := json.Unmarshal(ir.Attrs, &v); err != nil {
+		return pubsubSubscriptionAttrsView{}, false
+	}
+	return v, true
+}
+
+/* ------------------------------------------------------------------ */
+/* google_secret_manager_secret                                       */
+/* ------------------------------------------------------------------ */
+
+// secretManagerSecretAttrsView is the minimal typed projection of ir.Attrs
+// needed to build the wizard's DTO summary + tags. Mirrors
+// generated.GoogleSecretManagerSecret. Replication is a repeated block with
+// mutually-exclusive Auto/UserManaged sub-blocks; the summary uses whichever
+// is present.
+type secretManagerSecretAttrsView struct {
+	Replication []struct {
+		Auto []struct {
+			CustomerManagedEncryption []json.RawMessage `json:"CustomerManagedEncryption,omitempty"`
+		} `json:"Auto,omitempty"`
+		UserManaged []struct {
+			Replicas []struct {
+				Location *struct {
+					Literal string `json:"literal"`
+				} `json:"Location,omitempty"`
+			} `json:"Replicas,omitempty"`
+		} `json:"UserManaged,omitempty"`
+	} `json:"Replication,omitempty"`
+	Rotation []struct {
+		RotationPeriod *struct {
+			Literal string `json:"literal"`
+		} `json:"RotationPeriod,omitempty"`
+	} `json:"Rotation,omitempty"`
+	Labels map[string]struct {
+		Literal string `json:"literal"`
+	} `json:"Labels,omitempty"`
+}
+
+// buildSecretManagerSecretSummary renders "<replication> · rotate=<period>".
+// Replication is "auto" / "auto+cmek" / "user-managed:r1,r2".
+func buildSecretManagerSecretSummary(ir ImportedResource) string {
+	v, ok := readSecretManagerSecretAttrsView(ir)
+	if !ok {
+		return ""
+	}
+	parts := []string{}
+	if rep := secretManagerReplicationSummary(v); rep != "" {
+		parts = append(parts, rep)
+	}
+	if len(v.Rotation) > 0 {
+		r := v.Rotation[0]
+		if r.RotationPeriod != nil && r.RotationPeriod.Literal != "" {
+			parts = append(parts, "rotate="+r.RotationPeriod.Literal)
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+// secretManagerReplicationSummary returns a short human-readable description of
+// the replication policy: "auto", "auto+cmek", or "user-managed:r1,r2". Empty
+// when no replication block is populated.
+func secretManagerReplicationSummary(v secretManagerSecretAttrsView) string {
+	if len(v.Replication) == 0 {
+		return ""
+	}
+	rep := v.Replication[0]
+	if len(rep.Auto) > 0 {
+		if len(rep.Auto[0].CustomerManagedEncryption) > 0 {
+			return "auto+cmek"
+		}
+		return "auto"
+	}
+	if len(rep.UserManaged) > 0 {
+		um := rep.UserManaged[0]
+		locs := make([]string, 0, len(um.Replicas))
+		for _, r := range um.Replicas {
+			if r.Location != nil && r.Location.Literal != "" {
+				locs = append(locs, r.Location.Literal)
+			}
+		}
+		if len(locs) == 0 {
+			return "user-managed"
+		}
+		return "user-managed:" + strings.Join(locs, ",")
+	}
+	return ""
+}
+
+// readSecretManagerSecretLabels surfaces user labels from ir.Attrs. Empty map
+// (not nil) when no labels populated.
+func readSecretManagerSecretLabels(ir ImportedResource) map[string]string {
+	out := map[string]string{}
+	v, ok := readSecretManagerSecretAttrsView(ir)
+	if !ok || v.Labels == nil {
+		return out
+	}
+	for k, lit := range v.Labels {
+		out[k] = lit.Literal
+	}
+	return out
+}
+
+// readSecretManagerSecretAttrsView parses ir.Attrs into the minimal
+// secretManagerSecretAttrsView. Returns (zero, false) on absent / unparseable
+// Attrs.
+func readSecretManagerSecretAttrsView(ir ImportedResource) (secretManagerSecretAttrsView, bool) {
+	if len(ir.Attrs) == 0 {
+		return secretManagerSecretAttrsView{}, false
+	}
+	var v secretManagerSecretAttrsView
+	if err := json.Unmarshal(ir.Attrs, &v); err != nil {
+		return secretManagerSecretAttrsView{}, false
+	}
+	return v, true
+}
+
+/* ------------------------------------------------------------------ */
+/* google_compute_network                                             */
+/* ------------------------------------------------------------------ */
+
+// computeNetworkAttrsView is the minimal typed projection of ir.Attrs needed
+// for the summary. Mirrors generated.GoogleComputeNetwork field names.
+type computeNetworkAttrsView struct {
+	RoutingMode *struct {
+		Literal string `json:"literal"`
+	} `json:"RoutingMode,omitempty"`
+	AutoCreateSubnetworks *struct {
+		Literal bool `json:"literal"`
+	} `json:"AutoCreateSubnetworks,omitempty"`
+}
+
+// buildComputeNetworkSummary renders "routing=<mode> · auto_subnets=<bool>".
+func buildComputeNetworkSummary(ir ImportedResource) string {
+	v, ok := readComputeNetworkAttrsView(ir)
+	if !ok {
+		return ""
+	}
+	parts := []string{}
+	if v.RoutingMode != nil && v.RoutingMode.Literal != "" {
+		parts = append(parts, "routing="+v.RoutingMode.Literal)
+	}
+	if v.AutoCreateSubnetworks != nil {
+		parts = append(parts, "auto_subnets="+strconv.FormatBool(v.AutoCreateSubnetworks.Literal))
+	}
+	return strings.Join(parts, " · ")
+}
+
+// readComputeNetworkAttrsView parses ir.Attrs into the minimal
+// computeNetworkAttrsView. Returns (zero, false) on absent / unparseable
+// Attrs.
+func readComputeNetworkAttrsView(ir ImportedResource) (computeNetworkAttrsView, bool) {
+	if len(ir.Attrs) == 0 {
+		return computeNetworkAttrsView{}, false
+	}
+	var v computeNetworkAttrsView
+	if err := json.Unmarshal(ir.Attrs, &v); err != nil {
+		return computeNetworkAttrsView{}, false
+	}
+	return v, true
+}

--- a/pkg/composer/imported/discover_projection_test.go
+++ b/pkg/composer/imported/discover_projection_test.go
@@ -1,0 +1,203 @@
+package imported
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// mustAttrs marshals a map to json.RawMessage for the Attrs field.
+func mustAttrs(t *testing.T, m map[string]any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal attrs: %v", err)
+	}
+	return b
+}
+
+// TestDiscoverSummary pins the curated one-line summaries the importer wizard
+// renders. These strings are behavior-preserving with the reliable mappers
+// this projection replaced (reliable#2239) — the assertions mirror
+// reliable's internal/agentapi/import_discover_test.go.
+func TestDiscoverSummary(t *testing.T) {
+	t.Run("bucket: storage_class · location", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_storage_bucket", Location: "US-CENTRAL1"},
+			Attrs:    mustAttrs(t, map[string]any{"StorageClass": map[string]any{"literal": "NEARLINE"}}),
+		}
+		if got := DiscoverSummary(ir); got != "NEARLINE · US-CENTRAL1" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("bucket: location-only when storage_class absent", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{Type: "google_storage_bucket", Location: "US"}}
+		if got := DiscoverSummary(ir); got != "US" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("bucket: unparseable attrs → location fallback, no panic", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_storage_bucket", Location: "US"},
+			Attrs:    json.RawMessage(`{ this is not valid json `),
+		}
+		if got := DiscoverSummary(ir); got != "US" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("pubsub_topic: regions · retention", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_pubsub_topic"},
+			Attrs: mustAttrs(t, map[string]any{
+				"MessageRetentionDuration": map[string]any{"literal": "86400s"},
+				"MessageStoragePolicy": []any{map[string]any{
+					"AllowedPersistenceRegions": []any{
+						map[string]any{"literal": "us-east1"},
+						map[string]any{"literal": "us-central1"},
+					},
+				}},
+			}),
+		}
+		if got := DiscoverSummary(ir); got != "us-east1,us-central1 · 86400s" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("pubsub_topic: retention-only", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_pubsub_topic"},
+			Attrs:    mustAttrs(t, map[string]any{"MessageRetentionDuration": map[string]any{"literal": "604800s"}}),
+		}
+		if got := DiscoverSummary(ir); got != "604800s" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("pubsub_subscription: topic=<short> · <ack>s", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_pubsub_subscription"},
+			Attrs: mustAttrs(t, map[string]any{
+				"Topic":              map[string]any{"literal": "projects/p/topics/events"},
+				"AckDeadlineSeconds": map[string]any{"literal": 30},
+			}),
+		}
+		if got := DiscoverSummary(ir); got != "topic=events · 30s" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("pubsub_subscription: topic-only", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_pubsub_subscription"},
+			Attrs:    mustAttrs(t, map[string]any{"Topic": map[string]any{"literal": "projects/p/topics/events"}}),
+		}
+		if got := DiscoverSummary(ir); got != "topic=events" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("secret: auto · rotate", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_secret_manager_secret"},
+			Attrs: mustAttrs(t, map[string]any{
+				"Replication": []any{map[string]any{"Auto": []any{map[string]any{}}}},
+				"Rotation":    []any{map[string]any{"RotationPeriod": map[string]any{"literal": "2592000s"}}},
+			}),
+		}
+		if got := DiscoverSummary(ir); got != "auto · rotate=2592000s" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("secret: auto+cmek", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_secret_manager_secret"},
+			Attrs: mustAttrs(t, map[string]any{
+				"Replication": []any{map[string]any{"Auto": []any{map[string]any{
+					"CustomerManagedEncryption": []any{map[string]any{"kms_key_name": map[string]any{"literal": "k"}}},
+				}}}},
+			}),
+		}
+		if got := DiscoverSummary(ir); got != "auto+cmek" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("secret: user-managed:regions", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_secret_manager_secret"},
+			Attrs: mustAttrs(t, map[string]any{
+				"Replication": []any{map[string]any{"UserManaged": []any{map[string]any{
+					"Replicas": []any{
+						map[string]any{"Location": map[string]any{"literal": "us-east1"}},
+						map[string]any{"Location": map[string]any{"literal": "europe-west1"}},
+					},
+				}}}},
+			}),
+		}
+		if got := DiscoverSummary(ir); got != "user-managed:us-east1,europe-west1" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("compute_network: routing · auto_subnets", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_compute_network"},
+			Attrs: mustAttrs(t, map[string]any{
+				"RoutingMode":           map[string]any{"literal": "REGIONAL"},
+				"AutoCreateSubnetworks": map[string]any{"literal": false},
+			}),
+		}
+		if got := DiscoverSummary(ir); got != "routing=REGIONAL · auto_subnets=false" {
+			t.Errorf("got %q", got)
+		}
+	})
+
+	t.Run("unmapped type → empty summary", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{Type: "google_compute_instance"}}
+		if got := DiscoverSummary(ir); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+// TestDiscoverLabels pins the enriched label overlay and the non-nil-empty
+// contract for types / payloads without labels.
+func TestDiscoverLabels(t *testing.T) {
+	t.Run("bucket labels overlay", func(t *testing.T) {
+		ir := ImportedResource{
+			Identity: ResourceIdentity{Type: "google_storage_bucket"},
+			Attrs: mustAttrs(t, map[string]any{"Labels": map[string]any{
+				"env":   map[string]any{"literal": "prod"},
+				"owner": map[string]any{"literal": "platform"},
+			}}),
+		}
+		got := DiscoverLabels(ir)
+		want := map[string]string{"env": "prod", "owner": "platform"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("compute_network has no label surface → empty non-nil", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{Type: "google_compute_network"}}
+		got := DiscoverLabels(ir)
+		if got == nil {
+			t.Fatal("DiscoverLabels returned nil; want empty map")
+		}
+		if len(got) != 0 {
+			t.Errorf("got %v, want empty", got)
+		}
+	})
+
+	t.Run("unmapped type → empty non-nil", func(t *testing.T) {
+		ir := ImportedResource{Identity: ResourceIdentity{Type: "aws_lambda_function"}}
+		got := DiscoverLabels(ir)
+		if got == nil || len(got) != 0 {
+			t.Errorf("got %v, want empty non-nil", got)
+		}
+	})
+}

--- a/pkg/composer/imported/management.go
+++ b/pkg/composer/imported/management.go
@@ -1,0 +1,25 @@
+package imported
+
+import "strings"
+
+// TerraformStateBucketType is the AWS Terraform resource type used to back a
+// Terraform S3 state backend. InsideOut/sandbox deploys provision one such
+// bucket per project for their own Terraform state; a reverse-import
+// already-managed guard recognizes it so a deploy's own state bucket is never
+// offered as an importable customer resource.
+//
+// Exposed as presets-owned vocabulary so consumers do not hardcode the
+// "aws_s3_bucket" type literal — per-type Terraform vocabulary lives upstream
+// (reliable#2239, umbrella #1479). The deploy-specific bucket NAMING
+// convention (e.g. luther-<project>-…-tfstate-s3-…) stays with the consumer
+// that owns the deploy pipeline; only the resource-type gate is presets
+// vocabulary.
+const TerraformStateBucketType = "aws_s3_bucket"
+
+// IsTerraformStateBucketType reports whether tfType is the AWS Terraform S3
+// state-backend resource type (TerraformStateBucketType). Surrounding
+// whitespace is trimmed to match callers that gate on a raw Identity.Type
+// string.
+func IsTerraformStateBucketType(tfType string) bool {
+	return strings.TrimSpace(tfType) == TerraformStateBucketType
+}

--- a/pkg/composer/imported/management_test.go
+++ b/pkg/composer/imported/management_test.go
@@ -1,0 +1,24 @@
+package imported
+
+import "testing"
+
+func TestIsTerraformStateBucketType(t *testing.T) {
+	if TerraformStateBucketType != "aws_s3_bucket" {
+		t.Fatalf("TerraformStateBucketType = %q, want aws_s3_bucket", TerraformStateBucketType)
+	}
+	cases := []struct {
+		tfType string
+		want   bool
+	}{
+		{"aws_s3_bucket", true},
+		{"  aws_s3_bucket  ", true}, // whitespace trimmed, matches the consumer's prior inline gate
+		{"aws_s3_bucket_versioning", false},
+		{"google_storage_bucket", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := IsTerraformStateBucketType(c.tfType); got != c.want {
+			t.Errorf("IsTerraformStateBucketType(%q) = %v, want %v", c.tfType, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Upstream half of reliable#2239 (clearing the last 2 rows of reliable's `importedPerTypeAllowlist` — the #1479 zero-per-type-code criterion):

- `pkg/composer/imported/discover_projection.go` — `DiscoverSummary` / `DiscoverLabels`: the 5 per-type GCP DTO summary/label mappers ported verbatim from reliable's `import_dtos.go` (exact output strings pinned in `discover_projection_test.go`), so the discover-card vocabulary lives presets-side.
- `pkg/composer/imported/management.go` — `TerraformStateBucketType` / `IsTerraformStateBucketType`: the management-state-bucket type discrimination reliable's `import_managed.go` previously hardcoded.

Stdlib-only, no new deps, no preset/module changes, no generated-surface impact (helper APIs only — reliable's `make regen-imported` confirmed no drift downstream).

## Test plan

- `go test ./pkg/composer/imported/` — new `discover_projection_test.go` pins the exact summary/label strings per type (including the unparseable-attrs location fallback); `management_test.go` covers the type discrimination.
- `go vet ./pkg/composer/imported/` clean.
- Downstream: reliable branch `wt/2239-allowlist` pins this commit, deletes the reliable-side copies (−566 lines), and passes its full drift-guard + discover test suite with byte-identical rendered output (adversarially reviewed).

Refs reliable#2239, reliable#1479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wu4oR3W34ETiwo7UtJE4LK)_