### PR TITLE
feat(depchase): closure contract — reference, don't adopt, out-of-scope dependencies (#864)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,8 @@ test-golden-stack: ## Replay genconfig cleanup over captured real-world stacks a
 .PHONY: test-tfvalidate
 test-tfvalidate: ## Build-tagged terraform-validate harnesses: emit real HCL (imported.tf + AWS provider blocks incl. retry tuning #780) and run `terraform validate` against the live provider schema. Needs terraform + the AWS provider; NO AWS creds. -p 1: the harnesses share TF_PLUGIN_CACHE_DIR, so serialize packages to avoid a concurrent-init plugin handshake race.
 	$(GO) test -tags tfvalidate -count=1 -p 1 -timeout 10m \
-		-run 'TestImportedTF_TerraformValidate|TestEmitProviders_TerraformValidate|TestRenderImportedProvidersTF_TerraformValidate' \
-		./pkg/composer/ ./cmd/insideout-import/genconfig/ ./pkg/reverseimport/
+		-run 'TestImportedTF_TerraformValidate|TestEmitProviders_TerraformValidate|TestRenderImportedProvidersTF_TerraformValidate|TestReferenceRepresentation_Validates' \
+		./pkg/composer/ ./cmd/insideout-import/genconfig/ ./pkg/reverseimport/ ./cmd/insideout-import/depchase/
 
 .PHONY: reverse-e2e
 reverse-e2e: ## Live whole-account reverse-import e2e: discover->genconfig->driftfix->depchase->plan via the prod engine, asserting a clean tag-only plan. Needs real AWS creds + terraform + an offline provider mirror. REVERSE_E2E_REGIONS=all for multi-region; see scripts/reverse-e2e.sh header for knobs.

--- a/cmd/insideout-import/depchase/adoption.go
+++ b/cmd/insideout-import/depchase/adoption.go
@@ -1,0 +1,155 @@
+package depchase
+
+import (
+	"sort"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// The closure contract (presets#864). Historically the dep-chase loop adopted
+// EVERY importable, discovered dependency into the managed import set — an
+// unbounded transitive closure. A single-category selection could therefore
+// adopt admin IAM roles, VPCs, and security-group rules the operator never
+// picked (reliable#2231: 238 resources from one "Data storage" pick). This file
+// introduces the decision layer that bounds the closure: a discovered
+// dependency is ADOPTED (managed, gets an `import {}` block) only when the
+// configured AdoptionPolicy allows it; otherwise it is REFERENCED — the literal
+// stays in the consumer's HCL (already valid Terraform for a concrete external
+// identifier) and no resource is adopted. See docs/depchase-closure-contract.md.
+//
+// The un-importability gate (imported.UnimportableReason, presets#834) already
+// enforces two of the issue's three criteria: an inherently un-adoptable target
+// (AWS-managed KMS key, service-linked role) and an already-InsideOut-claimed
+// target (ReasonInsideOutImported) are left as references before the policy is
+// ever consulted. AdoptionPolicy adds the remaining, optional criterion:
+// selection scope.
+
+// AdoptionDecision is the closure-contract verdict for one discovered
+// dependency. Adopt=true keeps the historical behavior (adopt into the managed
+// set). Adopt=false represents the dependency as a reference; Reason is a stable
+// code recorded on the depchase_reference_retained warning so reliable's
+// disclosure surface can explain the omission without re-deriving it.
+type AdoptionDecision struct {
+	Adopt  bool
+	Reason string
+}
+
+// AdoptionPolicy decides, per discovered dependency, whether the dep-chase loop
+// adopts it or represents it as a reference. A nil policy means adopt-all — the
+// historical unbounded closure, preserved as the default so existing callers are
+// unaffected. consumers are the in-set Terraform addresses whose generated HCL
+// referenced the dependency (sorted, may be empty).
+type AdoptionPolicy interface {
+	AdoptDependency(ir imported.ImportedResource, consumers []string) AdoptionDecision
+}
+
+// ReferenceReasonOutOfScope is the AdoptionDecision.Reason a SelectionScopePolicy
+// records when it declines to adopt a dependency because its Terraform type is
+// outside the selection scope. It rides the depchase_reference_retained warning
+// Code (presets#854) through to reliable.
+const ReferenceReasonOutOfScope = "out_of_selection_scope"
+
+// decideAdoption applies an AdoptionPolicy, treating a nil policy as adopt-all
+// so the historical behavior is the zero-value default.
+func decideAdoption(p AdoptionPolicy, ir imported.ImportedResource, consumers []string) AdoptionDecision {
+	if p == nil {
+		return AdoptionDecision{Adopt: true}
+	}
+	return p.AdoptDependency(ir, consumers)
+}
+
+// SelectionScopePolicy bounds the closure to the selection scope: a discovered
+// dependency is adopted only when its Terraform type is one the operator was
+// already importing (InScopeTypes), otherwise it is represented as a reference
+// with ReferenceReasonOutOfScope. This is the concrete policy reverse-import
+// constructs from the selected + closure resource set when
+// Options.BoundClosureToSelection is set. It directly bounds the reliable#2231
+// incident shape: a data-store selection (s3/dynamodb types) referencing a
+// foreign admin IAM role / VPC (types not in the selection) yields references,
+// not adoptions.
+//
+// The check is intentionally type-granular rather than instance-granular:
+// depchase already knows the reference's Terraform type from the parsed ARN, so
+// a type-scoped verdict needs no extra cloud lookup, and "the operator is
+// importing resources of this type" is a faithful proxy for "this belongs in the
+// selection." A future richer scope (tag/account/VPC membership) can implement
+// AdoptionPolicy without touching the loop.
+type SelectionScopePolicy struct {
+	// InScopeTypes is the set of Terraform types the operator's selection
+	// covers. A discovered dependency whose type is absent is referenced.
+	InScopeTypes map[string]struct{}
+}
+
+// AdoptDependency implements AdoptionPolicy.
+func (p SelectionScopePolicy) AdoptDependency(ir imported.ImportedResource, _ []string) AdoptionDecision {
+	if _, ok := p.InScopeTypes[ir.Identity.Type]; ok {
+		return AdoptionDecision{Adopt: true}
+	}
+	return AdoptionDecision{Adopt: false, Reason: ReferenceReasonOutOfScope}
+}
+
+// NewSelectionScopePolicy builds a SelectionScopePolicy whose InScopeTypes is
+// the deduplicated set of Terraform types present in the supplied resource set
+// (the selected + selection-closure resources entering dep-chase). An empty
+// input yields a policy that references everything — callers that want
+// adopt-all must pass a nil AdoptionPolicy instead.
+func NewSelectionScopePolicy(resources []imported.ImportedResource) SelectionScopePolicy {
+	types := make(map[string]struct{}, len(resources))
+	for _, r := range resources {
+		if t := r.Identity.Type; t != "" {
+			types[t] = struct{}{}
+		}
+	}
+	return SelectionScopePolicy{InScopeTypes: types}
+}
+
+// mergeProvenance records (or extends) the dependency-chase provenance for the
+// resource at addr, unioning the referencing consumer addresses into a sorted,
+// de-duplicated set. A blank addr is ignored. The stored *PulledInBy is mutated
+// in place so every reference to it (res.Added entries, res.Resources stamps)
+// observes the union.
+func mergeProvenance(m map[string]*imported.PulledInBy, addr string, consumers []string) {
+	if addr == "" {
+		return
+	}
+	p := m[addr]
+	if p == nil {
+		p = &imported.PulledInBy{Reason: imported.PulledInReasonDependencyChase}
+		m[addr] = p
+	}
+	seen := make(map[string]struct{}, len(p.Consumers)+len(consumers))
+	for _, c := range p.Consumers {
+		seen[c] = struct{}{}
+	}
+	for _, c := range consumers {
+		if c == "" {
+			continue
+		}
+		if _, dup := seen[c]; dup {
+			continue
+		}
+		seen[c] = struct{}{}
+		p.Consumers = append(p.Consumers, c)
+	}
+	sort.Strings(p.Consumers)
+}
+
+// stampProvenance applies the accumulated closure provenance onto a resource
+// slice by Terraform address: every resource whose address is in provByAddr and
+// that does not already carry provenance is stamped with its *PulledInBy. Called
+// after genconfig replaces res.Resources so the provenance survives the
+// round-trip into imported.json. Operator-selected resources (absent from
+// provByAddr) are never touched.
+func stampProvenance(resources []imported.ImportedResource, provByAddr map[string]*imported.PulledInBy) {
+	if len(provByAddr) == 0 {
+		return
+	}
+	for i := range resources {
+		if resources[i].PulledInBy != nil {
+			continue
+		}
+		if p, ok := provByAddr[resources[i].Identity.Address]; ok {
+			resources[i].PulledInBy = p
+		}
+	}
+}

--- a/cmd/insideout-import/depchase/adoption.go
+++ b/cmd/insideout-import/depchase/adoption.go
@@ -135,12 +135,19 @@ func mergeProvenance(m map[string]*imported.PulledInBy, addr string, consumers [
 }
 
 // stampProvenance applies the accumulated closure provenance onto a resource
-// slice by Terraform address: every resource whose address is in provByAddr and
-// that does not already carry provenance is stamped with its *PulledInBy. Called
-// after genconfig replaces res.Resources so the provenance survives the
-// round-trip into imported.json. Operator-selected resources (absent from
-// provByAddr) are never touched.
-func stampProvenance(resources []imported.ImportedResource, provByAddr map[string]*imported.PulledInBy) {
+// slice by Terraform address: every resource whose address is in provByAddr,
+// is NOT an operator-selected address, and does not already carry provenance
+// is stamped with its *PulledInBy. Called after genconfig replaces
+// res.Resources so the provenance survives the round-trip into imported.json.
+//
+// operatorAddrs (the pre-chase in-set address snapshot) makes the "operator-
+// selected resources are never touched" guarantee real: address alone is not
+// enough, because a chased duplicate can generate the SAME address as an
+// in-set resource (the dedupeByAddress collision class) and provByAddr is
+// keyed purely by address — without the snapshot, the operator-selected entry
+// at the collided address would be mislabeled pulled_in_by:dependency_chase
+// (#866 review finding).
+func stampProvenance(resources []imported.ImportedResource, provByAddr map[string]*imported.PulledInBy, operatorAddrs map[string]struct{}) {
 	if len(provByAddr) == 0 {
 		return
 	}
@@ -148,7 +155,11 @@ func stampProvenance(resources []imported.ImportedResource, provByAddr map[strin
 		if resources[i].PulledInBy != nil {
 			continue
 		}
-		if p, ok := provByAddr[resources[i].Identity.Address]; ok {
+		addr := resources[i].Identity.Address
+		if _, operatorSelected := operatorAddrs[addr]; operatorSelected {
+			continue
+		}
+		if p, ok := provByAddr[addr]; ok {
 			resources[i].PulledInBy = p
 		}
 	}

--- a/cmd/insideout-import/depchase/adoption_test.go
+++ b/cmd/insideout-import/depchase/adoption_test.go
@@ -291,3 +291,50 @@ func TestMergeProvenance_UnionsConsumers(t *testing.T) {
 		t.Errorf("blank addr recorded provenance")
 	}
 }
+
+// TestStampProvenance_SkipsOperatorSelectedAddressOnCollision pins the #866
+// review finding: when a chased duplicate generates the SAME Terraform address
+// as an operator-selected resource (the dedupeByAddress collision class —
+// e.g. an IAM role selected by bare ImportID while another resource references
+// its full ARN), the address-keyed provByAddr must NOT stamp
+// pulled_in_by:dependency_chase onto the operator-selected entry.
+// dedupeByAddress keeps that first entry, so a stamp there would ship a
+// provenance lie into imported.json. Genuinely-discovered addresses still get
+// stamped, and an existing stamp is never overwritten.
+func TestStampProvenance_SkipsOperatorSelectedAddressOnCollision(t *testing.T) {
+	t.Parallel()
+	const collidedAddr = "aws_iam_role.admin"
+	const discoveredAddr = "aws_kms_key.k"
+
+	prior := &imported.PulledInBy{Reason: imported.PulledInReasonDependencyChase, Consumers: []string{"aws_sqs_queue.prior"}}
+	resources := []imported.ImportedResource{
+		// Operator-selected original (pre-chase in-set).
+		{Identity: imported.ResourceIdentity{Address: collidedAddr}},
+		// Chased duplicate at the SAME address, appended by a later iteration.
+		{Identity: imported.ResourceIdentity{Address: collidedAddr}},
+		// Genuinely discovered resource at a fresh address.
+		{Identity: imported.ResourceIdentity{Address: discoveredAddr}},
+		// Already-stamped entry must keep its existing provenance pointer.
+		{Identity: imported.ResourceIdentity{Address: discoveredAddr}, PulledInBy: prior},
+	}
+	provByAddr := map[string]*imported.PulledInBy{
+		collidedAddr:   {Reason: imported.PulledInReasonDependencyChase, Consumers: []string{"aws_sqs_queue.c"}},
+		discoveredAddr: {Reason: imported.PulledInReasonDependencyChase, Consumers: []string{"aws_sqs_queue.d"}},
+	}
+	operatorAddrs := map[string]struct{}{collidedAddr: {}}
+
+	stampProvenance(resources, provByAddr, operatorAddrs)
+
+	if resources[0].PulledInBy != nil {
+		t.Errorf("operator-selected entry at %s was stamped %+v; must stay nil", collidedAddr, resources[0].PulledInBy)
+	}
+	if resources[1].PulledInBy != nil {
+		t.Errorf("duplicate at the collided operator address was stamped; dedupeByAddress keeps entry 0, and Added carries the chase provenance instead")
+	}
+	if resources[2].PulledInBy == nil || len(resources[2].PulledInBy.Consumers) != 1 || resources[2].PulledInBy.Consumers[0] != "aws_sqs_queue.d" {
+		t.Errorf("discovered entry at %s not stamped correctly: %+v", discoveredAddr, resources[2].PulledInBy)
+	}
+	if resources[3].PulledInBy != prior {
+		t.Errorf("pre-stamped entry's provenance pointer was replaced")
+	}
+}

--- a/cmd/insideout-import/depchase/adoption_test.go
+++ b/cmd/insideout-import/depchase/adoption_test.go
@@ -1,0 +1,293 @@
+package depchase
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+)
+
+// scopeOf builds an in-scope type set for a SelectionScopePolicy in tests.
+func scopeOf(types ...string) AdoptionPolicy {
+	set := make(map[string]struct{}, len(types))
+	for _, t := range types {
+		set[t] = struct{}{}
+	}
+	return SelectionScopePolicy{InScopeTypes: set}
+}
+
+// TestRun_ClosureContract_OutOfScopeRefIsReferencedNotAdopted is the
+// reliable#2231 incident-shape regression (presets#864). A single-category
+// "Data storage" selection (an aws_dynamodb_table, plus the customer KMS key it
+// encrypts with) references, in its generated HCL, a foreign admin IAM role the
+// operator never selected. Historically dep-chase adopted that role transitively
+// (the 238-resource blow-up). With the closure contract's SelectionScopePolicy
+// scoped to the selection's types, the out-of-scope IAM role must be REPRESENTED
+// AS A REFERENCE — the literal stays in the generated config (valid Terraform
+// for a concrete ARN) and the role is NOT adopted — while the in-scope KMS key
+// is still adopted, carrying pulled_in_by provenance.
+func TestRun_ClosureContract_OutOfScopeRefIsReferencedNotAdopted(t *testing.T) {
+	t.Parallel()
+	const kmsARN = "arn:aws:kms:us-east-1:123:key/abcd-1234-in-scope"
+	const adminRoleARN = "arn:aws:iam::123:role/admin-out-of-scope"
+
+	// The selected data store references BOTH an in-scope KMS key and an
+	// out-of-scope admin IAM role.
+	gen0 := `
+resource "aws_dynamodb_table" "orders" {
+  name        = "io-orders"
+  kms_key_arn = "` + kmsARN + `"
+  role_arn    = "` + adminRoleARN + `"
+}`
+	// After the KMS key is adopted, genconfig re-emits with its resource block so
+	// the KMS ARN enters the resolved set. The admin-role literal is retained in
+	// the dynamodb block (proving reference-representation) but is terminal so it
+	// does not resurface.
+	gen1 := gen0 + `
+resource "aws_kms_key" "orders_key" {
+  arn = "` + kmsARN + `"
+}`
+	dir := writeGen(t, gen0)
+
+	table := newRes("aws_dynamodb_table.orders", "io-orders",
+		"arn:aws:dynamodb:us-east-1:123:table/io-orders", "aws_dynamodb_table")
+	kmsKey := newRes("aws_kms_key.orders_key", kmsARN, kmsARN, "aws_kms_key")
+	// The admin role is importable and unclaimed — the ONLY thing keeping it out
+	// of the managed set is the scope bound.
+	adminRole := newRes("aws_iam_role.admin", "admin-out-of-scope", adminRoleARN, "aws_iam_role")
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_kms_key|" + kmsARN:        kmsKey,
+		"aws_iam_role|" + adminRoleARN: adminRole,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen1}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer:     disc,
+		Pipeline:       p.fns(),
+		AdoptionPolicy: scopeOf("aws_dynamodb_table", "aws_kms_key"),
+	}, []imported.ImportedResource{table})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The out-of-scope admin role must NOT be adopted; the in-scope KMS key must.
+	if len(got.Added) != 1 || got.Added[0].Identity.Type != "aws_kms_key" {
+		t.Fatalf("Added=%+v, want exactly one aws_kms_key (admin role must be referenced, not adopted)", got.Added)
+	}
+	for _, r := range got.Added {
+		if r.Identity.Type == "aws_iam_role" {
+			t.Fatalf("the out-of-scope admin IAM role was ADOPTED — the closure was not bounded: %+v", r)
+		}
+	}
+
+	// The adopted KMS key must carry pulled_in_by provenance naming its consumer.
+	prov := got.Added[0].PulledInBy
+	if prov == nil {
+		t.Fatalf("adopted KMS key missing pulled_in_by provenance")
+	}
+	if prov.Reason != imported.PulledInReasonDependencyChase {
+		t.Errorf("provenance Reason=%q, want %q", prov.Reason, imported.PulledInReasonDependencyChase)
+	}
+	if len(prov.Consumers) != 1 || prov.Consumers[0] != "aws_dynamodb_table.orders" {
+		t.Errorf("provenance Consumers=%v, want [aws_dynamodb_table.orders]", prov.Consumers)
+	}
+
+	// imported.json is written from res.Resources — the KMS key there must ALSO
+	// carry provenance, and the selected table must NOT.
+	var sawKeyProv, sawTable bool
+	for _, r := range got.Resources {
+		switch r.Identity.Address {
+		case "aws_kms_key.orders_key":
+			sawKeyProv = r.PulledInBy != nil && r.PulledInBy.Reason == imported.PulledInReasonDependencyChase
+		case "aws_dynamodb_table.orders":
+			sawTable = true
+			if r.PulledInBy != nil {
+				t.Errorf("selected table carries pulled_in_by=%+v, want nil (operator-selected)", r.PulledInBy)
+			}
+		case "aws_iam_role.admin":
+			t.Errorf("out-of-scope admin role leaked into res.Resources: %+v", r)
+		}
+	}
+	if !sawKeyProv {
+		t.Errorf("res.Resources KMS key missing provenance; got %+v", got.Resources)
+	}
+	if !sawTable {
+		t.Errorf("selected table missing from res.Resources: %+v", got.Resources)
+	}
+
+	// A machine-readable reference-retained warning must explain the omission.
+	var refWarn *Warning
+	for i := range got.Warnings {
+		if got.Warnings[i].Code == CodeReferenceRetained {
+			refWarn = &got.Warnings[i]
+		}
+	}
+	if refWarn == nil {
+		t.Fatalf("no %s warning emitted; got %+v", CodeReferenceRetained, got.Warnings)
+	}
+	if refWarn.Literal != adminRoleARN {
+		t.Errorf("reference-retained warning Literal=%q, want %q", refWarn.Literal, adminRoleARN)
+	}
+	if refWarn.Reason != ReferenceReasonOutOfScope {
+		t.Errorf("reference-retained warning Reason=%q, want %q", refWarn.Reason, ReferenceReasonOutOfScope)
+	}
+	if refWarn.Consumer != "aws_dynamodb_table.orders" {
+		t.Errorf("reference-retained warning Consumer=%q, want the referencing table", refWarn.Consumer)
+	}
+
+	// No managed→managed edge to the un-adopted role.
+	for _, e := range got.Edges {
+		if strings.Contains(e.To, "aws_iam_role") {
+			t.Errorf("edge to un-adopted role recorded: %+v", e)
+		}
+	}
+
+	// The literal must be RETAINED in the generated config — the proof that the
+	// generated config still validates without adopting the role (a concrete ARN
+	// string literal is valid Terraform).
+	raw, err := os.ReadFile(filepath.Join(dir, generatedFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), adminRoleARN) {
+		t.Errorf("admin-role literal was not retained in generated.tf; reference representation broken:\n%s", raw)
+	}
+}
+
+// TestRun_ClosureContract_NilPolicyAdoptsEverything guards the default: with no
+// AdoptionPolicy the historical adopt-all closure is unchanged — BOTH the
+// in-scope KMS key AND the (now un-bounded) admin IAM role are adopted. This is
+// the safety pin proving the contract is opt-in and prod behavior is untouched
+// unless a caller passes a policy. Provenance is stamped either way.
+func TestRun_ClosureContract_NilPolicyAdoptsEverything(t *testing.T) {
+	t.Parallel()
+	const kmsARN = "arn:aws:kms:us-east-1:123:key/abcd-1234"
+	const adminRoleARN = "arn:aws:iam::123:role/admin"
+
+	gen0 := `
+resource "aws_dynamodb_table" "orders" {
+  name        = "io-orders"
+  kms_key_arn = "` + kmsARN + `"
+  role_arn    = "` + adminRoleARN + `"
+}`
+	gen1 := gen0 + `
+resource "aws_kms_key" "orders_key" {
+  arn = "` + kmsARN + `"
+}
+resource "aws_iam_role" "admin" {
+  arn = "` + adminRoleARN + `"
+}`
+	dir := writeGen(t, gen0)
+
+	table := newRes("aws_dynamodb_table.orders", "io-orders",
+		"arn:aws:dynamodb:us-east-1:123:table/io-orders", "aws_dynamodb_table")
+	kmsKey := newRes("aws_kms_key.orders_key", kmsARN, kmsARN, "aws_kms_key")
+	adminRole := newRes("aws_iam_role.admin", "admin", adminRoleARN, "aws_iam_role")
+
+	disc := &fakeDiscoverer{byID: map[string]imported.ImportedResource{
+		"aws_kms_key|" + kmsARN:        kmsKey,
+		"aws_iam_role|" + adminRoleARN: adminRole,
+	}}
+	p := &scriptedPipeline{t: t, workdir: dir, generatedTF: []string{gen1}}
+
+	got, err := Run(context.Background(), Options{
+		Workdir: dir, Region: "us-east-1", AccountID: "123",
+		Discoverer: disc,
+		Pipeline:   p.fns(),
+		// AdoptionPolicy intentionally nil — historical adopt-all.
+	}, []imported.ImportedResource{table})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(got.Added) != 2 {
+		t.Fatalf("Added=%d, want 2 (nil policy adopts everything importable)", len(got.Added))
+	}
+	// No reference-retained warnings under adopt-all.
+	for _, w := range got.Warnings {
+		if w.Code == CodeReferenceRetained {
+			t.Errorf("unexpected reference-retained warning under nil policy: %+v", w)
+		}
+	}
+	// Provenance is stamped regardless of policy — both auto-included resources
+	// carry pulled_in_by.
+	for _, r := range got.Added {
+		if r.PulledInBy == nil || r.PulledInBy.Reason != imported.PulledInReasonDependencyChase {
+			t.Errorf("adopted %s missing dependency_chase provenance: %+v", r.Identity.Address, r.PulledInBy)
+		}
+	}
+}
+
+// TestSelectionScopePolicy_AdoptDependency unit-pins the policy's verdict:
+// in-scope types adopt, out-of-scope types reference with the stable reason.
+func TestSelectionScopePolicy_AdoptDependency(t *testing.T) {
+	t.Parallel()
+	pol := SelectionScopePolicy{InScopeTypes: map[string]struct{}{"aws_s3_bucket": {}}}
+
+	inScope := imported.ImportedResource{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket"}}
+	if d := pol.AdoptDependency(inScope, nil); !d.Adopt {
+		t.Errorf("in-scope type: Adopt=false, want true (%+v)", d)
+	}
+
+	outScope := imported.ImportedResource{Identity: imported.ResourceIdentity{Type: "aws_iam_role"}}
+	d := pol.AdoptDependency(outScope, nil)
+	if d.Adopt {
+		t.Errorf("out-of-scope type: Adopt=true, want false")
+	}
+	if d.Reason != ReferenceReasonOutOfScope {
+		t.Errorf("out-of-scope Reason=%q, want %q", d.Reason, ReferenceReasonOutOfScope)
+	}
+}
+
+// TestNewSelectionScopePolicy_BuildsFromResourceTypes pins the scope-derivation
+// helper reverse-import uses: InScopeTypes is exactly the set of Terraform types
+// present in the resource set entering dep-chase.
+func TestNewSelectionScopePolicy_BuildsFromResourceTypes(t *testing.T) {
+	t.Parallel()
+	pol := NewSelectionScopePolicy([]imported.ImportedResource{
+		{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_dynamodb_table"}},
+		{Identity: imported.ResourceIdentity{Type: "aws_s3_bucket"}}, // dup collapses
+		{Identity: imported.ResourceIdentity{Type: ""}},              // blank skipped
+	})
+	if len(pol.InScopeTypes) != 2 {
+		t.Fatalf("InScopeTypes=%v, want exactly {aws_s3_bucket, aws_dynamodb_table}", pol.InScopeTypes)
+	}
+	for _, want := range []string{"aws_s3_bucket", "aws_dynamodb_table"} {
+		if _, ok := pol.InScopeTypes[want]; !ok {
+			t.Errorf("InScopeTypes missing %q", want)
+		}
+	}
+	if _, ok := pol.InScopeTypes[""]; ok {
+		t.Errorf("InScopeTypes contains the blank type")
+	}
+}
+
+// TestMergeProvenance_UnionsConsumers pins that a target referenced by two
+// consumers accumulates both, sorted and de-duplicated.
+func TestMergeProvenance_UnionsConsumers(t *testing.T) {
+	t.Parallel()
+	m := map[string]*imported.PulledInBy{}
+	mergeProvenance(m, "aws_kms_key.k", []string{"aws_sqs_queue.b"})
+	mergeProvenance(m, "aws_kms_key.k", []string{"aws_sqs_queue.a", "aws_sqs_queue.b"})
+	mergeProvenance(m, "", []string{"ignored"}) // blank addr is a no-op
+
+	p := m["aws_kms_key.k"]
+	if p == nil {
+		t.Fatal("provenance not recorded")
+	}
+	if p.Reason != imported.PulledInReasonDependencyChase {
+		t.Errorf("Reason=%q, want %q", p.Reason, imported.PulledInReasonDependencyChase)
+	}
+	want := []string{"aws_sqs_queue.a", "aws_sqs_queue.b"}
+	if len(p.Consumers) != len(want) || p.Consumers[0] != want[0] || p.Consumers[1] != want[1] {
+		t.Errorf("Consumers=%v, want %v (sorted, de-duplicated)", p.Consumers, want)
+	}
+	if _, ok := m[""]; ok {
+		t.Errorf("blank addr recorded provenance")
+	}
+}

--- a/cmd/insideout-import/depchase/adoption_tfvalidate_test.go
+++ b/cmd/insideout-import/depchase/adoption_tfvalidate_test.go
@@ -1,0 +1,97 @@
+//go:build tfvalidate
+
+// Build-tagged Terraform-validate proof for the closure contract's
+// reference-representation fallback (presets#864).
+//
+// Normal `go test` skips this file — it shells out to the `terraform` binary and
+// does a one-time provider download. Run it explicitly:
+//
+//	go test -tags tfvalidate -run TestReferenceRepresentation_Validates -v ./cmd/insideout-import/depchase/
+//
+// The closure contract's core safety claim is: when dep-chase declines to adopt
+// an out-of-scope dependency, it leaves the reference as a bare literal in the
+// consumer's HCL, and the generated config STILL passes `terraform validate`
+// with no import block and no managed resource for the target. This test proves
+// that claim against the pinned hashicorp/aws ~> 6.0 provider: an aws_sqs_queue
+// referencing a foreign KMS key purely by literal ARN (the reference
+// representation) validates, whereas an equivalent stack that also declared and
+// imported the key would be the adoption the contract avoids. `terraform
+// validate` is a pure provider-schema check — no AWS credentials, no network
+// beyond the one-time provider download.
+
+package depchase
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReferenceRepresentation_Validates(t *testing.T) {
+	if _, err := exec.LookPath("terraform"); err != nil {
+		t.Skip("terraform binary not on PATH")
+	}
+
+	// A concrete external identifier left as a bare literal — exactly what the
+	// closure contract retains when it declines to adopt an out-of-scope
+	// dependency. There is NO aws_kms_key resource and NO import block for it.
+	const foreignKMSARN = "arn:aws:kms:us-east-1:123456789012:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+	main := `
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+}
+
+# Reference representation: the queue points at a foreign KMS key by literal ARN.
+# The key itself is NOT adopted (no resource block, no import block) — the
+# closure contract's bound. This must still validate.
+resource "aws_sqs_queue" "orders" {
+  name              = "io-orders"
+  kms_master_key_id = "` + foreignKMSARN + `"
+}
+`
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(main), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := filepath.Join(os.TempDir(), "tf-plugin-cache")
+	_ = os.MkdirAll(cache, 0o755)
+	env := append(os.Environ(), "TF_PLUGIN_CACHE_DIR="+cache, "TF_IN_AUTOMATION=1")
+	run := func(args ...string) (string, error) {
+		cmd := exec.Command("terraform", args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		b, cerr := cmd.CombinedOutput()
+		return string(b), cerr
+	}
+
+	if initOut, ierr := run("init", "-backend=false", "-input=false", "-no-color"); ierr != nil {
+		// An unprivileged sandbox may not reach the registry; skip rather than
+		// fail (CI's terraform lane has access). Mirrors the reverseimport
+		// tfvalidate harness.
+		t.Skipf("terraform init could not fetch the provider (%v):\n%s", ierr, initOut)
+	}
+
+	validateOut, verr := run("validate", "-no-color")
+	t.Logf("terraform validate output:\n%s", validateOut)
+	if verr != nil {
+		t.Fatalf("terraform validate FAILED on the reference-representation stack (exit %v) — a retained literal reference must remain valid without adopting the target:\n%s", verr, validateOut)
+	}
+	if strings.Contains(validateOut, "Error:") {
+		t.Fatalf("terraform validate surfaced an error on the reference-representation stack:\n%s", validateOut)
+	}
+}

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -99,6 +99,16 @@ type Options struct {
 	Discoverer    Discoverer
 	Pipeline      PipelineFns
 
+	// AdoptionPolicy bounds the closure (presets#864). For each discovered,
+	// importable dependency it decides ADOPT (add to the managed import set,
+	// historical behavior) vs REFERENCE (leave the literal in the consumer's
+	// HCL and record a depchase_reference_retained warning). Nil means
+	// adopt-all — the historical unbounded closure — so existing callers are
+	// unaffected. reverse-import constructs a SelectionScopePolicy here when
+	// Options.BoundClosureToSelection is set. See
+	// docs/depchase-closure-contract.md.
+	AdoptionPolicy AdoptionPolicy
+
 	// Stdout, when non-nil, receives a concise per-iteration progress
 	// line ("depchase: iteration k: discovered N resource(s)…") so a
 	// long-running caller — the Mars reverse-import job — can surface live
@@ -226,6 +236,15 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	// (consumer → discovered) pair can re-surface if the regenerate
 	// step rewrites the consumer's HCL without changing the reference.
 	seenEdges := make(map[string]struct{})
+
+	// provByAddr accumulates the closure provenance (presets#864) for every
+	// resource the loop adopts, keyed by Terraform address. It is applied to
+	// res.Resources at the end of each iteration (after genconfig replaces the
+	// slice) so imported.json — which reverse-import writes from res.Resources —
+	// carries a pulled_in_by reason on each auto-included resource regardless of
+	// genconfig round-tripping the resource list. Consumer edges are unioned
+	// across literals/iterations that resolve to the same target.
+	provByAddr := make(map[string]*imported.PulledInBy)
 
 	for iter := 1; iter <= opts.MaxIterations; iter++ {
 		raw, err := os.ReadFile(generatedPath)
@@ -456,6 +475,33 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				ignoredARNs[s.arn] = struct{}{}
 				continue
 			}
+			// Closure-contract bound (presets#864). The target is importable and
+			// unclaimed (the UnimportableReason gate above already rejects
+			// InsideOut-claimed and inherently un-adoptable targets), so the only
+			// remaining question is scope: does the configured AdoptionPolicy
+			// want this dependency ADOPTED or represented as a REFERENCE? A
+			// declined dependency is left as its literal in the consumer's HCL —
+			// already valid Terraform for a concrete external identifier — and is
+			// NOT adopted. Mark it terminal-by-design (chased) and ignored so it
+			// drains from the unresolved accounting and the loop converges
+			// without burning a regenerate cycle for it. A nil policy (the
+			// default) adopts everything, preserving historical behavior.
+			if decision := decideAdoption(opts.AdoptionPolicy, ir, consumersByARN[s.arn]); !decision.Adopt {
+				consumer := ""
+				if cs := consumersByARN[s.arn]; len(cs) > 0 {
+					consumer = cs[0]
+				}
+				addWarning(res, seenWarning, Warning{
+					Code:     CodeReferenceRetained,
+					Literal:  s.arn,
+					TFType:   s.ref.TFType,
+					Consumer: consumer,
+					Reason:   decision.Reason,
+				})
+				chased[s.arn] = struct{}{}
+				ignoredARNs[s.arn] = struct{}{}
+				continue
+			}
 			// Record the discovery for edge accounting regardless, but adopt the
 			// resource into the import set at most once per address (F8): a
 			// second seed pointing at the same target (same key by ARN and by
@@ -526,6 +572,13 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				for _, fromAddr := range consumersByARN[d.seed.arn] {
 					recordEdge(res, seenEdges, fromAddr, toAddr)
 				}
+				// Record the closure provenance for this adoption (presets#864):
+				// the consumers that referenced it become PulledInBy.Consumers,
+				// unioned across every literal/iteration that resolves to the
+				// same address (F8) so a target referenced twice carries all its
+				// consumers. Recorded even before the F8 dedup below so both
+				// seeds' consumers land on the single Added entry.
+				mergeProvenance(provByAddr, toAddr, consumersByARN[d.seed.arn])
 				// Adopt the resource into res.Added once per address (F8): both
 				// seeds' edges above are still recorded, but two literals
 				// resolving to the same target contribute a single Added entry.
@@ -534,8 +587,15 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 				}
 				seenAddedAddr[toAddr] = struct{}{}
 			}
+			d.resource.PulledInBy = provByAddr[toAddr]
 			res.Added = append(res.Added, d.resource)
 		}
+		// Stamp the accumulated provenance onto res.Resources (presets#864). Done
+		// every iteration because genconfig replaced the slice above; provByAddr
+		// accumulates, so re-applying it to the current slice keeps every prior
+		// iteration's adoption stamped through to the converged final set that
+		// reverse-import serializes into imported.json.
+		stampProvenance(res.Resources, provByAddr)
 
 		if _, err := opts.Pipeline.RunDriftfix(ctx); err != nil {
 			sortEdges(res)

--- a/cmd/insideout-import/depchase/depchase.go
+++ b/cmd/insideout-import/depchase/depchase.go
@@ -246,6 +246,24 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 	// across literals/iterations that resolve to the same target.
 	provByAddr := make(map[string]*imported.PulledInBy)
 
+	// operatorAddrs snapshots the Terraform addresses of the operator-selected
+	// resources present BEFORE the first chase iteration. stampProvenance must
+	// never stamp these: on an address collision — a chased duplicate whose
+	// identity tuple generates the SAME address as an in-set resource (the
+	// dedupeByAddress class, pkg/reverseimport/run.go) — a purely address-keyed
+	// stamp would mislabel the operator-selected entry as
+	// pulled_in_by:dependency_chase, and dedupeByAddress keeps that first
+	// (operator) entry, so imported.json would misreport why the resource is in
+	// the set (#866 review finding). The discovered duplicate itself still
+	// carries its provenance on the res.Added entry (stamped directly at
+	// adoption above).
+	operatorAddrs := make(map[string]struct{}, len(res.Resources))
+	for i := range res.Resources {
+		if addr := res.Resources[i].Identity.Address; addr != "" {
+			operatorAddrs[addr] = struct{}{}
+		}
+	}
+
 	for iter := 1; iter <= opts.MaxIterations; iter++ {
 		raw, err := os.ReadFile(generatedPath)
 		if err != nil {
@@ -595,7 +613,7 @@ func Run(ctx context.Context, opts Options, resources []imported.ImportedResourc
 		// accumulates, so re-applying it to the current slice keeps every prior
 		// iteration's adoption stamped through to the converged final set that
 		// reverse-import serializes into imported.json.
-		stampProvenance(res.Resources, provByAddr)
+		stampProvenance(res.Resources, provByAddr, operatorAddrs)
 
 		if _, err := opts.Pipeline.RunDriftfix(ctx); err != nil {
 			sortEdges(res)

--- a/cmd/insideout-import/depchase/warning.go
+++ b/cmd/insideout-import/depchase/warning.go
@@ -33,6 +33,7 @@ import (
 //	depchase_discover_error       (F1)   — non-fatal hard error on a terminal seed
 //	depchase_config_omitted       class H — discovered but genconfig dropped it
 //	depchase_unresolved_stable    class I — reference cycle / stable unresolved
+//	depchase_reference_retained   class J — bounded by the closure contract (#864)
 const (
 	CodeNestedRefLiteral   = "depchase_nested_ref_literal"
 	CodeNonARNRefLiteral   = "depchase_non_arn_ref_literal"
@@ -44,6 +45,15 @@ const (
 	CodeDiscoverError      = "depchase_discover_error"
 	CodeConfigOmitted      = "depchase_config_omitted"
 	CodeUnresolvedStable   = "depchase_unresolved_stable"
+	// CodeReferenceRetained (class J, presets#864) marks a discovered,
+	// importable dependency that the closure contract's AdoptionPolicy chose to
+	// represent as a REFERENCE rather than adopt into the managed set — e.g. a
+	// data-store selection referencing a foreign, out-of-scope admin IAM role.
+	// The literal stays in the consumer's HCL (valid Terraform for a concrete
+	// external identifier); the target is not adopted. Reason carries the
+	// stable decision code (ReferenceReasonOutOfScope) so reliable's disclosure
+	// surface can explain the bound without re-deriving it.
+	CodeReferenceRetained = "depchase_reference_retained"
 )
 
 // Warning is a single structured depchase diagnostic. Code is the stable
@@ -129,6 +139,12 @@ func (w Warning) String() string {
 			w.Literal, w.TFType, w.Consumer)
 	case CodeUnresolvedStable:
 		return fmt.Sprintf("unresolved ARN reference (stable across iterations): %q", w.Literal)
+	case CodeReferenceRetained:
+		// The closure-contract bound (presets#864): an importable dependency
+		// intentionally left as a reference instead of adopted. Consumer is the
+		// referencing resource; Reason is the stable decision code.
+		return fmt.Sprintf("%s %q (%s) referenced by %s left as a reference (not adopted: %s) — bounded by the reverse-import closure contract; the literal is retained and the target is not managed",
+			refNoun(w.Literal), w.Literal, w.TFType, w.Consumer, w.Reason)
 	default:
 		// Defensive: an unmapped code still renders something traceable rather
 		// than an empty string.

--- a/docs/depchase-closure-contract.md
+++ b/docs/depchase-closure-contract.md
@@ -1,0 +1,239 @@
+# Dependency-chase closure contract: reference, don't adopt, out-of-scope deps
+
+Source-of-truth design doc for how the reverse-import **dependency-chase**
+phase bounds the set of resources it pulls into the managed import set
+(presets#864). It exists so the intent is explicit for future agents — the
+behavior it changes was paid for in a production incident.
+
+Scope: `cmd/insideout-import/depchase` (the fixpoint chase loop),
+`pkg/reverseimport/{run,closure}.go` (the phases that drive it), and the
+`pkg/composer/imported.ImportedResource` provenance field consumed downstream
+by reliable. Companion to [`docs/reverse-import-contract.md`](reverse-import-contract.md).
+
+---
+
+## 1. The incident and what shipped before this
+
+`cmd/insideout-import/depchase` runs a bounded (5-iteration) fixpoint over the
+generated Terraform: it reads `generated.tf`, finds ARN / identifier string
+literals that reference resources **not** in the current import set, discovers
+each via `DiscoverByID`, and — historically — **adopted every importable one**
+into the managed set (adds an `import {}` block + a resource block), then
+regenerated and looped until the reference graph closed.
+
+That closure was **unbounded by the operator's selection**. A single-category
+pick could therefore transitively adopt admin IAM roles, VPCs, and
+security-group rules the operator never selected. The concrete incident
+(reliable#2231): one "Data storage" category pick expanded to **238 resources**
+(`irun_jFcsE0sgd8NH`).
+
+The reliable-side halves already shipped (reliable#2234) make the expansion
+*observable and frozen*, but not *smaller*:
+
+- the existence verdict is frozen per draft (plan-preview and apply compose
+  the identical set);
+- the expansion is disclosed pre-apply (`expansion {selected, composed,
+  auto_included}` + a banner);
+- an `import_expansion_ratio` warn makes the class observable.
+
+What remained is the **contract half**, in this repo: the chase itself was still
+unbounded. This doc is that half.
+
+---
+
+## 2. The contract
+
+A discovered dependency is **ADOPTED** (managed — gets an `import {}` block and
+a resource block, and counts toward the import) only when it is:
+
+1. **importable** — `imported.UnimportableReason(ir) == ""`; and
+2. **unclaimed** — not already owned by InsideOut (or another import project);
+   and
+3. **(optionally) in-scope** — within the operator's selection scope.
+
+Otherwise it is **REFERENCED**: the literal stays in the consumer's HCL and the
+target is **not** adopted. A concrete external identifier (an ARN, a KMS KeyId)
+is already valid Terraform as a bare string attribute, so the generated config
+still passes `terraform init` / `validate` / `plan` with the literal in place —
+no data source and no import block are required for validity.
+
+### 2.1 Criteria 1 & 2 were already enforced
+
+`imported.UnimportableReason` (presets#834, #709) already gates:
+
+- inherently un-adoptable targets — AWS-managed KMS keys (`KeyManager=AWS`),
+  service-linked IAM roles (`role/aws-service-role/…`), service-managed ENIs,
+  ephemeral log streams, AWS-managed default parameter groups /
+  EventBridge rules; and
+- **already-InsideOut-claimed** targets (`ReasonInsideOutImported`, from the
+  imported marker tag/label) — i.e. a resource a *different* import project
+  already owns.
+
+Both classes were **already** left as references (with a precise
+`depchase_unimportable_target` warning) before this change. So "importable AND
+unclaimed" is substantially the pre-existing behavior; the genuinely new
+capability this contract adds is **criterion 3, selection scope**, plus the
+formal *reference-representation* framing and *provenance*.
+
+### 2.2 Criterion 3: selection scope (`AdoptionPolicy`)
+
+`depchase.Options.AdoptionPolicy` is the decision layer. For each discovered,
+importable dependency it returns `AdoptionDecision{Adopt, Reason}`:
+
+- `Adopt == true` → historical adoption path (edge recorded, resource added).
+- `Adopt == false` → reference representation: emit a
+  `depchase_reference_retained` warning carrying the stable `Reason`, mark the
+  literal terminal-by-design (`chased`) and ignored so it drains from the
+  unresolved accounting, and **do not** adopt.
+
+**A nil policy means adopt-all** — the historical unbounded closure. This is the
+zero-value default, so every existing caller and the whole default reverse-import
+path are byte-for-byte unchanged until a caller opts in.
+
+The concrete policy is `depchase.SelectionScopePolicy{InScopeTypes}`: a
+dependency is adopted only when its Terraform **type** is one the operator's
+selection already covers, otherwise referenced with
+`ReferenceReasonOutOfScope`. reverse-import builds `InScopeTypes` from the
+selected + selection-closure resource set (`NewSelectionScopePolicy`) when
+`Options.BoundClosureToSelection` is set (default **off**).
+
+Why type-granular, not instance-granular: depchase already knows the
+reference's Terraform type from the parsed ARN, so a type-scoped verdict costs
+no extra cloud lookup, and "the operator is importing resources of this type" is
+a faithful, cheap proxy for "this belongs in the selection." It directly bounds
+the incident shape — a data-store selection (s3/dynamodb types) referencing a
+foreign admin IAM role / VPC (types not in the selection) yields references, not
+adoptions. A richer scope (tag / account / VPC-membership / provenance-owner)
+can implement `AdoptionPolicy` later without touching the loop.
+
+---
+
+## 3. Reference representation: data source vs literal ID
+
+Two ways to represent an un-adopted reference so the generated config stays
+valid:
+
+| Representation | When it is safe | Used here? |
+|---|---|---|
+| **Literal ID** — leave the concrete ARN/UUID string in the attribute | Always, when the value is a concrete external identifier already present in the HCL. `terraform validate`/`plan` type-check a string attribute against the provider schema; they do **not** require the referenced resource to be in state. | **Yes** — this is the fallback depchase uses. |
+| **`data` source** — replace the reference with `data.aws_x.y.arn` | When the consumer needs an attribute of the external resource it does **not** already hold as a literal, or when a stable symbolic handle is wanted. Requires emitting a `data {}` block (a small readback) and rewriting the attribute. | **Not needed by depchase**: the literal is already in the HCL by construction (that is *how* the unresolved reference was found), so the literal ID is always available and always sufficient. |
+
+Because depchase only ever acts on **concrete quoted string literals** it found
+in `generated.tf` (see `finder.go`: interpolations, function calls, and
+traversals are deliberately left alone), the literal-ID representation is
+always available and always valid. The reference-representation fallback is
+therefore simply **"leave the literal untouched and do not adopt"** — the least
+invasive, provably-valid option. A `data`-source rewrite is documented here as
+the alternative for a future consumer that needs a computed attribute of an
+un-adopted target, but is out of scope for this change.
+
+---
+
+## 4. Provenance: `pulled_in_by` on `ImportedResource`
+
+Every **auto-adopted** resource carries machine-readable provenance so
+reliable's disclosure surface can render *why* it is in the set without
+re-deriving it from `graph.json` / the dependency edges:
+
+```go
+// pkg/composer/imported/resource.go
+type ImportedResource struct {
+    // …
+    PulledInBy *PulledInBy `json:"pulled_in_by,omitempty"`
+}
+
+type PulledInBy struct {
+    Reason    string   `json:"reason"`              // PulledInReason* code
+    Consumers []string `json:"consumers,omitempty"` // in-set addresses that caused the pull-in, sorted
+}
+```
+
+Reasons:
+
+- `dependency_chase` — depchase adopted it because an in-set resource's HCL
+  referenced its literal. `Consumers` are the referencing addresses (unioned
+  across every literal/iteration that resolves to the same target).
+- `selection_closure` — the selection-closure phase adopted it as a registered
+  scoped child of a selected parent. `Consumers` is the selected parent.
+
+Operator-selected resources are **never** stamped (`PulledInBy == nil`).
+
+**Where it is stamped.** genconfig replaces `res.Resources` on every chase
+iteration, so provenance is accumulated in a per-address map and re-applied to
+`res.Resources` at the end of each iteration (`stampProvenance`). This survives
+the round-trip into `imported.json` (which reverse-import writes from
+`res.Resources`) regardless of genconfig rebuilding the resource list. Closure
+children are stamped inline in `mergeClosureResources`.
+
+Provenance is stamped **regardless of `AdoptionPolicy`** — it is pure additive
+metadata on resources that were going to be adopted anyway, so it lands even
+with the scope bound switched off.
+
+### 4.1 Warning carrier (#854)
+
+The per-reference *reasons for NOT adopting* ride the structured warning codes
+from presets#854. A new class:
+
+- `depchase_reference_retained` (class J) — an importable dependency the
+  `AdoptionPolicy` chose to reference. `Consumer` is the referencing address,
+  `Reason` the stable decision code (`out_of_selection_scope`). reverse-import's
+  `foldDepChaseWarnings` already maps every warning `Code` →
+  `job.Diagnostic.Code`, so this surfaces to reliable with no extra wiring.
+
+---
+
+## 5. Compatibility posture
+
+- **`imported.json` change is additive.** `PulledInBy` is an `omitempty`
+  pointer; a nil field is omitted, so existing goldens and round-trips are
+  unchanged. Per the snapshot envelope rules
+  (`pkg/imported/snapshot`), an additive per-resource struct field rides the
+  versioned `"resources"` array and **does not** require a `CurrentVersion`
+  bump. Downstream reliable renders `pulled_in_by.reason` / `.consumers`
+  verbatim — it does not re-derive them.
+- **Default behavior is unchanged.** `AdoptionPolicy` defaults to nil
+  (adopt-all) and `BoundClosureToSelection` defaults to false, so the
+  production reverse-import path is byte-for-byte identical until a caller
+  opts in. The provenance stamp is the only visible default-on change, and it
+  is purely additive.
+- **New warning code is additive.** `depchase_reference_retained` only appears
+  when the scope bound is engaged; reliable classifies on `Code` and ignores
+  unknown codes gracefully.
+
+---
+
+## 6. Explicitly out of scope
+
+- **`data`-source rewriting** of un-adopted references (section 3) — not needed
+  while the literal ID is always sufficient; deferred to a consumer that needs a
+  computed attribute of an un-adopted target.
+- **Instance-level / tag / VPC-membership scope policies** — the
+  `AdoptionPolicy` interface accommodates them; only the type-scoped
+  `SelectionScopePolicy` ships here.
+- **Pre-discovery scope short-circuit** — the scope verdict is taken *after*
+  `DiscoverByID` (the policy takes a discovered `ImportedResource` so a future
+  policy can inspect tags). This means out-of-scope refs are still *discovered*
+  (a read-only cost identical to today), just not *adopted*. A type-only
+  fast-path that skips discovery for clearly out-of-scope types is a future
+  optimization.
+- **Flipping `BoundClosureToSelection` on by default** — a behavior change with
+  real blast radius (a genuinely-needed dep of a different type would become a
+  reference); it is a separate, deliberate rollout decision for reliable/ui-core
+  to own, gated on the disclosure surface (reliable#2234) being live.
+- **The reliable-side rendering** of `pulled_in_by` and the expansion banner —
+  those live in reliable (reliable#2234/#2236); this repo only produces the
+  data.
+
+---
+
+## 7. Files
+
+| File | Role |
+|---|---|
+| `pkg/composer/imported/resource.go` | `PulledInBy` field + type + `PulledInReason*` consts (additive) |
+| `cmd/insideout-import/depchase/adoption.go` | `AdoptionPolicy`, `SelectionScopePolicy`, `NewSelectionScopePolicy`, provenance merge/stamp helpers |
+| `cmd/insideout-import/depchase/depchase.go` | `Options.AdoptionPolicy`, the adopt-vs-reference decision point, provenance stamping |
+| `cmd/insideout-import/depchase/warning.go` | `CodeReferenceRetained` (class J) + prose |
+| `pkg/reverseimport/options.go` | `Options.BoundClosureToSelection` |
+| `pkg/reverseimport/run.go` | builds `SelectionScopePolicy` when opted in, threads it into `depchase.Options` |
+| `pkg/reverseimport/closure.go` | stamps `selection_closure` provenance on closure children |

--- a/pkg/composer/imported/resource.go
+++ b/pkg/composer/imported/resource.go
@@ -84,7 +84,48 @@ type ImportedResource struct {
 	// (see imported_resource_address_collision); the four-key provenance
 	// schema is not emitted. Read-only metadata; callers should not set it.
 	WeakLocked bool `json:"weak_locked,omitempty"`
+
+	// PulledInBy records why a resource is in the import set even though the
+	// operator did not directly select it: the reverse-import pipeline
+	// auto-included it because an already-in-set resource referenced it (the
+	// dependency-chase phase) or because it is a scoped child of a selected
+	// parent (the selection-closure phase). Nil for operator-selected
+	// resources.
+	//
+	// This is the machine-readable provenance the reverse-import closure
+	// contract (presets#864, reliable#2234) threads onto every auto-adopted
+	// resource so reliable's disclosure surface can render *why* each
+	// auto-included resource is present without re-deriving it from graph.json
+	// or the dependency edges. Additive per the snapshot envelope rules
+	// (pkg/imported/snapshot): an omitempty pointer round-trips through the
+	// versioned "resources" array via encoding/json without a version bump.
+	PulledInBy *PulledInBy `json:"pulled_in_by,omitempty"`
 }
+
+// PulledInBy is the provenance stamp for an auto-included imported resource —
+// the reverse-import counterpart of "the operator picked this row." Reason is a
+// stable machine-readable code (one of the PulledInReason* consts); Consumers
+// are the Terraform addresses of the already-in-set resources whose presence
+// caused this resource to be pulled in (the referencing resources for a
+// dependency chase, or the selected parent for a selection-closure child),
+// sorted and de-duplicated. See presets#864.
+type PulledInBy struct {
+	// Reason is the stable pull-in mechanism code (PulledInReason*).
+	Reason string `json:"reason"`
+	// Consumers are the in-set addresses that caused the pull-in, sorted.
+	Consumers []string `json:"consumers,omitempty"`
+}
+
+const (
+	// PulledInReasonDependencyChase marks a resource the dependency-chase phase
+	// (cmd/insideout-import/depchase) adopted because an in-set resource's
+	// generated HCL referenced its ARN / identifier literal.
+	PulledInReasonDependencyChase = "dependency_chase"
+	// PulledInReasonSelectionClosure marks a resource the selection-closure
+	// phase (pkg/reverseimport/closure.go) adopted because it is a registered
+	// scoped child of a selected parent.
+	PulledInReasonSelectionClosure = "selection_closure"
+)
 
 // ForceTakeover is the audited operator override for a cross-session
 // provenance conflict. Every field is required: a takeover with missing

--- a/pkg/reverseimport/closure.go
+++ b/pkg/reverseimport/closure.go
@@ -238,6 +238,17 @@ func mergeClosureResources(in mergeClosureInput) ([]imported.ImportedResource, m
 			continue
 		}
 		r.Identity.ParentAddress = selectedParentAddr
+		// Closure provenance (presets#864): this child is auto-included because
+		// its parent was selected. Stamp pulled_in_by so reliable's disclosure
+		// surface can render *why* it appears in the import set (auto_included)
+		// without re-deriving it from the dependency edges. Only set when absent
+		// so a resource that arrived with provenance keeps it.
+		if r.PulledInBy == nil {
+			r.PulledInBy = &imported.PulledInBy{
+				Reason:    imported.PulledInReasonSelectionClosure,
+				Consumers: []string{selectedParentAddr},
+			}
+		}
 		existing[resourceKey(r.Identity)] = struct{}{}
 		merged = append(merged, r)
 		deps[selectedParentAddr] = append(deps[selectedParentAddr], r.Identity)

--- a/pkg/reverseimport/closure_provenance_test.go
+++ b/pkg/reverseimport/closure_provenance_test.go
@@ -1,0 +1,145 @@
+package reverseimport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/luthersystems/insideout-terraform-presets/cmd/insideout-import/depchase"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/composer/imported"
+	"github.com/luthersystems/insideout-terraform-presets/pkg/reverseimport/job"
+)
+
+// TestMergeClosure_StampsPulledInByProvenance pins the closure-contract
+// provenance half (presets#864): a child auto-included because its parent was
+// selected must carry a pulled_in_by stamp naming the selection_closure reason
+// and the selected parent as its consumer, so reliable's disclosure surface can
+// render *why* the child appears (auto_included) without re-deriving it. The
+// selected parent itself must NOT be stamped.
+func TestMergeClosure_StampsPulledInByProvenance(t *testing.T) {
+	selectedBucket := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:    "aws",
+			Type:     "aws_s3_bucket",
+			Address:  "aws_s3_bucket.selected",
+			ImportID: "io-selected",
+			Region:   "us-east-1",
+		},
+	}
+	child := imported.ImportedResource{
+		Identity: imported.ResourceIdentity{
+			Cloud:         "aws",
+			Type:          "aws_s3_bucket_versioning",
+			Address:       "aws_s3_bucket_versioning.selected",
+			ImportID:      "io-selected",
+			Region:        "us-east-1",
+			ParentAddress: "aws_s3_bucket.selected",
+			NativeIDs:     map[string]string{"bucket": "io-selected"},
+		},
+	}
+
+	merged, _, _ := mergeClosureResources(mergeClosureInput{
+		current:         []imported.ImportedResource{selectedBucket},
+		selectedParents: []imported.ImportedResource{selectedBucket},
+		parentTypes:     []string{"aws_s3_bucket"},
+		childTypes:      []string{"aws_s3_bucket_versioning"},
+		discovered:      []imported.ImportedResource{selectedBucket, child},
+	})
+
+	var checkedChild, checkedParent bool
+	for _, r := range merged {
+		switch r.Identity.Address {
+		case "aws_s3_bucket_versioning.selected":
+			checkedChild = true
+			if r.PulledInBy == nil {
+				t.Fatalf("closure child missing pulled_in_by provenance")
+			}
+			if r.PulledInBy.Reason != imported.PulledInReasonSelectionClosure {
+				t.Errorf("child provenance Reason=%q, want %q", r.PulledInBy.Reason, imported.PulledInReasonSelectionClosure)
+			}
+			if len(r.PulledInBy.Consumers) != 1 || r.PulledInBy.Consumers[0] != "aws_s3_bucket.selected" {
+				t.Errorf("child provenance Consumers=%v, want [aws_s3_bucket.selected]", r.PulledInBy.Consumers)
+			}
+		case "aws_s3_bucket.selected":
+			checkedParent = true
+			if r.PulledInBy != nil {
+				t.Errorf("selected parent carries pulled_in_by=%+v, want nil (operator-selected)", r.PulledInBy)
+			}
+		}
+	}
+	if !checkedChild {
+		t.Error("closure child was not present in merged set")
+	}
+	if !checkedParent {
+		t.Error("selected parent was not present in merged set")
+	}
+}
+
+// capturingDepChase records the depchase.Options it was handed so a test can
+// assert what Run threaded through.
+type capturingDepChase struct {
+	opts depchase.Options
+}
+
+func (c *capturingDepChase) run(_ context.Context, opts depchase.Options, resources []imported.ImportedResource) (*depchase.Result, error) {
+	c.opts = opts
+	return &depchase.Result{Resources: resources}, nil
+}
+
+// TestRun_BoundClosureToSelection_PassesScopePolicy pins the run.go wiring
+// (presets#864): when Options.BoundClosureToSelection is set, Run must construct
+// a SelectionScopePolicy from the resource set entering dep-chase and pass it as
+// depchase.Options.AdoptionPolicy — and when the flag is unset, the policy must
+// be nil (historical adopt-all). The scope must cover the selected resource's
+// type.
+func TestRun_BoundClosureToSelection_PassesScopePolicy(t *testing.T) {
+	req := job.Request{
+		Version: job.Version,
+		Resources: []job.ResourceSpec{{
+			Identity: imported.ResourceIdentity{
+				Cloud:    "aws",
+				Type:     "aws_sqs_queue",
+				Address:  "aws_sqs_queue.orders",
+				ImportID: "https://sqs.us-east-1.amazonaws.com/123/orders",
+				Region:   "us-east-1",
+			},
+			Tier:   imported.TierImportedFlat,
+			Source: imported.SourceImporter,
+		}},
+	}
+
+	newRunOpts := func(dir string, bound bool, cap *capturingDepChase) Options {
+		return Options{
+			OutputDir:               dir,
+			Discoverer:              stubByIDDiscoverer{},
+			BoundClosureToSelection: bound,
+			deps: deps{
+				runGenconfig: fakeGenconfig,
+				runDriftfix:  fakeDriftfix,
+				runDepChase:  cap.run,
+				tf:           fakeTerraformRunner{},
+			},
+		}
+	}
+
+	// Flag set → non-nil SelectionScopePolicy covering the selected type.
+	boundCap := &capturingDepChase{}
+	if _, err := Run(context.Background(), req, newRunOpts(t.TempDir(), true, boundCap)); err != nil {
+		t.Fatalf("Run (bound): %v", err)
+	}
+	pol, ok := boundCap.opts.AdoptionPolicy.(depchase.SelectionScopePolicy)
+	if !ok {
+		t.Fatalf("AdoptionPolicy=%T, want depchase.SelectionScopePolicy", boundCap.opts.AdoptionPolicy)
+	}
+	if _, inScope := pol.InScopeTypes["aws_sqs_queue"]; !inScope {
+		t.Errorf("scope policy InScopeTypes=%v, want it to cover the selected aws_sqs_queue", pol.InScopeTypes)
+	}
+
+	// Flag unset → nil policy (historical adopt-all).
+	unboundCap := &capturingDepChase{}
+	if _, err := Run(context.Background(), req, newRunOpts(t.TempDir(), false, unboundCap)); err != nil {
+		t.Fatalf("Run (unbound): %v", err)
+	}
+	if unboundCap.opts.AdoptionPolicy != nil {
+		t.Errorf("AdoptionPolicy=%#v, want nil when BoundClosureToSelection is unset", unboundCap.opts.AdoptionPolicy)
+	}
+}

--- a/pkg/reverseimport/options.go
+++ b/pkg/reverseimport/options.go
@@ -66,6 +66,19 @@ type Options struct {
 	Discoverer            Discoverer
 	ClosureDiscoverer     ClosureDiscoverer
 
+	// BoundClosureToSelection opts the dependency-chase phase into the closure
+	// contract (presets#864): a discovered dependency whose Terraform type is
+	// outside the selection scope (the types the operator's selected + closure
+	// resources cover) is represented as a REFERENCE — the literal stays in the
+	// generated HCL and the target is not adopted into the managed import set —
+	// instead of being transitively adopted. Off by default, so the historical
+	// adopt-all behavior is unchanged unless a caller opts in. When set, Run
+	// builds a depchase.SelectionScopePolicy from the resource set entering
+	// dep-chase and passes it as depchase.Options.AdoptionPolicy. Provenance
+	// (pulled_in_by) is stamped on auto-included resources regardless of this
+	// flag. See docs/depchase-closure-contract.md.
+	BoundClosureToSelection bool
+
 	// Parallelism overrides the `-parallelism=<n>` flag passed to the
 	// engine's final `terraform plan` (the authoritative combined-stack plan
 	// over the full imported set) AND propagated to the genconfig readback /

--- a/pkg/reverseimport/run.go
+++ b/pkg/reverseimport/run.go
@@ -152,17 +152,26 @@ func Run(ctx context.Context, req job.Request, opts Options) (job.Result, error)
 				return &depchase.DriftfixResult{GeneratedPath: r.GeneratedPath, Iterations: r.Iterations}, nil
 			},
 		}
+		// Closure contract (presets#864): when the caller opts in, bound the
+		// chase to the selection scope by handing depchase a SelectionScopePolicy
+		// built from the resource set entering the phase (selected + closure
+		// resources). Off by default → nil policy → historical adopt-all.
+		var adoptionPolicy depchase.AdoptionPolicy
+		if opts.BoundClosureToSelection {
+			adoptionPolicy = depchase.NewSelectionScopePolicy(resources)
+		}
 		opts.progressf("reverse-import: chasing resource dependencies…\n")
 		if err := opts.runPhase("chasing resource dependencies", func() error {
 			var chaseErr error
 			dcRes, chaseErr = opts.deps.runDepChase(ctx, depchase.Options{
-				Workdir:       workdir,
-				Region:        region,
-				AccountID:     firstResourceField(resources, func(id imported.ResourceIdentity) string { return id.AccountID }),
-				MaxIterations: opts.MaxDepChaseIterations,
-				Discoverer:    opts.Discoverer,
-				Pipeline:      pipeline,
-				Stdout:        opts.Stdout,
+				Workdir:        workdir,
+				Region:         region,
+				AccountID:      firstResourceField(resources, func(id imported.ResourceIdentity) string { return id.AccountID }),
+				MaxIterations:  opts.MaxDepChaseIterations,
+				Discoverer:     opts.Discoverer,
+				Pipeline:       pipeline,
+				Stdout:         opts.Stdout,
+				AdoptionPolicy: adoptionPolicy,
 			}, resources)
 			return chaseErr
 		}); err != nil {


### PR DESCRIPTION
## What & why

Follow-up to reliable#2231 (a single "Data storage" category pick expanded to **238 resources**, `irun_jFcsE0sgd8NH`). The reliable-side halves shipped in reliable#2234 *disclose* and *freeze* the expansion but do not make it smaller. This PR is the **contract half**, which lives here: the dependency-chase closure was still unbounded by the operator's selection.

The dep-chase loop (`cmd/insideout-import/depchase`) historically **adopted every importable, discovered dependency** into the managed import set — so a data-store pick could transitively adopt admin IAM roles, VPCs, and SG rules the operator never selected. This teaches the pipeline a bounded closure contract: **adopt only when importable AND unclaimed AND (optionally) in-scope; otherwise represent the reference as a literal so the generated config still validates without adopting the target.**

Design doc (in-repo): [`docs/depchase-closure-contract.md`](https://github.com/luthersystems/insideout-terraform-presets/blob/claude/issue-864-depchase-closure/docs/depchase-closure-contract.md)

## Architecture assumptions

- **Literal-ID reference representation is always valid and always available.** depchase only ever acts on concrete quoted string literals it found in `generated.tf` (interpolations/functions/traversals are left alone). A concrete ARN/UUID in a provider attribute type-checks against the schema with no import block and no managed resource, so `terraform init/validate/plan` pass with the literal left in place. A `data`-source rewrite is documented as the alternative for a future consumer that needs a *computed* attribute of an un-adopted target, but is unnecessary here (the literal is already in the HCL by construction).
- **Criteria 1 & 2 (importable, unclaimed) were already enforced** by `imported.UnimportableReason` (`ReasonInsideOutImported` covers already-claimed; the AWS-managed/service-linked reasons cover inherently un-adoptable). The genuinely new capability is **criterion 3, selection scope**, plus the formal reference-representation framing and provenance.
- **Opt-in, default-off.** `depchase.Options.AdoptionPolicy` defaults to `nil` = adopt-all (historical closure). `reverseimport.Options.BoundClosureToSelection` defaults to `false`. Production behavior is byte-for-byte unchanged until a caller opts in. The only default-on change is the additive `pulled_in_by` provenance stamp.
- **Scope is type-granular, not instance-granular.** depchase already knows a reference's Terraform type from the parsed ARN, so a type-scoped verdict needs no extra cloud lookup, and "the operator is importing resources of this type" is a faithful proxy for "this belongs in the selection." Flipping the flag on by default (a real behavior change) is deliberately deferred to reliable/ui-core.
- **`imported.json` change is additive** — `PulledInBy` is an `omitempty` pointer; a nil field is omitted, so existing goldens/round-trips are unchanged. Per `pkg/imported/snapshot` rules, an additive per-resource struct field rides the versioned `resources` array and needs **no** `CurrentVersion` bump. Reliable renders `pulled_in_by.reason`/`.consumers` verbatim; it does not re-derive them.
- **Warning carrier rides #854.** New class `depchase_reference_retained`; `reverseimport.foldDepChaseWarnings` already maps every warning `Code` → `job.Diagnostic.Code`, so it reaches reliable with no extra wiring.

## Incident-shape regression evidence

`TestRun_ClosureContract_OutOfScopeRefIsReferencedNotAdopted` reproduces the incident shape: a selected `aws_dynamodb_table` (a "Data storage" pick, plus the in-scope customer KMS key) whose generated HCL references a foreign admin IAM role the operator never selected. With a `SelectionScopePolicy` scoped to the selection's types it asserts:

- the out-of-scope admin `aws_iam_role` is **referenced, not adopted** (absent from `Added` and `Resources`, no managed→managed edge);
- the admin-role literal is **retained** in `generated.tf` (the reference representation);
- the in-scope KMS key **is** adopted and carries `pulled_in_by{reason: dependency_chase, consumers: [aws_dynamodb_table.orders]}` on both `Added` and `Resources` (the imported.json carrier); the selected table carries no provenance;
- a machine-readable `depchase_reference_retained` diagnostic (`reason: out_of_selection_scope`) explains the omission.

`TestRun_ClosureContract_NilPolicyAdoptsEverything` is the safety pin: with no policy, both the KMS key and the admin role are still adopted (historical adopt-all), proving the contract is opt-in.

`TestReferenceRepresentation_Validates` (`//go:build tfvalidate`) emits an `aws_sqs_queue` referencing a foreign KMS key purely by literal ARN (no key resource, no import block) and runs real `terraform init` + `validate` against pinned `hashicorp/aws ~> 6.0` — proving the reference representation validates without adopting the target. Wired into CI via `make test-tfvalidate`.

## Test results (all green locally)

- `go build ./...`, `go vet ./...` — clean
- `go test ./... -count=1` — full suite passes (exit 0)
- `go test -tags tfvalidate -run TestReferenceRepresentation_Validates ./cmd/insideout-import/depchase/` — passes (terraform available; downloaded provider + validated in 12.8s)
- `terraform fmt -check -recursive`, `make go-fmt-check`, `make verify-gen` — clean
- CI HCL lint scripts (`lint-project-tag`, `lint-project-label`, `lint-sensitive-for-each`, `lint-foreach-unknown-keys`) — PASS (no `.tf` files changed)

## Files

| File | Change |
|---|---|
| `pkg/composer/imported/resource.go` | `PulledInBy` field + type + `PulledInReason*` consts (additive) |
| `cmd/insideout-import/depchase/adoption.go` | `AdoptionPolicy`, `SelectionScopePolicy`, `NewSelectionScopePolicy`, provenance merge/stamp helpers |
| `cmd/insideout-import/depchase/depchase.go` | `Options.AdoptionPolicy`, adopt-vs-reference decision point, provenance stamping |
| `cmd/insideout-import/depchase/warning.go` | `CodeReferenceRetained` (class J) + prose |
| `pkg/reverseimport/{options,run,closure}.go` | `BoundClosureToSelection`, policy wiring, closure-child provenance |
| `docs/depchase-closure-contract.md` | design doc |
| `Makefile` | wire the new tfvalidate test into `make test-tfvalidate` |
| tests | `adoption_test.go`, `adoption_tfvalidate_test.go`, `closure_provenance_test.go` |

Refs #864, luthersystems/reliable#2231, luthersystems/reliable#2234, #854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoXMaMHq1LrTJo1DtxwGMR)_