### PR TITLE
fix(composer): deterministic module-argument emission in root main.tf

### DIFF
--- a/pkg/composer/compose_stack_test.go
+++ b/pkg/composer/compose_stack_test.go
@@ -3070,3 +3070,75 @@ func TestComposeStack_GCPCloudKMS_MovedBlocksRebindUpstreamState(t *testing.T) {
 	require.NotContains(t, planStr, "slice end_index",
 		"terraform plan surfaced 'slice end_index' (issue #182 regression):\n%s", planStr)
 }
+
+// TestComposeStack_Deterministic pins the composed archive to be byte-for-byte
+// identical across repeated in-process composes of the same stack. This is the
+// poka-yoke drift guard for reliable#2286: EmitRootMainTFWithLocals ranged Go
+// maps directly for the module `providers = {…}` pairs, the Raw (DefaultWiring
+// RawHCL) args, and the namespaced Inputs, so module-argument order shuffled
+// between two identical `GET /api/v2/tf-download` calls and the emitted archive
+// (and its hash) differed run-to-run. The stack selection deliberately includes
+// WAF (exercises the multi-key `providers` map site: `aws = aws`,
+// `aws.us_east_1 = aws.us_east_1`) and RDS (exercises the wired Raw/Inputs
+// arg sites), so a regression at any of the three sorted sites re-surfaces here.
+func TestComposeStack_Deterministic(t *testing.T) {
+	selected := []ComponentKey{
+		KeyAWSVPC,
+		KeyAWSEKS,
+		KeyAWSBastion,
+		KeyAWSALB,
+		KeyAWSRDS,
+		KeyAWSElastiCache,
+		KeyAWSWAF,
+		KeyAWSCloudfront,
+		KeyAWSCloudWatchLogs,
+		KeyAWSSQS,
+		KeyAWSCloudWatchMonitoring,
+		KeyAWSGitHubActions,
+	}
+
+	compose := func() Files {
+		c := newTestClient()
+		out, err := c.ComposeStack(ComposeStackOpts{
+			Cloud:        "aws",
+			SelectedKeys: selected,
+			Comps:        awsKitchenSinkCompsV2(),
+			Cfg:          awsKitchenSinkCfgV2(),
+			Project:      "demo",
+			Region:       "us-west-2",
+		})
+		require.NoError(t, err, "ComposeStack should succeed")
+		return out
+	}
+
+	first := compose()
+	require.NotEmpty(t, first, "compose produced no files")
+	// The providers map site must actually be exercised by this fixture,
+	// otherwise the guard can pass while that loop stays unsorted.
+	require.Contains(t, string(first["/main.tf"]), "aws.us_east_1 = aws.us_east_1",
+		"fixture must exercise the multi-key module providers map (WAF)")
+
+	// Sorted key list of the first compose, for stable comparison messaging.
+	firstKeys := make([]string, 0, len(first))
+	for k := range first {
+		firstKeys = append(firstKeys, k)
+	}
+	sort.Strings(firstKeys)
+
+	for i := 0; i < 10; i++ {
+		got := compose()
+
+		gotKeys := make([]string, 0, len(got))
+		for k := range got {
+			gotKeys = append(gotKeys, k)
+		}
+		sort.Strings(gotKeys)
+		require.Equal(t, firstKeys, gotKeys,
+			"compose iteration %d produced a different set of files", i)
+
+		for _, name := range firstKeys {
+			require.Equal(t, first[name], got[name],
+				"compose iteration %d: file %q differs byte-for-byte from the first compose (reliable#2286 nondeterminism regressed)", i, name)
+		}
+	}
+}

--- a/pkg/composer/emit.go
+++ b/pkg/composer/emit.go
@@ -435,19 +435,45 @@ func EmitRootMainTFWithLocals(blocks []ModuleBlock, locals map[string]string) []
 		mb := b.Body()
 		mb.SetAttributeValue("source", cty.StringVal(m.Source))
 
+		// Emit the providers map, Raw (DefaultWiring RawHCL args), and Inputs
+		// (namespaced var refs) each in sorted key order. Ranging a Go map
+		// yields keys in randomized order, so identical composes previously
+		// shuffled module-argument order between calls (reliable#2286: the
+		// tf-download archive differed byte-for-byte across identical
+		// tf-download requests). Sorting each site makes the emission
+		// deterministic. The Raw-before-Inputs grouping is preserved — sorting
+		// only orders keys *within* each group. Idiom matches
+		// EmitVariablesTFWithSchema / the locals block / renderRequiredProviders.
 		if len(m.Providers) > 0 {
-			var pairs []string
-			for k, v := range m.Providers {
-				pairs = append(pairs, fmt.Sprintf("%s = %s", k, v))
+			provKeys := make([]string, 0, len(m.Providers))
+			for k := range m.Providers {
+				provKeys = append(provKeys, k)
+			}
+			sort.Strings(provKeys)
+			pairs := make([]string, 0, len(provKeys))
+			for _, k := range provKeys {
+				pairs = append(pairs, fmt.Sprintf("%s = %s", k, m.Providers[k]))
 			}
 			mapExpr := fmt.Sprintf("{ %s }", strings.Join(pairs, ", "))
 			setRawExpr(mb, "providers", mapExpr)
 		}
 
-		for k, raw := range m.Raw {
-			setRawExpr(mb, k, raw)
+		rawKeys := make([]string, 0, len(m.Raw))
+		for k := range m.Raw {
+			rawKeys = append(rawKeys, k)
 		}
-		for k, v := range m.Inputs {
+		sort.Strings(rawKeys)
+		for _, k := range rawKeys {
+			setRawExpr(mb, k, m.Raw[k])
+		}
+
+		inputKeys := make([]string, 0, len(m.Inputs))
+		for k := range m.Inputs {
+			inputKeys = append(inputKeys, k)
+		}
+		sort.Strings(inputKeys)
+		for _, k := range inputKeys {
+			v := m.Inputs[k]
 			if _, exists := m.Raw[k]; exists {
 				continue
 			}


### PR DESCRIPTION
## Problem

Composed root `main.tf` output is non-deterministic: module-argument order shuffles between identical composes (luthersystems/reliable#2286, task 1). Verified live — two back-to-back `GET /api/v2/tf-download` calls for the same session and version returned byte-different `main.tf` (sorted-line content identical), and a local repro showed `/main.tf` differing in 9–16 of 19 in-process composes.

Root cause: three map-range loops in `EmitRootMainTFWithLocals` fed rendered output directly from Go map iteration order:

- the module `providers = { … }` pairs
- the `Raw` (DefaultWiring RawHCL) arguments
- the namespaced `Inputs` var refs

Every other emission site in the package already sorts (variables, locals, required_providers, tfvars) — these three were the outliers.

## Change

- Sort keys before each of the three loops. Raw-before-Inputs grouping and all emission semantics unchanged; only intra-group key order changes.
- Add `TestComposeStack_Deterministic`: composes a kitchen-sink stack (WAF for the multi-key providers map, RDS for wired Raw/Inputs args) 10x in-process and requires every emitted file byte-equal to the first compose. Asserts the fixture actually exercises the providers-map site so the guard can't silently lose coverage. Guards the whole class of unsorted-map-emission regressions, per this repo's drift-guard convention.

Purely cosmetic for Terraform semantics (argument order within a block is meaningless to plan/apply); makes archives content-addressable for diffs, caching, and provenance.

## Testing

- `go test ./pkg/composer/...` passes; new test also run with `-count=5`
- `gofmt` clean; `go build ./...` clean

## Follow-up

After merge, bump the presets pin in reliable's `go.mod` (paired with luthersystems/reliable PR for archive entry-order determinism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VV88uuWhoctc8NAY5KGqbr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VV88uuWhoctc8NAY5KGqbr)_