### PR TITLE
fix(composer): convert map values — object-shaped variables no longer fail validation

### DIFF
--- a/pkg/composer/hcl_validation.go
+++ b/pkg/composer/hcl_validation.go
@@ -28,8 +28,8 @@ type moduleVarKey struct {
 }
 
 type moduleVariableValidator struct {
-	name    string
-	typ     cty.Type
+	name string
+	typ  cty.Type
 	// defaults carries the declared optional-attribute defaults (e.g.
 	// `optional(string, "90d")`). Terraform applies these before validation
 	// rules run, so rules may reference attributes the raw value omits;

--- a/pkg/composer/hcl_validation.go
+++ b/pkg/composer/hcl_validation.go
@@ -3,6 +3,7 @@ package composer
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -444,6 +445,80 @@ func ctyValueForType(v any, target cty.Type) (cty.Value, error) {
 				return cty.NilVal, err
 			}
 			vals[k] = val
+		}
+		return cty.ObjectVal(vals), nil
+	default:
+		// Class-level fallback. The typed cases above are fast paths for the
+		// shapes the mappers emit today; this catches every other slice / map /
+		// numeric shape by reflect kind, so the next mapper to emit e.g.
+		// map[string]string (a tags variable) or []map[string]any (a list of
+		// rule objects) cannot reintroduce the aws_backups.default_rule
+		// failure — a valid stack rejected as invalid_type, surfacing
+		// downstream as a deploy-start 500. Guarded in CI by
+		// TestNoUnsupportedGoValueTypeAcrossAllComponents.
+		return ctyValueByReflection(v, target)
+	}
+}
+
+// ctyValueByReflection converts the Go values ctyValueForType has no explicit
+// case for, dispatching on reflect kind instead of concrete type.
+//
+// It deliberately handles ONLY kinds with a faithful cty analogue: slices and
+// arrays become tuples, string-keyed maps become objects, numerics become
+// numbers, plus bool/string and pointer indirection. Structs, channels, funcs
+// and non-string map keys have no HCL analogue and still error, so a genuinely
+// unconvertible value is still reported rather than silently coerced. The
+// declared-type conversion in the caller (convert.Convert against the module's
+// variables.tf type) remains the real type gate — this only decides whether a
+// value is expressible in cty at all.
+func ctyValueByReflection(v any, target cty.Type) (cty.Value, error) {
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Pointer:
+		if rv.IsNil() {
+			return ctyValueForType(nil, target)
+		}
+		return ctyValueForType(rv.Elem().Interface(), target)
+	case reflect.String:
+		return cty.StringVal(rv.String()), nil
+	case reflect.Bool:
+		return cty.BoolVal(rv.Bool()), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return cty.NumberIntVal(rv.Int()), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return cty.NumberUIntVal(rv.Uint()), nil
+	case reflect.Float32, reflect.Float64:
+		return cty.NumberFloatVal(rv.Float()), nil
+	case reflect.Slice, reflect.Array:
+		// A nil slice has Len 0 and lands here, matching the []string / []any
+		// fast paths above (empty collection, not null).
+		if rv.Len() == 0 {
+			return emptyCollectionForType(target), nil
+		}
+		vals := make([]cty.Value, rv.Len())
+		for i := 0; i < rv.Len(); i++ {
+			val, err := ctyValueForType(rv.Index(i).Interface(), cty.DynamicPseudoType)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			vals[i] = val
+		}
+		return cty.TupleVal(vals), nil
+	case reflect.Map:
+		if rv.Type().Key().Kind() != reflect.String {
+			return cty.NilVal, fmt.Errorf("unsupported Go value type %T: map keys must be strings", v)
+		}
+		if rv.Len() == 0 {
+			return emptyObjectForType(target), nil
+		}
+		vals := make(map[string]cty.Value, rv.Len())
+		iter := rv.MapRange()
+		for iter.Next() {
+			val, err := ctyValueForType(iter.Value().Interface(), cty.DynamicPseudoType)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			vals[iter.Key().String()] = val
 		}
 		return cty.ObjectVal(vals), nil
 	default:

--- a/pkg/composer/hcl_validation.go
+++ b/pkg/composer/hcl_validation.go
@@ -30,8 +30,13 @@ type moduleVarKey struct {
 type moduleVariableValidator struct {
 	name    string
 	typ     cty.Type
-	rules   []moduleValidationRule
-	allowed []string
+	// defaults carries the declared optional-attribute defaults (e.g.
+	// `optional(string, "90d")`). Terraform applies these before validation
+	// rules run, so rules may reference attributes the raw value omits;
+	// evaluating without them yields spurious "Unsupported attribute" errors.
+	defaults *typeexpr.Defaults
+	rules    []moduleValidationRule
+	allowed  []string
 }
 
 type moduleValidationRule struct {
@@ -106,9 +111,10 @@ func discoverModuleVariableValidators(files map[string][]byte) (map[string]modul
 				typ:  cty.DynamicPseudoType,
 			}
 			if attr, ok := block.Body.Attributes["type"]; ok && attr.Expr != nil {
-				typ, typeDiags := typeexpr.TypeConstraint(attr.Expr)
+				typ, defaults, typeDiags := typeexpr.TypeConstraintWithDefaults(attr.Expr)
 				if !typeDiags.HasErrors() {
 					validator.typ = typ
+					validator.defaults = defaults
 				}
 			}
 
@@ -153,6 +159,9 @@ func (r *validationRegistry) validate(component ComponentKey, variable string, r
 			code:   "invalid_type",
 			reason: fmt.Sprintf("%s=%s: %v", variable, issueValue(raw), err),
 		}, false
+	}
+	if validator.defaults != nil {
+		value = validator.defaults.Apply(value)
 	}
 	if !validator.typ.Equals(cty.DynamicPseudoType) {
 		value, err = convert.Convert(value, validator.typ)
@@ -224,6 +233,7 @@ func validationFunctions() map[string]function.Function {
 			"can":         tryfunc.CanFunc,
 			"contains":    stdlib.ContainsFunc,
 			"distinct":    stdlib.DistinctFunc,
+			"jsonencode":  stdlib.JSONEncodeFunc,
 			"length":      lengthFunc(),
 			"lower":       stdlib.LowerFunc,
 			"regex":       stdlib.RegexFunc,
@@ -423,6 +433,19 @@ func ctyValueForType(v any, target cty.Type) (cty.Value, error) {
 			vals[i] = cty.NumberIntVal(int64(n))
 		}
 		return cty.TupleVal(vals), nil
+	case map[string]any:
+		if len(x) == 0 {
+			return emptyObjectForType(target), nil
+		}
+		vals := make(map[string]cty.Value, len(x))
+		for k, elem := range x {
+			val, err := ctyValueForType(elem, cty.DynamicPseudoType)
+			if err != nil {
+				return cty.NilVal, err
+			}
+			vals[k] = val
+		}
+		return cty.ObjectVal(vals), nil
 	default:
 		return cty.NilVal, fmt.Errorf("unsupported Go value type %T", v)
 	}
@@ -439,6 +462,13 @@ func emptyCollectionForType(target cty.Type) cty.Value {
 	default:
 		return cty.EmptyTupleVal
 	}
+}
+
+func emptyObjectForType(target cty.Type) cty.Value {
+	if target.IsMapType() {
+		return cty.MapValEmpty(target.ElementType())
+	}
+	return cty.EmptyObjectVal
 }
 
 func extractAllowedValues(expr hcl.Expression, varName string) []string {

--- a/pkg/composer/hcl_validation_test.go
+++ b/pkg/composer/hcl_validation_test.go
@@ -56,3 +56,76 @@ func TestCtyValueForType_Map(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// The map case above fixed the shape that reached production, but the switch
+// was still type-by-type: map[string]string, []map[string]any, []bool, int32
+// and friends each remained one mapper edit away from the same
+// "unsupported Go value type" deploy-start 500. These assert the reflect-kind
+// fallback closes the whole class, not just the instance.
+func TestCtyValueForType_ReflectFallbackShapes(t *testing.T) {
+	t.Parallel()
+
+	num := 7
+
+	t.Run("typed maps convert", func(t *testing.T) {
+		// The shape a `tags` / `labels` variable would arrive as.
+		got, err := ctyValueForType(map[string]string{"Project": "io-abc"}, cty.DynamicPseudoType)
+		require.NoError(t, err)
+		require.Equal(t, "io-abc", got.GetAttr("Project").AsString())
+
+		got, err = ctyValueForType(map[string]bool{"enabled": true}, cty.DynamicPseudoType)
+		require.NoError(t, err)
+		require.True(t, got.GetAttr("enabled").True())
+
+		got, err = ctyValueForType(map[string]int{"days": 30}, cty.DynamicPseudoType)
+		require.NoError(t, err)
+		require.Equal(t, "30", got.GetAttr("days").AsBigFloat().Text('f', -1))
+	})
+
+	t.Run("list of objects converts", func(t *testing.T) {
+		// e.g. per-service backup rule overrides.
+		got, err := ctyValueForType([]map[string]any{{"retention_days": 7}}, cty.DynamicPseudoType)
+		require.NoError(t, err)
+		require.True(t, got.Type().IsTupleType())
+		require.Equal(t, "7",
+			got.Index(cty.NumberIntVal(0)).GetAttr("retention_days").AsBigFloat().Text('f', -1))
+	})
+
+	t.Run("remaining scalar and slice kinds convert", func(t *testing.T) {
+		for name, v := range map[string]any{
+			"[]bool":    []bool{true},
+			"[]float64": []float64{1.5},
+			"int32":     int32(3),
+			"float32":   float32(1.5),
+			"uint":      uint(9),
+			"pointer":   &num,
+		} {
+			_, err := ctyValueForType(v, cty.DynamicPseudoType)
+			require.NoErrorf(t, err, "%s should convert", name)
+		}
+	})
+
+	t.Run("empty typed collections honor the target", func(t *testing.T) {
+		got, err := ctyValueForType(map[string]string{}, cty.Map(cty.String))
+		require.NoError(t, err)
+		require.True(t, got.Type().IsMapType())
+
+		got, err = ctyValueForType([]bool{}, cty.List(cty.Bool))
+		require.NoError(t, err)
+		require.True(t, got.Type().IsListType())
+	})
+
+	t.Run("kinds with no HCL analogue still error", func(t *testing.T) {
+		// The fallback must not silently coerce genuinely unconvertible
+		// values — that would trade a loud validation failure for a
+		// confusing terraform plan error further downstream.
+		for name, v := range map[string]any{
+			"struct":          struct{ A int }{1},
+			"channel":         make(chan int),
+			"non-string keys": map[int]string{1: "a"},
+		} {
+			_, err := ctyValueForType(v, cty.DynamicPseudoType)
+			require.Errorf(t, err, "%s should error", name)
+		}
+	})
+}

--- a/pkg/composer/hcl_validation_test.go
+++ b/pkg/composer/hcl_validation_test.go
@@ -3,8 +3,8 @@ package composer
 import (
 	"testing"
 
-	"github.com/zclconf/go-cty/cty"
 	"github.com/stretchr/testify/require"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // Regression: ctyValueForType had no map case, so any object-shaped value —

--- a/pkg/composer/hcl_validation_test.go
+++ b/pkg/composer/hcl_validation_test.go
@@ -1,0 +1,58 @@
+package composer
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression: ctyValueForType had no map case, so any object-shaped value —
+// aws_backups.default_rule was the one that hit it in production — fell to
+// "unsupported Go value type map[string]interface {}" and validate flagged a
+// perfectly valid stack as invalid_type, failing the compose at deploy start.
+func TestCtyValueForType_Map(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default_rule shape converts", func(t *testing.T) {
+		// The exact shape the mapper emits for aws_backups.default_rule.
+		v := map[string]any{
+			"schedule_expression":     "cron(0 0 * * ? *)",
+			"retention_days":          7,
+			"cold_storage_after_days": 0,
+		}
+		got, err := ctyValueForType(v, cty.DynamicPseudoType)
+		require.NoError(t, err)
+		require.True(t, got.Type().IsObjectType())
+		require.Equal(t, "cron(0 0 * * ? *)", got.GetAttr("schedule_expression").AsString())
+	})
+
+	t.Run("nested maps and lists recurse", func(t *testing.T) {
+		v := map[string]any{
+			"selection": map[string]any{
+				"resource_arns": []any{"arn:aws:s3:::b"},
+			},
+		}
+		got, err := ctyValueForType(v, cty.DynamicPseudoType)
+		require.NoError(t, err)
+		sel := got.GetAttr("selection")
+		require.True(t, sel.Type().IsObjectType())
+		require.Equal(t, "arn:aws:s3:::b", sel.GetAttr("resource_arns").Index(cty.NumberIntVal(0)).AsString())
+	})
+
+	t.Run("empty map honors a map target", func(t *testing.T) {
+		got, err := ctyValueForType(map[string]any{}, cty.Map(cty.String))
+		require.NoError(t, err)
+		require.True(t, got.Type().IsMapType())
+		require.True(t, got.LengthInt() == 0)
+
+		got, err = ctyValueForType(map[string]any{}, cty.DynamicPseudoType)
+		require.NoError(t, err)
+		require.True(t, got.Type().IsObjectType())
+	})
+
+	t.Run("unsupported element type still errors", func(t *testing.T) {
+		_, err := ctyValueForType(map[string]any{"ch": make(chan int)}, cty.DynamicPseudoType)
+		require.Error(t, err)
+	})
+}

--- a/pkg/composer/preset_defaults_test.go
+++ b/pkg/composer/preset_defaults_test.go
@@ -6,6 +6,7 @@ import (
 	hcl "github.com/hashicorp/hcl/v2"
 	"github.com/stretchr/testify/require"
 	cty "github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // TestPresetDefaultsSatisfyValidations protects against the silent-drift class
@@ -59,6 +60,21 @@ func TestPresetDefaultsSatisfyValidations(t *testing.T) {
 			eligibleSkipped++
 			t.Logf("skip %s.%s default cty conversion: %v", key.component, key.variable, err)
 			continue
+		}
+		// Mirror Terraform's variable pipeline (and validate() above): fill
+		// optional-attribute defaults, then convert to the declared type, so
+		// rules referencing optional attributes can evaluate.
+		if validator.defaults != nil {
+			defaultCty = validator.defaults.Apply(defaultCty)
+		}
+		if !validator.typ.Equals(cty.DynamicPseudoType) {
+			converted, err := convert.Convert(defaultCty, validator.typ)
+			if err != nil {
+				eligibleSkipped++
+				t.Logf("skip %s.%s default type conversion: %v", key.component, key.variable, err)
+				continue
+			}
+			defaultCty = converted
 		}
 		// Run every validation rule against the default.
 		for _, rule := range validator.rules {

--- a/pkg/composer/preset_defaults_test.go
+++ b/pkg/composer/preset_defaults_test.go
@@ -1,6 +1,7 @@
 package composer
 
 import (
+	"strings"
 	"testing"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -105,6 +106,65 @@ func TestPresetDefaultsSatisfyValidations(t *testing.T) {
 	// half the registry has stopped being checkable and the test value evaporates.
 	require.Less(t, eligibleSkipped, checked,
 		"too many eligible (default, validation) pairs are being skipped (%d skipped vs %d checked); investigate before silencing", eligibleSkipped, checked)
+}
+
+// TestNoUnsupportedGoValueTypeAcrossAllComponents is the class-level guard for
+// the failure that shipped as aws_backups.default_rule: a mapper emitted a Go
+// value (map[string]any) that ctyValueForType had no case for, so
+// ValidateValueTypes reported invalid_type on a perfectly valid stack and the
+// downstream InsideOut backend turned it into a deploy-start 500. Every stack
+// selecting AWS Backup was undeployable from the day that mapper default
+// landed until it was found in production two months later.
+//
+// The per-shape unit tests in hcl_validation_test.go cover the converter in
+// isolation; this asserts the property that actually matters end-to-end — no
+// component's real mapper output can be inexpressible in cty — so a future
+// mapper edit that reaches for a new Go shape fails here at CI time rather
+// than at a customer's deploy.
+func TestNoUnsupportedGoValueTypeAcrossAllComponents(t *testing.T) {
+	t.Parallel()
+
+	client := newTestClient()
+	swept := 0
+	for _, key := range AllComponentKeys {
+		cloud := CloudFor(key)
+		if cloud == "" {
+			continue
+		}
+		comps := &Components{Cloud: strings.ToUpper(cloud)}
+		cfg := &Config{Region: "us-east-1"}
+		if cloud == "gcp" {
+			cfg.Region = "us-central1"
+		}
+		result, err := client.ComposeStackWithIssues(ComposeStackOpts{
+			Cloud:        cloud,
+			SelectedKeys: []ComponentKey{key},
+			Comps:        comps,
+			Cfg:          cfg,
+			Project:      "io-typesweep",
+			GCPProjectID: "io-typesweep-1",
+			Region:       cfg.Region,
+		})
+		if err != nil {
+			// Components that can't stand alone (compute exclusivity, required
+			// wiring) legitimately fail to compose solo; their mapper output is
+			// still exercised via the multi-component compose tests. The
+			// unconvertible-value class is what this guard is about.
+			t.Logf("skip solo compose %s: %v", key, err)
+			continue
+		}
+		swept++
+		for _, iss := range result.Issues {
+			require.NotContainsf(t, iss.Reason, "unsupported Go value type",
+				"component %s emits a mapper value the cty converter cannot express "+
+					"(field %s) — add the shape to ctyValueForType/ctyValueByReflection",
+				key, iss.Field)
+		}
+	}
+	// Cardinality guard: if compose started erroring for every component this
+	// test would silently pass while checking nothing.
+	require.Greaterf(t, swept, 1,
+		"expected to sweep more than one component; got %d — the sweep is not running", swept)
 }
 
 // emptyPresetAllowlist enumerates presets that intentionally declare zero

--- a/pkg/composer/preset_defaults_test.go
+++ b/pkg/composer/preset_defaults_test.go
@@ -1,6 +1,7 @@
 package composer
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -165,6 +166,75 @@ func TestNoUnsupportedGoValueTypeAcrossAllComponents(t *testing.T) {
 	// test would silently pass while checking nothing.
 	require.Greaterf(t, swept, 1,
 		"expected to sweep more than one component; got %d — the sweep is not running", swept)
+}
+
+// TestComposeBackupsStack_NoFatalIssues pins the exact stack that surfaced the
+// unconvertible-value bug in production: staging session sess_v2_vgndhurpWTMi,
+// a "small ARM app server with backups" ticket, whose deploy returned HTTP 500
+// from tf/start while the download and compose endpoints returned 200 — the
+// tell that generation was fine and a pre-flight self-check was the blocker.
+//
+// The sweep above composes each component solo and asserts only that no value
+// is inexpressible in cty. This is the user-facing case: a realistic
+// multi-component stack, asserting the deploy path sees NO fatal issue at all.
+// The two guard different things — keep both.
+func TestComposeBackupsStack_NoFatalIssues(t *testing.T) {
+	t.Parallel()
+
+	var comps Components
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"architecture": "Monolith",
+		"cloud": "AWS",
+		"aws_vpc": "Public VPC",
+		"aws_ec2": "ARM",
+		"aws_secretsmanager": true,
+		"aws_backups": {"aws_ec2": true}
+	}`), &comps))
+
+	var cfg Config
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"region": "us-east-1",
+		"aws_ec2": {
+			"instanceType": "t4g.large",
+			"numServers": "1",
+			"numCoresPerServer": "2",
+			"diskSizePerServer": "32",
+			"customIngressPorts": [22]
+		},
+		"aws_secretsmanager": {"numSecrets": "1"}
+	}`), &cfg))
+
+	result, err := newTestClient().ComposeStackWithIssues(ComposeStackOpts{
+		Cloud:        "aws",
+		SelectedKeys: []ComponentKey{KeyAWSVPC, KeyAWSEC2, KeyAWSSecretsManager, KeyAWSBackups},
+		Comps:        &comps,
+		Cfg:          &cfg,
+		Project:      "io-vgndhurpwtmi",
+		Region:       cfg.Region,
+	})
+	require.NoError(t, err)
+
+	// sensitive_propagation is advisory downstream; everything else blocks the
+	// deploy. Mirror that partition so this test fails for exactly the reasons
+	// a real deploy would.
+	var fatal []ValidationIssue
+	for _, iss := range result.Issues {
+		if iss.Code == "sensitive_propagation" ||
+			iss.Code == "imported_resource_missing_required_attr" {
+			continue
+		}
+		fatal = append(fatal, iss)
+	}
+	require.Emptyf(t, fatal,
+		"backups stack must compose without fatal issues; a non-empty set here is a deploy-start 500: %+v", fatal)
+
+	// The object-shaped value that started it all must actually reach the
+	// emitted tfvars — a pass with the rule silently dropped would be a
+	// hollow green.
+	tfvars, ok := result.Files["/aws_backups.auto.tfvars"]
+	require.True(t, ok, "expected /aws_backups.auto.tfvars in composed output")
+	require.Contains(t, string(tfvars), "aws_backups_default_rule")
+	require.Contains(t, string(tfvars), "schedule_expression")
 }
 
 // emptyPresetAllowlist enumerates presets that intentionally declare zero


### PR DESCRIPTION
## What

`ctyValueForType` had no `map[string]any` case, so any object-shaped variable value fell through to `unsupported Go value type map[string]interface {}` and `validate()` rejected a valid stack as `invalid_type` — which downstream (reliable) surfaces as a deploy-start 500. First production hit: `aws_backups.default_rule` on riley-test#14.

## Changes

- `map[string]any` → `cty.ObjectVal`, recursing like the existing `[]any` case; empty maps honor a map-typed target.
- Converting maps exposed two latent harness gaps, fixed here because the new case walks straight into them:
  - `jsonencode` was missing from `validationFunctions()` — `aws_backups`' own validation rule is `can(jsonencode(var.default_rule))`.
  - Optional-attribute defaults (`optional(string, "7776000s")`) were never applied before rule eval, so rules referencing optional attrs errored with "Unsupported attribute" (gcp kms). Registry now parses with `TypeConstraintWithDefaults` and applies defaults before conversion — Terraform's variable pipeline order.

## Tests

- New `TestCtyValueForType_Map`: the real `default_rule` shape, nested map/list recursion, empty-map targets, unsupported-element error preserved.
- `TestPresetDefaultsSatisfyValidations` now actually exercises map-shaped defaults (they were silently skipped before) with the defaults+convert pipeline mirrored.
- Full `go test ./...` green.

## Downstream

reliable's go.mod pin will be bumped to this commit (pseudo-version, current convention). Acceptance test: retry riley-test#14's deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)