### PR TITLE
ci: pin govulncheck Go to 1.26.x instead of floating on "stable"

### DIFF
--- a/.github/workflows/govulncheck-scheduled.yml
+++ b/.github/workflows/govulncheck-scheduled.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "stable"
+          go-version: "1.26.x"
           cache: true
 
       - name: Install govulncheck

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "stable"
+          go-version: "1.26.x"
           cache: true
       - name: Run govulncheck
         run: |


### PR DESCRIPTION
setup-go's `"stable"` flipped to **go1.27.0** in August 2026, and the org is not on Go 1.27 yet. Two reasons to pin:

1. **govulncheck scans the stdlib of the toolchain it runs under** — a 1.27 toolchain reports 1.27 stdlib findings against binaries the org actually builds with 1.26, which is the wrong signal.
2. The same flip already broke golangci-lint jobs fleet-wide (go1.26-built linters panic under a go1.27 toolchain — lutherauth#55, lutherauth-sdk-go#31 carry that half of the fix).

One-line-per-file change: `go-version: "stable"` → `"1.26.x"` in the govulncheck workflows. Bump deliberately when the org moves to 1.27.

Part of a fleet sweep — same PR shape on mars and sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_