### PR TITLE
Pin terraform-aws-modules/eks to 21.24.0 to satisfy the aws 6.52.0 base pin

### DIFF
--- a/aws/eks/main.tf
+++ b/aws/eks/main.tf
@@ -203,8 +203,16 @@ resource "aws_iam_role_policy_attachment" "ebs_csi" {
 }
 
 module "eks" {
-  source  = "terraform-aws-modules/eks/aws"
-  version = "~> 21.0"
+  source = "terraform-aws-modules/eks/aws"
+  # Pinned exactly: composed archives pin hashicorp/aws to the mars
+  # provider-mirror bake (= 6.52.0, pkg/composer/imported/provider_pins.go),
+  # and a floating "~> 21.0" here resolved eks v21.25.0 the day it released,
+  # which requires aws >= 6.59 — making the composed constraint set
+  # unsatisfiable and failing every terraform init (CI go-test run
+  # 32429710972 and customer deploys alike). v21.24.0 is the newest release
+  # compatible with the 6.52.0 pin (requires aws >= 6.52). Bump this pin
+  # together with the base provider pin / mars bake.
+  version = "21.24.0"
 
   name               = local.cluster_name
   kubernetes_version = var.cluster_version


### PR DESCRIPTION
## Root cause

`go-test` is failing on `main` itself (seen twice on run [32429710972](https://github.com/luthersystems/insideout-terraform-presets/actions/runs/32429710972), a workflow-only PR for #880), in `pkg/composer`:

- `TestComposeStack_TerraformInit`
- `TestComposeStack_AWS_PublicVPC_TerraformValidate/Public_VPC_+_EKS_keeps_private_subnets_+_NAT`

Both die at `terraform init`:

```
Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints >= 6.0.0, >= 6.28.0, 6.52.0, >= 6.59.0
```

Composed archives pin `hashicorp/aws = 6.52.0` (`pkg/composer/imported/provider_pins.go`, matching the mars provider-mirror bake, #786). `aws/eks` wrapped the community EKS module with a floating `~> 21.0`, and upstream released **terraform-aws-modules/eks v21.25.0**, which bumps its aws provider requirement from `>= 6.52` to `>= 6.59`. The constraint union became unsatisfiable the day it released — no repo commit involved, and it breaks customer deploy archives containing EKS the same way, not just CI.

This is the same nondeterminism class the base-provider pin was introduced to kill (the 6.49→6.50 incident), arriving via a floating *module* version instead of a floating provider range.

## Fix

Pin the wrapped module to `21.24.0` — the newest release compatible with the `= 6.52.0` base pin (requires `aws >= 6.52`) — with a comment saying to bump it together with the base provider pin / mars bake. Follows the "Pinned versions" convention already used for the base providers.

Note: `aws/vpc` wraps `terraform-aws-modules/vpc/aws` with a floating `~> 6.0` (currently resolves 6.6.1, requiring `aws >= 6.28` — fine today). It has the same latent exposure; left untouched here to keep this PR minimal, but worth pinning in a follow-up.

## Verification

- Both CI-failing tests reproduced locally on unmodified `main` behavior (identical constraint error), and pass with this change.
- Full `go test -race ./pkg/composer/` passes locally: `ok ... 310.8s`, zero failures.
- `terraform fmt -check aws/eks/` clean.

## Impact

Unblocks `ci-gate`/`go-test` for #880 and every other PR to this repo, and restores `terraform init` for composed customer stacks that include EKS.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_