### PR TITLE
Pin four wrapped registry modules exactly to satisfy the composed provider pins

### DIFF
--- a/aws/vpc/main.tf
+++ b/aws/vpc/main.tf
@@ -42,8 +42,18 @@ locals {
 }
 
 module "this" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 6.0"
+  source = "terraform-aws-modules/vpc/aws"
+  # Pinned exactly: composed archives pin hashicorp/aws to the mars
+  # provider-mirror bake (= 6.52.0, pkg/composer/imported/provider_pins.go),
+  # and a floating "~> 6.0" resolves whatever the registry's newest 6.x is at
+  # init time without considering provider constraints — upstream vpc already
+  # raised its aws floor once inside 6.x (>= 6.0 → >= 6.28 at v6.6.0), so the
+  # next floor raise past 6.52 would make the composed constraint set
+  # unsatisfiable and fail every customer deploy archive's terraform init
+  # (the #839/#881 failure class — see aws/eks for the eks v21.25.0 instance).
+  # v6.7.0 is the newest release compatible with the 6.52.0 pin (requires
+  # aws >= 6.28). Bump this pin together with the base provider pin / mars bake.
+  version = "6.7.0"
 
   name = module.name.name
   cidr = var.vpc_cidr

--- a/gcp/gke/main.tf
+++ b/gcp/gke/main.tf
@@ -68,8 +68,16 @@ locals {
 }
 
 module "gke" {
-  source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version = "~> 33.0"
+  source = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  # Pinned exactly: composed archives pin hashicorp/google to the mars
+  # provider-mirror bake (= 6.10.0, pkg/composer/imported/provider_pins.go),
+  # and a floating "~> 33.0" resolves the newest 33.x at init time without
+  # considering provider constraints (the #839/#881 failure class — see
+  # aws/eks). v33.1.0 is the newest 33.x (private-cluster submodule requires
+  # google >= 5.40.0, < 7 — satisfied by 6.10.0). Do NOT jump majors:
+  # kubernetes-engine >= 35 requires google >= 6.11, incompatible with the
+  # 6.10.0 pin. Bump this pin together with the base provider pin / mars bake.
+  version = "33.1.0"
 
   project_id = var.project_id
   name       = local.cluster_name

--- a/gcp/vpc/main.tf
+++ b/gcp/vpc/main.tf
@@ -17,8 +17,15 @@ locals {
 }
 
 module "vpc" {
-  source  = "terraform-google-modules/network/google"
-  version = "~> 9.0"
+  source = "terraform-google-modules/network/google"
+  # Pinned exactly: composed archives pin hashicorp/google to the mars
+  # provider-mirror bake (= 6.10.0, pkg/composer/imported/provider_pins.go),
+  # and a floating "~> 9.0" resolves the newest 9.x at init time without
+  # considering provider constraints (the #839/#881 failure class — see
+  # aws/eks). v9.3.0 is the newest 9.x (requires google >= 4.64, < 7 —
+  # satisfied by 6.10.0). Bump this pin together with the base provider
+  # pin / mars bake.
+  version = "9.3.0"
 
   project_id   = var.project_id
   network_name = local.network_name
@@ -59,9 +66,13 @@ resource "google_compute_router" "router" {
 
 # Cloud NAT for private instances
 module "cloud_nat" {
-  count   = var.enable_cloud_nat ? 1 : 0
-  source  = "terraform-google-modules/cloud-nat/google"
-  version = "~> 5.0"
+  count  = var.enable_cloud_nat ? 1 : 0
+  source = "terraform-google-modules/cloud-nat/google"
+  # Pinned exactly: same rationale as module "vpc" above (= 6.10.0 google
+  # pin, #839/#881 failure class). v5.4.0 is the newest 5.x (requires
+  # google >= 4.51, < 8 — satisfied by 6.10.0). Bump this pin together
+  # with the base provider pin / mars bake.
+  version = "5.4.0"
 
   project_id = var.project_id
   region     = var.region


### PR DESCRIPTION
## Summary

Pins four floating upstream registry-module references to exact versions so they cannot collide with the composer's exact provider pins (`aws = 6.52.0`, `google`/`google-beta` `= 6.10.0` — `pkg/composer/imported/provider_pins.go`, matching the mars v0.125.0 provider-mirror bake). Same failure class as the just-merged eks fix (#881) and the nested-object/pin conventions in CLAUDE.md (#839/#881).

## The collision mechanism

Terraform resolves a module range like `~> 6.0` to the newest matching release at `terraform init` time **without considering provider constraints**. When that newest release raises its provider floor above our exact pin, the composed constraint set (`= 6.52.0` ∩ `>= 6.59`, say) is empty and every `terraform init` fails — breaking customer deploy archives and CI simultaneously, with no change on our side. That is exactly how eks v21.25.0 broke everything the day it released (#881).

## Changes

| Module | Was | Now | Verified provider floor | vs pin |
|---|---|---|---|---|
| `aws/vpc` → `terraform-aws-modules/vpc/aws` | `~> 6.0` | **6.7.0** | `aws >= 6.28` | ✅ ≤ 6.52.0 |
| `gcp/gke` → `kubernetes-engine//modules/private-cluster` | `~> 33.0` | **33.1.0** | `google >= 5.40.0, < 7` (submodule) | ✅ ≤ 6.10.0 |
| `gcp/vpc` → `terraform-google-modules/network` | `~> 9.0` | **9.3.0** | `google >= 4.64, < 7` | ✅ ≤ 6.10.0 |
| `gcp/vpc` → `terraform-google-modules/cloud-nat` | `~> 5.0` | **5.4.0** | `google >= 4.51, < 8` | ✅ ≤ 6.10.0 |

Each floor was confirmed against the Terraform registry's per-release metadata (`/v1/modules/.../versions`), for the gke case against the `modules/private-cluster` submodule specifically. Each pin is the newest release inside the previously-floating range; each carries an eks-style comment noting it must be bumped together with the base provider pin / mars bake.

## Risk assessment per pin

- **`aws/vpc` (critical — feeds customer VPC deploy archives): the live twin of #881.** Upstream vpc has already raised its aws floor once *inside* 6.x (`>= 6.0` → `>= 6.28` at v6.6.0), so the next floor raise past 6.52 would have detonated the same way eks did. 6.7.0 is additionally the newest stable release overall, so this is a pure de-risking with zero version movement.
- **GCP pins (dormant but pre-armed):** google is pinned at 6.10.0 and kubernetes-engine `>= 35` already requires `google >= 6.11` — the incompatible releases exist today; only the `~> 33.0` range fence keeps them out. A floor raise within 33.x (or within network 9.x / cloud-nat 5.x) would arm the same trap. Note kubernetes-engine 34.0.0's constraint (`>= 5.44.2, != 6.0.0…6.6.0, < 7`) technically also admits 6.10.0, but a major-version jump changes module inputs and is out of scope here — do NOT jump majors while the 6.10.0 pin stands.

## Validation

- `terraform init -backend=false && terraform validate` passes for `aws/vpc`, `gcp/gke`, and `gcp/vpc` at the pinned versions (Terraform v1.7.5).
- `terraform fmt -check` clean on all three touched files.
- Full 188-job CI matrix left to GitHub Actions per usual.

Refs #881, #839.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sdr7gadsurqY9Xh9FFJkHY)_